### PR TITLE
fix: remap legacy migration history on existing VPS databases

### DIFF
--- a/OpenRestoApi/Extensions/DatabaseExtensions.cs
+++ b/OpenRestoApi/Extensions/DatabaseExtensions.cs
@@ -38,6 +38,117 @@ public static partial class DatabaseExtensions
     [LoggerMessage(Level = LogLevel.Critical, Message = "FATAL ERROR during database initialization. The application cannot start.")]
     private static partial void LogFatalError(ILogger logger, Exception ex);
 
+    [LoggerMessage(Level = LogLevel.Information, Message = "  - Legacy migration history detected. Remapping {Count} old migration(s) to consolidated InitialCreate.")]
+    private static partial void LogMigrationRemap(ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "  - Migration history is already up to date. No remap needed.")]
+    private static partial void LogMigrationRemapSkipped(ILogger logger);
+
+    private const string ConsolidatedMigrationId = "20260530173531_InitialCreate";
+
+    // Migration IDs that existed before the history was squashed into InitialCreate.
+    private static readonly string[] LegacyMigrationIds =
+    [
+        "20260129132410_AddSectionsAndTables",
+        "20260131215731_AddBookingsTable",
+        "20260503001441_AddRestaurantPauseUntil",
+        "20260518000001_AddBookingSearchIndexes",
+        "20260524000001_AddSendBookingConfirmations",
+        "20260524000002_AddMediaImageUrls",
+        "20260525213129_AddEmailFailures",
+    ];
+
+    private static void RemapLegacyMigrationHistory(AppDbContext db, ILogger logger)
+    {
+        // Only attempt this if the DB already exists (i.e. the history table exists).
+        if (!db.Database.CanConnect())
+            return;
+
+        try
+        {
+            // Check whether the history table even exists before querying it.
+            var tableExists = db.Database.ExecuteSqlRaw(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'") >= 0;
+
+            // Use raw SQL so we don't depend on the EF migration infrastructure itself.
+            var connection = db.Database.GetDbConnection();
+            if (connection.State != System.Data.ConnectionState.Open)
+                connection.Open();
+
+            using var checkCmd = connection.CreateCommand();
+            checkCmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'";
+            var tableCount = (long)(checkCmd.ExecuteScalar() ?? 0L);
+            if (tableCount == 0)
+                return; // fresh install — nothing to remap
+
+            // Count how many legacy migration IDs are present.
+            var placeholders = string.Join(",", LegacyMigrationIds.Select((_, i) => $"@p{i}"));
+            using var countCmd = connection.CreateCommand();
+            countCmd.CommandText = $"SELECT COUNT(*) FROM __EFMigrationsHistory WHERE MigrationId IN ({placeholders})";
+            for (int i = 0; i < LegacyMigrationIds.Length; i++)
+            {
+                var p = countCmd.CreateParameter();
+                p.ParameterName = $"@p{i}";
+                p.Value = LegacyMigrationIds[i];
+                countCmd.Parameters.Add(p);
+            }
+            var legacyCount = (long)(countCmd.ExecuteScalar() ?? 0L);
+
+            if (legacyCount == 0)
+            {
+                LogMigrationRemapSkipped(logger);
+                return;
+            }
+
+            LogMigrationRemap(logger, (int)legacyCount);
+
+            // Wrap the remap in a transaction for atomicity.
+            using var tx = connection.BeginTransaction();
+            try
+            {
+                // Remove all legacy entries.
+                using var deleteCmd = connection.CreateCommand();
+                deleteCmd.Transaction = tx;
+                deleteCmd.CommandText = $"DELETE FROM __EFMigrationsHistory WHERE MigrationId IN ({placeholders})";
+                for (int i = 0; i < LegacyMigrationIds.Length; i++)
+                {
+                    var p = deleteCmd.CreateParameter();
+                    p.ParameterName = $"@p{i}";
+                    p.Value = LegacyMigrationIds[i];
+                    deleteCmd.Parameters.Add(p);
+                }
+                deleteCmd.ExecuteNonQuery();
+
+                // Insert the consolidated migration ID if it isn't there yet.
+                using var insertCmd = connection.CreateCommand();
+                insertCmd.Transaction = tx;
+                insertCmd.CommandText =
+                    "INSERT OR IGNORE INTO __EFMigrationsHistory (MigrationId, ProductVersion) VALUES (@id, @ver)";
+                var idParam = insertCmd.CreateParameter();
+                idParam.ParameterName = "@id";
+                idParam.Value = ConsolidatedMigrationId;
+                insertCmd.Parameters.Add(idParam);
+                var verParam = insertCmd.CreateParameter();
+                verParam.ParameterName = "@ver";
+                verParam.Value = "10.0.0";
+                insertCmd.Parameters.Add(verParam);
+                insertCmd.ExecuteNonQuery();
+
+                tx.Commit();
+            }
+            catch
+            {
+                tx.Rollback();
+                throw;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: if the remap fails, Migrate() will surface a clearer error.
+            logger.LogWarning(ex, "Could not remap legacy migration history. Proceeding anyway.");
+        }
+    }
+
     public static string GetAppConnectionString(this IConfiguration configuration, IWebHostEnvironment env)
     {
         string? connectionString = configuration.GetConnectionString("DefaultConnection")
@@ -128,6 +239,11 @@ public static partial class DatabaseExtensions
                     }
                 }
             }
+
+            // Squash migration history: if the DB still has the old incremental migration IDs
+            // (from before the consolidation into InitialCreate), replace them all with the
+            // single consolidated migration so EF doesn't try to CREATE already-existing tables.
+            RemapLegacyMigrationHistory(db, logger);
 
             // Apply any pending EF migrations (creates DB on first run, adds columns on upgrade)
             int maxRetries = 10;

--- a/OpenRestoApi/Extensions/DatabaseExtensions.cs
+++ b/OpenRestoApi/Extensions/DatabaseExtensions.cs
@@ -66,80 +66,87 @@ public static partial class DatabaseExtensions
 
         try
         {
-            // Check whether the history table even exists before querying it.
-            var tableExists = db.Database.ExecuteSqlRaw(
-                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'") >= 0;
-
-            // Use raw SQL so we don't depend on the EF migration infrastructure itself.
+            // Use raw ADO.NET so we don't depend on the EF migration infrastructure itself.
+            // Track whether we opened the connection so we can restore its original state.
             var connection = db.Database.GetDbConnection();
-            if (connection.State != System.Data.ConnectionState.Open)
+            bool weOpenedConnection = connection.State != System.Data.ConnectionState.Open;
+            if (weOpenedConnection)
                 connection.Open();
 
-            using var checkCmd = connection.CreateCommand();
-            checkCmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'";
-            var tableCount = (long)(checkCmd.ExecuteScalar() ?? 0L);
-            if (tableCount == 0)
-                return; // fresh install — nothing to remap
-
-            // Count how many legacy migration IDs are present.
-            var placeholders = string.Join(",", LegacyMigrationIds.Select((_, i) => $"@p{i}"));
-            using var countCmd = connection.CreateCommand();
-            countCmd.CommandText = $"SELECT COUNT(*) FROM __EFMigrationsHistory WHERE MigrationId IN ({placeholders})";
-            for (int i = 0; i < LegacyMigrationIds.Length; i++)
-            {
-                var p = countCmd.CreateParameter();
-                p.ParameterName = $"@p{i}";
-                p.Value = LegacyMigrationIds[i];
-                countCmd.Parameters.Add(p);
-            }
-            var legacyCount = (long)(countCmd.ExecuteScalar() ?? 0L);
-
-            if (legacyCount == 0)
-            {
-                LogMigrationRemapSkipped(logger);
-                return;
-            }
-
-            LogMigrationRemap(logger, (int)legacyCount);
-
-            // Wrap the remap in a transaction for atomicity.
-            using var tx = connection.BeginTransaction();
             try
             {
-                // Remove all legacy entries.
-                using var deleteCmd = connection.CreateCommand();
-                deleteCmd.Transaction = tx;
-                deleteCmd.CommandText = $"DELETE FROM __EFMigrationsHistory WHERE MigrationId IN ({placeholders})";
+                using var checkCmd = connection.CreateCommand();
+                checkCmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'";
+                var tableCount = (long)(checkCmd.ExecuteScalar() ?? 0L);
+                if (tableCount == 0)
+                    return; // fresh install — nothing to remap
+
+                // Count how many legacy migration IDs are present.
+                var placeholders = string.Join(",", LegacyMigrationIds.Select((_, i) => $"@p{i}"));
+                using var countCmd = connection.CreateCommand();
+                countCmd.CommandText = $"SELECT COUNT(*) FROM __EFMigrationsHistory WHERE MigrationId IN ({placeholders})";
                 for (int i = 0; i < LegacyMigrationIds.Length; i++)
                 {
-                    var p = deleteCmd.CreateParameter();
+                    var p = countCmd.CreateParameter();
                     p.ParameterName = $"@p{i}";
                     p.Value = LegacyMigrationIds[i];
-                    deleteCmd.Parameters.Add(p);
+                    countCmd.Parameters.Add(p);
                 }
-                deleteCmd.ExecuteNonQuery();
+                var legacyCount = (long)(countCmd.ExecuteScalar() ?? 0L);
 
-                // Insert the consolidated migration ID if it isn't there yet.
-                using var insertCmd = connection.CreateCommand();
-                insertCmd.Transaction = tx;
-                insertCmd.CommandText =
-                    "INSERT OR IGNORE INTO __EFMigrationsHistory (MigrationId, ProductVersion) VALUES (@id, @ver)";
-                var idParam = insertCmd.CreateParameter();
-                idParam.ParameterName = "@id";
-                idParam.Value = ConsolidatedMigrationId;
-                insertCmd.Parameters.Add(idParam);
-                var verParam = insertCmd.CreateParameter();
-                verParam.ParameterName = "@ver";
-                verParam.Value = "10.0.0";
-                insertCmd.Parameters.Add(verParam);
-                insertCmd.ExecuteNonQuery();
+                if (legacyCount == 0)
+                {
+                    LogMigrationRemapSkipped(logger);
+                    return;
+                }
 
-                tx.Commit();
+                LogMigrationRemap(logger, (int)legacyCount);
+
+                // Wrap the remap in a transaction for atomicity.
+                using var tx = connection.BeginTransaction();
+                try
+                {
+                    // Remove all legacy entries.
+                    using var deleteCmd = connection.CreateCommand();
+                    deleteCmd.Transaction = tx;
+                    deleteCmd.CommandText = $"DELETE FROM __EFMigrationsHistory WHERE MigrationId IN ({placeholders})";
+                    for (int i = 0; i < LegacyMigrationIds.Length; i++)
+                    {
+                        var p = deleteCmd.CreateParameter();
+                        p.ParameterName = $"@p{i}";
+                        p.Value = LegacyMigrationIds[i];
+                        deleteCmd.Parameters.Add(p);
+                    }
+                    deleteCmd.ExecuteNonQuery();
+
+                    // Insert the consolidated migration ID if it isn't there yet.
+                    using var insertCmd = connection.CreateCommand();
+                    insertCmd.Transaction = tx;
+                    insertCmd.CommandText =
+                        "INSERT OR IGNORE INTO __EFMigrationsHistory (MigrationId, ProductVersion) VALUES (@id, @ver)";
+                    var idParam = insertCmd.CreateParameter();
+                    idParam.ParameterName = "@id";
+                    idParam.Value = ConsolidatedMigrationId;
+                    insertCmd.Parameters.Add(idParam);
+                    var verParam = insertCmd.CreateParameter();
+                    verParam.ParameterName = "@ver";
+                    verParam.Value = "10.0.0";
+                    insertCmd.Parameters.Add(verParam);
+                    insertCmd.ExecuteNonQuery();
+
+                    tx.Commit();
+                }
+                catch
+                {
+                    tx.Rollback();
+                    throw;
+                }
             }
-            catch
+            finally
             {
-                tx.Rollback();
-                throw;
+                // Restore connection to its original state so EF's Migrate() isn't surprised.
+                if (weOpenedConnection)
+                    connection.Close();
             }
         }
         catch (Exception ex)

--- a/openresto-frontend/e2e/booking.spec.ts
+++ b/openresto-frontend/e2e/booking.spec.ts
@@ -15,6 +15,10 @@ test.describe("Booking Flow", () => {
     await page.waitForURL(/.*book\?restaurantId=.*/, { timeout: 10000 });
 
     // 3. Fill out the form
+    const nameInput = page.getByPlaceholder("Your full name");
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill("E2E Test User");
+
     const emailInput = page.getByPlaceholder("your@email.com");
     await expect(emailInput).toBeVisible();
     await emailInput.fill("test-e2e@example.com");

--- a/openresto-frontend/tests/components/restaurant/RestaurantCard.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/RestaurantCard.test.tsx
@@ -95,12 +95,16 @@ describe("RestaurantCard", () => {
   });
 
   it("shows Closed badge when restaurant is closed", async () => {
-    render(
-      <RestaurantCard restaurant={{ ...mockRestaurant, openTime: "23:00", closeTime: "23:59" }} />
-    );
-    await waitFor(() =>
-      expect(screen.queryByText("Closed") ?? screen.queryByText("23:00")).toBeTruthy()
-    );
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-01T14:00:00Z")); // fixed noon UTC — outside 23:00-23:59 window
+    try {
+      render(
+        <RestaurantCard restaurant={{ ...mockRestaurant, openTime: "23:00", closeTime: "23:59" }} />
+      );
+      await waitFor(() => expect(screen.queryByText("Closed")).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("shows 'Open till' badge when restaurant is open", async () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- PR #80 consolidated 7 incremental EF migrations into a single `InitialCreate` migration, which breaks existing VPS deployments on startup
- When the app calls `db.Database.Migrate()`, EF sees `InitialCreate` is not in `__EFMigrationsHistory` and tries to `CREATE TABLE` on tables that already exist → crash
- Added `RemapLegacyMigrationHistory()` that runs before `Migrate()`: detects old migration IDs in the history table, removes them, and inserts the consolidated `InitialCreate` ID so EF treats the schema as current

## Test plan

- [ ] Fresh install (no existing DB): `RemapLegacyMigrationHistory` no-ops, `Migrate()` creates schema normally
- [ ] Existing VPS DB with old migration history: history is remapped, `Migrate()` finds `InitialCreate` already applied and skips, app starts healthy
- [ ] Already-remapped DB (re-deploy): `legacyCount == 0` path is hit, no-op, app starts normally

https://claude.ai/code/session_01J31TDiGx9Q1SJpHVU84kpc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J31TDiGx9Q1SJpHVU84kpc)_