### PR TITLE
Use STATUS_COLORS.cancelled token in bookings list instead of hardcoded red

### DIFF
--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "react-native";
 import { useRouter, Stack, useLocalSearchParams } from "expo-router";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { COLORS, FORM_SIZES, getThemeColors } from "@/theme/theme";
+import { COLORS, FORM_SIZES, getThemeColors, STATUS_COLORS } from "@/theme/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { useBrand } from "@/context/BrandContext";
 
@@ -380,7 +380,7 @@ export default function AdminBookingsScreen() {
               [
                 { key: "active", label: "Active", color: PRIMARY },
                 { key: "past", label: "Past", color: "#7c3aed" },
-                { key: "cancelled", label: "Cancelled", color: "#dc2626" },
+                { key: "cancelled", label: "Cancelled", color: STATUS_COLORS.cancelled.text },
               ] as const
             ).map(({ key, label, color }) => (
               <Pressable
@@ -629,8 +629,13 @@ export default function AdminBookingsScreen() {
 
               <View style={styles.colStatus}>
                 {b.isCancelled ? (
-                  <View style={[styles.badge, { backgroundColor: "rgba(220,38,38,0.1)" }]}>
-                    <ThemedText style={[styles.badgeText, { color: "#dc2626" }]}>
+                  <View
+                    style={[
+                      styles.badge,
+                      { backgroundColor: STATUS_COLORS.cancelled.bg[isDark ? "dark" : "light"] },
+                    ]}
+                  >
+                    <ThemedText style={[styles.badgeText, { color: STATUS_COLORS.cancelled.text }]}>
                       Cancelled
                     </ThemedText>
                   </View>
@@ -642,13 +647,16 @@ export default function AdminBookingsScreen() {
               <View style={styles.colAction}>
                 {!b.isCancelled && (
                   <Pressable
-                    style={[styles.rowActionBtn, { backgroundColor: "rgba(220,38,38,0.1)" }]}
+                    style={[
+                      styles.rowActionBtn,
+                      { backgroundColor: STATUS_COLORS.cancelled.bg[isDark ? "dark" : "light"] },
+                    ]}
                     onPress={(e) => {
                       (e as { stopPropagation?: () => void }).stopPropagation?.();
                       setCancelTarget(b);
                     }}
                   >
-                    <Ionicons name="close-outline" size={14} color="#dc2626" />
+                    <Ionicons name="close-outline" size={14} color={STATUS_COLORS.cancelled.text} />
                   </Pressable>
                 )}
               </View>
@@ -706,8 +714,18 @@ export default function AdminBookingsScreen() {
                 </View>
                 <View style={styles.listCardRight}>
                   {b.isCancelled ? (
-                    <View style={[styles.badge, { backgroundColor: "rgba(220,38,38,0.1)" }]}>
-                      <ThemedText style={[styles.badgeText, { color: "#dc2626" }]}>
+                    <View
+                      style={[
+                        styles.badge,
+                        {
+                          backgroundColor:
+                            STATUS_COLORS.cancelled.bg[isDark ? "dark" : "light"],
+                        },
+                      ]}
+                    >
+                      <ThemedText
+                        style={[styles.badgeText, { color: STATUS_COLORS.cancelled.text }]}
+                      >
                         Cancelled
                       </ThemedText>
                     </View>

--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -635,9 +635,7 @@ export default function AdminBookingsScreen() {
                       { backgroundColor: STATUS_COLORS.cancelled.bg[isDark ? "dark" : "light"] },
                     ]}
                   >
-                    <ThemedText
-                      style={[styles.badgeText, { color: STATUS_COLORS.cancelled.text }]}
-                    >
+                    <ThemedText style={[styles.badgeText, { color: STATUS_COLORS.cancelled.text }]}>
                       Cancelled
                     </ThemedText>
                   </View>
@@ -658,11 +656,7 @@ export default function AdminBookingsScreen() {
                       setCancelTarget(b);
                     }}
                   >
-                    <Ionicons
-                      name="close-outline"
-                      size={14}
-                      color={STATUS_COLORS.cancelled.text}
-                    />
+                    <Ionicons name="close-outline" size={14} color={STATUS_COLORS.cancelled.text} />
                   </Pressable>
                 )}
               </View>
@@ -724,8 +718,7 @@ export default function AdminBookingsScreen() {
                       style={[
                         styles.badge,
                         {
-                          backgroundColor:
-                            STATUS_COLORS.cancelled.bg[isDark ? "dark" : "light"],
+                          backgroundColor: STATUS_COLORS.cancelled.bg[isDark ? "dark" : "light"],
                         },
                       ]}
                     >

--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -635,7 +635,9 @@ export default function AdminBookingsScreen() {
                       { backgroundColor: STATUS_COLORS.cancelled.bg[isDark ? "dark" : "light"] },
                     ]}
                   >
-                    <ThemedText style={[styles.badgeText, { color: STATUS_COLORS.cancelled.text }]}>
+                    <ThemedText
+                      style={[styles.badgeText, { color: STATUS_COLORS.cancelled.text }]}
+                    >
                       Cancelled
                     </ThemedText>
                   </View>
@@ -656,7 +658,11 @@ export default function AdminBookingsScreen() {
                       setCancelTarget(b);
                     }}
                   >
-                    <Ionicons name="close-outline" size={14} color={STATUS_COLORS.cancelled.text} />
+                    <Ionicons
+                      name="close-outline"
+                      size={14}
+                      color={STATUS_COLORS.cancelled.text}
+                    />
                   </Pressable>
                 )}
               </View>


### PR DESCRIPTION
## Summary

- The `STATUS_COLORS.cancelled` theme token (`text: COLORS.error`, `bg: rgba(220,38,38,0.1/0.15)`) already existed but the bookings list was duplicating those values as hardcoded hex strings
- Imports `STATUS_COLORS` and replaces all 4 hardcoded red occurrences: the Cancelled filter button, the table-view badge, the mobile card badge, and the cancel action button icon
- Background tint now correctly uses the dark-mode variant (`rgba(220,38,38,0.15)`) instead of always using the light one

## Test plan

- [ ] Open the admin bookings list — verify Cancelled badges and the cancel (×) button icon still appear red
- [ ] Toggle dark mode — verify the badge background is slightly more opaque in dark mode
- [ ] Click the Cancelled filter tab — verify it highlights in the same red as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQMNbds5Bm7ViaCsHjFmuL)_