### PR TITLE
Fix inactive day button text colour ignoring theme in dark mode

### DIFF
--- a/openresto-frontend/components/admin/settings/EmailSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/EmailSettingsCard.tsx
@@ -4,7 +4,7 @@ import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
 import Button from "@/components/common/Button";
 import { Ionicons } from "@expo/vector-icons";
-import { COLORS } from "@/theme/theme";
+import { COLORS, getThemeColors } from "@/theme/theme";
 import {
   getEmailSettings,
   saveEmailSettings,
@@ -131,6 +131,7 @@ export function EmailSettingsCard({
   cardBg: string;
   isDark: boolean;
 }) {
+  const { text: textColor } = getThemeColors(isDark);
   // surface-2: the slightly recessed inner surface (used inside cards)
   const surface2 = isDark ? "#252729" : "#f9fafb";
   const borderStrong = isDark ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)";
@@ -342,7 +343,7 @@ export function EmailSettingsCard({
                   <ThemedText
                     style={{
                       fontSize: 12,
-                      color: port === String(p) ? (isDark ? "#fff" : "#000") : mutedColor,
+                      color: port === String(p) ? textColor : mutedColor,
                     }}
                   >
                     {p}
@@ -404,7 +405,7 @@ export function EmailSettingsCard({
               style={{
                 fontSize: 13,
                 fontWeight: !enableSsl ? "500" : "400",
-                color: !enableSsl ? (isDark ? "#fff" : "#000") : mutedColor,
+                color: !enableSsl ? textColor : mutedColor,
               }}
             >
               None

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -289,7 +289,7 @@ export function RestaurantInfoForm({
                   }}
                 >
                   <ThemedText
-                    style={{ fontSize: 12, fontWeight: "500", color: active ? "#fff" : undefined }}
+                    style={{ fontSize: 12, fontWeight: "500", color: active ? "#fff" : colors.text }}
                   >
                     {label}
                   </ThemedText>

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -289,7 +289,11 @@ export function RestaurantInfoForm({
                   }}
                 >
                   <ThemedText
-                    style={{ fontSize: 12, fontWeight: "500", color: active ? "#fff" : colors.text }}
+                    style={{
+                      fontSize: 12,
+                      fontWeight: "500",
+                      color: active ? "#fff" : colors.text,
+                    }}
                   >
                     {label}
                   </ThemedText>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `ThemedText` resolves theme text colour as the first entry in `StyleSheet.flatten([{ color }, styles[type], style])` — the caller's `style` comes last, so any property it sets wins, even `color: undefined`
- The "Open days" day picker in `RestaurantInfoForm` passed `color: active ? "#fff" : undefined` — in the inactive state, `undefined` overwrote the theme colour, leaving buttons with no explicit text colour in dark mode (rendered as system-default black on a dark surface, i.e. invisible)
- Fixed by passing `colors.text` explicitly for the inactive state so the correct light/dark theme colour is always applied

## Test plan

- [ ] Open admin Settings → select a location
- [ ] Toggle between light and dark mode
- [ ] Verify inactive day-of-week buttons (Mon–Sun) show legible text in both modes
- [ ] Verify active (selected) buttons still show white text on the primary-colour background

https://claude.ai/code/session_01ATgmwpsvzn1bgCv52b7gwW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATgmwpsvzn1bgCv52b7gwW)_