### PR TITLE
feat: Lookup Booking by email and/or reference in admin sidebar

### DIFF
--- a/OpenRestoApi/Controllers/AdminController.cs
+++ b/OpenRestoApi/Controllers/AdminController.cs
@@ -24,11 +24,13 @@ public class AdminController(AdminService adminService, IEmailService emailServi
         [FromQuery] int? restaurantId,
         [FromQuery] DateTime? date,
         [FromQuery] bookingStatus status = bookingStatus.active,
-        [FromQuery] bool cancelled = false)
+        [FromQuery] bool cancelled = false,
+        [FromQuery] string? email = null,
+        [FromQuery] string? bookingRef = null)
     {
         //this is business logic that should likely belong in the service but its OK for now
         string effectiveStatus = cancelled ? nameof(bookingStatus.cancelled) : status.ToString();
-        return Ok(await _adminService.GetBookingsAsync(restaurantId, date, effectiveStatus));
+        return Ok(await _adminService.GetBookingsAsync(restaurantId, date, effectiveStatus, email, bookingRef));
     }
 
     [HttpGet("bookings/{id}")]

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -80,7 +80,7 @@ public class AdminService(AppDbContext db, IHoldService holdService)
         };
     }
 
-    public virtual async Task<List<BookingDetailDto>> GetBookingsAsync(int? restaurantId, DateTime? bookingDate, string status)
+    public virtual async Task<List<BookingDetailDto>> GetBookingsAsync(int? restaurantId, DateTime? bookingDate, string status, string? email = null, string? bookingRef = null)
     {
         IQueryable<Booking> q = _db.Bookings
             .Include(b => b.Restaurant)
@@ -153,6 +153,18 @@ public class AdminService(AppDbContext db, IHoldService holdService)
                 DateTime nextDayStart = dayStart.AddDays(1);
                 q = q.Where(b => b.Date >= dayStart && b.Date < nextDayStart);
             }
+        }
+
+        if (!string.IsNullOrWhiteSpace(email))
+        {
+            string normalizedEmail = email.Trim().ToLowerInvariant();
+            q = q.Where(b => b.CustomerEmail != null && b.CustomerEmail.ToLower().Contains(normalizedEmail));
+        }
+
+        if (!string.IsNullOrWhiteSpace(bookingRef))
+        {
+            string normalizedRef = bookingRef.Trim().ToLowerInvariant();
+            q = q.Where(b => b.BookingRef != null && b.BookingRef.ToLower().Contains(normalizedRef));
         }
 
         return await q

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -119,13 +119,17 @@ export type BookingStatusFilter = "active" | "past" | "cancelled" | "all";
 export async function getAdminBookings(
   restaurantId?: number,
   date?: string,
-  status: BookingStatusFilter = "active"
+  status: BookingStatusFilter = "active",
+  email?: string,
+  bookingRef?: string
 ): Promise<BookingDetailDto[]> {
   try {
     const params = new URLSearchParams();
     if (restaurantId != null) params.set("restaurantId", String(restaurantId));
     if (date) params.set("date", date);
     if (status !== "active") params.set("status", status);
+    if (email) params.set("email", email);
+    if (bookingRef) params.set("bookingRef", bookingRef);
     const query = params.toString() ? `?${params}` : "";
     const res = await get(`/admin/bookings${query}`);
     if (!res.ok) throw new Error("Failed to fetch admin bookings");
@@ -134,6 +138,17 @@ export async function getAdminBookings(
     console.error("getAdminBookings error:", err);
     return [];
   }
+}
+
+export async function adminLookupBookings(query: string): Promise<BookingDetailDto[]> {
+  const isEmail = query.includes("@");
+  return getAdminBookings(
+    undefined,
+    undefined,
+    "all",
+    isEmail ? query : undefined,
+    isEmail ? undefined : query
+  );
 }
 
 export async function getAdminBooking(id: number): Promise<BookingDetailDto | null> {

--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -61,7 +61,8 @@ export default function AdminBookingsScreen() {
   const [showNewModal, setShowNewModal] = useState(false);
 
   const router = useRouter();
-  const { create } = useLocalSearchParams<{ create?: string }>();
+  const { create, email: emailParam, bookingRef: bookingRefParam } = useLocalSearchParams<{ create?: string; email?: string; bookingRef?: string }>();
+  const searchQuery = emailParam || bookingRefParam || null;
 
   useEffect(() => {
     if (create === "1") {
@@ -95,8 +96,21 @@ export default function AdminBookingsScreen() {
     };
   }, []);
 
-  // Fetch bookings whenever restaurant or filter changes
+  // Fetch bookings whenever restaurant, filter, or search query changes
   useEffect(() => {
+    if (searchQuery) {
+      let cancelled = false;
+      setLoading(true);
+      getAdminBookings(undefined, undefined, "all", emailParam, bookingRefParam).then((b) => {
+        if (!cancelled) {
+          setBookings(b);
+          setLoading(false);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
     if (!selectedRestaurantId) return;
     let cancelled = false;
     setLoading(true);
@@ -109,7 +123,7 @@ export default function AdminBookingsScreen() {
     return () => {
       cancelled = true;
     };
-  }, [statusFilter, selectedRestaurantId]);
+  }, [statusFilter, selectedRestaurantId, searchQuery, emailParam, bookingRefParam]);
 
   const handleSelectRestaurant = (id: number) => {
     if (id === selectedRestaurantId) return;
@@ -174,29 +188,43 @@ export default function AdminBookingsScreen() {
       <View style={styles.pageHeader}>
         <View style={{ flex: 1 }}>
           <ThemedText style={styles.pageTitle}>
-            {viewMode === "grid"
-              ? "Availability"
-              : statusFilter === "past"
-                ? "Past Bookings"
-                : statusFilter === "cancelled"
-                  ? "Cancelled Bookings"
-                  : "Live Bookings"}
+            {searchQuery
+              ? "Search Results"
+              : viewMode === "grid"
+                ? "Availability"
+                : statusFilter === "past"
+                  ? "Past Bookings"
+                  : statusFilter === "cancelled"
+                    ? "Cancelled Bookings"
+                    : "Live Bookings"}
           </ThemedText>
           <ThemedText style={[styles.pageSub, { color: mutedColor }]}>
-            {viewMode === "list"
-              ? `${bookings.length} total · ${todayCount} today`
-              : fmtDate(gridDate)}
+            {searchQuery
+              ? `${bookings.length} result${bookings.length !== 1 ? "s" : ""} for "${searchQuery}"`
+              : viewMode === "list"
+                ? `${bookings.length} total · ${todayCount} today`
+                : fmtDate(gridDate)}
           </ThemedText>
         </View>
 
         <View style={styles.headerControls}>
-          <Pressable
-            style={[styles.newBookingBtn, { backgroundColor: PRIMARY }]}
-            onPress={() => setShowNewModal(true)}
-          >
-            <Ionicons name="add-outline" size={16} color="#fff" />
-            <ThemedText style={styles.newBookingBtnText}>New Booking</ThemedText>
-          </Pressable>
+          {searchQuery ? (
+            <Pressable
+              style={[styles.newBookingBtn, { backgroundColor: mutedColor }]}
+              onPress={() => router.replace("/(admin)/bookings")}
+            >
+              <Ionicons name="close-outline" size={16} color="#fff" />
+              <ThemedText style={styles.newBookingBtnText}>Clear Search</ThemedText>
+            </Pressable>
+          ) : (
+            <Pressable
+              style={[styles.newBookingBtn, { backgroundColor: PRIMARY }]}
+              onPress={() => setShowNewModal(true)}
+            >
+              <Ionicons name="add-outline" size={16} color="#fff" />
+              <ThemedText style={styles.newBookingBtnText}>New Booking</ThemedText>
+            </Pressable>
+          )}
 
           {/* Restaurant selector chips */}
           {restaurants.length > 1 &&

--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -61,7 +61,11 @@ export default function AdminBookingsScreen() {
   const [showNewModal, setShowNewModal] = useState(false);
 
   const router = useRouter();
-  const { create, email: emailParam, bookingRef: bookingRefParam } = useLocalSearchParams<{ create?: string; email?: string; bookingRef?: string }>();
+  const {
+    create,
+    email: emailParam,
+    bookingRef: bookingRefParam,
+  } = useLocalSearchParams<{ create?: string; email?: string; bookingRef?: string }>();
   const searchQuery = emailParam || bookingRefParam || null;
 
   useEffect(() => {

--- a/openresto-frontend/components/layout/AdminSidebar.tsx
+++ b/openresto-frontend/components/layout/AdminSidebar.tsx
@@ -1,4 +1,4 @@
-import { View, StyleSheet, Pressable, Platform } from "react-native";
+import { View, StyleSheet, Pressable, Platform, TextInput, ActivityIndicator } from "react-native";
 import { usePathname, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ThemedView } from "@/components/themed-view";
@@ -12,6 +12,7 @@ import { hexToRgba } from "@/utils/colors";
 import { Ionicons } from "@expo/vector-icons";
 import { useEffect, useState } from "react";
 import { fetchRestaurants } from "@/api/restaurants";
+import { adminLookupBookings } from "@/api/admin";
 
 const NAV_ITEMS = [
   {
@@ -45,12 +46,41 @@ export default function AdminSidebar() {
   const PRIMARY = brand.primaryColor || COLORS.primary;
   const insets = useSafeAreaInsets();
 
+  const [lookupQuery, setLookupQuery] = useState("");
+  const [lookupLoading, setLookupLoading] = useState(false);
+  const [lookupStatus, setLookupStatus] = useState<"idle" | "not_found" | "multiple">("idle");
+
   const hoverBg = isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.04)";
   const activeBg = isDark ? hexToRgba(PRIMARY, 0.18) : hexToRgba(PRIMARY, 0.09);
 
   useEffect(() => {
     fetchRestaurants().then((data) => setLocationCount(data.length));
   }, []);
+
+  const handleLookup = async () => {
+    const q = lookupQuery.trim();
+    if (!q) return;
+    setLookupLoading(true);
+    setLookupStatus("idle");
+    try {
+      const results = await adminLookupBookings(q);
+      if (results.length === 0) {
+        setLookupStatus("not_found");
+      } else if (results.length === 1) {
+        setLookupQuery("");
+        router.push(`/(admin)/bookings/${results[0].id}`);
+      } else {
+        setLookupStatus("multiple");
+        const isEmail = q.includes("@");
+        router.push({
+          pathname: "/(admin)/bookings",
+          params: isEmail ? { email: q } : { bookingRef: q },
+        });
+      }
+    } finally {
+      setLookupLoading(false);
+    }
+  };
 
   const handleLogout = async () => {
     await logout();
@@ -132,13 +162,45 @@ export default function AdminSidebar() {
       <View style={styles.spacer} />
 
       <View style={styles.ctaWrapper}>
-        <Pressable
-          style={[styles.ctaBtn, { backgroundColor: PRIMARY }]}
-          onPress={() => router.push({ pathname: "/(admin)/bookings", params: { create: "1" } })}
-        >
-          <Ionicons name="add-circle-outline" size={16} color="#fff" />
-          <ThemedText style={styles.ctaBtnText}>New Booking</ThemedText>
-        </Pressable>
+        <ThemedText style={[styles.lookupLabel, { color: colors.muted }]}>
+          Lookup Booking
+        </ThemedText>
+        <View style={[styles.lookupRow, { borderColor: colors.border, backgroundColor: colors.input ?? (isDark ? "#1e1e1e" : "#f5f5f5") }]}>
+          <TextInput
+            style={[styles.lookupInput, { color: colors.text }]}
+            placeholder="Email or reference…"
+            placeholderTextColor={colors.muted}
+            value={lookupQuery}
+            onChangeText={(t) => {
+              setLookupQuery(t);
+              if (lookupStatus !== "idle") setLookupStatus("idle");
+            }}
+            autoCapitalize="none"
+            returnKeyType="search"
+            onSubmitEditing={handleLookup}
+          />
+          <Pressable
+            onPress={handleLookup}
+            disabled={lookupLoading || !lookupQuery.trim()}
+            style={[styles.lookupBtn, { backgroundColor: PRIMARY }, (!lookupQuery.trim() || lookupLoading) && { opacity: 0.5 }]}
+          >
+            {lookupLoading ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Ionicons name="search-outline" size={14} color="#fff" />
+            )}
+          </Pressable>
+        </View>
+        {lookupStatus === "not_found" && (
+          <ThemedText style={[styles.lookupHint, { color: COLORS.error }]}>
+            No booking found.
+          </ThemedText>
+        )}
+        {lookupStatus === "multiple" && (
+          <ThemedText style={[styles.lookupHint, { color: PRIMARY }]}>
+            Showing all matches…
+          </ThemedText>
+        )}
       </View>
 
       <View style={[styles.divider, { backgroundColor: colors.border }]} />
@@ -259,19 +321,36 @@ const styles = StyleSheet.create({
   ctaWrapper: {
     paddingHorizontal: 12,
     paddingBottom: 12,
+    gap: 6,
   },
-  ctaBtn: {
+  lookupLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.4,
+    paddingLeft: 2,
+  },
+  lookupRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
-    gap: 6,
-    paddingVertical: 10,
     borderRadius: 8,
+    borderWidth: 1,
+    overflow: "hidden",
   },
-  ctaBtnText: {
-    color: "#fff",
-    fontSize: 15,
-    fontWeight: "700",
+  lookupInput: {
+    flex: 1,
+    height: 36,
+    paddingHorizontal: 10,
+    fontSize: 13,
+  },
+  lookupBtn: {
+    width: 36,
+    height: 36,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  lookupHint: {
+    fontSize: 11,
+    paddingLeft: 2,
   },
   footer: {
     paddingTop: 4,

--- a/openresto-frontend/components/layout/AdminSidebar.tsx
+++ b/openresto-frontend/components/layout/AdminSidebar.tsx
@@ -165,7 +165,15 @@ export default function AdminSidebar() {
         <ThemedText style={[styles.lookupLabel, { color: colors.muted }]}>
           Lookup Booking
         </ThemedText>
-        <View style={[styles.lookupRow, { borderColor: colors.border, backgroundColor: colors.input ?? (isDark ? "#1e1e1e" : "#f5f5f5") }]}>
+        <View
+          style={[
+            styles.lookupRow,
+            {
+              borderColor: colors.border,
+              backgroundColor: colors.input ?? (isDark ? "#1e1e1e" : "#f5f5f5"),
+            },
+          ]}
+        >
           <TextInput
             style={[styles.lookupInput, { color: colors.text }]}
             placeholder="Email or reference…"
@@ -182,7 +190,11 @@ export default function AdminSidebar() {
           <Pressable
             onPress={handleLookup}
             disabled={lookupLoading || !lookupQuery.trim()}
-            style={[styles.lookupBtn, { backgroundColor: PRIMARY }, (!lookupQuery.trim() || lookupLoading) && { opacity: 0.5 }]}
+            style={[
+              styles.lookupBtn,
+              { backgroundColor: PRIMARY },
+              (!lookupQuery.trim() || lookupLoading) && { opacity: 0.5 },
+            ]}
           >
             {lookupLoading ? (
               <ActivityIndicator size="small" color="#fff" />

--- a/openresto-frontend/tests/components/AdminSidebar.test.tsx
+++ b/openresto-frontend/tests/components/AdminSidebar.test.tsx
@@ -20,7 +20,7 @@ jest.mock("expo-router", () => {
   return {
     Link,
     usePathname: jest.fn().mockReturnValue("/dashboard"),
-    useRouter: () => ({ replace: jest.fn() }),
+    useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
   };
 });
 
@@ -30,6 +30,10 @@ jest.mock("@expo/vector-icons", () => ({
 
 jest.mock("@/api/auth", () => ({
   logout: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock("@/api/admin", () => ({
+  adminLookupBookings: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@/context/BrandContext", () => ({
@@ -69,6 +73,14 @@ describe("AdminSidebar", () => {
       expect(screen.getByText("Bookings")).toBeTruthy();
       expect(screen.getByText("Settings")).toBeTruthy();
       expect(screen.getByText("Back to site")).toBeTruthy();
+    });
+  });
+
+  it("renders the lookup booking widget", async () => {
+    renderWithProviders(<AdminSidebar />);
+    await waitFor(() => {
+      expect(screen.getByText("Lookup Booking")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Email or reference…")).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Replaces the left-side "New Booking" button in the admin sidebar with a Lookup Booking search widget.

Admins can now search by email or booking reference from any admin page.

Closes #41

Generated with [Claude Code](https://claude.ai/code)