### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy to VPS


### PR DESCRIPTION
Potential fix for [https://github.com/karanshukla/openresto/security/code-scanning/6](https://github.com/karanshukla/openresto/security/code-scanning/6)

Add an explicit `permissions` block at the workflow root so all jobs default to least privilege.  
For this workflow, the safest minimal setting is:

- `contents: read`

This is typically sufficient for actions that may need repository read access while preventing write-level token capabilities. Since the shown job only runs `appleboy/ssh-action` with secrets and remote commands, no additional write scopes are indicated.

Edit `.github/workflows/deploy.yml` by inserting `permissions:` between `concurrency` and `jobs` (or anywhere at root level), without changing job logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
