### PR TITLE
Improve legibility of hero highlights label and byline

### DIFF
--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -121,7 +121,8 @@ export default function HomeScreen() {
               <ThemedText
                 style={[
                   styles.highlightsLabel,
-                  { color: hasHero ? "rgba(255,255,255,0.75)" : mutedColor },
+                  { color: hasHero ? "rgba(255,255,255,0.92)" : mutedColor },
+                  hasHero && ({ textShadow: heroTextShadow } as object),
                 ]}
               >
                 Restaurant highlights
@@ -129,7 +130,8 @@ export default function HomeScreen() {
               <ThemedText
                 style={[
                   styles.highlightsBy,
-                  { color: hasHero ? "rgba(255,255,255,0.65)" : mutedColor },
+                  { color: hasHero ? "rgba(255,255,255,0.82)" : mutedColor },
+                  hasHero && ({ textShadow: heroTextShadow } as object),
                 ]}
               >
                 Curated by the owner

--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -254,6 +254,7 @@ const styles = StyleSheet.create({
   },
   heroSub: {
     fontSize: 17,
+    fontWeight: "500",
     lineHeight: 26,
     maxWidth: 500,
   },
@@ -281,6 +282,7 @@ const styles = StyleSheet.create({
   },
   highlightsBy: {
     fontSize: 12,
+    fontWeight: "500",
   },
   highlightsGrid: {
     gap: 12,


### PR DESCRIPTION
## Summary

- "Restaurant highlights" opacity: `0.75` → `0.92`
- "Curated by the owner" opacity: `0.65` → `0.82`
- Both now get the same layered `textShadow` applied to the title and subtitle

These are 12–13 px elements with no previous shadow, making them the hardest text to read over a photo background. The opacity/shadow values mirror the subtitle treatment, which is visually consistent.

https://claude.ai/code/session_01T9KziL4DhyxUb23TtjZTsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9KziL4DhyxUb23TtjZTsp)_