### PR TITLE
Fix timetable wrong-day bug and clean up list view filter

### DIFF
--- a/OpenRestoApi.Tests/Utilities/TimezoneLogicTests.cs
+++ b/OpenRestoApi.Tests/Utilities/TimezoneLogicTests.cs
@@ -16,12 +16,11 @@ public class TimezoneLogicTests
     [Fact]
     public void GetUtcRange_Toronto_ReturnsCorrectUTCRange()
     {
-        // April 18, 2026 at 10:00 AM UTC
-        // Toronto is UTC-4 in April. 
-        // Local time is 06:00 AM. 
-        // Today (local) is April 18.
-        // UTC Range should be April 18 04:00 UTC to April 19 04:00 UTC.
-        DateTime refDate = new DateTime(2026, 4, 18, 10, 0, 0, DateTimeKind.Utc);
+        // Admin navigates to April 18 (restaurant-local date).
+        // Toronto is UTC-4 in April.
+        // UTC Range for April 18 Toronto: April 18 04:00 UTC to April 19 04:00 UTC.
+        // Input is Unspecified (as ASP.NET parses a date-only query param).
+        DateTime refDate = new DateTime(2026, 4, 18, 0, 0, 0, DateTimeKind.Unspecified);
         string tz = "America/Toronto";
 
         (DateTime start, DateTime end) = InvokeGetUtcRange(refDate, tz);
@@ -33,17 +32,15 @@ public class TimezoneLogicTests
     [Fact]
     public void GetUtcRange_Sydney_ReturnsCorrectUTCRange()
     {
-        // April 18, 2026 at 20:00 (8 PM) UTC
-        // Sydney is UTC+10 (Standard) or +11 (DST). In April it's +10.
-        // Local time: April 19, 06:00 AM.
-        // Today (local) is April 19.
-        // UTC Range should be April 18 14:00 UTC to April 19 14:00 UTC.
-        DateTime refDate = new DateTime(2026, 4, 18, 20, 0, 0, DateTimeKind.Utc);
+        // Admin navigates to April 19 (restaurant-local date).
+        // Sydney is UTC+10 in April.
+        // UTC Range for April 19 Sydney: April 18 14:00 UTC to April 19 14:00 UTC.
+        // Input is Unspecified (as ASP.NET parses a date-only query param).
+        DateTime refDate = new DateTime(2026, 4, 19, 0, 0, 0, DateTimeKind.Unspecified);
         string tz = "AUS Eastern Standard Time"; // Windows ID for Sydney
 
         (DateTime start, DateTime end) = InvokeGetUtcRange(refDate, tz);
 
-        // Sydney (UTC+10) Day start (00:00) is 14:00 previous day UTC
         Assert.Equal(new DateTime(2026, 4, 18, 14, 0, 0, DateTimeKind.Utc), start);
         Assert.Equal(new DateTime(2026, 4, 19, 14, 0, 0, DateTimeKind.Utc), end);
     }
@@ -51,7 +48,7 @@ public class TimezoneLogicTests
     [Fact]
     public void GetUtcRange_InvalidTz_DefaultsToUTC()
     {
-        DateTime refDate = new DateTime(2026, 4, 18, 10, 0, 0, DateTimeKind.Utc);
+        DateTime refDate = new DateTime(2026, 4, 18, 0, 0, 0, DateTimeKind.Unspecified);
         (DateTime start, DateTime end) = InvokeGetUtcRange(refDate, "Invalid/Timezone");
 
         Assert.Equal(new DateTime(2026, 4, 18, 0, 0, 0, DateTimeKind.Utc), start);
@@ -61,12 +58,11 @@ public class TimezoneLogicTests
     [Fact]
     public void GetUtcRange_Tokyo_ReturnsCorrectUTCRange()
     {
-        // April 18, 2026 at 10:00 AM UTC
-        // Tokyo is UTC+9. 
-        // Local time is 19:00 (7 PM). 
-        // Today (local) is April 18.
-        // UTC Range should be April 17 15:00 UTC to April 18 15:00 UTC.
-        DateTime refDate = new DateTime(2026, 4, 18, 10, 0, 0, DateTimeKind.Utc);
+        // Admin navigates to April 18 (restaurant-local date).
+        // Tokyo is UTC+9.
+        // UTC Range for April 18 Tokyo: April 17 15:00 UTC to April 18 15:00 UTC.
+        // Input is Unspecified (as ASP.NET parses a date-only query param).
+        DateTime refDate = new DateTime(2026, 4, 18, 0, 0, 0, DateTimeKind.Unspecified);
         string tz = "Tokyo Standard Time";
 
         (DateTime start, DateTime end) = InvokeGetUtcRange(refDate, tz);

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -673,10 +673,13 @@ public class AdminService(AppDbContext db, IHoldService holdService)
             tz = TimeZoneInfo.Utc;
         }
 
-        DateTime localDay = TimeZoneInfo.ConvertTimeFromUtc(referenceDate.ToUniversalTime(), tz).Date;
+        // referenceDate comes from the client as a date-only query param (e.g. "2026-05-26"),
+        // parsed by ASP.NET as Unspecified midnight. Treat it directly as the restaurant's
+        // local calendar date — converting through UTC first shifts the day for UTC- timezones.
+        DateTime localDay = referenceDate.Date;
 
-        DateTime localStart = localDay;
-        DateTime localEnd = localDay.AddDays(1);
+        DateTime localStart = DateTime.SpecifyKind(localDay, DateTimeKind.Unspecified);
+        DateTime localEnd = DateTime.SpecifyKind(localDay.AddDays(1), DateTimeKind.Unspecified);
 
         DateTime utcStart = TimeZoneInfo.ConvertTimeToUtc(localStart, tz);
         DateTime utcEnd = TimeZoneInfo.ConvertTimeToUtc(localEnd, tz);

--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -59,7 +59,7 @@ export default function AdminBookingsScreen() {
   const [bookings, setBookings] = useState<BookingDetailDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>("timetable");
-  const [statusFilter, setStatusFilter] = useState<BookingStatusFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<BookingStatusFilter>("active");
 
   const [gridDate, setGridDate] = useState(new Date());
   const [gridSections, setGridSections] = useState<SectionWithTables[]>([]);
@@ -373,7 +373,6 @@ export default function AdminBookingsScreen() {
           <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
             {(
               [
-                { key: "all", label: "All", color: colors.text },
                 { key: "active", label: "Active", color: PRIMARY },
                 { key: "past", label: "Past", color: "#7c3aed" },
                 { key: "cancelled", label: "Cancelled", color: "#dc2626" },

--- a/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
+++ b/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
@@ -25,10 +25,10 @@ function getRestaurantHour(dateStr: string, timezone: string): number {
   try {
     const parts = new Intl.DateTimeFormat("en-US", {
       timeZone: timezone,
-      hour: "numeric",
-      hour12: false,
+      hour: "2-digit",
+      hourCycle: "h23",
     }).formatToParts(new Date(dateStr));
-    return parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10) % 24;
+    return parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10);
   } catch {
     return new Date(dateStr).getHours();
   }


### PR DESCRIPTION
## Summary

### Backend — timetable fetches wrong day for UTC- restaurants

`GetUtcRangeForLocalDay` was calling `referenceDate.ToUniversalTime()` on a `DateTime` with `Kind = Unspecified` (how ASP.NET parses a date-only query param like `date=2026-05-26`). On a UTC server, `.ToUniversalTime()` on Unspecified leaves the value unchanged — but `ConvertTimeFromUtc` then converts it from UTC midnight into the restaurant's timezone. For any restaurant west of UTC (e.g. NYC at UTC-4), UTC midnight on May 26 is 8 PM on **May 25** locally, so `.Date` returned May 25 — causing the timetable to always show the previous day's bookings.

Fix: use `referenceDate.Date` directly as the restaurant's local calendar date. The frontend sends a date-only string representing the day the admin is navigating to, so no UTC round-trip is needed.

### Frontend — timetable hour matching

Switched `getRestaurantHour` to `hourCycle: "h23"` + `hour: "2-digit"`, which gives a clean 0–23 integer without the `hour12: false` midnight-as-24 quirk present in some JS engines.

### Frontend — list view filter

- Removed the "All" filter tab (too noisy)
- Restored `"active"` as the default status filter

## Test plan

- [ ] Open timetable for a restaurant whose timezone is behind UTC (e.g. America/New_York) — bookings for the selected date should appear in the correct columns
- [ ] Navigate forward/backward days; bookings update to match the selected date
- [ ] List view opens on "Active" tab by default; "Past" and "Cancelled" tabs still work
- [ ] No "All" tab visible in the list view

https://claude.ai/code/session_01RZAdJrThcCormT3ffAejeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZAdJrThcCormT3ffAejeY)_