### PR TITLE
Enforce Admin role on AdminController JWT authorization

### DIFF
--- a/OpenRestoApi/Controllers/AdminController.cs
+++ b/OpenRestoApi/Controllers/AdminController.cs
@@ -8,7 +8,7 @@ namespace OpenRestoApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize]
+[Authorize(Roles = "Admin")]
 public class AdminController(AdminService adminService, IEmailService emailService) : ControllerBase
 {
     public enum bookingStatus { active, cancelled, all, past, upcoming }


### PR DESCRIPTION
## Summary

- Tightens the `[Authorize]` attribute on `AdminController` to `[Authorize(Roles = "Admin")]`
- `[Authorize]` alone accepts any structurally valid JWT, regardless of its role claim; this change ensures only tokens carrying `ClaimTypes.Role = "Admin"` (issued at login) can reach any admin endpoint, including the booking lookup endpoint (`GET /api/admin/bookings/{id}`)
- No behaviour change for legitimate callers — login already issues tokens with `Role: Admin`

## Security context

The existing JWT pipeline is otherwise sound:
- Signature, issuer (`openresto-api`), audience (`openresto-admin`), and expiry are all validated with zero clock skew
- `UseAuthentication` → `UseAuthorization` middleware order is correct
- Cookie fallback (`openresto_auth` HttpOnly) is in place

This is a defence-in-depth fix: without it, any valid JWT (even one missing the Admin role) would be accepted by the controller.

## Test plan

- [ ] `POST /api/admin/auth/login` with valid credentials → 200, receives JWT cookie/token
- [ ] `GET /api/admin/bookings/{id}` with valid Admin JWT → 200 with booking data
- [ ] `GET /api/admin/bookings/{id}` with no token → 401
- [ ] `GET /api/admin/bookings/{id}` with an expired or tampered token → 401
- [ ] `GET /api/admin/bookings/{id}` with a token missing the Admin role claim → 403

https://claude.ai/code/session_012fgNTSv7Kcu3eGs8QoeqVG

---
_Generated by [Claude Code](https://claude.ai/code/session_012fgNTSv7Kcu3eGs8QoeqVG)_