### PR TITLE
Replace frosted glass pill with themed surface box on hero

### DIFF
--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -97,29 +97,19 @@ export default function HomeScreen() {
             <View
               style={[
                 styles.heroTextPill,
-                hasHero &&
-                  ({
-                    borderRadius: 16,
-                    paddingHorizontal: 24,
-                    paddingVertical: 20,
-                    backdropFilter: "blur(12px)",
-                    WebkitBackdropFilter: "blur(12px)",
-                    background: "rgba(0,0,0,0.22)",
-                  } as object),
+                hasHero && {
+                  backgroundColor: surface,
+                  borderColor: border,
+                  borderRadius: 12,
+                  borderWidth: 1,
+                  padding: 16,
+                },
               ]}
             >
-              <ThemedText
-                style={[
-                  styles.heroTitle,
-                  isMobile && { fontSize: 40, lineHeight: 44 },
-                  hasHero && { color: "#ffffff" },
-                ]}
-              >
+              <ThemedText style={[styles.heroTitle, isMobile && { fontSize: 40, lineHeight: 44 }]}>
                 {brand.appName}
               </ThemedText>
-              <ThemedText
-                style={[styles.heroSub, { color: hasHero ? "rgba(255,255,255,0.90)" : mutedColor }]}
-              >
+              <ThemedText style={[styles.heroSub, { color: mutedColor }]}>
                 Scroll down to pick a location below, choose a time, enter your email address, and
                 you're booked!
               </ThemedText>


### PR DESCRIPTION
## Summary

- Replaces the `backdrop-filter` frosted glass container with a solid themed box matching the highlight cards exactly: `backgroundColor: surface`, `borderColor: border`, `borderRadius: 12`, `borderWidth: 1`, `padding: 16`
- Text colors revert to normal theme values — no longer forced white, since the box provides its own solid background
- The gradient scrim remains for the highlights label/byline area which is still directly over the image

https://claude.ai/code/session_01T9KziL4DhyxUb23TtjZTsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9KziL4DhyxUb23TtjZTsp)_