### PR TITLE
feat: scroll-to-top on Home button + portrait mobile FAB

### DIFF
--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -1,15 +1,17 @@
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { fetchRestaurants, fetchHighlights, RestaurantDto, HighlightDto } from "@/api/restaurants";
-import { useEffect, useState, type ComponentProps } from "react";
+import { useEffect, useState, useRef, useCallback, type ComponentProps } from "react";
 import {
   ActivityIndicator,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   useWindowDimensions,
   View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
 import Navbar from "@/components/layout/Navbar";
 import RestaurantCard from "@/components/restaurant/RestaurantCard";
@@ -20,10 +22,19 @@ export default function HomeScreen() {
   const [restaurants, setRestaurants] = useState<RestaurantDto[]>([]);
   const [highlights, setHighlights] = useState<HighlightDto[]>([]);
   const [loading, setLoading] = useState(true);
-  const { width } = useWindowDimensions();
+  const [scrollY, setScrollY] = useState(0);
+  const { width, height } = useWindowDimensions();
   const { brand, colors, primaryColor, isDark } = useAppTheme();
+  const insets = useSafeAreaInsets();
+  const scrollRef = useRef<ScrollView>(null);
 
   const isMobile = width < 700;
+  const isPortrait = height > width;
+  const showFab = isMobile && isPortrait && scrollY > 300;
+
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+  }, []);
   const party = 2;
 
   useEffect(() => {
@@ -53,12 +64,15 @@ export default function HomeScreen() {
   return (
     <ThemedView style={[styles.root, { backgroundColor: bg }]}>
       {Platform.OS !== "web" && <Stack.Screen options={{ title: brand.appName }} />}
-      <Navbar />
+      <Navbar onScrollToTop={scrollToTop} />
 
       <ScrollView
+        ref={scrollRef}
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        scrollEventThrottle={100}
       >
         {/* ── Hero ── */}
         <View
@@ -221,6 +235,17 @@ export default function HomeScreen() {
           )}
         </View>
       </ScrollView>
+
+      {showFab && (
+        <Pressable
+          style={[styles.fab, { backgroundColor: primaryColor, bottom: insets.bottom + 20 }]}
+          onPress={scrollToTop}
+          accessibilityLabel="Scroll to top"
+          accessibilityRole="button"
+        >
+          <Ionicons name="chevron-up" size={22} color="#fff" />
+        </Pressable>
+      )}
     </ThemedView>
   );
 }
@@ -348,6 +373,20 @@ const styles = StyleSheet.create({
   },
   spinner: {
     marginTop: 60,
+  },
+  fab: {
+    position: "absolute",
+    right: 20,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 6,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.18,
+    shadowRadius: 8,
   },
 
   // Footer

--- a/openresto-frontend/components/layout/Navbar.tsx
+++ b/openresto-frontend/components/layout/Navbar.tsx
@@ -34,7 +34,11 @@ const NAV_LINKS = [
 
 const NAV_HEIGHT = 64;
 
-export default function Navbar() {
+interface NavbarProps {
+  onScrollToTop?: () => void;
+}
+
+export default function Navbar({ onScrollToTop }: NavbarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { toggle } = useTheme();
@@ -76,8 +80,8 @@ export default function Navbar() {
             </Pressable>
           )}
 
-          <Link href="/" asChild>
-            <Pressable style={styles.brand}>
+          {pathname === "/" && onScrollToTop ? (
+            <Pressable style={styles.brand} onPress={onScrollToTop}>
               <ThemedText
                 style={[styles.brandText, { color: primaryColor }, isTiny && { fontSize: 18 }]}
                 numberOfLines={1}
@@ -85,12 +89,63 @@ export default function Navbar() {
                 {brand.appName}
               </ThemedText>
             </Pressable>
-          </Link>
+          ) : (
+            <Link href="/" asChild>
+              <Pressable style={styles.brand}>
+                <ThemedText
+                  style={[styles.brandText, { color: primaryColor }, isTiny && { fontSize: 18 }]}
+                  numberOfLines={1}
+                >
+                  {brand.appName}
+                </ThemedText>
+              </Pressable>
+            </Link>
+          )}
         </View>
 
         <View style={[styles.links, isMobile && { gap: 0 }]}>
           {visibleLinks.map(({ label, href, match }) => {
             const active = match(pathname);
+            const isHomeActive = href === "/" && active && !!onScrollToTop;
+
+            const linkContent = (
+              <>
+                <ThemedText
+                  style={[
+                    styles.linkText,
+                    { color: active ? primaryColor : colors.muted },
+                    isMobile && { fontSize: 14 },
+                  ]}
+                >
+                  {label}
+                </ThemedText>
+                {active && (
+                  <View
+                    style={[
+                      styles.linkUnderline,
+                      { backgroundColor: primaryColor },
+                      isMobile && { left: 8, right: 8 },
+                    ]}
+                  />
+                )}
+              </>
+            );
+
+            if (isHomeActive) {
+              return (
+                <Pressable
+                  key={href}
+                  style={StyleSheet.flatten([
+                    styles.linkBtn,
+                    isMobile && { paddingHorizontal: 10 },
+                  ])}
+                  onPress={onScrollToTop}
+                >
+                  {linkContent}
+                </Pressable>
+              );
+            }
+
             return (
               <Link key={href} href={href} asChild>
                 <Pressable
@@ -99,24 +154,7 @@ export default function Navbar() {
                     isMobile && { paddingHorizontal: 10 },
                   ])}
                 >
-                  <ThemedText
-                    style={[
-                      styles.linkText,
-                      { color: active ? primaryColor : colors.muted },
-                      isMobile && { fontSize: 14 },
-                    ]}
-                  >
-                    {label}
-                  </ThemedText>
-                  {active && (
-                    <View
-                      style={[
-                        styles.linkUnderline,
-                        { backgroundColor: primaryColor },
-                        isMobile && { left: 8, right: 8 },
-                      ]}
-                    />
-                  )}
+                  {linkContent}
                 </Pressable>
               </Link>
             );


### PR DESCRIPTION
Closes #106

## Changes

- **Home button/brand name**: when already on `/`, pressing either scrolls to the top instead of doing nothing
- **Scroll-to-top FAB**: a circular floating button (chevron-up) appears on portrait mobile once the user has scrolled past 300 px; hidden on desktop and landscape

Generated with [Claude Code](https://claude.ai/code)