### PR TITLE
test: achieve 100% unit test coverage (batch 4)

### DIFF
--- a/openresto-frontend/tests/api/availability.test.ts
+++ b/openresto-frontend/tests/api/availability.test.ts
@@ -1,0 +1,43 @@
+import { fetchAvailability } from "@/api/availability";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  jest.spyOn(console, "error").mockImplementation();
+});
+
+describe("fetchAvailability", () => {
+  it("fetches availability for given params and returns data", async () => {
+    const data = {
+      restaurantId: 1,
+      date: "2026-06-15",
+      slots: [{ time: "19:00", isAvailable: true, availableTableIds: [1], category: "Dinner" }],
+    };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => data });
+
+    const result = await fetchAvailability(1, "2026-06-15", 2);
+
+    expect(result).toEqual(data);
+    expect(mockFetch.mock.calls[0][0]).toContain("/availability/1");
+    expect(mockFetch.mock.calls[0][0]).toContain("date=2026-06-15");
+    expect(mockFetch.mock.calls[0][0]).toContain("seats=2");
+  });
+
+  it("returns null when response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const result = await fetchAvailability(1, "2026-06-15", 2);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network failure"));
+
+    const result = await fetchAvailability(1, "2026-06-15", 2);
+
+    expect(result).toBeNull();
+  });
+});

--- a/openresto-frontend/tests/app/html.test.tsx
+++ b/openresto-frontend/tests/app/html.test.tsx
@@ -15,7 +15,6 @@ describe("+html Root", () => {
 
   it("renders a valid React element without crashing", () => {
     const { default: Root } = require("@/app/+html");
-    const React = require("react");
     const element = React.createElement(Root, {}, React.createElement("span", {}, "child"));
     expect(element).not.toBeNull();
     expect(element.type).toBe(Root);

--- a/openresto-frontend/tests/app/html.test.tsx
+++ b/openresto-frontend/tests/app/html.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+
+jest.mock("expo-router/html", () => ({
+  ScrollViewStyleReset: () => null,
+}));
+
+describe("+html Root", () => {
+  it("exports a default React component function", () => {
+    const { default: Root } = require("@/app/+html");
+    expect(typeof Root).toBe("function");
+  });
+
+  it("renders a valid React element without crashing", () => {
+    const { default: Root } = require("@/app/+html");
+    const React = require("react");
+    const element = React.createElement(Root, {}, React.createElement("span", {}, "child"));
+    expect(element).not.toBeNull();
+    expect(element.type).toBe(Root);
+  });
+});

--- a/openresto-frontend/tests/components/admin/bookings/BookingActionButtons.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingActionButtons.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { BookingActionButtons } from "@/components/admin/bookings/BookingActionButtons";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+const baseProps = {
+  isCancelled: false,
+  uncancelling: false,
+  deleting: false,
+  mutedColor: "#888",
+  onUncancel: jest.fn(),
+  onCancel: jest.fn(),
+  onPurge: jest.fn(),
+};
+
+describe("BookingActionButtons", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows Cancel Booking when not cancelled", () => {
+    render(<BookingActionButtons {...baseProps} />);
+    expect(screen.getByText("Cancel Booking")).toBeTruthy();
+  });
+
+  it("does not show Restore Booking when not cancelled", () => {
+    render(<BookingActionButtons {...baseProps} />);
+    expect(screen.queryByText("Restore Booking")).toBeNull();
+  });
+
+  it("shows Restore Booking when cancelled", () => {
+    render(<BookingActionButtons {...baseProps} isCancelled />);
+    expect(screen.getByText("Restore Booking")).toBeTruthy();
+  });
+
+  it("does not show Cancel Booking when already cancelled", () => {
+    render(<BookingActionButtons {...baseProps} isCancelled />);
+    expect(screen.queryByText("Cancel Booking")).toBeNull();
+  });
+
+  it("always shows Permanently Delete (GDPR)", () => {
+    render(<BookingActionButtons {...baseProps} />);
+    expect(screen.getByText("Permanently Delete (GDPR)")).toBeTruthy();
+  });
+
+  it("shows Cancelling… when deleting is true", () => {
+    render(<BookingActionButtons {...baseProps} deleting />);
+    expect(screen.getByText("Cancelling…")).toBeTruthy();
+  });
+
+  it("shows Restoring… when uncancelling is true", () => {
+    render(<BookingActionButtons {...baseProps} isCancelled uncancelling />);
+    expect(screen.getByText("Restoring…")).toBeTruthy();
+  });
+
+  it("calls onCancel when Cancel Booking is pressed", () => {
+    render(<BookingActionButtons {...baseProps} />);
+    fireEvent.press(screen.getByText("Cancel Booking"));
+    expect(baseProps.onCancel).toHaveBeenCalled();
+  });
+
+  it("calls onPurge when Permanently Delete is pressed", () => {
+    render(<BookingActionButtons {...baseProps} />);
+    fireEvent.press(screen.getByText("Permanently Delete (GDPR)"));
+    expect(baseProps.onPurge).toHaveBeenCalled();
+  });
+
+  it("calls onUncancel when Restore Booking is pressed", () => {
+    render(<BookingActionButtons {...baseProps} isCancelled />);
+    fireEvent.press(screen.getByText("Restore Booking"));
+    expect(baseProps.onUncancel).toHaveBeenCalled();
+  });
+});

--- a/openresto-frontend/tests/components/admin/bookings/BookingDetailPopup.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingDetailPopup.test.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react-native";
+import { BookingDetailPopup } from "@/components/admin/bookings/BookingDetailPopup";
+import * as adminApi from "@/api/admin";
+import * as restaurantsApi from "@/api/restaurants";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/api/admin", () => ({
+  getAdminBooking: jest.fn(),
+  adminDeleteBooking: jest.fn(),
+  adminExtendBooking: jest.fn(),
+  adminPurgeBooking: jest.fn(),
+  sendBookingEmail: jest.fn(),
+  adminRestoreBooking: jest.fn(),
+  adminUpdateBookingFull: jest.fn(),
+}));
+
+jest.mock("@/api/restaurants", () => ({
+  fetchRestaurants: jest.fn(),
+}));
+
+jest.mock("@/context/BrandContext", () => {
+  const brand = { primaryColor: "#0a7ea4", appName: "Open Resto" };
+  return { useBrand: () => brand };
+});
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+jest.mock("@/components/admin/bookings/BookingDetailsCard", () => {
+  const { View, Text } = require("react-native");
+  return {
+    BookingDetailsCard: ({ booking }: { booking: { bookingRef: string } }) => (
+      <View>
+        <Text testID="booking-details-card">{booking.bookingRef}</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock("@/components/admin/bookings/EditBookingForm", () => {
+  const { View } = require("react-native");
+  return { EditBookingForm: () => <View testID="edit-booking-form" /> };
+});
+
+jest.mock("@/components/admin/bookings/ExtendBookingActions", () => {
+  const { View } = require("react-native");
+  return { ExtendBookingActions: () => <View testID="extend-booking-actions" /> };
+});
+
+jest.mock("@/components/admin/bookings/EmailGuestForm", () => {
+  const { View } = require("react-native");
+  return { EmailGuestForm: () => <View testID="email-guest-form" /> };
+});
+
+jest.mock("@/components/admin/bookings/BookingActionButtons", () => {
+  const { View } = require("react-native");
+  return { BookingActionButtons: () => <View testID="booking-action-buttons" /> };
+});
+
+jest.mock("@/components/common/ConfirmModal", () => {
+  const { View } = require("react-native");
+  return { __esModule: true, default: () => <View /> };
+});
+
+jest.mock("@/components/common/AlertModal", () => {
+  const { View } = require("react-native");
+  return { __esModule: true, default: () => <View /> };
+});
+
+const mockBooking = {
+  id: 42,
+  bookingRef: "REF-001",
+  customerName: "Jane Doe",
+  customerEmail: "jane@example.com",
+  date: "2026-06-15T19:00:00Z",
+  seats: 2,
+  tableId: 100,
+  sectionId: 10,
+  restaurantId: 1,
+  isCancelled: false,
+  specialRequests: null,
+  endTime: null,
+  status: "confirmed",
+};
+
+describe("BookingDetailPopup", () => {
+  const onClose = jest.fn();
+  const onDeleted = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([]);
+  });
+
+  it("does not show Booking Details when bookingId is null", () => {
+    (adminApi.getAdminBooking as jest.Mock).mockResolvedValue(null);
+    render(<BookingDetailPopup bookingId={null} onClose={onClose} />);
+    expect(screen.queryByText("Booking Details")).toBeNull();
+  });
+
+  it("shows Booking Details title when bookingId is set", async () => {
+    (adminApi.getAdminBooking as jest.Mock).mockResolvedValue(mockBooking);
+    render(<BookingDetailPopup bookingId={42} onClose={onClose} />);
+    await waitFor(() => {
+      expect(screen.getByText("Booking Details")).toBeTruthy();
+    });
+  });
+
+  it("calls getAdminBooking with the bookingId", async () => {
+    (adminApi.getAdminBooking as jest.Mock).mockResolvedValue(mockBooking);
+    render(<BookingDetailPopup bookingId={42} onClose={onClose} />);
+    await waitFor(() => {
+      expect(adminApi.getAdminBooking).toHaveBeenCalledWith(42);
+    });
+  });
+
+  it("shows booking details card after loading", async () => {
+    (adminApi.getAdminBooking as jest.Mock).mockResolvedValue(mockBooking);
+    render(<BookingDetailPopup bookingId={42} onClose={onClose} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("booking-details-card")).toBeTruthy();
+    });
+  });
+
+  it("shows Booking not found when booking is null", async () => {
+    (adminApi.getAdminBooking as jest.Mock).mockResolvedValue(null);
+    render(<BookingDetailPopup bookingId={99} onClose={onClose} />);
+    await waitFor(() => {
+      expect(screen.getByText("Booking not found.")).toBeTruthy();
+    });
+  });
+
+  it("shows extend actions and action buttons for loaded booking", async () => {
+    (adminApi.getAdminBooking as jest.Mock).mockResolvedValue(mockBooking);
+    render(<BookingDetailPopup bookingId={42} onClose={onClose} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("extend-booking-actions")).toBeTruthy();
+      expect(screen.getByTestId("booking-action-buttons")).toBeTruthy();
+    });
+  });
+
+  it("resets booking when bookingId becomes null", async () => {
+    (adminApi.getAdminBooking as jest.Mock).mockResolvedValue(mockBooking);
+    const { rerender } = render(<BookingDetailPopup bookingId={42} onClose={onClose} />);
+    await waitFor(() => expect(screen.getByText("Booking Details")).toBeTruthy());
+
+    await act(async () => {
+      rerender(<BookingDetailPopup bookingId={null} onClose={onClose} />);
+    });
+    expect(screen.queryByText("Booking Details")).toBeNull();
+  });
+});

--- a/openresto-frontend/tests/components/admin/bookings/BookingDetailPopup.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingDetailPopup.test.tsx
@@ -90,7 +90,6 @@ const mockBooking = {
 
 describe("BookingDetailPopup", () => {
   const onClose = jest.fn();
-  const onDeleted = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/openresto-frontend/tests/components/admin/settings/EmailSettingsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/EmailSettingsCard.test.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { EmailSettingsCard } from "@/components/admin/settings/EmailSettingsCard";
+import * as adminApi from "@/api/admin";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/api/admin", () => ({
+  getEmailSettings: jest.fn(),
+  saveEmailSettings: jest.fn(),
+  testEmailConnection: jest.fn(),
+}));
+
+jest.mock("@/context/BrandContext", () => {
+  const brand = { primaryColor: "#0a7ea4", appName: "Open Resto" };
+  return { useBrand: () => brand };
+});
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+const mockSettings = {
+  host: "",
+  port: 587,
+  username: "",
+  password: "",
+  enableSsl: true,
+  fromName: null,
+  fromEmail: null,
+  isConfigured: false,
+  sendBookingConfirmations: false,
+};
+
+const baseProps = {
+  borderColor: "#ddd",
+  mutedColor: "#888",
+  cardBg: "#fff",
+  isDark: false,
+};
+
+describe("EmailSettingsCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (adminApi.getEmailSettings as jest.Mock).mockResolvedValue(mockSettings);
+  });
+
+  it("renders Email (SMTP) header", async () => {
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("Email (SMTP)")).toBeTruthy();
+    });
+  });
+
+  it("shows Setup required subtitle when not configured", async () => {
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("Setup required")).toBeTruthy();
+    });
+  });
+
+  it("is collapsed by default (no Provider label visible)", async () => {
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Email (SMTP)")).toBeTruthy());
+    expect(screen.queryByText("Gmail")).toBeNull();
+  });
+
+  it("expands when header is pressed", async () => {
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Email (SMTP)")).toBeTruthy());
+    fireEvent.press(screen.getByText("Email (SMTP)"));
+    await waitFor(() => {
+      expect(screen.getByText("Gmail")).toBeTruthy();
+      expect(screen.getByText("Outlook 365")).toBeTruthy();
+      expect(screen.getByText("Custom SMTP")).toBeTruthy();
+    });
+  });
+
+  it("shows SMTP Host input after expanding", async () => {
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Email (SMTP)")).toBeTruthy());
+    fireEvent.press(screen.getByText("Email (SMTP)"));
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("smtp.gmail.com")).toBeTruthy();
+    });
+  });
+
+  it("shows Save SMTP settings button after expanding", async () => {
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Email (SMTP)")).toBeTruthy());
+    fireEvent.press(screen.getByText("Email (SMTP)"));
+    await waitFor(() => {
+      expect(screen.getByText("Save SMTP settings")).toBeTruthy();
+    });
+  });
+
+  it("shows connected host in subtitle when configured", async () => {
+    (adminApi.getEmailSettings as jest.Mock).mockResolvedValue({
+      ...mockSettings,
+      host: "smtp.gmail.com",
+      username: "user@example.com",
+      isConfigured: true,
+    });
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("Connected · smtp.gmail.com")).toBeTruthy();
+    });
+  });
+
+  it("shows save success message after saving", async () => {
+    (adminApi.getEmailSettings as jest.Mock).mockResolvedValue({
+      ...mockSettings,
+      host: "smtp.gmail.com",
+      username: "user@example.com",
+    });
+    (adminApi.saveEmailSettings as jest.Mock).mockResolvedValue({
+      message: "Settings saved.",
+      ok: true,
+    });
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Email (SMTP)")).toBeTruthy());
+    fireEvent.press(screen.getByText("Email (SMTP)"));
+    await waitFor(() => expect(screen.getByText("Save SMTP settings")).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save SMTP settings"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Settings saved.")).toBeTruthy();
+    });
+  });
+
+  it("shows Failed to save on save error", async () => {
+    (adminApi.getEmailSettings as jest.Mock).mockResolvedValue({
+      ...mockSettings,
+      host: "smtp.gmail.com",
+      username: "user@example.com",
+    });
+    (adminApi.saveEmailSettings as jest.Mock).mockResolvedValue(null);
+    render(<EmailSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Email (SMTP)")).toBeTruthy());
+    fireEvent.press(screen.getByText("Email (SMTP)"));
+    await waitFor(() => expect(screen.getByText("Save SMTP settings")).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save SMTP settings"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Failed to save.")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Unit test coverage batch 4/N — adds tests for 5 previously uncovered modules.

### Files covered in this PR

| File | Tests added |
|------|-------------|
| `components/admin/bookings/BookingActionButtons` | 10 tests |
| `components/admin/bookings/BookingDetailPopup` | 7 tests |
| `components/admin/settings/EmailSettingsCard` | 9 tests |
| `api/availability` | 3 tests |
| `app/+html` | 2 tests |

### Tests added (31 total)

**BookingActionButtons** — Cancel/Restore mutually exclusive based on `isCancelled`, GDPR delete always shown, loading states "Cancelling…"/"Restoring…", all three callbacks fired correctly.

**BookingDetailPopup** — Hidden when bookingId=null, shows "Booking Details" title when open, fetches booking by ID, renders booking details card and action sub-components, shows "Booking not found." on null API response, resets on close.

**EmailSettingsCard** — Title/subtitle rendering, collapsed by default, expands on press, shows provider options and SMTP host input, Save button visible, success/error save messages, connected host shown in subtitle.

**availability** — `fetchAvailability` calls correct endpoint with params, returns null on non-ok response, returns null on network error.

**+html** — Exports a valid React function component (module smoke test).

### Intentionally excluded lines

- `+html.tsx`: The component is pure static HTML markup for the Expo web document root. It uses native `<html>/<head>/<body>` elements that require a full browser DOM to render — `@testing-library/react` is not installed and `@testing-library/react-native` doesn't support raw HTML elements. The export smoke test covers the module's loadability.
- `LocationCard.tsx`: Uses `document.createElement("input")` for file upload and raw `<img>` elements — also deferred for the same DOM rendering reason. Covered in a future batch with proper jsdom setup.

https://claude.ai/code/session_01E96ob1MzsgWZsqmuL9DRSG

---
_Generated by [Claude Code](https://claude.ai/code/session_01E96ob1MzsgWZsqmuL9DRSG)_