### PR TITLE
Persist Data Protection keys so recent-bookings cookie survives redeploys

### DIFF
--- a/OpenRestoApi.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/OpenRestoApi.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -86,7 +86,7 @@ public class ServiceCollectionExtensionsTests
             // Calling Protect triggers key ring initialisation, which writes the key XML to disk
             provider.GetRequiredService<Microsoft.AspNetCore.DataProtection.IDataProtectionProvider>()
                 .CreateProtector("test")
-                .Protect("data");
+                .Protect(System.Text.Encoding.UTF8.GetBytes("data"));
             Assert.NotEmpty(Directory.GetFiles(tmpDir, "*.xml"));
         }
         finally

--- a/OpenRestoApi.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/OpenRestoApi.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -71,4 +71,28 @@ public class ServiceCollectionExtensionsTests
         services.AddProjectDependencies();
         // Just verify it doesn't throw
     }
+
+    [Fact]
+    public void AddProjectDependencies_PersistsKeysWhenPathEnvVarSet()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tmpDir);
+        Environment.SetEnvironmentVariable("DATA_PROTECTION_KEYS_PATH", tmpDir);
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddProjectDependencies();
+            using var provider = services.BuildServiceProvider();
+            // Calling Protect triggers key ring initialisation, which writes the key XML to disk
+            provider.GetRequiredService<Microsoft.AspNetCore.DataProtection.IDataProtectionProvider>()
+                .CreateProtector("test")
+                .Protect("data");
+            Assert.NotEmpty(Directory.GetFiles(tmpDir, "*.xml"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DATA_PROTECTION_KEYS_PATH", null);
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
 }

--- a/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
+++ b/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Threading.RateLimiting;
 using MailKit.Net.Smtp;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.IdentityModel.Tokens;
 using OpenRestoApi.Core.Application.Interfaces;
@@ -171,7 +172,10 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<OpenRestoApi.Core.Application.Mappings.BookingMapper>();
 
-        services.AddDataProtection();
+        var dpKeysPath = Environment.GetEnvironmentVariable("DATA_PROTECTION_KEYS_PATH");
+        var dpBuilder = services.AddDataProtection().SetApplicationName("openresto");
+        if (!string.IsNullOrEmpty(dpKeysPath))
+            dpBuilder.PersistKeysToFileSystem(new DirectoryInfo(dpKeysPath));
         services.AddSingleton<OpenRestoApi.Infrastructure.Email.CredentialProtector>();
         services.AddSingleton<OpenRestoApi.Infrastructure.Cookies.RecentBookingsCookie>();
         services.AddScoped<Func<ISmtpClient>>(_ => () => new SmtpClient());

--- a/docker-compose.vps.yml
+++ b/docker-compose.vps.yml
@@ -14,6 +14,7 @@ services:
       - ADMIN_EMAIL=${ADMIN_EMAIL}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - CONNECTION_STRING=${CONNECTION_STRING:-Data Source=/data/openresto.db}
+      - DATA_PROTECTION_KEYS_PATH=/data/dp-keys
     volumes:
       - ./data:/data
       - media_data:/app/wwwroot/media


### PR DESCRIPTION
## Problem

The recent-bookings cookie is encrypted with ASP.NET Core Data Protection. With the default `AddDataProtection()` call, keys are stored **in memory only** — every container restart or redeploy regenerates them, so previously encrypted cookies fail to decrypt and are silently dropped. Users lose their recent bookings list on every deploy.

## Fix

Two changes:

**`ServiceCollectionExtensions.cs`**
- Read `DATA_PROTECTION_KEYS_PATH` from env
- If set, persist keys to that directory via `PersistKeysToFileSystem`
- `SetApplicationName("openresto")` scopes the keys to this app
- Falls back to the existing in-memory behaviour when the env var is absent (local dev, CI)

**`docker-compose.vps.yml`**
- Set `DATA_PROTECTION_KEYS_PATH=/data/dp-keys` in the backend container
- `/data` is already the host-mounted volume (`./data:/data`) used for the SQLite DB, so no new volume is needed — keys just live alongside the database and survive redeploys

## Test plan

- [ ] Deploy to VPS, look up a booking (cookie is written with new keys)
- [ ] Redeploy (new container starts), visit the page — recent bookings should still appear
- [ ] Local `docker compose up` still works (no `DATA_PROTECTION_KEYS_PATH` set, in-memory keys, no change in behaviour)

https://claude.ai/code/session_013CRmDkjJVS3tNj3gxsEVvV

---
_Generated by [Claude Code](https://claude.ai/code/session_013CRmDkjJVS3tNj3gxsEVvV)_