### PR TITLE
Fix OWASP ZAP scanning full API surface, not just /api/health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,16 +212,26 @@ jobs:
           echo "$HEADERS" | grep -qi "x-content-type-options: nosniff" || exit 1
           echo "$HEADERS" | grep -qi "x-frame-options: DENY" || exit 1
 
+      - name: Verify OpenAPI spec reachable via nginx
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5062/openapi/v1.json)
+          echo "GET /openapi/v1.json -> $STATUS"
+          [ "$STATUS" = "200" ] || exit 1
+
       - name: OWASP ZAP API Scan
         uses: zaproxy/action-api-scan@v0.9.0
         with:
-          target: http://localhost:5062/api/health
+          # Target is the OpenAPI spec so ZAP discovers all endpoints, not just /api/health.
+          # The spec is exposed only in Development mode (docker-compose.yml sets this).
+          # The /openapi/ nginx route (dev only) makes it reachable through the full proxy stack.
+          target: http://localhost:5062/openapi/v1.json
           rules_file_name: .zap-rules.tsv
           cmd_options: >
             -a
             -j
             -l WARN
             -z "-config api.disablekey=true
+            -config openapi.targetUrl=http://localhost:5062
             -config spider.maxDuration=2
             -config scanner.maxScanDurationInMins=5"
           allow_issue_writing: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Run everything (recommended for local dev)
+```bash
+npm run dev          # starts backend (dotnet watch) + frontend (expo) concurrently
+```
+
+### Backend only
+```bash
+cd OpenRestoApi
+dotnet watch run     # hot reload on :8080
+dotnet test          # all backend tests
+dotnet test --filter "FullyQualifiedName~BookingServiceTests"  # single test class
+```
+
+### Frontend only
+```bash
+cd openresto-frontend
+npm run web          # Expo web dev server on :8081
+npm test             # Jest unit tests
+npm test -- --testPathPattern=BookingForm  # single test file
+npm test -- --coverage  # coverage report
+npm run test:e2e     # Playwright E2E tests
+npm run check        # prettier + eslint (what CI runs)
+npm run lint:fix     # auto-fix lint issues
+```
+
+### Docker (full stack through nginx)
+```bash
+docker compose up    # full stack on localhost:5062
+```
+
+## Architecture
+
+Three-container stack: **Nginx** (`:5062`) → routes `/api/*` to **ASP.NET Core** (`:8080`) and `/*` to **Expo/React Native** (`:8081`). A shared Docker volume (`media_data`) serves uploaded images at `/media/`.
+
+### Backend — Clean-ish layered architecture
+
+```
+OpenRestoApi/
+├── Controllers/          # Thin HTTP layer — validate auth, call services, return DTOs
+├── Core/
+│   ├── Domain/           # Plain C# entities (Restaurant, Booking, Table, Section, …)
+│   ├── Application/
+│   │   ├── Services/     # Business logic (BookingService, AvailabilityService, AdminService, …)
+│   │   ├── Interfaces/   # Contracts for repos, email, clock, holds
+│   │   ├── DTOs/         # Request/response shapes
+│   │   └── Mappings/     # Mapperly source-gen mappers (no AutoMapper)
+└── Infrastructure/
+    ├── Persistence/      # EF Core + SQLite (AppDbContext, repositories)
+    ├── Holds/            # In-memory table hold service (singleton ConcurrentDictionary)
+    ├── Email/            # MailKit SMTP wrapper
+    ├── Cookies/          # Encrypted HttpOnly cookie for recent bookings (DataProtection)
+    └── Auth/             # JWT generation helpers
+```
+
+**Key conventions:**
+- All `DateTime` values are stored and passed as **UTC**. EF Core value converters enforce this globally in `AppDbContext`. Restaurant-local times are converted using the restaurant's IANA `Timezone` field only at display/availability-calculation time.
+- `OpenDays` is a comma-separated string of ISO 8601 day numbers (`1`=Monday … `7`=Sunday).
+- `HoldService` is a **singleton** in-memory store — appropriate for single-instance deployment. Holds expire after 5 minutes. If you need multi-instance, swap for Redis.
+- The OpenAPI spec (`/openapi/v1.json`) is only exposed when `ASPNETCORE_ENVIRONMENT=Development`. The dev nginx template (`nginx/default.conf.template`) proxies `/openapi/` to the backend for ZAP CI scanning; the prod nginx (`nginx-vps/`) does not.
+
+### Frontend — Expo Router file-based routing
+
+```
+openresto-frontend/
+├── app/
+│   ├── (user)/           # Customer-facing: index (search), book, lookup
+│   └── (admin)/          # Admin dashboard, bookings list, settings
+├── api/                  # Typed fetch wrappers (one file per resource: restaurants, bookings, holds, …)
+├── components/
+│   ├── booking/          # BookingForm, PopularTimesPicker, HoldStatusBanner, useTableHold
+│   ├── restaurant/       # RestaurantCard (home page tiles)
+│   └── admin/            # Dashboard, tables, settings components
+├── context/
+│   ├── BrandContext      # Fetches /api/brand on mount; provides appName + primaryColor globally
+│   └── ThemeContext
+└── hooks/                # useColorScheme, etc.
+```
+
+**Key conventions:**
+- `EXPO_PUBLIC_API_URL` drives all API calls. In Docker it is `/api` (relative, goes through nginx). In standalone dev it is `http://localhost:5062`. The `buildEndpoint` helper in `BrandContext` normalises both forms.
+- Availability is fetched per `(restaurantId, date, seats)`. The API returns 15-minute slots with `{ time, isAvailable, availableTableIds, category }`. `PopularTimesPicker` shows only `isAvailable: true` slots; closed days return an empty slots array from the backend.
+- Table holds flow: frontend calls `POST /api/holds` → backend validates open hours + pause state + conflict-checks → returns a `holdId` + expiry. The `holdId` must be included in the subsequent `POST /api/bookings` request.
+
+### Auth model
+
+Two roles via JWT:
+- **Admin** — obtained by `POST /api/auth/login`. Stored in `AdminCredential` (one row per restaurant, bcrypt password hash). Required for all `/admin/*` endpoints.
+- **Customer bookings** — no auth. Customers identify via `BookingRef` (short random string) or the encrypted recent-bookings cookie.
+
+### Testing
+
+- **Backend**: xUnit + Moq. Tests live in `OpenRestoApi.Tests/`. Services are tested in isolation with mocked repos and a mock `ISystemClock` (inject `MockSystemClock` to control time-dependent hold/availability logic).
+- **Frontend**: Jest + React Native Testing Library. 100% coverage target. E2E with Playwright (`tests/e2e/`).
+- **CI ZAP scan**: runs against the full Docker stack; the OpenAPI spec (`/openapi/v1.json`) is used as the scan target so ZAP discovers all endpoints. Ignored rules are listed in `.zap-rules.tsv`.

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -58,6 +58,13 @@ server {
         return 200 "OK";
     }
 
+    # OpenAPI spec — only reachable when backend runs with ASPNETCORE_ENVIRONMENT=Development
+    # Used by ZAP in CI to discover all API endpoints; not present in prod nginx config.
+    location /openapi/ {
+        set $backend_host ${BACKEND_HOST};
+        proxy_pass http://$backend_host:${BACKEND_PORT};
+    }
+
     # API — Proxy to Backend
     location /api/ {
         include /etc/nginx/conf.d/security-headers.conf;


### PR DESCRIPTION
## Problem

ZAP was only scanning `/api/health` because it had no API definition to discover endpoints from. The OpenAPI spec is generated in Development mode but nginx only proxied `/api/*`, so the spec was unreachable through the proxy stack that ZAP hits.

## Changes

**`nginx/default.conf.template`** — adds an `/openapi/` proxy route that forwards to the backend. This is only in the dev/CI nginx config; the VPS/prod config (`nginx-vps/`) is unchanged and never exposes this path.

**`.github/workflows/ci.yml`**:
- Points ZAP at `http://localhost:5062/openapi/v1.json` (the spec) instead of a single endpoint, so it discovers and tests every registered API route
- Adds `-config openapi.targetUrl=http://localhost:5062` so all ZAP probes go through nginx (the full proxy stack), not directly to the backend port
- Adds a preflight `curl` step to assert the spec is reachable before ZAP starts, giving a clearer failure message if not

## Why this is safe

- OpenAPI is only exposed when `ASPNETCORE_ENVIRONMENT=Development` (set in `docker-compose.yml`, not in `docker-compose.vps.yml`)
- The `/openapi/` nginx route is only in the dev template — production nginx has no such route
- ZAP still scans through nginx, so it tests the real request path including security headers, rate limiting, and proxy behaviour

https://claude.ai/code/session_01SRzqSEe1Rkj5shAHxbWNGy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRzqSEe1Rkj5shAHxbWNGy)_