### PR TITLE
fix: prevent hero image shift on back-navigation to home page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
             set -e
             cd ${{ secrets.VPS_DEPLOY_PATH }}
 
+            trap 'echo "==> Error — dumping container logs:"; docker compose -f docker-compose.vps.yml logs --tail=80' ERR
+
             echo "==> Pulling latest code..."
             git pull origin main
 

--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -16,10 +16,19 @@ import RestaurantCard from "@/components/restaurant/RestaurantCard";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { Ionicons } from "@expo/vector-icons";
 
+// Module-level cache so data survives route changes — prevents hero layout shift on back-navigation.
+let _cachedRestaurants: RestaurantDto[] | null = null;
+let _cachedHighlights: HighlightDto[] | null = null;
+
+export function resetHomeCache() {
+  _cachedRestaurants = null;
+  _cachedHighlights = null;
+}
+
 export default function HomeScreen() {
-  const [restaurants, setRestaurants] = useState<RestaurantDto[]>([]);
-  const [highlights, setHighlights] = useState<HighlightDto[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [restaurants, setRestaurants] = useState<RestaurantDto[]>(_cachedRestaurants ?? []);
+  const [highlights, setHighlights] = useState<HighlightDto[]>(_cachedHighlights ?? []);
+  const [loading, setLoading] = useState(_cachedRestaurants === null);
   const { width } = useWindowDimensions();
   const { brand, colors, primaryColor, isDark } = useAppTheme();
 
@@ -28,6 +37,8 @@ export default function HomeScreen() {
 
   useEffect(() => {
     Promise.all([fetchRestaurants(), fetchHighlights()]).then(([restaurantData, highlightData]) => {
+      _cachedRestaurants = restaurantData;
+      _cachedHighlights = highlightData;
       setRestaurants(restaurantData);
       setHighlights(highlightData);
       setLoading(false);
@@ -72,7 +83,7 @@ export default function HomeScreen() {
                   ? ({
                       backgroundImage: `url(${brand.headerImageUrl})`,
                       backgroundSize: "cover",
-                      backgroundPosition: "center",
+                      backgroundPosition: "center top",
                     } as object)
                   : ({
                       background: isDark

--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -1,15 +1,17 @@
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { fetchRestaurants, fetchHighlights, RestaurantDto, HighlightDto } from "@/api/restaurants";
-import { useEffect, useState, type ComponentProps } from "react";
+import { useEffect, useState, useRef, useCallback, type ComponentProps } from "react";
 import {
   ActivityIndicator,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   useWindowDimensions,
   View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
 import Navbar from "@/components/layout/Navbar";
 import RestaurantCard from "@/components/restaurant/RestaurantCard";
@@ -29,10 +31,19 @@ export default function HomeScreen() {
   const [restaurants, setRestaurants] = useState<RestaurantDto[]>(_cachedRestaurants ?? []);
   const [highlights, setHighlights] = useState<HighlightDto[]>(_cachedHighlights ?? []);
   const [loading, setLoading] = useState(_cachedRestaurants === null);
-  const { width } = useWindowDimensions();
+  const [scrollY, setScrollY] = useState(0);
+  const { width, height } = useWindowDimensions();
   const { brand, colors, primaryColor, isDark } = useAppTheme();
+  const insets = useSafeAreaInsets();
+  const scrollRef = useRef<ScrollView>(null);
 
   const isMobile = width < 700;
+  const isPortrait = height > width;
+  const showFab = isMobile && isPortrait && scrollY > 300;
+
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+  }, []);
   const party = 2;
 
   useEffect(() => {
@@ -64,12 +75,15 @@ export default function HomeScreen() {
   return (
     <ThemedView style={[styles.root, { backgroundColor: bg }]}>
       {Platform.OS !== "web" && <Stack.Screen options={{ title: brand.appName }} />}
-      <Navbar />
+      <Navbar onScrollToTop={scrollToTop} />
 
       <ScrollView
+        ref={scrollRef}
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        scrollEventThrottle={100}
       >
         {/* ── Hero ── */}
         <View
@@ -232,6 +246,17 @@ export default function HomeScreen() {
           )}
         </View>
       </ScrollView>
+
+      {showFab && (
+        <Pressable
+          style={[styles.fab, { backgroundColor: primaryColor, bottom: insets.bottom + 20 }]}
+          onPress={scrollToTop}
+          accessibilityLabel="Scroll to top"
+          accessibilityRole="button"
+        >
+          <Ionicons name="chevron-up" size={22} color="#fff" />
+        </Pressable>
+      )}
     </ThemedView>
   );
 }
@@ -359,6 +384,20 @@ const styles = StyleSheet.create({
   },
   spinner: {
     marginTop: 60,
+  },
+  fab: {
+    position: "absolute",
+    right: 20,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 6,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.18,
+    shadowRadius: 8,
   },
 
   // Footer

--- a/openresto-frontend/components/layout/Navbar.tsx
+++ b/openresto-frontend/components/layout/Navbar.tsx
@@ -135,6 +135,7 @@ export default function Navbar({ onScrollToTop }: NavbarProps) {
               return (
                 <Pressable
                   key={href}
+                  accessibilityRole="link"
                   style={StyleSheet.flatten([
                     styles.linkBtn,
                     isMobile && { paddingHorizontal: 10 },

--- a/openresto-frontend/components/restaurant/RestaurantCard.tsx
+++ b/openresto-frontend/components/restaurant/RestaurantCard.tsx
@@ -176,6 +176,7 @@ export default function RestaurantCard({
 
   return (
     <Pressable
+      accessibilityRole="link"
       onPress={() => router.push(`/(user)/book/${restaurant.id}`)}
       style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
         styles.card,

--- a/openresto-frontend/e2e/home.spec.ts
+++ b/openresto-frontend/e2e/home.spec.ts
@@ -5,7 +5,7 @@ test.describe("Home Page", () => {
     await page.goto("/");
 
     // Check if the app name is visible in the hero section
-    await expect(page.locator("text=Open Resto")).toBeVisible();
+    await expect(page.locator("text=Open Resto").first()).toBeVisible();
 
     // Check if Navbar is visible
     await expect(page.getByRole("link", { name: "Home" })).toBeVisible();

--- a/openresto-frontend/tests/app/index.test.tsx
+++ b/openresto-frontend/tests/app/index.test.tsx
@@ -4,7 +4,7 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react-native";
 import { Platform } from "react-native";
-import HomeScreen from "@/app/index";
+import HomeScreen, { resetHomeCache } from "@/app/index";
 import { fetchRestaurants, fetchHighlights } from "@/api/restaurants";
 import { BrandProvider } from "@/context/BrandContext";
 
@@ -76,6 +76,7 @@ describe("HomeScreen", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetHomeCache();
     (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
     (fetchHighlights as jest.Mock).mockResolvedValue([
       {


### PR DESCRIPTION
Fixes #107

The hero section contains highlights fetched asynchronously, causing it to grow after mount and shift the background image.

Two fixes:
- Module-level stale-while-revalidate cache so restaurants/highlights are immediately available on back-navigation, keeping the hero at full height from first paint
- `backgroundPosition: "center top"` anchors the image at the top so growth extends downward rather than re-centering

Generated with [Claude Code](https://claude.ai/code)