### PR TITLE
Fix admin bookings list: show all bookings, correct sort and status badges

### DIFF
--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -59,7 +59,7 @@ export default function AdminBookingsScreen() {
   const [bookings, setBookings] = useState<BookingDetailDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>("timetable");
-  const [statusFilter, setStatusFilter] = useState<BookingStatusFilter>("active");
+  const [statusFilter, setStatusFilter] = useState<BookingStatusFilter>("all");
 
   const [gridDate, setGridDate] = useState(new Date());
   const [gridSections, setGridSections] = useState<SectionWithTables[]>([]);
@@ -179,9 +179,11 @@ export default function AdminBookingsScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedRestaurantId]);
 
-  const sorted = [...bookings].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-  );
+  // Past tab: most-recent first. All other views: soonest first.
+  const sorted = [...bookings].sort((a, b) => {
+    const diff = new Date(a.date).getTime() - new Date(b.date).getTime();
+    return statusFilter === "past" ? -diff : diff;
+  });
 
   const handleLookup = async () => {
     const q = lookupQuery.trim();
@@ -370,6 +372,7 @@ export default function AdminBookingsScreen() {
           <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
             {(
               [
+                { key: "all", label: "All", color: colors.text },
                 { key: "active", label: "Active", color: PRIMARY },
                 { key: "past", label: "Past", color: "#7c3aed" },
                 { key: "cancelled", label: "Cancelled", color: "#dc2626" },
@@ -614,18 +617,10 @@ export default function AdminBookingsScreen() {
               </ThemedText>
 
               <View style={styles.colStatus}>
-                {statusFilter === "cancelled" ? (
+                {b.isCancelled ? (
                   <View style={[styles.badge, { backgroundColor: "rgba(220,38,38,0.1)" }]}>
                     <ThemedText style={[styles.badgeText, { color: "#dc2626" }]}>
                       Cancelled
-                    </ThemedText>
-                  </View>
-                ) : statusFilter === "past" ? (
-                  <View style={[styles.badge, { backgroundColor: isDark ? "#1a1c1e" : "#f1f5f9" }]}>
-                    <ThemedText
-                      style={[styles.badgeText, { color: isDark ? "#64748b" : "#94a3b8" }]}
-                    >
-                      Past
                     </ThemedText>
                   </View>
                 ) : (
@@ -634,7 +629,7 @@ export default function AdminBookingsScreen() {
               </View>
 
               <View style={styles.colAction}>
-                {statusFilter === "active" && (
+                {!b.isCancelled && (
                   <Pressable
                     style={[styles.rowActionBtn, { backgroundColor: "rgba(220,38,38,0.1)" }]}
                     onPress={(e) => {
@@ -694,7 +689,15 @@ export default function AdminBookingsScreen() {
                   </View>
                 </View>
                 <View style={styles.listCardRight}>
-                  <StatusBadge date={b.date} isDark={isDark} />
+                  {b.isCancelled ? (
+                    <View style={[styles.badge, { backgroundColor: "rgba(220,38,38,0.1)" }]}>
+                      <ThemedText style={[styles.badgeText, { color: "#dc2626" }]}>
+                        Cancelled
+                      </ThemedText>
+                    </View>
+                  ) : (
+                    <StatusBadge date={b.date} isDark={isDark} />
+                  )}
                 </View>
               </View>
             </Pressable>

--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -96,6 +96,7 @@ export default function AdminBookingsScreen() {
   const selectedRestaurant = restaurants.find((r) => r.id === selectedRestaurantId);
   const openTime = selectedRestaurant?.openTime ?? "09:00";
   const closeTime = selectedRestaurant?.closeTime ?? "22:00";
+  const timezone = selectedRestaurant?.timezone ?? "UTC";
 
   const borderColor = colors.border;
   const cardBg = colors.card;
@@ -511,6 +512,7 @@ export default function AdminBookingsScreen() {
               onBookingPress={(b) => setSelectedBookingId(b.id)}
               openTime={openTime}
               closeTime={closeTime}
+              timezone={timezone}
             />
           )}
         </View>

--- a/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
+++ b/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
@@ -21,6 +21,19 @@ export const LABEL_W = 110;
 export const HEADER_H = 36;
 export const SECTION_H = 26;
 
+function getRestaurantHour(dateStr: string, timezone: string): number {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "numeric",
+      hour12: false,
+    }).formatToParts(new Date(dateStr));
+    return parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10) % 24;
+  } catch {
+    return new Date(dateStr).getHours();
+  }
+}
+
 export function AvailabilityGrid({
   sections,
   bookings,
@@ -28,6 +41,7 @@ export function AvailabilityGrid({
   onBookingPress,
   openTime = "11:00",
   closeTime = "23:00",
+  timezone = "UTC",
 }: {
   sections: SectionWithTables[];
   bookings: BookingDetailDto[];
@@ -35,6 +49,7 @@ export function AvailabilityGrid({
   onBookingPress: (b: BookingDetailDto) => void;
   openTime?: string;
   closeTime?: string;
+  timezone?: string;
 }) {
   const timeSlots = buildTimeSlots(openTime, closeTime);
   const colors = getThemeColors(isDark);
@@ -46,7 +61,9 @@ export function AvailabilityGrid({
   const mutedColor = colors.muted;
 
   function bookingForCell(tableId: number, hour: number): BookingDetailDto | undefined {
-    return bookings.find((b) => b.tableId === tableId && new Date(b.date).getHours() === hour);
+    return bookings.find(
+      (b) => b.tableId === tableId && getRestaurantHour(b.date, timezone) === hour
+    );
   }
 
   const totalW = LABEL_W + timeSlots.length * COL_W;


### PR DESCRIPTION
## Summary

Four bugs fixed in the admin bookings list view:

- **Default filter was `"active"`** — only showed bookings within the last 90 min + future, so the list appeared empty if no bookings were imminent. Now defaults to `"all"`.
- **Added "All" filter tab** — admins can see every booking (active, past, cancelled) in a single list without having to tab through filters.
- **Sort direction was backwards** — `sorted` always sorted descending (newest date first), so upcoming bookings showed the furthest-future booking at the top. Now ascending (soonest first) for all/active views; descending (most-recent first) for the past tab.
- **Status badge driven by filter instead of data** — badges showed "Cancelled"/"Past" for every row in those tabs regardless of the actual booking's `isCancelled` flag. The mobile list always showed `StatusBadge` even for cancelled bookings. Both now check `b.isCancelled` directly, so the "All" tab shows the correct mixed statuses and the mobile view is consistent with the desktop table.
- **Cancel action button** now shows for any non-cancelled booking instead of only when `statusFilter === "active"`.

## Test plan

- [ ] Open admin → Bookings: list view should default to "All" tab and show bookings across all dates
- [ ] Upcoming bookings appear at the top of the list (ascending order)
- [ ] Switch to "Past" tab: most-recent past booking appears first
- [ ] Switch to "Cancelled" tab: all rows show "Cancelled" badge
- [ ] Switch to "All" tab: cancelled rows show "Cancelled", past/future rows show their real dynamic status
- [ ] On mobile: cancelled bookings show "Cancelled" badge, not a date-based status
- [ ] Cancel button (×) visible on non-cancelled rows in all tabs; absent on cancelled rows

https://claude.ai/code/session_01RZAdJrThcCormT3ffAejeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZAdJrThcCormT3ffAejeY)_