### PR TITLE
feat: add scroll-to-top FAB to all user-facing pages

### DIFF
--- a/openresto-frontend/app/(user)/book/[restaurantId].tsx
+++ b/openresto-frontend/app/(user)/book/[restaurantId].tsx
@@ -1,7 +1,7 @@
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { fetchRestaurantById, RestaurantDto } from "@/api/restaurants";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { Image } from "expo-image";
 import { Platform, ScrollView, StyleSheet } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -12,6 +12,7 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { COLORS, BORDER_RADIUS, getThemeColors } from "@/theme/theme";
 import { convertLocalToUtc } from "@/utils/date";
 import BookingSkeleton from "@/components/booking/BookingSkeleton";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 
 export default function BookScreen() {
   const {
@@ -31,6 +32,11 @@ export default function BookScreen() {
   const [loading, setLoading] = useState(true);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [imageError, setImageError] = useState(false);
+  const [scrollY, setScrollY] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+  }, []);
   const router = useRouter();
   const isDark = useColorScheme() === "dark";
   const mutedColor = getThemeColors(isDark).muted;
@@ -108,7 +114,12 @@ export default function BookScreen() {
 
   return (
     <ThemedView style={styles.root}>
-      <ScrollView style={styles.scroll}>
+      <ScrollView
+        ref={scrollRef}
+        style={styles.scroll}
+        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        scrollEventThrottle={100}
+      >
         <PageContainer style={styles.page}>
           {restaurant.imageUrl && !imageError && (
             <Image
@@ -140,6 +151,7 @@ export default function BookScreen() {
           />
         </PageContainer>
       </ScrollView>
+      <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
     </ThemedView>
   );
 }

--- a/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
+++ b/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
@@ -130,304 +130,304 @@ export default function BookingConfirmationScreen() {
 
   return (
     <View style={{ flex: 1 }}>
-    <ScrollView
-      ref={scrollRef}
-      style={{ flex: 1, backgroundColor: colors.page }}
-      contentContainerStyle={styles.scrollContent}
-      onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
-      scrollEventThrottle={100}
-    >
-      {Platform.OS !== "web" && (
-        <Stack.Screen
-          options={{ title: booking.isCancelled ? "Booking Cancelled" : "Booking Confirmed" }}
-        />
-      )}
-      <PageContainer>
-        {/* Header — same spacing pattern as lookup page */}
-        <View style={styles.header}>
-          <View
-            style={[
-              styles.checkCircle,
-              { backgroundColor: booking.isCancelled ? COLORS.error : primaryColor },
-            ]}
-          >
-            <Ionicons
-              name={booking.isCancelled ? "close" : "checkmark"}
-              size={32}
-              color={COLORS.white}
-            />
-          </View>
-          <ThemedText style={styles.title}>
-            {booking.isCancelled ? "Booking Cancelled" : "Booking Confirmed"}
-          </ThemedText>
-          <ThemedText style={[styles.subtitle, { color: colors.muted }]}>
-            {booking.customerName ? `${booking.customerName}, ` : ""}
-            {booking.seats} {booking.seats === 1 ? "guest" : "guests"} at {restaurantName}
-          </ThemedText>
-        </View>
-
-        {/* Booking reference — above detail rows on mobile, inside right col on wide */}
-        {!isWide && (
-          <View
-            style={[
-              styles.refCard,
-              {
-                backgroundColor: colors.card,
-                borderColor: colors.border,
-                marginBottom: SPACING.lg,
-              },
-            ]}
-          >
-            <ThemedText style={[styles.refLabel, { color: colors.muted }]}>
-              Booking Reference
-            </ThemedText>
-            <View style={styles.refRow}>
-              <View
-                style={[
-                  styles.refBadge,
-                  { backgroundColor: isDark ? `${primaryColor}22` : `${primaryColor}14` },
-                ]}
-              >
-                <ThemedText style={[styles.refValue, { color: primaryColor }]}>{ref}</ThemedText>
-              </View>
-              {Platform.OS === "web" && (
-                <Pressable
-                  style={[styles.copyBtn, { borderColor: copied ? primaryColor : colors.border }]}
-                  onPress={() => {
-                    navigator.clipboard.writeText(ref);
-                    setCopied(true);
-                    setTimeout(() => setCopied(false), 2000);
-                  }}
-                >
-                  <Ionicons
-                    name={copied ? "checkmark" : "copy-outline"}
-                    size={14}
-                    color={copied ? primaryColor : colors.muted}
-                  />
-                  <ThemedText
-                    style={[styles.copyBtnText, { color: copied ? primaryColor : colors.muted }]}
-                  >
-                    {copied ? "Copied" : "Copy"}
-                  </ThemedText>
-                </Pressable>
-              )}
-            </View>
-            <ThemedText style={[styles.refHint, { color: colors.muted }]}>
-              Use this reference and your email to look up your booking
-            </ThemedText>
-          </View>
+      <ScrollView
+        ref={scrollRef}
+        style={{ flex: 1, backgroundColor: colors.page }}
+        contentContainerStyle={styles.scrollContent}
+        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        scrollEventThrottle={100}
+      >
+        {Platform.OS !== "web" && (
+          <Stack.Screen
+            options={{ title: booking.isCancelled ? "Booking Cancelled" : "Booking Confirmed" }}
+          />
         )}
-
-        {/* Two-column on wide: [details] | [ref card + calendar] */}
-        <View style={isWide ? styles.wideRow : styles.narrowGap}>
-          {/* Left / top on narrow: detail rows */}
-          <View
-            style={[
-              styles.detailCard,
-              { backgroundColor: colors.card, borderColor: colors.border },
-              isWide && styles.wideCol,
-            ]}
-          >
-            <BookingDetailRows
-              booking={booking}
-              restaurant={restaurant}
-              mutedColor={colors.muted}
-              borderColor={colors.border}
-            />
-          </View>
-
-          {/* Right col on wide: ref card + calendar + directions stacked */}
-          <View style={[isWide && styles.wideCol, styles.rightCol]}>
-            {isWide && (
-              <View
-                style={[
-                  styles.refCard,
-                  { backgroundColor: colors.card, borderColor: colors.border },
-                ]}
-              >
-                <ThemedText style={[styles.refLabel, { color: colors.muted }]}>
-                  Booking Reference
-                </ThemedText>
-                <View style={styles.refRow}>
-                  <View
-                    style={[
-                      styles.refBadge,
-                      { backgroundColor: isDark ? `${primaryColor}22` : `${primaryColor}14` },
-                    ]}
-                  >
-                    <ThemedText style={[styles.refValue, { color: primaryColor }]}>
-                      {ref}
-                    </ThemedText>
-                  </View>
-                  {Platform.OS === "web" && (
-                    <Pressable
-                      style={[
-                        styles.copyBtn,
-                        { borderColor: copied ? primaryColor : colors.border },
-                      ]}
-                      onPress={() => {
-                        navigator.clipboard.writeText(ref);
-                        setCopied(true);
-                        setTimeout(() => setCopied(false), 2000);
-                      }}
-                    >
-                      <Ionicons
-                        name={copied ? "checkmark" : "copy-outline"}
-                        size={14}
-                        color={copied ? primaryColor : colors.muted}
-                      />
-                      <ThemedText
-                        style={[
-                          styles.copyBtnText,
-                          { color: copied ? primaryColor : colors.muted },
-                        ]}
-                      >
-                        {copied ? "Copied" : "Copy"}
-                      </ThemedText>
-                    </Pressable>
-                  )}
-                </View>
-                <ThemedText style={[styles.refHint, { color: colors.muted }]}>
-                  Use this reference and your email to look up your booking
-                </ThemedText>
-              </View>
-            )}
-
-            {Platform.OS === "web" && ref && (
-              <View
-                style={[
-                  styles.actionCard,
-                  { backgroundColor: colors.card, borderColor: colors.border },
-                ]}
-              >
-                <CalendarActions
-                  bookingRef={ref}
-                  date={booking.date}
-                  seats={booking.seats}
-                  specialRequests={booking.specialRequests}
-                  restaurantName={restaurantName}
-                  restaurantAddress={restaurant?.address ?? ""}
-                  variant="full"
-                />
-              </View>
-            )}
-
-            {restaurant?.address && (
-              <View
-                style={[
-                  styles.actionCard,
-                  styles.directionsCard,
-                  { backgroundColor: colors.card, borderColor: colors.border },
-                ]}
-              >
-                <ThemedText style={[styles.refLabel, { color: colors.muted }]}>
-                  Get Directions
-                </ThemedText>
-                {Platform.OS === "web" &&
-                  mapCoords &&
-                  React.createElement("iframe", {
-                    src: `https://www.openstreetmap.org/export/embed.html?bbox=${mapCoords.lng - 0.005},${mapCoords.lat - 0.005},${mapCoords.lng + 0.005},${mapCoords.lat + 0.005}&layer=mapnik&marker=${mapCoords.lat},${mapCoords.lng}`,
-                    style: {
-                      width: "100%",
-                      height: 160,
-                      border: 0,
-                      borderRadius: BORDER_RADIUS.md,
-                    },
-                    loading: "lazy",
-                  })}
-                <View style={styles.mapAddressRow}>
-                  <View style={styles.mapMeta}>
-                    <Ionicons name="location-outline" size={13} color={colors.muted} />
-                    <ThemedText
-                      style={[styles.mapAddress, { color: colors.muted }]}
-                      numberOfLines={2}
-                    >
-                      {restaurant.address}
-                    </ThemedText>
-                  </View>
-                  <View style={styles.mapLinks}>
-                    <Pressable
-                      style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
-                        styles.mapLink,
-                        {
-                          backgroundColor: isDark ? colors.border : `${primaryColor}0f`,
-                          borderColor: hovered || pressed ? primaryColor : colors.border,
-                        },
-                      ]}
-                      onPress={() =>
-                        Linking.openURL(
-                          `https://maps.google.com/?q=${encodeURIComponent(restaurant.address!)}`
-                        )
-                      }
-                      accessibilityLabel="Open in Google Maps"
-                    >
-                      <Ionicons name="navigate-outline" size={13} color={colors.muted} />
-                      <ThemedText style={[styles.mapLinkText, { color: colors.muted }]}>
-                        Google
-                      </ThemedText>
-                    </Pressable>
-                    <Pressable
-                      style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
-                        styles.mapLink,
-                        {
-                          backgroundColor: isDark ? colors.border : `${primaryColor}0f`,
-                          borderColor: hovered || pressed ? primaryColor : colors.border,
-                        },
-                      ]}
-                      onPress={() =>
-                        Linking.openURL(
-                          `https://maps.apple.com/?q=${encodeURIComponent(restaurant.address!)}`
-                        )
-                      }
-                      accessibilityLabel="Open in Apple Maps"
-                    >
-                      <Ionicons name="navigate-outline" size={13} color={colors.muted} />
-                      <ThemedText style={[styles.mapLinkText, { color: colors.muted }]}>
-                        Apple
-                      </ThemedText>
-                    </Pressable>
-                  </View>
-                </View>
-              </View>
-            )}
-
+        <PageContainer>
+          {/* Header — same spacing pattern as lookup page */}
+          <View style={styles.header}>
             <View
               style={[
-                styles.actionCard,
-                { backgroundColor: colors.card, borderColor: colors.border },
+                styles.checkCircle,
+                { backgroundColor: booking.isCancelled ? COLORS.error : primaryColor },
               ]}
             >
-              <Pressable
-                style={[styles.cancelBtn, booking.isCancelled && { opacity: 0.4 }]}
-                onPress={() => !booking.isCancelled && setShowCancelConfirm(true)}
-                disabled={cancelling || booking.isCancelled}
-              >
-                <Ionicons name="trash-outline" size={15} color={COLORS.error} />
-                <ThemedText style={styles.cancelBtnText}>
-                  {booking.isCancelled ? "Already Cancelled" : "Cancel This Booking"}
-                </ThemedText>
-              </Pressable>
+              <Ionicons
+                name={booking.isCancelled ? "close" : "checkmark"}
+                size={32}
+                color={COLORS.white}
+              />
             </View>
-
-            <ThemedText style={[styles.cancelHint, { color: colors.muted }]}>
-              This booking cannot be modified. However, feel free to cancel and rebook if need be.
+            <ThemedText style={styles.title}>
+              {booking.isCancelled ? "Booking Cancelled" : "Booking Confirmed"}
+            </ThemedText>
+            <ThemedText style={[styles.subtitle, { color: colors.muted }]}>
+              {booking.customerName ? `${booking.customerName}, ` : ""}
+              {booking.seats} {booking.seats === 1 ? "guest" : "guests"} at {restaurantName}
             </ThemedText>
           </View>
-        </View>
-      </PageContainer>
 
-      <ConfirmModal
-        visible={showCancelConfirm}
-        title="Cancel Reservation"
-        message="Are you sure you want to cancel this booking? This action cannot be undone."
-        confirmLabel={cancelling ? "Cancelling..." : "Cancel Booking"}
-        cancelLabel="Keep Booking"
-        destructive
-        onConfirm={handleCancelBooking}
-        onCancel={() => !cancelling && setShowCancelConfirm(false)}
-      />
-    </ScrollView>
-    <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
+          {/* Booking reference — above detail rows on mobile, inside right col on wide */}
+          {!isWide && (
+            <View
+              style={[
+                styles.refCard,
+                {
+                  backgroundColor: colors.card,
+                  borderColor: colors.border,
+                  marginBottom: SPACING.lg,
+                },
+              ]}
+            >
+              <ThemedText style={[styles.refLabel, { color: colors.muted }]}>
+                Booking Reference
+              </ThemedText>
+              <View style={styles.refRow}>
+                <View
+                  style={[
+                    styles.refBadge,
+                    { backgroundColor: isDark ? `${primaryColor}22` : `${primaryColor}14` },
+                  ]}
+                >
+                  <ThemedText style={[styles.refValue, { color: primaryColor }]}>{ref}</ThemedText>
+                </View>
+                {Platform.OS === "web" && (
+                  <Pressable
+                    style={[styles.copyBtn, { borderColor: copied ? primaryColor : colors.border }]}
+                    onPress={() => {
+                      navigator.clipboard.writeText(ref);
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 2000);
+                    }}
+                  >
+                    <Ionicons
+                      name={copied ? "checkmark" : "copy-outline"}
+                      size={14}
+                      color={copied ? primaryColor : colors.muted}
+                    />
+                    <ThemedText
+                      style={[styles.copyBtnText, { color: copied ? primaryColor : colors.muted }]}
+                    >
+                      {copied ? "Copied" : "Copy"}
+                    </ThemedText>
+                  </Pressable>
+                )}
+              </View>
+              <ThemedText style={[styles.refHint, { color: colors.muted }]}>
+                Use this reference and your email to look up your booking
+              </ThemedText>
+            </View>
+          )}
+
+          {/* Two-column on wide: [details] | [ref card + calendar] */}
+          <View style={isWide ? styles.wideRow : styles.narrowGap}>
+            {/* Left / top on narrow: detail rows */}
+            <View
+              style={[
+                styles.detailCard,
+                { backgroundColor: colors.card, borderColor: colors.border },
+                isWide && styles.wideCol,
+              ]}
+            >
+              <BookingDetailRows
+                booking={booking}
+                restaurant={restaurant}
+                mutedColor={colors.muted}
+                borderColor={colors.border}
+              />
+            </View>
+
+            {/* Right col on wide: ref card + calendar + directions stacked */}
+            <View style={[isWide && styles.wideCol, styles.rightCol]}>
+              {isWide && (
+                <View
+                  style={[
+                    styles.refCard,
+                    { backgroundColor: colors.card, borderColor: colors.border },
+                  ]}
+                >
+                  <ThemedText style={[styles.refLabel, { color: colors.muted }]}>
+                    Booking Reference
+                  </ThemedText>
+                  <View style={styles.refRow}>
+                    <View
+                      style={[
+                        styles.refBadge,
+                        { backgroundColor: isDark ? `${primaryColor}22` : `${primaryColor}14` },
+                      ]}
+                    >
+                      <ThemedText style={[styles.refValue, { color: primaryColor }]}>
+                        {ref}
+                      </ThemedText>
+                    </View>
+                    {Platform.OS === "web" && (
+                      <Pressable
+                        style={[
+                          styles.copyBtn,
+                          { borderColor: copied ? primaryColor : colors.border },
+                        ]}
+                        onPress={() => {
+                          navigator.clipboard.writeText(ref);
+                          setCopied(true);
+                          setTimeout(() => setCopied(false), 2000);
+                        }}
+                      >
+                        <Ionicons
+                          name={copied ? "checkmark" : "copy-outline"}
+                          size={14}
+                          color={copied ? primaryColor : colors.muted}
+                        />
+                        <ThemedText
+                          style={[
+                            styles.copyBtnText,
+                            { color: copied ? primaryColor : colors.muted },
+                          ]}
+                        >
+                          {copied ? "Copied" : "Copy"}
+                        </ThemedText>
+                      </Pressable>
+                    )}
+                  </View>
+                  <ThemedText style={[styles.refHint, { color: colors.muted }]}>
+                    Use this reference and your email to look up your booking
+                  </ThemedText>
+                </View>
+              )}
+
+              {Platform.OS === "web" && ref && (
+                <View
+                  style={[
+                    styles.actionCard,
+                    { backgroundColor: colors.card, borderColor: colors.border },
+                  ]}
+                >
+                  <CalendarActions
+                    bookingRef={ref}
+                    date={booking.date}
+                    seats={booking.seats}
+                    specialRequests={booking.specialRequests}
+                    restaurantName={restaurantName}
+                    restaurantAddress={restaurant?.address ?? ""}
+                    variant="full"
+                  />
+                </View>
+              )}
+
+              {restaurant?.address && (
+                <View
+                  style={[
+                    styles.actionCard,
+                    styles.directionsCard,
+                    { backgroundColor: colors.card, borderColor: colors.border },
+                  ]}
+                >
+                  <ThemedText style={[styles.refLabel, { color: colors.muted }]}>
+                    Get Directions
+                  </ThemedText>
+                  {Platform.OS === "web" &&
+                    mapCoords &&
+                    React.createElement("iframe", {
+                      src: `https://www.openstreetmap.org/export/embed.html?bbox=${mapCoords.lng - 0.005},${mapCoords.lat - 0.005},${mapCoords.lng + 0.005},${mapCoords.lat + 0.005}&layer=mapnik&marker=${mapCoords.lat},${mapCoords.lng}`,
+                      style: {
+                        width: "100%",
+                        height: 160,
+                        border: 0,
+                        borderRadius: BORDER_RADIUS.md,
+                      },
+                      loading: "lazy",
+                    })}
+                  <View style={styles.mapAddressRow}>
+                    <View style={styles.mapMeta}>
+                      <Ionicons name="location-outline" size={13} color={colors.muted} />
+                      <ThemedText
+                        style={[styles.mapAddress, { color: colors.muted }]}
+                        numberOfLines={2}
+                      >
+                        {restaurant.address}
+                      </ThemedText>
+                    </View>
+                    <View style={styles.mapLinks}>
+                      <Pressable
+                        style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
+                          styles.mapLink,
+                          {
+                            backgroundColor: isDark ? colors.border : `${primaryColor}0f`,
+                            borderColor: hovered || pressed ? primaryColor : colors.border,
+                          },
+                        ]}
+                        onPress={() =>
+                          Linking.openURL(
+                            `https://maps.google.com/?q=${encodeURIComponent(restaurant.address!)}`
+                          )
+                        }
+                        accessibilityLabel="Open in Google Maps"
+                      >
+                        <Ionicons name="navigate-outline" size={13} color={colors.muted} />
+                        <ThemedText style={[styles.mapLinkText, { color: colors.muted }]}>
+                          Google
+                        </ThemedText>
+                      </Pressable>
+                      <Pressable
+                        style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
+                          styles.mapLink,
+                          {
+                            backgroundColor: isDark ? colors.border : `${primaryColor}0f`,
+                            borderColor: hovered || pressed ? primaryColor : colors.border,
+                          },
+                        ]}
+                        onPress={() =>
+                          Linking.openURL(
+                            `https://maps.apple.com/?q=${encodeURIComponent(restaurant.address!)}`
+                          )
+                        }
+                        accessibilityLabel="Open in Apple Maps"
+                      >
+                        <Ionicons name="navigate-outline" size={13} color={colors.muted} />
+                        <ThemedText style={[styles.mapLinkText, { color: colors.muted }]}>
+                          Apple
+                        </ThemedText>
+                      </Pressable>
+                    </View>
+                  </View>
+                </View>
+              )}
+
+              <View
+                style={[
+                  styles.actionCard,
+                  { backgroundColor: colors.card, borderColor: colors.border },
+                ]}
+              >
+                <Pressable
+                  style={[styles.cancelBtn, booking.isCancelled && { opacity: 0.4 }]}
+                  onPress={() => !booking.isCancelled && setShowCancelConfirm(true)}
+                  disabled={cancelling || booking.isCancelled}
+                >
+                  <Ionicons name="trash-outline" size={15} color={COLORS.error} />
+                  <ThemedText style={styles.cancelBtnText}>
+                    {booking.isCancelled ? "Already Cancelled" : "Cancel This Booking"}
+                  </ThemedText>
+                </Pressable>
+              </View>
+
+              <ThemedText style={[styles.cancelHint, { color: colors.muted }]}>
+                This booking cannot be modified. However, feel free to cancel and rebook if need be.
+              </ThemedText>
+            </View>
+          </View>
+        </PageContainer>
+
+        <ConfirmModal
+          visible={showCancelConfirm}
+          title="Cancel Reservation"
+          message="Are you sure you want to cancel this booking? This action cannot be undone."
+          confirmLabel={cancelling ? "Cancelling..." : "Cancel Booking"}
+          cancelLabel="Keep Booking"
+          destructive
+          onConfirm={handleCancelBooking}
+          onCancel={() => !cancelling && setShowCancelConfirm(false)}
+        />
+      </ScrollView>
+      <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
     </View>
   );
 }

--- a/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
+++ b/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
@@ -1,7 +1,7 @@
 import { ThemedText } from "@/components/themed-text";
 import { getBookingByRef, getBookingById, cancelBookingByRef, BookingDto } from "@/api/bookings";
 import { fetchRestaurantById, RestaurantDto } from "@/api/restaurants";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import {
   Alert,
   Linking,
@@ -21,6 +21,7 @@ import BookingDetailRows from "@/components/booking/BookingDetailRows";
 import BookingConfirmationSkeleton from "@/components/booking/BookingConfirmationSkeleton";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 
 export default function BookingConfirmationScreen() {
   const { bookingRef, email } = useLocalSearchParams<{ bookingRef: string; email: string }>();
@@ -35,6 +36,11 @@ export default function BookingConfirmationScreen() {
   const { colors, primaryColor, isDark } = useAppTheme();
   const { width } = useWindowDimensions();
   const isWide = Platform.OS === "web" && width >= 768;
+  const [scrollY, setScrollY] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+  }, []);
 
   useEffect(() => {
     if (!bookingRef) return;
@@ -123,9 +129,13 @@ export default function BookingConfirmationScreen() {
   };
 
   return (
+    <View style={{ flex: 1 }}>
     <ScrollView
+      ref={scrollRef}
       style={{ flex: 1, backgroundColor: colors.page }}
       contentContainerStyle={styles.scrollContent}
+      onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+      scrollEventThrottle={100}
     >
       {Platform.OS !== "web" && (
         <Stack.Screen
@@ -417,6 +427,8 @@ export default function BookingConfirmationScreen() {
         onCancel={() => !cancelling && setShowCancelConfirm(false)}
       />
     </ScrollView>
+    <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
+    </View>
   );
 }
 

--- a/openresto-frontend/app/(user)/lookup.tsx
+++ b/openresto-frontend/app/(user)/lookup.tsx
@@ -2,7 +2,7 @@ import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { getBookingByRef, BookingDto, cancelBookingByRef } from "@/api/bookings";
 import { fetchRestaurantById, RestaurantDto } from "@/api/restaurants";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -34,6 +34,7 @@ import CalendarActions from "@/components/booking/CalendarActions";
 import BookingDetailRows from "@/components/booking/BookingDetailRows";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { buildCalendarUrls } from "@/utils/calendar";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 
 export default function LookupScreen() {
   const [refInput, setRefInput] = useState("");
@@ -45,6 +46,11 @@ export default function LookupScreen() {
   const [cached, setCached] = useState<CachedBooking[]>([]);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [scrollY, setScrollY] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+  }, []);
 
   const { width } = useWindowDimensions();
   const { colors, primaryColor, isDark } = useAppTheme();
@@ -99,7 +105,13 @@ export default function LookupScreen() {
 
   return (
     <ThemedView style={styles.root}>
-      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+      <ScrollView
+        ref={scrollRef}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        scrollEventThrottle={100}
+      >
         <PageContainer>
           <View style={[styles.header, !isWide && { marginBottom: 12 }]}>
             <Ionicons name="search-outline" size={32} color={primaryColor} />
@@ -239,6 +251,8 @@ export default function LookupScreen() {
           )}
         </PageContainer>
       </ScrollView>
+
+      <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
 
       <ConfirmModal
         visible={showCancelConfirm}

--- a/openresto-frontend/app/(user)/restaurant/[id].tsx
+++ b/openresto-frontend/app/(user)/restaurant/[id].tsx
@@ -1,18 +1,24 @@
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { fetchRestaurantById, RestaurantDto } from "@/api/restaurants";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { ScrollView, StyleSheet } from "react-native";
 import RestaurantDetails from "@/components/restaurant/RestaurantDetails";
 import { Link, useLocalSearchParams } from "expo-router";
 import PageContainer from "@/components/layout/PageContainer";
 import Button from "@/components/common/Button";
 import RestaurantSkeleton from "@/components/restaurant/RestaurantSkeleton";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 
 export default function RestaurantScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [restaurant, setRestaurant] = useState<RestaurantDto | null>(null);
   const [loading, setLoading] = useState(true);
+  const [scrollY, setScrollY] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+  }, []);
 
   useEffect(() => {
     if (id) {
@@ -55,7 +61,12 @@ export default function RestaurantScreen() {
 
   return (
     <ThemedView style={styles.root}>
-      <ScrollView style={styles.scroll}>
+      <ScrollView
+        ref={scrollRef}
+        style={styles.scroll}
+        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        scrollEventThrottle={100}
+      >
         <PageContainer style={styles.page}>
           <RestaurantDetails restaurant={restaurant} />
           <Link href={`/(user)/book/${id}`} asChild>
@@ -63,6 +74,7 @@ export default function RestaurantScreen() {
           </Link>
         </PageContainer>
       </ScrollView>
+      <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
     </ThemedView>
   );
 }

--- a/openresto-frontend/app/index.tsx
+++ b/openresto-frontend/app/index.tsx
@@ -5,18 +5,17 @@ import { useEffect, useState, useRef, useCallback, type ComponentProps } from "r
 import {
   ActivityIndicator,
   Platform,
-  Pressable,
   ScrollView,
   StyleSheet,
   useWindowDimensions,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
 import Navbar from "@/components/layout/Navbar";
 import RestaurantCard from "@/components/restaurant/RestaurantCard";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { Ionicons } from "@expo/vector-icons";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 
 // Module-level cache so data survives route changes — prevents hero layout shift on back-navigation.
 let _cachedRestaurants: RestaurantDto[] | null = null;
@@ -32,14 +31,11 @@ export default function HomeScreen() {
   const [highlights, setHighlights] = useState<HighlightDto[]>(_cachedHighlights ?? []);
   const [loading, setLoading] = useState(_cachedRestaurants === null);
   const [scrollY, setScrollY] = useState(0);
-  const { width, height } = useWindowDimensions();
+  const { width } = useWindowDimensions();
   const { brand, colors, primaryColor, isDark } = useAppTheme();
-  const insets = useSafeAreaInsets();
   const scrollRef = useRef<ScrollView>(null);
 
   const isMobile = width < 700;
-  const isPortrait = height > width;
-  const showFab = isMobile && isPortrait && scrollY > 300;
 
   const scrollToTop = useCallback(() => {
     scrollRef.current?.scrollTo({ y: 0, animated: true });
@@ -247,16 +243,7 @@ export default function HomeScreen() {
         </View>
       </ScrollView>
 
-      {showFab && (
-        <Pressable
-          style={[styles.fab, { backgroundColor: primaryColor, bottom: insets.bottom + 20 }]}
-          onPress={scrollToTop}
-          accessibilityLabel="Scroll to top"
-          accessibilityRole="button"
-        >
-          <Ionicons name="chevron-up" size={22} color="#fff" />
-        </Pressable>
-      )}
+      <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
     </ThemedView>
   );
 }
@@ -385,21 +372,6 @@ const styles = StyleSheet.create({
   spinner: {
     marginTop: 60,
   },
-  fab: {
-    position: "absolute",
-    right: 20,
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    alignItems: "center",
-    justifyContent: "center",
-    elevation: 6,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 3 },
-    shadowOpacity: 0.18,
-    shadowRadius: 8,
-  },
-
   // Footer
   footer: {
     borderTopWidth: 1,

--- a/openresto-frontend/components/common/ScrollToTopFab.tsx
+++ b/openresto-frontend/components/common/ScrollToTopFab.tsx
@@ -1,0 +1,48 @@
+import { Pressable, StyleSheet, useWindowDimensions } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAppTheme } from "@/hooks/use-app-theme";
+
+interface Props {
+  scrollY: number;
+  onPress: () => void;
+}
+
+export default function ScrollToTopFab({ scrollY, onPress }: Props) {
+  const { width, height } = useWindowDimensions();
+  const { primaryColor } = useAppTheme();
+  const insets = useSafeAreaInsets();
+
+  const isMobile = width < 700;
+  const isPortrait = height > width;
+
+  if (!isMobile || !isPortrait || scrollY <= 300) return null;
+
+  return (
+    <Pressable
+      style={[styles.fab, { backgroundColor: primaryColor, bottom: insets.bottom + 20 }]}
+      onPress={onPress}
+      accessibilityLabel="Scroll to top"
+      accessibilityRole="button"
+    >
+      <Ionicons name="chevron-up" size={22} color="#fff" />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  fab: {
+    position: "absolute",
+    right: 20,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 6,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.18,
+    shadowRadius: 8,
+  },
+});

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { AppThemeProvider } from "@/context/ThemeContext";
+import { BrandProvider } from "@/context/BrandContext";
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ appName: "Open Resto", primaryColor: "#0a7ea4" }),
+  })
+) as jest.Mock;
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: jest.fn(() => "light"),
+}));
+
+const mockWindowDimensions = { width: 375, height: 812 };
+jest.mock("react-native/Libraries/Utilities/useWindowDimensions", () => ({
+  default: () => mockWindowDimensions,
+}));
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { x: 0, y: 0, width: 375, height: 812 },
+        insets: { top: 0, left: 0, right: 0, bottom: 0 },
+      }}
+    >
+      <AppThemeProvider>
+        <BrandProvider>{ui}</BrandProvider>
+      </AppThemeProvider>
+    </SafeAreaProvider>
+  );
+
+describe("ScrollToTopFab", () => {
+  it("renders when mobile portrait and scrollY > 300", () => {
+    const onPress = jest.fn();
+    renderWithProviders(<ScrollToTopFab scrollY={350} onPress={onPress} />);
+    expect(screen.getByRole("button")).toBeTruthy();
+  });
+
+  it("does not render when scrollY <= 300", () => {
+    const onPress = jest.fn();
+    renderWithProviders(<ScrollToTopFab scrollY={300} onPress={onPress} />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("does not render on wide screens (landscape/desktop)", () => {
+    const { default: useWindowDimensions } = require(
+      "react-native/Libraries/Utilities/useWindowDimensions"
+    );
+    jest.spyOn({ useWindowDimensions }, "useWindowDimensions").mockReturnValueOnce({
+      width: 1024,
+      height: 768,
+    });
+
+    // Override mock for this test
+    const wdModule = require("react-native/Libraries/Utilities/useWindowDimensions");
+    const original = wdModule.default;
+    wdModule.default = () => ({ width: 1024, height: 768 });
+
+    const onPress = jest.fn();
+    renderWithProviders(<ScrollToTopFab scrollY={500} onPress={onPress} />);
+    expect(screen.queryByRole("button")).toBeNull();
+
+    wdModule.default = original;
+  });
+
+  it("calls onPress when pressed", () => {
+    const onPress = jest.fn();
+    renderWithProviders(<ScrollToTopFab scrollY={400} onPress={onPress} />);
+    fireEvent.press(screen.getByRole("button"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -56,9 +56,8 @@ describe("ScrollToTopFab", () => {
   });
 
   it("does not render on wide screens (landscape/desktop)", () => {
-    const { default: useWindowDimensions } = require(
-      "react-native/Libraries/Utilities/useWindowDimensions"
-    );
+    const { default: useWindowDimensions } =
+      require("react-native/Libraries/Utilities/useWindowDimensions");
     jest.spyOn({ useWindowDimensions }, "useWindowDimensions").mockReturnValueOnce({
       width: 1024,
       height: 768,

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -56,8 +56,9 @@ describe("ScrollToTopFab", () => {
   });
 
   it("does not render on wide screens (landscape/desktop)", () => {
-    const { default: useWindowDimensions } =
-      require("react-native/Libraries/Utilities/useWindowDimensions");
+    const {
+      default: useWindowDimensions,
+    } = require("react-native/Libraries/Utilities/useWindowDimensions");
     jest.spyOn({ useWindowDimensions }, "useWindowDimensions").mockReturnValueOnce({
       width: 1024,
       height: 768,


### PR DESCRIPTION
Extracts the scroll-to-top FAB from the home page into a reusable `ScrollToTopFab` component and adds it to all user-facing pages (restaurant detail, booking, lookup, booking confirmation).

The FAB shows on mobile portrait screens when scrolled past 300px, and scrolls back to the top when tapped.

Closes #127

Generated with [Claude Code](https://claude.ai/code)