### PR TITLE
test: achieve higher unit test coverage (batch 2 of 5 files)

### DIFF
--- a/openresto-frontend/tests/app/(admin)/dashboard.test.tsx
+++ b/openresto-frontend/tests/app/(admin)/dashboard.test.tsx
@@ -17,17 +17,57 @@ global.fetch = jest.fn(() =>
 ) as jest.Mock;
 
 jest.mock("@/api/admin");
-jest.mock("@/components/admin/bookings/RestaurantActionModal", () => ({
-  __esModule: true,
-  default: () => null,
-}));
-jest.mock("@/components/admin/bookings/BookingDetailPopup", () => ({
-  BookingDetailPopup: () => null,
-}));
-jest.mock("@/components/common/AlertModal", () => ({
-  __esModule: true,
-  default: () => null,
-}));
+jest.mock("@/components/admin/bookings/RestaurantActionModal", () => {
+  const { View, Pressable, Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ visible, onClose, onSuccess }: any) => {
+      if (!visible) return null;
+      return (
+        <View testID="action-modal">
+          <Pressable testID="action-modal-close" onPress={onClose}>
+            <Text>Close Action Modal</Text>
+          </Pressable>
+          <Pressable testID="action-modal-success" onPress={() => onSuccess("Action succeeded")}>
+            <Text>Action Done</Text>
+          </Pressable>
+        </View>
+      );
+    },
+  };
+});
+jest.mock("@/components/admin/bookings/BookingDetailPopup", () => {
+  const { View, Pressable, Text } = require("react-native");
+  return {
+    BookingDetailPopup: ({ bookingId, onClose }: any) => {
+      if (!bookingId) return null;
+      return (
+        <View testID="booking-detail-popup">
+          <Pressable testID="booking-popup-close" onPress={onClose}>
+            <Text>Close Popup</Text>
+          </Pressable>
+        </View>
+      );
+    },
+  };
+});
+jest.mock("@/components/common/AlertModal", () => {
+  const { View, Pressable, Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ visible, onClose, message }: any) => {
+      if (!visible) return null;
+      return (
+        <View testID="alert-modal">
+          <Text>{message}</Text>
+          <Pressable testID="alert-modal-close" onPress={onClose}>
+            <Text>Close Alert</Text>
+          </Pressable>
+        </View>
+      );
+    },
+  };
+});
 const mockPush = jest.fn();
 jest.mock("expo-router", () => ({
   useRouter: () => ({ push: mockPush }),
@@ -272,5 +312,47 @@ describe("AdminDashboardScreen", () => {
     const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
 
     await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+  });
+
+  it("calls RestaurantActionModal onClose callback (line 239)", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+    await waitFor(() => screen.getByText("Pause Bookings"));
+    fireEvent.press(screen.getByText("Pause Bookings"));
+    await waitFor(() => expect(screen.getByTestId("action-modal")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("action-modal-close"));
+    await waitFor(() => expect(screen.queryByTestId("action-modal")).toBeNull());
+  });
+
+  it("calls RestaurantActionModal onSuccess callback (lines 241-242)", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+    await waitFor(() => screen.getByText("Pause Bookings"));
+    fireEvent.press(screen.getByText("Pause Bookings"));
+    await waitFor(() => expect(screen.getByTestId("action-modal")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("action-modal-success"));
+    await waitFor(() => expect(screen.getByTestId("alert-modal")).toBeTruthy());
+    expect(screen.getByText("Action succeeded")).toBeTruthy();
+  });
+
+  it("calls AlertModal onClose callback (line 250)", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+    fireEvent.press(screen.getByText("Pause Bookings"));
+    await waitFor(() => expect(screen.getByTestId("action-modal")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("action-modal-success"));
+    await waitFor(() => expect(screen.getByTestId("alert-modal")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("alert-modal-close"));
+    await waitFor(() => expect(screen.queryByTestId("alert-modal")).toBeNull());
+  });
+
+  it("calls BookingDetailPopup onClose callback (line 255)", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+    await waitFor(() => screen.getByText("today@test.com"));
+    fireEvent.press(screen.getByText("today@test.com"));
+    await waitFor(() => expect(screen.getByTestId("booking-detail-popup")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("booking-popup-close"));
+    await waitFor(() => expect(screen.queryByTestId("booking-detail-popup")).toBeNull());
   });
 });

--- a/openresto-frontend/tests/components/Select.test.tsx
+++ b/openresto-frontend/tests/components/Select.test.tsx
@@ -50,4 +50,11 @@ describe("Select", () => {
     expect(screen.getByText("Option 1")).toBeTruthy();
     jest.dontMock("@/hooks/use-color-scheme");
   });
+
+  it("shows checkmark on selected item inside modal", () => {
+    render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
+    fireEvent.press(screen.getByText("Option 1"));
+    // Inside the modal, the selected item shows a checkmark
+    expect(screen.getByText("✓")).toBeTruthy();
+  });
 });

--- a/openresto-frontend/tests/components/TimePicker.web.test.tsx
+++ b/openresto-frontend/tests/components/TimePicker.web.test.tsx
@@ -39,4 +39,37 @@ describe("TimePicker Web", () => {
     fireEvent(input, "blur");
     expect(wrapper).toBeTruthy();
   });
+
+  it("clamps value below minTime to minTime", () => {
+    const localSelect = jest.fn();
+    const { getByTestId } = render(
+      <TimePickerWeb onSelect={localSelect} minTime="12:00" maxTime="22:00" />
+    );
+    const wrapper = getByTestId("time-picker-web");
+    const input = (wrapper as any).children[0];
+    // 08:00 is before minTime 12:00, so should be clamped to 12:00
+    fireEvent(input, "change", { target: { value: "08:00" } });
+    expect(localSelect).toHaveBeenCalledWith("12:00");
+  });
+
+  it("clamps value above maxTime to maxTime", () => {
+    const localSelect = jest.fn();
+    const { getByTestId } = render(
+      <TimePickerWeb onSelect={localSelect} minTime="09:00" maxTime="18:00" />
+    );
+    const wrapper = getByTestId("time-picker-web");
+    const input = (wrapper as any).children[0];
+    // 22:00 is after maxTime 18:00, so should be clamped to 18:00
+    fireEvent(input, "change", { target: { value: "22:00" } });
+    expect(localSelect).toHaveBeenCalledWith("18:00");
+  });
+
+  it("does not call onSelect when value is empty (early return)", () => {
+    const localSelect = jest.fn();
+    const { getByTestId } = render(<TimePickerWeb onSelect={localSelect} />);
+    const wrapper = getByTestId("time-picker-web");
+    const input = (wrapper as any).children[0];
+    fireEvent(input, "change", { target: { value: "" } });
+    expect(localSelect).not.toHaveBeenCalled();
+  });
 });

--- a/openresto-frontend/tests/components/admin/settings/SecurityCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/SecurityCard.test.tsx
@@ -204,6 +204,40 @@ describe("SecurityCard", () => {
     expect(authApi.changePassword).not.toHaveBeenCalled();
   });
 
+  it("closes password form when Cancel is pressed", async () => {
+    render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
+    await waitFor(() => expect(screen.getByText("Change your admin password")).toBeTruthy());
+    const changeBtns = screen.queryAllByText("Change");
+    fireEvent.press(changeBtns[changeBtns.length - 1]);
+    await waitFor(() => expect(screen.getByText("Current password")).toBeTruthy());
+    // Press Cancel in the password form
+    const cancelBtns = screen.queryAllByText("Cancel");
+    fireEvent.press(cancelBtns[cancelBtns.length - 1]);
+    await waitFor(() => expect(screen.queryByText("Current password")).toBeNull());
+  });
+
+  it("shows error when setupPvq fails", async () => {
+    (authApi.setupPvq as jest.Mock).mockResolvedValue({
+      ok: false,
+      message: "Failed to save question.",
+    });
+    render(<SecurityCard {...baseProps} />);
+    fireEvent.press(screen.getByText("Account Security"));
+    await waitFor(() => expect(screen.getByText("Set up")).toBeTruthy());
+    fireEvent.press(screen.getByText("Set up"));
+    fireEvent.changeText(
+      screen.getByPlaceholderText("e.g. What was the name of your first pet?"),
+      "My question?"
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("Your answer"), "my answer");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save Question"));
+    });
+    await waitFor(() => expect(screen.getByText("Failed to save question.")).toBeTruthy());
+    expect(authApi.setupPvq).toHaveBeenCalledWith("My question?", "my answer");
+  });
+
   it("calls changePassword and clears form on success", async () => {
     (authApi.changePassword as jest.Mock).mockResolvedValue({
       ok: true,

--- a/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
@@ -161,6 +161,21 @@ describe("TableRow", () => {
     expect(screen.getByText("T1")).toBeTruthy();
   });
 
+  it("renders tableIcon with seats=1 (person-outline branch)", () => {
+    render(<TableRow {...baseProps} table={{ ...baseTable, seats: 1 }} />);
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("renders tableIcon with seats=8 (apps-outline branch)", () => {
+    render(<TableRow {...baseProps} table={{ ...baseTable, seats: 8 }} />);
+    expect(screen.getByText("8")).toBeTruthy();
+  });
+
+  it("renders tableIcon with seats=10 (albums-outline branch)", () => {
+    render(<TableRow {...baseProps} table={{ ...baseTable, seats: 10 }} />);
+    expect(screen.getByText("10")).toBeTruthy();
+  });
+
   it("shows saving state while updating", async () => {
     let resolve: (v: typeof baseTable | null) => void;
     (restaurantsApi.updateTable as jest.Mock).mockReturnValue(


### PR DESCRIPTION
## Summary

- **dashboard.tsx**: 89.79% → 100% statements — updated mocks for `RestaurantActionModal`, `AlertModal`, and `BookingDetailPopup` to expose `onClose`/`onSuccess` callbacks via test buttons; added 4 tests that exercise those callback paths
- **TableRow.tsx**: 87.8% → 97.56% — added 3 tests covering `tableIcon()` branches for seats=1 (`person-outline`), seats=8 (`apps-outline`), seats=10 (`albums-outline`)
- **TimePicker.web.tsx**: 88.46% → 100% — added 3 tests exercising `clampTime` min-clamp, max-clamp, and `handleChange` empty-value early return
- **SecurityCard.tsx**: 92.85% → 94.64% — added "Cancel password form" and "setupPvq failure" tests
- **Select.tsx**: added checkmark rendering test (the `onRequestClose`/backdrop `onPress` callbacks remain uncovered as their `/* istanbul ignore next */` comments don't apply in JSX prop context)

+13 new tests (77 tests pass, all passing)

## Test plan

- [ ] `npm test -- --testPathPattern="(TimePicker.web|Select.test|SecurityCard|TableRow|dashboard)"` — all 77 tests pass
- [ ] `npx prettier --check` passes on all 5 files
- [ ] No regressions in the full test suite

https://claude.ai/code/session_01Jc47YDSUoTRGSTSTiAhVbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc47YDSUoTRGSTSTiAhVbq)_