### PR TITLE
fix: widen TIME column in admin bookings list to prevent overflow

### DIFF
--- a/openresto-frontend/components/admin/bookings/bookings.styles.ts
+++ b/openresto-frontend/components/admin/bookings/bookings.styles.ts
@@ -109,7 +109,7 @@ export const styles = StyleSheet.create({
     paddingHorizontal: SPACING.lg,
     paddingVertical: 14,
   },
-  colTime: { width: 88 },
+  colTime: { width: 140 },
   colGuest: { flex: 1, paddingHorizontal: SPACING.sm },
   colParty: { width: 64, alignItems: "flex-start" },
   colTable: { width: 64 },


### PR DESCRIPTION
Fixes #113

The TIME column in the admin bookings list view was too narrow (88px) to fit the avatar + gap + time text, causing the time to overflow and visually overlap with the GUEST column. Increased `colTime` width to 140px.

Generated with [Claude Code](https://claude.ai/code)