### PR TITLE
Fix availability times shown on closed days and during paused bookings

### DIFF
--- a/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
+++ b/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
@@ -31,6 +31,26 @@ public class AvailabilityService(
         // 2. Define the local operating hours for the requested date
         DateTime localDate = TimeZoneInfo.ConvertTimeFromUtc(bookingDate.ToUniversalTime(), tz).Date;
 
+        // Check if this day of week is an open day
+        if (!string.IsNullOrEmpty(restaurant.OpenDays))
+        {
+            int jsDay = (int)localDate.DayOfWeek; // 0=Sun…6=Sat
+            int isoDay = jsDay == 0 ? 7 : jsDay;  // 1=Mon…7=Sun
+            var openDaysList = restaurant.OpenDays
+                .Split(',')
+                .Select(d => int.TryParse(d.Trim(), out int x) ? x : 0)
+                .ToHashSet();
+            if (!openDaysList.Contains(isoDay))
+            {
+                return new AvailabilityResponseDto
+                {
+                    RestaurantId = restaurantId,
+                    Date = bookingDate,
+                    Slots = new List<TimeSlotDto>()
+                };
+            }
+        }
+
         if (!TryParseTime(restaurant.OpenTime, out int openHour, out int openMin))
         {
             openHour = 9; openMin = 0;

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -150,6 +150,14 @@ export default function BookingForm({
 
   // Fetch availability when date/seats change
   useEffect(() => {
+    const openDaysList = restaurant.openDays?.split(",").map(Number) ?? [1, 2, 3, 4, 5, 6, 7];
+    const jsDay = date ? new Date(date + "T12:00:00").getDay() : -1;
+    const isoDay = jsDay === 0 ? 7 : jsDay;
+    if (date && !openDaysList.includes(isoDay)) {
+      setAvailabilitySlots([]);
+      setLoadingAvailability(false);
+      return;
+    }
     async function loadAvailability() {
       setLoadingAvailability(true);
       try {
@@ -283,13 +291,19 @@ export default function BookingForm({
           <ThemedText style={styles.label}>Popular Times</ThemedText>
           {loadingAvailability && <ActivityIndicator size="small" color={PRIMARY} />}
         </View>
-        <PopularTimesPicker
-          slots={availabilitySlots}
-          selectedTime={time}
-          onSelectTime={setTime}
-          selectedDate={date}
-          timezone={timezone}
-        />
+        {isClosedDay ? (
+          <ThemedText style={[styles.closedDayNotice, { color: colors.error }]}>
+            The restaurant is closed on this day. Please select a different date.
+          </ThemedText>
+        ) : (
+          <PopularTimesPicker
+            slots={availabilitySlots}
+            selectedTime={time}
+            onSelectTime={setTime}
+            selectedDate={date}
+            timezone={timezone}
+          />
+        )}
       </View>
 
       {/* Row 1: Guests + Date */}
@@ -475,6 +489,10 @@ const styles = StyleSheet.create({
     color: "#e53e3e",
     fontSize: 13,
     marginBottom: 12,
+  },
+  closedDayNotice: {
+    fontSize: 13,
+    marginBottom: 8,
   },
   timezoneHint: {
     fontSize: 12,

--- a/openresto-frontend/components/restaurant/RestaurantCard.tsx
+++ b/openresto-frontend/components/restaurant/RestaurantCard.tsx
@@ -95,7 +95,13 @@ export default function RestaurantCard({
 
   useEffect(() => {
     const tz = restaurant.timezone ?? "UTC";
-    const { totalMins } = getRestaurantNow(tz);
+    const { totalMins, isoDay } = getRestaurantNow(tz);
+    const openDaysList = restaurant.openDays?.split(",").map(Number) ?? [1, 2, 3, 4, 5, 6, 7];
+    if (!openDaysList.includes(isoDay)) {
+      setSlots([]);
+      setSlotsLoading(false);
+      return;
+    }
     const date = getRestaurantDate(tz);
     fetchAvailability(restaurant.id, date, party).then((data) => {
       if (data && Array.isArray(data.slots)) {
@@ -110,7 +116,7 @@ export default function RestaurantCard({
       }
       setSlotsLoading(false);
     });
-  }, [restaurant.id, restaurant.timezone, party]);
+  }, [restaurant.id, restaurant.timezone, restaurant.openDays, party]);
 
   const open = isOpenNow(
     restaurant.openTime,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Backend**: `AvailabilityService` now returns empty slots when the requested date is not in the restaurant's `OpenDays` list, instead of returning slots that appeared available (no bookings = free tables on a closed day)
- **BookingForm**: Skips the availability API call on closed days and shows a "restaurant is closed on this day" notice in place of `PopularTimesPicker`
- **RestaurantCard (home page)**: Skips the availability fetch entirely when today is not an open day, preventing misleading slot chips from appearing

Paused bookings were already handled correctly — the backend marks all slots `isAvailable: false` when paused, so both the home page and booking form naturally show no available times.

## Test plan

- [ ] Select a closed day in the booking form → notice appears, no time slots shown, submit button disabled
- [ ] Select an open day → `PopularTimesPicker` appears as normal
- [ ] Home page: if today is a closed day, restaurant card shows "No available slots today" (not time chips)
- [ ] Home page: if today is an open day, available slot chips appear as normal
- [ ] Pause restaurant bookings via admin → all slots show as unavailable on both home page and booking form

https://claude.ai/code/session_01SRzqSEe1Rkj5shAHxbWNGy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRzqSEe1Rkj5shAHxbWNGy)_