### PR TITLE
fix: availability engine returns no slots on Mondays for non-UTC restaurants

### DIFF
--- a/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
@@ -268,4 +268,34 @@ public class AvailabilityServiceTests
         // Lunch: 11:30 - 14:30
         // Dinner: 17:30 - 21:30
     }
+
+    [Fact]
+    public async Task GetAvailabilityAsync_ReturnsSlots_ForMondayInNegativeUtcOffsetTimezone()
+    {
+        // Regression test: midnight UTC on a Monday is Sunday evening in UTC-negative timezones.
+        // The service must treat the incoming date as the local date (not convert from UTC).
+        using AppDbContext db = CreateDb(nameof(GetAvailabilityAsync_ReturnsSlots_ForMondayInNegativeUtcOffsetTimezone));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "T",
+            OpenTime = "09:00",
+            CloseTime = "22:00",
+            Timezone = "America/New_York",  // UTC-4 in summer
+            OpenDays = "1,2,3,4,5"         // Mon–Fri only
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 2, SectionId = 1 });
+        db.SaveChanges();
+
+        var svc = new AvailabilityService(new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+
+        // Frontend sends the local date string "2026-06-01" (Monday), which ASP.NET Core
+        // model-binds as DateTimeKind.Unspecified. Simulate that here.
+        var monday = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        var result = await svc.GetAvailabilityAsync(1, monday, 2);
+
+        // Should return slots — the restaurant is open on Mondays
+        Assert.NotEmpty(result.Slots);
+    }
 }

--- a/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
+++ b/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
@@ -28,8 +28,11 @@ public class AvailabilityService(
         // 1. Fetch all active bookings for this restaurant on this date (broad UTC range)
         IEnumerable<Booking> activeBookings = await _bookingRepository.GetActiveBookingsForDateAsync(restaurantId, bookingDate);
 
-        // 2. Define the local operating hours for the requested date
-        DateTime localDate = TimeZoneInfo.ConvertTimeFromUtc(bookingDate.ToUniversalTime(), tz).Date;
+        // 2. Define the local operating hours for the requested date.
+        // bookingDate is sent as YYYY-MM-DD from the frontend (already the local date in the
+        // restaurant's timezone), so use it directly rather than converting from UTC — converting
+        // from UTC would shift midnight into the previous day for any UTC-negative timezone.
+        DateTime localDate = bookingDate.Date;
 
         // Check if this day of week is an open day
         if (!string.IsNullOrEmpty(restaurant.OpenDays))


### PR DESCRIPTION
Fixes #88

The availability service was calling `.ToUniversalTime()` on the date query parameter (which is `DateTimeKind.Unspecified` when bound from a `YYYY-MM-DD` string), then converting back from UTC into the restaurant’s timezone. For UTC-negative timezones (e.g. America/New_York, UTC-4 in summer), midnight Monday UTC becomes Sunday evening local time — so the day-of-week check saw Sunday instead of Monday and returned no slots.

The frontend already sends the correct local date string (via `getRestaurantDate(tz)`), so `bookingDate.Date` is used directly without any UTC re-conversion.

Also adds a regression test with `America/New_York` timezone and `DateTimeKind.Unspecified` to match real ASP.NET Core query-string model binding.

Generated with [Claude Code](https://claude.ai/code)