### PR TITLE
fix: add CustomerName column to existing DBs; stabilise time-sensitive tests

### DIFF
--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -143,7 +143,7 @@ public class AdminServiceTests : IDisposable
         AdminService svc = CreateService();
         SeedBase(1);
         DateTime nowUtc = DateTime.UtcNow;
-        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.AddMinutes(30), BookingRef = "TODAY", IsCancelled = false });
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(12), BookingRef = "TODAY", IsCancelled = false });
         await _db.SaveChangesAsync();
 
         AdminOverviewDto overview = await svc.GetOverviewAsync();
@@ -159,8 +159,8 @@ public class AdminServiceTests : IDisposable
         AdminService svc = CreateService();
         SeedBase(1);
         DateTime nowUtc = DateTime.UtcNow;
-        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.AddMinutes(30), BookingRef = "ACTIVE", IsCancelled = false });
-        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.AddMinutes(60), BookingRef = "CANCELLED", IsCancelled = true });
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(12), BookingRef = "ACTIVE", IsCancelled = false });
+        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(13), BookingRef = "CANCELLED", IsCancelled = true });
         await _db.SaveChangesAsync();
 
         AdminOverviewDto overview = await svc.GetOverviewAsync();
@@ -189,8 +189,8 @@ public class AdminServiceTests : IDisposable
         AdminService svc = CreateService();
         SeedBase(1);
         DateTime nowUtc = DateTime.UtcNow;
-        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.AddMinutes(30), BookingRef = "B1" });
-        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.AddMinutes(90), BookingRef = "B2" });
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(12), BookingRef = "B1" });
+        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(13), BookingRef = "B2" });
         await _db.SaveChangesAsync();
 
         AdminOverviewDto overview = await svc.GetOverviewAsync();

--- a/OpenRestoApi.Tests/Utilities/TimezoneLogicTests.cs
+++ b/OpenRestoApi.Tests/Utilities/TimezoneLogicTests.cs
@@ -37,7 +37,7 @@ public class TimezoneLogicTests
         // UTC Range for April 19 Sydney: April 18 14:00 UTC to April 19 14:00 UTC.
         // Input is Unspecified (as ASP.NET parses a date-only query param).
         DateTime refDate = new DateTime(2026, 4, 19, 0, 0, 0, DateTimeKind.Unspecified);
-        string tz = "AUS Eastern Standard Time"; // Windows ID for Sydney
+        string tz = "Australia/Sydney";
 
         (DateTime start, DateTime end) = InvokeGetUtcRange(refDate, tz);
 
@@ -63,7 +63,7 @@ public class TimezoneLogicTests
         // UTC Range for April 18 Tokyo: April 17 15:00 UTC to April 18 15:00 UTC.
         // Input is Unspecified (as ASP.NET parses a date-only query param).
         DateTime refDate = new DateTime(2026, 4, 18, 0, 0, 0, DateTimeKind.Unspecified);
-        string tz = "Tokyo Standard Time";
+        string tz = "Asia/Tokyo";
 
         (DateTime start, DateTime end) = InvokeGetUtcRange(refDate, tz);
 

--- a/OpenRestoApi/Extensions/DatabaseExtensions.cs
+++ b/OpenRestoApi/Extensions/DatabaseExtensions.cs
@@ -92,6 +92,8 @@ public static partial class DatabaseExtensions
                 if (initialCreateRecorded)
                 {
                     LogMigrationRemapSkipped(logger);
+                    // Still patch any columns that may be missing from older deployments.
+                    AddColumnIfMissing(connection, "Bookings", "CustomerName", "TEXT NULL");
                     return;
                 }
 

--- a/OpenRestoApi/Extensions/DatabaseExtensions.cs
+++ b/OpenRestoApi/Extensions/DatabaseExtensions.cs
@@ -154,6 +154,10 @@ public static partial class DatabaseExtensions
                     tx.Rollback();
                     throw;
                 }
+
+                // Add any columns that were introduced in InitialCreate but never existed in the
+                // old incremental migrations (e.g. CustomerName added to Booking in the squash PR).
+                AddColumnIfMissing(connection, "Bookings", "CustomerName", "TEXT NULL");
             }
             finally
             {
@@ -166,6 +170,19 @@ public static partial class DatabaseExtensions
         {
             // Non-fatal: if the remap fails, Migrate() will surface a clearer error.
             logger.LogWarning(ex, "Could not remap legacy migration history. Proceeding anyway.");
+        }
+    }
+
+    private static void AddColumnIfMissing(System.Data.Common.DbConnection connection, string table, string column, string definition)
+    {
+        using var checkCmd = connection.CreateCommand();
+        checkCmd.CommandText = $"SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name='{column}'";
+        var exists = (long)(checkCmd.ExecuteScalar() ?? 0L) > 0;
+        if (!exists)
+        {
+            using var alterCmd = connection.CreateCommand();
+            alterCmd.CommandText = $"ALTER TABLE {table} ADD COLUMN {column} {definition}";
+            alterCmd.ExecuteNonQuery();
         }
     }
 

--- a/openresto-frontend/tests/components/restaurant/RestaurantCard.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/RestaurantCard.test.tsx
@@ -59,19 +59,32 @@ describe("RestaurantCard", () => {
   });
 
   it("shows available time slot", async () => {
-    (fetchAvailability as jest.Mock).mockResolvedValue({
-      slots: [{ time: "23:30", isAvailable: true }],
-    });
-    render(<RestaurantCard restaurant={mockRestaurant} />);
-    await waitFor(() => expect(screen.getByText("23:30")).toBeTruthy());
+    // Pin clock to noon UTC so the 23:30 slot is always in the future.
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-01T12:00:00Z"));
+    try {
+      (fetchAvailability as jest.Mock).mockResolvedValue({
+        slots: [{ time: "23:30", isAvailable: true }],
+      });
+      render(<RestaurantCard restaurant={mockRestaurant} />);
+      await waitFor(() => expect(screen.getByText("23:30")).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("filters out unavailable slots", async () => {
-    (fetchAvailability as jest.Mock).mockResolvedValue({
-      slots: [{ time: "23:30", isAvailable: false }],
-    });
-    render(<RestaurantCard restaurant={mockRestaurant} />);
-    await waitFor(() => expect(screen.getByText("No available slots today")).toBeTruthy());
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-01T12:00:00Z"));
+    try {
+      (fetchAvailability as jest.Mock).mockResolvedValue({
+        slots: [{ time: "23:30", isAvailable: false }],
+      });
+      render(<RestaurantCard restaurant={mockRestaurant} />);
+      await waitFor(() => expect(screen.getByText("No available slots today")).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("navigates to booking when 'See details' is pressed", async () => {


### PR DESCRIPTION
## Summary

- **Root cause of broken bookings/restaurants on VPS**: `CustomerName` was added to the `Booking` EF model in PR #80 but never via an old migration. The migration remap stamped `InitialCreate` as applied without running it, so the column was never added to the live database. Any EF query touching `Bookings` (directly or via joins) failed with `no such column: CustomerName`.
- Added `AddColumnIfMissing` helper that runs after the history stamp to apply any columns introduced in the consolidation but absent from old DBs.
- Fixed two more time-sensitive `RestaurantCard` tests: `shows available time slot` and `filters out unavailable slots` both used a `23:30` slot that the component's future-filter discards when CI runs after 23:30 UTC.

## Test plan
- [ ] VPS with existing DB: `CustomerName` column added, bookings and restaurants load
- [ ] Fresh install: `AddColumnIfMissing` no-ops (column already present from `InitialCreate`)
- [ ] `RestaurantCard` tests pass at any time of day

https://claude.ai/code/session_01J31TDiGx9Q1SJpHVU84kpc

---
_Generated by [Claude Code](https://claude.ai/code/session_01J31TDiGx9Q1SJpHVU84kpc)_