### PR TITLE
Add frosted glass pill behind hero title and subtitle

### DIFF
--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -94,25 +94,36 @@ export default function HomeScreen() {
             />
           )}
           <View style={[styles.heroInner, isMobile && { paddingHorizontal: 20 }]}>
-            <ThemedText
+            <View
               style={[
-                styles.heroTitle,
-                isMobile && { fontSize: 40, lineHeight: 44 },
-                hasHero && ({ color: "#ffffff", textShadow: heroTextShadow } as object),
+                styles.heroTextPill,
+                hasHero &&
+                  ({
+                    borderRadius: 16,
+                    paddingHorizontal: 24,
+                    paddingVertical: 20,
+                    backdropFilter: "blur(12px)",
+                    WebkitBackdropFilter: "blur(12px)",
+                    background: "rgba(0,0,0,0.22)",
+                  } as object),
               ]}
             >
-              {brand.appName}
-            </ThemedText>
-            <ThemedText
-              style={[
-                styles.heroSub,
-                { color: hasHero ? "rgba(255,255,255,0.82)" : mutedColor },
-                hasHero && ({ textShadow: heroTextShadow } as object),
-              ]}
-            >
-              Scroll down to pick a location below, choose a time, enter your email address, and
-              you're booked!
-            </ThemedText>
+              <ThemedText
+                style={[
+                  styles.heroTitle,
+                  isMobile && { fontSize: 40, lineHeight: 44 },
+                  hasHero && { color: "#ffffff" },
+                ]}
+              >
+                {brand.appName}
+              </ThemedText>
+              <ThemedText
+                style={[styles.heroSub, { color: hasHero ? "rgba(255,255,255,0.90)" : mutedColor }]}
+              >
+                Scroll down to pick a location below, choose a time, enter your email address, and
+                you're booked!
+              </ThemedText>
+            </View>
           </View>
 
           {/* ── Highlights ── */}
@@ -243,6 +254,9 @@ const styles = StyleSheet.create({
     paddingTop: 56,
     paddingBottom: 28,
     position: "relative",
+  },
+  heroTextPill: {
+    alignSelf: "flex-start",
   },
   heroTitle: {
     fontSize: 64,

--- a/openresto-frontend/tests/app/index.test.tsx
+++ b/openresto-frontend/tests/app/index.test.tsx
@@ -3,6 +3,7 @@
  */
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react-native";
+import { Platform } from "react-native";
 import HomeScreen from "@/app/index";
 import { fetchRestaurants, fetchHighlights } from "@/api/restaurants";
 import { BrandProvider } from "@/context/BrandContext";
@@ -127,6 +128,9 @@ describe("HomeScreen", () => {
   });
 
   it("renders hero image overlay when headerImageUrl is set", async () => {
+    const originalOS = Platform.OS;
+    (Platform as unknown as { OS: string }).OS = "web";
+
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: () =>
@@ -138,7 +142,9 @@ describe("HomeScreen", () => {
     });
 
     renderWithProviders(<HomeScreen />);
-    // Wait until the brand with headerImageUrl has been applied — this exercises the scrim overlay code path
+    // Wait for the brand with headerImageUrl to apply — exercises hasHero=true code paths
     await waitFor(() => expect(screen.getAllByText("Hero Brand").length).toBeGreaterThan(0));
+
+    (Platform as unknown as { OS: string }).OS = originalOS;
   });
 });


### PR DESCRIPTION
## Summary

- Wraps the hero title + subtitle in a `View` with `backdrop-filter: blur(12px)` and `rgba(0,0,0,0.22)` background when a hero image is present
- Includes `-webkit-backdrop-filter` for Safari compatibility
- Pill only activates when `hasHero` is true — no visual change on the no-image gradient background
- Text shadows removed from title and subtitle (redundant inside the pill); highlights label and byline keep their shadows since they're still directly over the image
- Subtitle opacity bumped to `0.90` (was `0.82`) since the frosted background handles contrast

## Why

Bright restaurant photos were causing contrast issues regardless of scrim opacity. A localised frosted pill guarantees legibility on any photo — light, dark, or colourful — without darkening the image globally.

## Test plan

- [ ] Upload a bright/light hero image and confirm title + subtitle are readable
- [ ] Upload a dark hero image and confirm the pill doesn't look washed out
- [ ] Verify no pill/box appears when no header image is set
- [ ] Check on mobile viewport that the pill wraps naturally

https://claude.ai/code/session_01T9KziL4DhyxUb23TtjZTsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9KziL4DhyxUb23TtjZTsp)_