### PR TITLE
test: achieve 100% unit test coverage (batch 10)

### DIFF
--- a/openresto-frontend/components/booking/PopularTimesPicker.tsx
+++ b/openresto-frontend/components/booking/PopularTimesPicker.tsx
@@ -204,6 +204,7 @@ export default function PopularTimesPicker({
             ]}
           >
             <Pressable
+              testID="scroll-left-arrow"
               onPress={() => scrollBy(-180)}
               style={({ pressed }) => [
                 styles.arrowCircle,
@@ -226,6 +227,7 @@ export default function PopularTimesPicker({
             ]}
           >
             <Pressable
+              testID="scroll-right-arrow"
               onPress={() => scrollBy(180)}
               style={({ pressed }) => [
                 styles.arrowCircle,

--- a/openresto-frontend/components/common/DatePicker.web.tsx
+++ b/openresto-frontend/components/common/DatePicker.web.tsx
@@ -48,7 +48,7 @@ export default function DatePicker({
   const [isFocused, setIsFocused] = useState(false);
 
   return (
-    <View style={styles.wrapper}>
+    <View style={styles.wrapper} testID="date-picker-web">
       <input
         type="date"
         value={selectedDate || ""}

--- a/openresto-frontend/tests/components/PopularTimesPicker.test.tsx
+++ b/openresto-frontend/tests/components/PopularTimesPicker.test.tsx
@@ -167,4 +167,42 @@ describe("PopularTimesPicker", () => {
     // After auto-switch to All, 19:00 should be visible
     expect(screen.getByText("19:00")).toBeTruthy();
   });
+
+  it("fires onLayout on scrollWrapper to update containerWidth", () => {
+    render(<PopularTimesPicker slots={mockSlots} selectedTime="" onSelectTime={jest.fn()} />);
+    const ScrollViewType = require("react-native").ScrollView;
+    const scrollView = screen.UNSAFE_getByType(ScrollViewType);
+    const scrollWrapper = scrollView.parent;
+    act(() => {
+      fireEvent(scrollWrapper!, "layout", { nativeEvent: { layout: { width: 350, height: 65 } } });
+    });
+    expect(screen.getByText("12:00")).toBeTruthy();
+  });
+
+  it("shows and presses left and right scroll arrows when content overflows", () => {
+    render(<PopularTimesPicker slots={mockSlots} selectedTime="" onSelectTime={jest.fn()} />);
+    const ScrollViewType = require("react-native").ScrollView;
+    const scrollView = screen.UNSAFE_getByType(ScrollViewType);
+    const scrollWrapper = scrollView.parent!;
+
+    // Trigger state changes by directly calling prop handlers
+    act(() => {
+      scrollView.props.onContentSizeChange(600, 65);
+      scrollWrapper.props.onLayout({ nativeEvent: { layout: { width: 300 } } });
+      scrollView.props.onScroll({ nativeEvent: { contentOffset: { x: 50, y: 0 } } });
+    });
+
+    // Both arrows should now be visible (testIDs added to source for testability)
+    expect(screen.getByTestId("scroll-left-arrow")).toBeTruthy();
+    expect(screen.getByTestId("scroll-right-arrow")).toBeTruthy();
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("scroll-left-arrow")); // scrollBy(-180)
+    });
+    act(() => {
+      fireEvent.press(screen.getByTestId("scroll-right-arrow")); // scrollBy(180)
+    });
+
+    expect(screen.getByText("12:00")).toBeTruthy();
+  });
 });

--- a/openresto-frontend/tests/components/TimePicker.web.test.tsx
+++ b/openresto-frontend/tests/components/TimePicker.web.test.tsx
@@ -30,4 +30,13 @@ describe("TimePicker Web", () => {
     fireEvent(input, "change", { target: { value: "20:00" } });
     expect(onSelect).toHaveBeenCalledWith("20:00");
   });
+
+  it("fires onFocus and onBlur on the time input", () => {
+    const { getByTestId } = render(<TimePickerWeb selectedTime="19:00" onSelect={onSelect} />);
+    const wrapper = getByTestId("time-picker-web");
+    const input = (wrapper as any).children[0];
+    fireEvent(input, "focus");
+    fireEvent(input, "blur");
+    expect(wrapper).toBeTruthy();
+  });
 });

--- a/openresto-frontend/tests/components/admin/bookings/RestaurantActionModal.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/RestaurantActionModal.test.tsx
@@ -174,10 +174,7 @@ describe("RestaurantActionModal", () => {
       expect(queryByTestId("loading-indicator")).toBeNull();
     });
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Failed to load restaurants",
-      expect.any(Error)
-    );
+    expect(consoleSpy).toHaveBeenCalledWith("Failed to load restaurants", expect.any(Error));
     expect(getByText("No restaurants found.")).toBeTruthy();
     consoleSpy.mockRestore();
   });

--- a/openresto-frontend/tests/components/admin/bookings/RestaurantActionModal.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/RestaurantActionModal.test.tsx
@@ -161,4 +161,76 @@ describe("RestaurantActionModal", () => {
     fireEvent.press(getByTestId("close-modal-button"));
     expect(onClose).toHaveBeenCalled();
   });
+
+  it("handles error when loading restaurants fails", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    (adminApi.adminGetRestaurants as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+    const { getByText, queryByTestId } = render(
+      <RestaurantActionModal visible={true} actionType="pause" onClose={() => {}} />
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId("loading-indicator")).toBeNull();
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Failed to load restaurants",
+      expect.any(Error)
+    );
+    expect(getByText("No restaurants found.")).toBeTruthy();
+    consoleSpy.mockRestore();
+  });
+
+  it("calls onSuccess and onClose when extend returns no bookings", async () => {
+    const onSuccess = jest.fn();
+    const onClose = jest.fn();
+    (adminApi.extendRestaurantBookings as jest.Mock).mockResolvedValue({
+      ok: true,
+      extendedBookings: [],
+    });
+
+    const { getByText, queryByTestId } = render(
+      <RestaurantActionModal
+        visible={true}
+        actionType="extend"
+        onClose={onClose}
+        onSuccess={onSuccess}
+      />
+    );
+
+    await waitFor(() => expect(queryByTestId("loading-indicator")).toBeNull());
+
+    await act(async () => {
+      fireEvent.press(getByText("Test Restaurant 1"));
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(
+        "No active bookings found to extend for Test Restaurant 1."
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("handles error when action fails", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    (adminApi.pauseRestaurantBookings as jest.Mock).mockRejectedValue(new Error("Server error"));
+
+    const { getByText, queryByTestId } = render(
+      <RestaurantActionModal visible={true} actionType="pause" onClose={() => {}} />
+    );
+
+    await waitFor(() => expect(queryByTestId("loading-indicator")).toBeNull());
+
+    await act(async () => {
+      fireEvent.press(getByText("Test Restaurant 1"));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Failed to pause bookings for restaurant",
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
 });

--- a/openresto-frontend/tests/components/admin/settings/EditableRow.styles.test.ts
+++ b/openresto-frontend/tests/components/admin/settings/EditableRow.styles.test.ts
@@ -1,0 +1,12 @@
+import { editableRowStyles } from "@/components/admin/settings/EditableRow.styles";
+
+describe("EditableRow.styles", () => {
+  it("exports editableRowStyles with expected shape", () => {
+    expect(editableRowStyles).toBeDefined();
+    expect(editableRowStyles.editableRow).toBeDefined();
+    expect(editableRowStyles.rowActions).toBeDefined();
+    expect(editableRowStyles.smallBtn).toBeDefined();
+    expect(editableRowStyles.editableValue).toBeDefined();
+    expect(editableRowStyles.editableInput).toBeDefined();
+  });
+});

--- a/openresto-frontend/tests/components/common/DatePickerWeb.test.tsx
+++ b/openresto-frontend/tests/components/common/DatePickerWeb.test.tsx
@@ -58,4 +58,21 @@ describe("DatePicker (web)", () => {
     render(<DatePickerWeb onSelect={onSelect} openDays={[2, 3]} />);
     expect(screen.queryByText(/normally closed on this day/)).toBeNull();
   });
+
+  it("calls onSelect when date value changes", () => {
+    const { getByTestId } = render(<DatePickerWeb onSelect={onSelect} />);
+    const wrapper = getByTestId("date-picker-web");
+    const input = (wrapper as any).children[0];
+    fireEvent(input, "change", { target: { value: "2026-11-15" } });
+    expect(onSelect).toHaveBeenCalledWith("2026-11-15");
+  });
+
+  it("fires onFocus and onBlur on the date input", () => {
+    const { getByTestId } = render(<DatePickerWeb onSelect={onSelect} />);
+    const wrapper = getByTestId("date-picker-web");
+    const input = (wrapper as any).children[0];
+    fireEvent(input, "focus");
+    fireEvent(input, "blur");
+    expect(wrapper).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

- **EditableRow.styles.ts** (was 0%): new test importing the orphaned styles module to cover the `StyleSheet.create` export
- **TimePicker.web.tsx** (was 82.75%): added `onFocus`/`onBlur` event tests for lines 77-78
- **DatePicker.web.tsx** (was 88.88%): switched test to `@jest-environment jsdom`, added `onChange`/`onFocus`/`onBlur` event tests; added `testID` to wrapper View for test access
- **PopularTimesPicker.tsx** (was 88.63%): added tests for scroll arrow `onPress` handlers and `scrollBy` function (lines 127, 157, 207, 229); added `testID` props to arrow buttons for reliable test targeting
- **RestaurantActionModal.tsx** (was 88.37%): added tests for `loadRestaurants` error path, extend-with-no-bookings path, and `handleAction` error path (lines 57, 84-85, 99)

## Test plan

- [x] All 825 tests pass (`npx jest --no-coverage`)
- [x] Coverage verified for each of the 5 target files

https://claude.ai/code/session_01FhxysZjQE48rNCdhY6G5Gm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhxysZjQE48rNCdhY6G5Gm)_