### PR TITLE
feat: make admin settings sections collapsible

### DIFF
--- a/openresto-frontend/app/(admin)/settings.tsx
+++ b/openresto-frontend/app/(admin)/settings.tsx
@@ -151,6 +151,7 @@ export default function AdminSettingsScreen() {
   const [addingLocation, setAddingLocation] = useState(false);
   const [newLocationName, setNewLocationName] = useState("");
   const [savingLocation, setSavingLocation] = useState(false);
+  const [locationExpanded, setLocationExpanded] = useState(true);
   const isDark = useColorScheme() === "dark";
   const {
     state: confirmState,
@@ -198,143 +199,149 @@ export default function AdminSettingsScreen() {
     <ScrollView contentContainerStyle={styles.container}>
       {Platform.OS !== "web" && <Stack.Screen options={{ title: "Settings" }} />}
 
-      {/* Page header */}
-      <View style={styles.pageHeader}>
-        <View>
-          <ThemedText
-            style={{
-              fontSize: 12,
-              color: mutedColor,
-              textTransform: "uppercase",
-              letterSpacing: 1,
-              marginBottom: 4,
-            }}
-          >
-            Settings · Locations
-          </ThemedText>
-          <ThemedText style={styles.pageTitle}>Location Manager</ThemedText>
-          <ThemedText style={[styles.pageSub, { color: mutedColor }]}>
-            {restaurants.length} location{restaurants.length !== 1 ? "s" : ""} configured
-            {restaurants.length > 0 ? " · all active" : ""}
-          </ThemedText>
+      {/* Locations Section */}
+      <View style={styles.section}>
+        <ThemedText style={[styles.sectionHeading, { color: mutedColor }]}>LOCATIONS</ThemedText>
+        <View style={[styles.secCard, { backgroundColor: cardBg, borderColor }]}>
+          <Pressable style={styles.secHeader} onPress={() => setLocationExpanded((v) => !v)}>
+            <View style={[styles.secIcon, { backgroundColor: `${primaryColor}20` }]}>
+              <Ionicons name="storefront-outline" size={20} color={primaryColor} />
+            </View>
+            <View style={{ flex: 1 }}>
+              <ThemedText style={styles.secTitle}>Location Manager</ThemedText>
+              <ThemedText style={[styles.secSub, { color: mutedColor }]}>
+                {restaurants.length === 0
+                  ? "0 locations configured"
+                  : `${restaurants.length} location${restaurants.length !== 1 ? "s" : ""} configured · all active`}
+              </ThemedText>
+            </View>
+            <Ionicons
+              name={locationExpanded ? "chevron-up" : "chevron-down"}
+              size={18}
+              color={mutedColor}
+            />
+          </Pressable>
+
+          {locationExpanded && (
+            <View style={[styles.secForm, { borderTopColor: borderColor, gap: 12 }]}>
+              {restaurants.length > 0 ? (
+                <View style={{ gap: 12 }}>
+                  <LocationPills
+                    restaurants={restaurants}
+                    selectedId={selectedId}
+                    onSelect={setSelectedId}
+                    onAdd={() => setAddingLocation(true)}
+                    primaryColor={primaryColor}
+                    borderColor={borderColor}
+                    mutedColor={mutedColor}
+                    isDark={isDark}
+                  />
+                  {addingLocation && (
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        gap: 10,
+                        padding: 14,
+                        borderWidth: 1,
+                        borderColor,
+                        borderRadius: 14,
+                        backgroundColor: cardBg,
+                      }}
+                    >
+                      <TextInput
+                        value={newLocationName}
+                        onChangeText={setNewLocationName}
+                        placeholder="Location name (e.g. Downtown, Westside)"
+                        placeholderTextColor={mutedColor}
+                        autoFocus
+                        style={{
+                          flex: 1,
+                          fontSize: 14,
+                          color: isDark ? "#fff" : "#000",
+                          borderWidth: 1,
+                          borderColor,
+                          borderRadius: 8,
+                          paddingHorizontal: 12,
+                          paddingVertical: 8,
+                        }}
+                      />
+                      <Pressable
+                        disabled={savingLocation || !newLocationName.trim()}
+                        onPress={async () => {
+                          if (!newLocationName.trim()) return;
+                          setSavingLocation(true);
+                          const created = await createRestaurant(newLocationName.trim());
+                          setSavingLocation(false);
+                          if (created) {
+                            setRestaurants((prev) => [...prev, { ...created, sections: [] }]);
+                            setSelectedId(created.id);
+                          }
+                          setNewLocationName("");
+                          setAddingLocation(false);
+                        }}
+                        style={{
+                          backgroundColor: primaryColor,
+                          borderRadius: 8,
+                          paddingHorizontal: 14,
+                          paddingVertical: 8,
+                        }}
+                      >
+                        <ThemedText style={{ color: "#fff", fontSize: 14, fontWeight: "600" }}>
+                          {savingLocation ? "Adding…" : "Add"}
+                        </ThemedText>
+                      </Pressable>
+                      <Pressable
+                        onPress={
+                          /* istanbul ignore next */ () => {
+                            setAddingLocation(false);
+                            setNewLocationName("");
+                          }
+                        }
+                        style={{ padding: 8 }}
+                      >
+                        <Ionicons name="close-outline" size={20} color={mutedColor} />
+                      </Pressable>
+                    </View>
+                  )}
+                  {selectedRestaurant && (
+                    <View
+                      style={{
+                        borderWidth: 1,
+                        borderColor,
+                        borderRadius: 14,
+                        backgroundColor: cardBg,
+                        overflow: "hidden",
+                      }}
+                    >
+                      <LocationCard
+                        key={selectedRestaurant.id}
+                        restaurant={selectedRestaurant}
+                        onSaved={(patch) => patchRestaurant(selectedRestaurant.id, patch)}
+                        isDark={isDark}
+                        borderColor={borderColor}
+                        mutedColor={mutedColor}
+                        cardBg={cardBg}
+                        confirmAction={confirmAction}
+                      />
+                    </View>
+                  )}
+                </View>
+              ) : (
+                <View style={[styles.emptyCard, { borderColor, backgroundColor: cardBg }]}>
+                  <Ionicons name="storefront-outline" size={32} color={mutedColor} />
+                  <ThemedText style={[styles.emptyText, { color: mutedColor }]}>
+                    No locations found
+                  </ThemedText>
+                </View>
+              )}
+            </View>
+          )}
         </View>
       </View>
 
-      {/* Location pills + content */}
-      {restaurants.length > 0 ? (
-        <View style={{ gap: 12 }}>
-          <LocationPills
-            restaurants={restaurants}
-            selectedId={selectedId}
-            onSelect={setSelectedId}
-            onAdd={() => setAddingLocation(true)}
-            primaryColor={primaryColor}
-            borderColor={borderColor}
-            mutedColor={mutedColor}
-            isDark={isDark}
-          />
-          {addingLocation && (
-            <View
-              style={{
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 10,
-                padding: 14,
-                borderWidth: 1,
-                borderColor,
-                borderRadius: 14,
-                backgroundColor: cardBg,
-              }}
-            >
-              <TextInput
-                value={newLocationName}
-                onChangeText={setNewLocationName}
-                placeholder="Location name (e.g. Downtown, Westside)"
-                placeholderTextColor={mutedColor}
-                autoFocus
-                style={{
-                  flex: 1,
-                  fontSize: 14,
-                  color: isDark ? "#fff" : "#000",
-                  borderWidth: 1,
-                  borderColor,
-                  borderRadius: 8,
-                  paddingHorizontal: 12,
-                  paddingVertical: 8,
-                }}
-              />
-              <Pressable
-                disabled={savingLocation || !newLocationName.trim()}
-                onPress={async () => {
-                  if (!newLocationName.trim()) return;
-                  setSavingLocation(true);
-                  const created = await createRestaurant(newLocationName.trim());
-                  setSavingLocation(false);
-                  if (created) {
-                    setRestaurants((prev) => [...prev, { ...created, sections: [] }]);
-                    setSelectedId(created.id);
-                  }
-                  setNewLocationName("");
-                  setAddingLocation(false);
-                }}
-                style={{
-                  backgroundColor: primaryColor,
-                  borderRadius: 8,
-                  paddingHorizontal: 14,
-                  paddingVertical: 8,
-                }}
-              >
-                <ThemedText style={{ color: "#fff", fontSize: 14, fontWeight: "600" }}>
-                  {savingLocation ? "Adding…" : "Add"}
-                </ThemedText>
-              </Pressable>
-              <Pressable
-                onPress={
-                  /* istanbul ignore next */ () => {
-                    setAddingLocation(false);
-                    setNewLocationName("");
-                  }
-                }
-                style={{ padding: 8 }}
-              >
-                <Ionicons name="close-outline" size={20} color={mutedColor} />
-              </Pressable>
-            </View>
-          )}
-          {selectedRestaurant && (
-            <View
-              style={{
-                borderWidth: 1,
-                borderColor,
-                borderRadius: 14,
-                backgroundColor: cardBg,
-                overflow: "hidden",
-              }}
-            >
-              <LocationCard
-                key={selectedRestaurant.id}
-                restaurant={selectedRestaurant}
-                onSaved={(patch) => patchRestaurant(selectedRestaurant.id, patch)}
-                isDark={isDark}
-                borderColor={borderColor}
-                mutedColor={mutedColor}
-                cardBg={cardBg}
-                confirmAction={confirmAction}
-              />
-            </View>
-          )}
-        </View>
-      ) : (
-        <View style={[styles.emptyCard, { borderColor, backgroundColor: cardBg }]}>
-          <Ionicons name="storefront-outline" size={32} color={mutedColor} />
-          <ThemedText style={[styles.emptyText, { color: mutedColor }]}>
-            No locations found
-          </ThemedText>
-        </View>
-      )}
-
       {/* Global Settings */}
-      <View style={[styles.section, { marginTop: 8 }]}>
+      <View style={styles.section}>
         <ThemedText style={[styles.sectionHeading, { color: mutedColor }]}>
           GLOBAL SETTINGS
         </ThemedText>

--- a/openresto-frontend/components/admin/settings/HighlightsCard.tsx
+++ b/openresto-frontend/components/admin/settings/HighlightsCard.tsx
@@ -249,7 +249,9 @@ export function HighlightsCard({
                         />
                       </View>
                       <View style={{ flex: 1 }}>
-                        <ThemedText style={{ fontSize: 14, fontWeight: "600" }}>{h.title}</ThemedText>
+                        <ThemedText style={{ fontSize: 14, fontWeight: "600" }}>
+                          {h.title}
+                        </ThemedText>
                         <ThemedText style={{ fontSize: 12, color: mutedColor, marginTop: 2 }}>
                           {h.body}
                         </ThemedText>

--- a/openresto-frontend/components/admin/settings/HighlightsCard.tsx
+++ b/openresto-frontend/components/admin/settings/HighlightsCard.tsx
@@ -13,6 +13,7 @@ import {
   adminDeleteHighlight,
   AdminHighlightDto,
 } from "@/api/admin";
+import { styles } from "./settings.styles";
 
 const ICON_OPTIONS = [
   "flame-outline",
@@ -80,6 +81,7 @@ export function HighlightsCard({
   const [editingId, setEditingId] = useState<number | "new" | null>(null);
   const [editState, setEditState] = useState<EditState>(emptyEdit());
   const [saving, setSaving] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     adminGetHighlights().then((data) => {
@@ -140,77 +142,132 @@ export function HighlightsCard({
   };
 
   return (
-    <View
-      style={{
-        backgroundColor: cardBg,
-        borderWidth: 1,
-        borderColor,
-        borderRadius: 14,
-        padding: 22,
-        marginTop: 12,
-      }}
-    >
-      {/* Header */}
-      <View
-        style={{
-          flexDirection: "row",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: 16,
-        }}
-      >
+    <View style={[styles.secCard, { backgroundColor: cardBg, borderColor }]}>
+      <Pressable style={styles.secHeader} onPress={() => setExpanded((v) => !v)}>
+        <View style={[styles.secIcon, { backgroundColor: `${primaryColor}20` }]}>
+          <Ionicons name="sparkles-outline" size={20} color={primaryColor} />
+        </View>
         <View style={{ flex: 1 }}>
-          <ThemedText
-            style={{ fontSize: 16, fontWeight: "600", letterSpacing: -0.2, marginBottom: 4 }}
-          >
-            Highlights
-          </ThemedText>
-          <ThemedText style={{ fontSize: 13, color: mutedColor }}>
-            Shown on the home page. Up to 4 recommended.
+          <ThemedText style={styles.secTitle}>Highlights</ThemedText>
+          <ThemedText style={[styles.secSub, { color: mutedColor }]}>
+            {loading
+              ? "Loading…"
+              : highlights.length > 0
+                ? `${highlights.length} highlight${highlights.length !== 1 ? "s" : ""} · Home page`
+                : "None configured · Home page"}
           </ThemedText>
         </View>
-        <Pressable
-          onPress={startNew}
-          style={{
-            backgroundColor: primaryColor,
-            borderRadius: 10,
-            paddingHorizontal: 14,
-            paddingVertical: 8,
-            flexDirection: "row",
-            alignItems: "center",
-            gap: 6,
-          }}
-        >
-          <Ionicons name="add" size={16} color="#fff" />
-          <ThemedText style={{ fontSize: 13, fontWeight: "600", color: "#fff" }}>Add</ThemedText>
-        </Pressable>
-      </View>
+        <Ionicons name={expanded ? "chevron-up" : "chevron-down"} size={18} color={mutedColor} />
+      </Pressable>
 
-      {loading ? (
-        <ActivityIndicator color={primaryColor} />
-      ) : (
-        <View style={{ gap: 8 }}>
-          {highlights.length === 0 && editingId !== "new" && (
-            <View
-              style={{
-                padding: 20,
-                alignItems: "center",
-                gap: 6,
-                borderWidth: 1,
-                borderColor,
-                borderRadius: 10,
-                borderStyle: "dashed" as const,
-              }}
-            >
-              <Ionicons name="sparkles-outline" size={22} color={mutedColor} />
-              <ThemedText style={{ fontSize: 13, color: mutedColor, textAlign: "center" }}>
-                No highlights yet. Press Add to create your first one.
-              </ThemedText>
-            </View>
-          )}
-          {highlights.map((h) => (
-            <View key={h.id}>
-              {editingId === h.id ? (
+      {expanded && (
+        <View style={[styles.secForm, { borderTopColor: borderColor, gap: 12 }]}>
+          <Pressable
+            onPress={startNew}
+            style={{
+              backgroundColor: primaryColor,
+              borderRadius: 10,
+              paddingHorizontal: 14,
+              paddingVertical: 8,
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              alignSelf: "flex-start",
+            }}
+          >
+            <Ionicons name="add" size={16} color="#fff" />
+            <ThemedText style={{ fontSize: 13, fontWeight: "600", color: "#fff" }}>Add</ThemedText>
+          </Pressable>
+
+          {loading ? (
+            <ActivityIndicator color={primaryColor} />
+          ) : (
+            <View style={{ gap: 8 }}>
+              {highlights.length === 0 && editingId !== "new" && (
+                <View
+                  style={{
+                    padding: 20,
+                    alignItems: "center",
+                    gap: 6,
+                    borderWidth: 1,
+                    borderColor,
+                    borderRadius: 10,
+                    borderStyle: "dashed" as const,
+                  }}
+                >
+                  <Ionicons name="sparkles-outline" size={22} color={mutedColor} />
+                  <ThemedText style={{ fontSize: 13, color: mutedColor, textAlign: "center" }}>
+                    No highlights yet. Press Add to create your first one.
+                  </ThemedText>
+                </View>
+              )}
+              {highlights.map((h) => (
+                <View key={h.id}>
+                  {editingId === h.id ? (
+                    <HighlightEditForm
+                      state={editState}
+                      onChange={setEditState}
+                      onSave={save}
+                      onCancel={cancelEdit}
+                      saving={saving}
+                      primaryColor={primaryColor}
+                      surface2={surface2}
+                      borderColor={borderColor}
+                      mutedColor={mutedColor}
+                      colors={colors}
+                    />
+                  ) : (
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        alignItems: "flex-start",
+                        gap: 12,
+                        padding: 12,
+                        backgroundColor: surface2,
+                        borderWidth: 1,
+                        borderColor,
+                        borderRadius: 10,
+                      }}
+                    >
+                      <View
+                        style={{
+                          width: 36,
+                          height: 36,
+                          borderRadius: 10,
+                          backgroundColor: cardBg,
+                          borderWidth: 1,
+                          borderColor,
+                          alignItems: "center",
+                          justifyContent: "center",
+                          flexShrink: 0,
+                        }}
+                      >
+                        <Ionicons
+                          name={h.iconKey as ComponentProps<typeof Ionicons>["name"]}
+                          size={18}
+                          color={primaryColor}
+                        />
+                      </View>
+                      <View style={{ flex: 1 }}>
+                        <ThemedText style={{ fontSize: 14, fontWeight: "600" }}>{h.title}</ThemedText>
+                        <ThemedText style={{ fontSize: 12, color: mutedColor, marginTop: 2 }}>
+                          {h.body}
+                        </ThemedText>
+                      </View>
+                      <View style={{ flexDirection: "row", gap: 6 }}>
+                        <Pressable onPress={() => startEdit(h)} style={{ padding: 6 }}>
+                          <Ionicons name="pencil-outline" size={16} color={mutedColor} />
+                        </Pressable>
+                        <Pressable onPress={() => remove(h.id)} style={{ padding: 6 }}>
+                          <Ionicons name="trash-outline" size={16} color="#ef4444" />
+                        </Pressable>
+                      </View>
+                    </View>
+                  )}
+                </View>
+              ))}
+
+              {editingId === "new" && (
                 <HighlightEditForm
                   state={editState}
                   onChange={setEditState}
@@ -223,70 +280,8 @@ export function HighlightsCard({
                   mutedColor={mutedColor}
                   colors={colors}
                 />
-              ) : (
-                <View
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "flex-start",
-                    gap: 12,
-                    padding: 12,
-                    backgroundColor: surface2,
-                    borderWidth: 1,
-                    borderColor,
-                    borderRadius: 10,
-                  }}
-                >
-                  <View
-                    style={{
-                      width: 36,
-                      height: 36,
-                      borderRadius: 10,
-                      backgroundColor: cardBg,
-                      borderWidth: 1,
-                      borderColor,
-                      alignItems: "center",
-                      justifyContent: "center",
-                      flexShrink: 0,
-                    }}
-                  >
-                    <Ionicons
-                      name={h.iconKey as ComponentProps<typeof Ionicons>["name"]}
-                      size={18}
-                      color={primaryColor}
-                    />
-                  </View>
-                  <View style={{ flex: 1 }}>
-                    <ThemedText style={{ fontSize: 14, fontWeight: "600" }}>{h.title}</ThemedText>
-                    <ThemedText style={{ fontSize: 12, color: mutedColor, marginTop: 2 }}>
-                      {h.body}
-                    </ThemedText>
-                  </View>
-                  <View style={{ flexDirection: "row", gap: 6 }}>
-                    <Pressable onPress={() => startEdit(h)} style={{ padding: 6 }}>
-                      <Ionicons name="pencil-outline" size={16} color={mutedColor} />
-                    </Pressable>
-                    <Pressable onPress={() => remove(h.id)} style={{ padding: 6 }}>
-                      <Ionicons name="trash-outline" size={16} color="#ef4444" />
-                    </Pressable>
-                  </View>
-                </View>
               )}
             </View>
-          ))}
-
-          {editingId === "new" && (
-            <HighlightEditForm
-              state={editState}
-              onChange={setEditState}
-              onSave={save}
-              onCancel={cancelEdit}
-              saving={saving}
-              primaryColor={primaryColor}
-              surface2={surface2}
-              borderColor={borderColor}
-              mutedColor={mutedColor}
-              colors={colors}
-            />
           )}
         </View>
       )}

--- a/openresto-frontend/components/admin/settings/SecurityCard.tsx
+++ b/openresto-frontend/components/admin/settings/SecurityCard.tsx
@@ -146,7 +146,9 @@ export function SecurityCard({
                   {saving ? "Saving…" : "Save Question"}
                 </Button>
                 <Pressable style={styles.smallBtn} onPress={() => setShowPvqForm(false)}>
-                  <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+                  <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>
+                    Cancel
+                  </ThemedText>
                 </Pressable>
               </View>
             </View>
@@ -215,7 +217,9 @@ export function SecurityCard({
                   {saving ? "Saving…" : "Update Password"}
                 </Button>
                 <Pressable style={styles.smallBtn} onPress={() => setShowPwForm(false)}>
-                  <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+                  <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>
+                    Cancel
+                  </ThemedText>
                 </Pressable>
               </View>
             </View>

--- a/openresto-frontend/components/admin/settings/SecurityCard.tsx
+++ b/openresto-frontend/components/admin/settings/SecurityCard.tsx
@@ -28,6 +28,7 @@ export function SecurityCard({
   const [confirmPw, setConfirmPw] = useState("");
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<{ text: string; ok: boolean } | null>(null);
+  const [expanded, setExpanded] = useState(false);
 
   const brand = useBrand();
   const primaryColor = brand.primaryColor || COLORS.primary;
@@ -73,7 +74,7 @@ export function SecurityCard({
 
   return (
     <View style={[styles.secCard, { backgroundColor: cardBg, borderColor }]}>
-      <View style={styles.secHeader}>
+      <Pressable style={styles.secHeader} onPress={() => setExpanded((v) => !v)}>
         <View style={[styles.secIcon, { backgroundColor: `${primaryColor}14` }]}>
           <Ionicons name="shield-checkmark-outline" size={20} color={primaryColor} />
         </View>
@@ -83,145 +84,150 @@ export function SecurityCard({
             Manage your password and identity verification
           </ThemedText>
         </View>
-      </View>
+        <Ionicons name={expanded ? "chevron-up" : "chevron-down"} size={18} color={mutedColor} />
+      </Pressable>
 
-      {/* PVQ status row */}
-      <View style={[styles.secRow, { borderTopColor: borderColor }]}>
-        <View style={{ flex: 1, gap: 2 }}>
-          <ThemedText style={styles.secRowTitle}>Security Question</ThemedText>
-          {pvqStatus?.isConfigured ? (
-            <ThemedText style={[styles.secRowSub, { color: mutedColor }]} numberOfLines={1}>
-              {pvqStatus.question}
-            </ThemedText>
-          ) : (
-            <ThemedText style={[styles.secRowSub, { color: COLORS.warning }]}>
-              Not configured — set one up to enable password reset
-            </ThemedText>
-          )}
-        </View>
-        <Pressable
-          style={[styles.secBtn, { borderColor }]}
-          onPress={() => {
-            setShowPvqForm((v) => !v);
-            setShowPwForm(false);
-            setMsg(null);
-          }}
-        >
-          <ThemedText style={[styles.secBtnText, { color: primaryColor }]}>
-            {pvqStatus?.isConfigured ? "Change" : "Set up"}
-          </ThemedText>
-        </Pressable>
-      </View>
-
-      {showPvqForm && (
-        <View style={[styles.secForm, { borderTopColor: borderColor }]}>
-          <View style={styles.field}>
-            <ThemedText style={styles.fieldLabel}>Security question</ThemedText>
-            <Input
-              value={pvqQuestion}
-              onChangeText={setPvqQuestion}
-              placeholder="e.g. What was the name of your first pet?"
-            />
-          </View>
-          <View style={styles.field}>
-            <ThemedText style={styles.fieldLabel}>Answer (not case-sensitive)</ThemedText>
-            <Input
-              value={pvqAnswer}
-              onChangeText={setPvqAnswer}
-              placeholder="Your answer"
-              autoCapitalize="none"
-            />
-          </View>
-          {msg && !msg.ok && <ThemedText style={styles.errorText}>{msg.text}</ThemedText>}
-          <View style={{ flexDirection: "row", gap: 8, marginTop: 4 }}>
-            <Button
-              onPress={handleSavePvq}
-              disabled={saving || !pvqQuestion.trim() || !pvqAnswer.trim()}
-              style={{ flex: 1 }}
+      {expanded && (
+        <>
+          {/* PVQ status row */}
+          <View style={[styles.secRow, { borderTopColor: borderColor }]}>
+            <View style={{ flex: 1, gap: 2 }}>
+              <ThemedText style={styles.secRowTitle}>Security Question</ThemedText>
+              {pvqStatus?.isConfigured ? (
+                <ThemedText style={[styles.secRowSub, { color: mutedColor }]} numberOfLines={1}>
+                  {pvqStatus.question}
+                </ThemedText>
+              ) : (
+                <ThemedText style={[styles.secRowSub, { color: COLORS.warning }]}>
+                  Not configured — set one up to enable password reset
+                </ThemedText>
+              )}
+            </View>
+            <Pressable
+              style={[styles.secBtn, { borderColor }]}
+              onPress={() => {
+                setShowPvqForm((v) => !v);
+                setShowPwForm(false);
+                setMsg(null);
+              }}
             >
-              {saving ? "Saving…" : "Save Question"}
-            </Button>
-            <Pressable style={styles.smallBtn} onPress={() => setShowPvqForm(false)}>
-              <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+              <ThemedText style={[styles.secBtnText, { color: primaryColor }]}>
+                {pvqStatus?.isConfigured ? "Change" : "Set up"}
+              </ThemedText>
             </Pressable>
           </View>
-        </View>
-      )}
 
-      {/* Password row */}
-      <View style={[styles.secRow, { borderTopColor: borderColor }]}>
-        <View style={{ flex: 1 }}>
-          <ThemedText style={styles.secRowTitle}>Password</ThemedText>
-          <ThemedText style={[styles.secRowSub, { color: mutedColor }]}>
-            Change your admin password
-          </ThemedText>
-        </View>
-        <Pressable
-          style={[styles.secBtn, { borderColor }]}
-          onPress={() => {
-            setShowPwForm((v) => !v);
-            setShowPvqForm(false);
-            setMsg(null);
-          }}
-        >
-          <ThemedText style={[styles.secBtnText, { color: primaryColor }]}>Change</ThemedText>
-        </Pressable>
-      </View>
-
-      {showPwForm && (
-        <View style={[styles.secForm, { borderTopColor: borderColor }]}>
-          <View style={styles.field}>
-            <ThemedText style={styles.fieldLabel}>Current password</ThemedText>
-            <Input
-              value={currentPw}
-              onChangeText={setCurrentPw}
-              secureTextEntry
-              placeholder="••••••••"
-            />
-          </View>
-          <View style={styles.field}>
-            <ThemedText style={styles.fieldLabel}>New password</ThemedText>
-            <Input
-              value={newPw}
-              onChangeText={setNewPw}
-              secureTextEntry
-              placeholder="At least 6 characters"
-            />
-          </View>
-          <View style={styles.field}>
-            <ThemedText style={styles.fieldLabel}>Confirm new password</ThemedText>
-            <Input
-              value={confirmPw}
-              onChangeText={setConfirmPw}
-              secureTextEntry
-              placeholder="Repeat password"
-            />
-          </View>
-          {msg && (
-            <ThemedText style={msg.ok ? styles.successText : styles.errorText}>
-              {msg.text}
-            </ThemedText>
+          {showPvqForm && (
+            <View style={[styles.secForm, { borderTopColor: borderColor }]}>
+              <View style={styles.field}>
+                <ThemedText style={styles.fieldLabel}>Security question</ThemedText>
+                <Input
+                  value={pvqQuestion}
+                  onChangeText={setPvqQuestion}
+                  placeholder="e.g. What was the name of your first pet?"
+                />
+              </View>
+              <View style={styles.field}>
+                <ThemedText style={styles.fieldLabel}>Answer (not case-sensitive)</ThemedText>
+                <Input
+                  value={pvqAnswer}
+                  onChangeText={setPvqAnswer}
+                  placeholder="Your answer"
+                  autoCapitalize="none"
+                />
+              </View>
+              {msg && !msg.ok && <ThemedText style={styles.errorText}>{msg.text}</ThemedText>}
+              <View style={{ flexDirection: "row", gap: 8, marginTop: 4 }}>
+                <Button
+                  onPress={handleSavePvq}
+                  disabled={saving || !pvqQuestion.trim() || !pvqAnswer.trim()}
+                  style={{ flex: 1 }}
+                >
+                  {saving ? "Saving…" : "Save Question"}
+                </Button>
+                <Pressable style={styles.smallBtn} onPress={() => setShowPvqForm(false)}>
+                  <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+                </Pressable>
+              </View>
+            </View>
           )}
-          <View style={{ flexDirection: "row", gap: 8, marginTop: 4 }}>
-            <Button
-              onPress={handleChangePw}
-              disabled={saving || !currentPw || newPw.length < 6}
-              style={{ flex: 1 }}
+
+          {/* Password row */}
+          <View style={[styles.secRow, { borderTopColor: borderColor }]}>
+            <View style={{ flex: 1 }}>
+              <ThemedText style={styles.secRowTitle}>Password</ThemedText>
+              <ThemedText style={[styles.secRowSub, { color: mutedColor }]}>
+                Change your admin password
+              </ThemedText>
+            </View>
+            <Pressable
+              style={[styles.secBtn, { borderColor }]}
+              onPress={() => {
+                setShowPwForm((v) => !v);
+                setShowPvqForm(false);
+                setMsg(null);
+              }}
             >
-              {saving ? "Saving…" : "Update Password"}
-            </Button>
-            <Pressable style={styles.smallBtn} onPress={() => setShowPwForm(false)}>
-              <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+              <ThemedText style={[styles.secBtnText, { color: primaryColor }]}>Change</ThemedText>
             </Pressable>
           </View>
-        </View>
-      )}
 
-      {msg?.ok && (
-        <View style={styles.successBanner}>
-          <Ionicons name="checkmark-circle-outline" size={16} color="#16a34a" />
-          <ThemedText style={styles.successText}>{msg.text}</ThemedText>
-        </View>
+          {showPwForm && (
+            <View style={[styles.secForm, { borderTopColor: borderColor }]}>
+              <View style={styles.field}>
+                <ThemedText style={styles.fieldLabel}>Current password</ThemedText>
+                <Input
+                  value={currentPw}
+                  onChangeText={setCurrentPw}
+                  secureTextEntry
+                  placeholder="••••••••"
+                />
+              </View>
+              <View style={styles.field}>
+                <ThemedText style={styles.fieldLabel}>New password</ThemedText>
+                <Input
+                  value={newPw}
+                  onChangeText={setNewPw}
+                  secureTextEntry
+                  placeholder="At least 6 characters"
+                />
+              </View>
+              <View style={styles.field}>
+                <ThemedText style={styles.fieldLabel}>Confirm new password</ThemedText>
+                <Input
+                  value={confirmPw}
+                  onChangeText={setConfirmPw}
+                  secureTextEntry
+                  placeholder="Repeat password"
+                />
+              </View>
+              {msg && (
+                <ThemedText style={msg.ok ? styles.successText : styles.errorText}>
+                  {msg.text}
+                </ThemedText>
+              )}
+              <View style={{ flexDirection: "row", gap: 8, marginTop: 4 }}>
+                <Button
+                  onPress={handleChangePw}
+                  disabled={saving || !currentPw || newPw.length < 6}
+                  style={{ flex: 1 }}
+                >
+                  {saving ? "Saving…" : "Update Password"}
+                </Button>
+                <Pressable style={styles.smallBtn} onPress={() => setShowPwForm(false)}>
+                  <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+                </Pressable>
+              </View>
+            </View>
+          )}
+
+          {msg?.ok && (
+            <View style={styles.successBanner}>
+              <Ionicons name="checkmark-circle-outline" size={16} color="#16a34a" />
+              <ThemedText style={styles.successText}>{msg.text}</ThemedText>
+            </View>
+          )}
+        </>
       )}
     </View>
   );

--- a/openresto-frontend/tests/components/admin/settings/HighlightsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/HighlightsCard.test.tsx
@@ -59,8 +59,33 @@ describe("HighlightsCard", () => {
     });
   });
 
-  it("shows Add button", async () => {
+  it("renders collapsed by default (no Add button visible)", async () => {
     render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Highlights")).toBeTruthy());
+    expect(screen.queryByText("Add")).toBeNull();
+  });
+
+  it("expands when header is pressed", async () => {
+    render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
+    await waitFor(() => {
+      expect(screen.getByText("Add")).toBeTruthy();
+    });
+  });
+
+  it("collapses when header is pressed again", async () => {
+    render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Highlights"));
+    await waitFor(() => {
+      expect(screen.queryByText("Add")).toBeNull();
+    });
+  });
+
+  it("shows Add button when expanded", async () => {
+    render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => {
       expect(screen.getByText("Add")).toBeTruthy();
     });
@@ -68,6 +93,7 @@ describe("HighlightsCard", () => {
 
   it("shows empty state when no highlights", async () => {
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => {
       expect(screen.getByText(/No highlights yet/)).toBeTruthy();
     });
@@ -76,14 +102,24 @@ describe("HighlightsCard", () => {
   it("shows highlights list when highlights are loaded", async () => {
     (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue(mockHighlights);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => {
       expect(screen.getByText("Great Food")).toBeTruthy();
       expect(screen.getByText("Live Music")).toBeTruthy();
     });
   });
 
+  it("shows highlight count in subtitle when loaded", async () => {
+    (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue(mockHighlights);
+    render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText(/2 highlights · Home page/)).toBeTruthy();
+    });
+  });
+
   it("opens new highlight form when Add is pressed", async () => {
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
     await waitFor(() => {
@@ -93,6 +129,7 @@ describe("HighlightsCard", () => {
 
   it("cancels new form when Cancel is pressed", async () => {
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
     await waitFor(() => expect(screen.getByText("Cancel")).toBeTruthy());
@@ -106,6 +143,7 @@ describe("HighlightsCard", () => {
     const created = { id: 3, title: "New", body: "", iconKey: "star-outline", sortOrder: 0 };
     (adminApi.adminCreateHighlight as jest.Mock).mockResolvedValue(created);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
     await waitFor(() =>
@@ -122,6 +160,7 @@ describe("HighlightsCard", () => {
 
   it("does not call adminCreateHighlight when title is empty", async () => {
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
     await waitFor(() => expect(screen.getByText("Save")).toBeTruthy());
@@ -135,11 +174,12 @@ describe("HighlightsCard", () => {
     (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue(mockHighlights);
     (adminApi.adminDeleteHighlight as jest.Mock).mockResolvedValue(true);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Great Food")).toBeTruthy());
-    // Layout: Add[0,1], GreatFood-edit[2,3], GreatFood-delete[4,5], LiveMusic-edit[6,7], LiveMusic-delete[8,9]
+    // Layout: Header[0,1], Add[2,3], GreatFood-edit[4,5], GreatFood-delete[6,7], LiveMusic-edit[8,9], LiveMusic-delete[10,11]
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
     await act(async () => {
-      fireEvent.press(accessible[4]);
+      fireEvent.press(accessible[6]);
     });
     expect(adminApi.adminDeleteHighlight).toHaveBeenCalledWith(1);
   });
@@ -148,10 +188,12 @@ describe("HighlightsCard", () => {
     (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue([mockHighlights[0]]);
     (adminApi.adminDeleteHighlight as jest.Mock).mockResolvedValue(false);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Great Food")).toBeTruthy());
+    // Layout: Header[0,1], Add[2,3], GreatFood-edit[4,5], GreatFood-delete[6,7]
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
     await act(async () => {
-      fireEvent.press(accessible[4]);
+      fireEvent.press(accessible[6]);
     });
     expect(screen.getByText("Great Food")).toBeTruthy();
   });
@@ -159,10 +201,11 @@ describe("HighlightsCard", () => {
   it("opens edit form when pencil is pressed on existing highlight", async () => {
     (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue([mockHighlights[0]]);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Great Food")).toBeTruthy());
-    // accessible[2] = pencil edit button for first highlight
+    // Layout: Header[0,1], Add[2,3], GreatFood-edit[4,5], GreatFood-delete[6,7]
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
-    fireEvent.press(accessible[2]);
+    fireEvent.press(accessible[4]);
     await waitFor(() => {
       expect(screen.getByDisplayValue("Great Food")).toBeTruthy();
     });
@@ -173,9 +216,10 @@ describe("HighlightsCard", () => {
     (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue([mockHighlights[0]]);
     (adminApi.adminUpdateHighlight as jest.Mock).mockResolvedValue(updated);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Great Food")).toBeTruthy());
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
-    fireEvent.press(accessible[2]);
+    fireEvent.press(accessible[4]);
     await waitFor(() => expect(screen.getByDisplayValue("Great Food")).toBeTruthy());
     fireEvent.changeText(screen.getByDisplayValue("Great Food"), "Amazing Food");
     await act(async () => {
@@ -191,9 +235,10 @@ describe("HighlightsCard", () => {
     (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue([mockHighlights[0]]);
     (adminApi.adminUpdateHighlight as jest.Mock).mockResolvedValue(null);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Great Food")).toBeTruthy());
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
-    fireEvent.press(accessible[2]);
+    fireEvent.press(accessible[4]);
     await waitFor(() => expect(screen.getByDisplayValue("Great Food")).toBeTruthy());
     fireEvent.changeText(screen.getByDisplayValue("Great Food"), "New Title");
     await act(async () => {
@@ -205,6 +250,7 @@ describe("HighlightsCard", () => {
   it("does not add to list when adminCreateHighlight returns null", async () => {
     (adminApi.adminCreateHighlight as jest.Mock).mockResolvedValue(null);
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
     await waitFor(() =>
@@ -220,15 +266,15 @@ describe("HighlightsCard", () => {
 
   it("changes icon when an icon option is pressed", async () => {
     render(<HighlightsCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Highlights"));
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
     await waitFor(() =>
       expect(screen.getByPlaceholderText("e.g. Wood-fired kitchen")).toBeTruthy()
     );
-    // Icon picker options are rendered as Pressables — press the first accessible one after the cancel/save row
+    // Press the last accessible element — the icon pickers are the last rendered Pressables
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
-    // accessible[0] = Cancel, accessible[1] = Save (disabled), accessible[2..N] = icon pickers
-    fireEvent.press(accessible[2]);
+    fireEvent.press(accessible[accessible.length - 1]);
     expect(screen.getByPlaceholderText("e.g. Wood-fired kitchen")).toBeTruthy();
   });
 });

--- a/openresto-frontend/tests/components/admin/settings/SecurityCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/SecurityCard.test.tsx
@@ -41,9 +41,36 @@ describe("SecurityCard", () => {
     });
   });
 
+  it("renders collapsed by default (no rows visible)", async () => {
+    render(<SecurityCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Account Security")).toBeTruthy());
+    expect(screen.queryByText("Security Question")).toBeNull();
+    expect(screen.queryByText("Password")).toBeNull();
+  });
+
+  it("expands when header is pressed", async () => {
+    render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
+    await waitFor(() => {
+      expect(screen.getByText("Security Question")).toBeTruthy();
+      expect(screen.getByText("Password")).toBeTruthy();
+    });
+  });
+
+  it("collapses when header is pressed again", async () => {
+    render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
+    await waitFor(() => expect(screen.getByText("Security Question")).toBeTruthy());
+    fireEvent.press(screen.getByText("Account Security"));
+    await waitFor(() => {
+      expect(screen.queryByText("Security Question")).toBeNull();
+    });
+  });
+
   it("shows 'Not configured' when PVQ status is null", async () => {
     (authApi.getPvqStatus as jest.Mock).mockResolvedValue(null);
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => {
       expect(screen.getByText(/Not configured — set one up to enable password reset/)).toBeTruthy();
     });
@@ -55,6 +82,7 @@ describe("SecurityCard", () => {
       question: "What is your pet's name?",
     });
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => {
       expect(screen.getByText("What is your pet's name?")).toBeTruthy();
     });
@@ -62,6 +90,7 @@ describe("SecurityCard", () => {
 
   it("shows 'Set up' button when PVQ not configured", async () => {
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => {
       expect(screen.getByText("Set up")).toBeTruthy();
     });
@@ -73,6 +102,7 @@ describe("SecurityCard", () => {
       question: "My question",
     });
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => {
       expect(screen.getAllByText("Change").length).toBeGreaterThanOrEqual(1);
     });
@@ -80,6 +110,7 @@ describe("SecurityCard", () => {
 
   it("opens PVQ form when Set up is pressed", async () => {
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Set up")).toBeTruthy());
     fireEvent.press(screen.getByText("Set up"));
     expect(screen.getByText("Security question")).toBeTruthy();
@@ -88,6 +119,7 @@ describe("SecurityCard", () => {
 
   it("closes PVQ form when Cancel is pressed", async () => {
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Set up")).toBeTruthy());
     fireEvent.press(screen.getByText("Set up"));
     expect(screen.getByText("Security question")).toBeTruthy();
@@ -98,6 +130,7 @@ describe("SecurityCard", () => {
   it("calls setupPvq with question and answer on save", async () => {
     (authApi.setupPvq as jest.Mock).mockResolvedValue({ ok: true, message: "Saved." });
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Set up")).toBeTruthy());
     fireEvent.press(screen.getByText("Set up"));
     fireEvent.changeText(
@@ -113,6 +146,7 @@ describe("SecurityCard", () => {
 
   it("does not call setupPvq when question is empty", async () => {
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Set up")).toBeTruthy());
     fireEvent.press(screen.getByText("Set up"));
     fireEvent.changeText(screen.getByPlaceholderText("Your answer"), "some answer");
@@ -125,6 +159,7 @@ describe("SecurityCard", () => {
 
   it("opens password form when Change password is pressed", async () => {
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Change your admin password")).toBeTruthy());
     // Find the Change button for password (second Change button or the one in the password row)
     const changeBtns = screen.queryAllByText("Change");
@@ -140,6 +175,7 @@ describe("SecurityCard", () => {
 
   it("shows password mismatch error", async () => {
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Change your admin password")).toBeTruthy());
     const changeBtns = screen.queryAllByText("Change");
     fireEvent.press(changeBtns[changeBtns.length - 1]);
@@ -157,6 +193,7 @@ describe("SecurityCard", () => {
     // The button is disabled when newPw.length < 6 — the inline length check in handleChangePw
     // is defensive but unreachable via UI since the button never enables below 6 chars.
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Change your admin password")).toBeTruthy());
     const changeBtns = screen.queryAllByText("Change");
     fireEvent.press(changeBtns[changeBtns.length - 1]);
@@ -173,6 +210,7 @@ describe("SecurityCard", () => {
       message: "Password updated.",
     });
     render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
     await waitFor(() => expect(screen.getByText("Change your admin password")).toBeTruthy());
     const changeBtns = screen.queryAllByText("Change");
     fireEvent.press(changeBtns[changeBtns.length - 1]);


### PR DESCRIPTION
Make Location Manager, Highlights, and Account Security settings sections collapsible similar to Brand Identity.

- HighlightsCard: restructured to secCard/secHeader pattern with expand/collapse toggle and count subtitle
- SecurityCard: header converted to collapsible Pressable with chevron
- settings.tsx: location manager wrapped in collapsible card (defaults expanded); page header replaced with LOCATIONS section label

Closes #102

Generated with [Claude Code](https://claude.ai/code)