### PR TITLE
feat: smooth accordion animations and persisted state for location manager

### DIFF
--- a/openresto-frontend/app/(admin)/locations.tsx
+++ b/openresto-frontend/app/(admin)/locations.tsx
@@ -155,8 +155,14 @@ export default function AdminLocationsScreen() {
   const [addingLocation, setAddingLocation] = useState(false);
   const [newLocationName, setNewLocationName] = useState("");
   const [savingLocation, setSavingLocation] = useState(false);
-  const [locationExpanded, setLocationExpanded] = usePersistedState("locations:location:expanded", true);
-  const [dangerZoneExpanded, setDangerZoneExpanded] = usePersistedState("locations:danger:expanded", false);
+  const [locationExpanded, setLocationExpanded] = usePersistedState(
+    "locations:location:expanded",
+    true
+  );
+  const [dangerZoneExpanded, setDangerZoneExpanded] = usePersistedState(
+    "locations:danger:expanded",
+    false
+  );
   const [dangerSelectedId, setDangerSelectedId] = useState<number | null>(null);
   const [deleteStep, setDeleteStep] = useState<"idle" | "confirm">("idle");
   const [deleting, setDeleting] = useState(false);

--- a/openresto-frontend/app/(admin)/locations.tsx
+++ b/openresto-frontend/app/(admin)/locations.tsx
@@ -14,6 +14,8 @@ import {
   adminSetRestaurantArchived,
 } from "@/api/admin";
 import { useBrand } from "@/context/BrandContext";
+import { usePersistedState } from "@/hooks/use-persisted-state";
+import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 
 import { LocationCard } from "@/components/admin/settings/LocationCard";
 import { styles } from "@/components/admin/settings/settings.styles";
@@ -153,8 +155,8 @@ export default function AdminLocationsScreen() {
   const [addingLocation, setAddingLocation] = useState(false);
   const [newLocationName, setNewLocationName] = useState("");
   const [savingLocation, setSavingLocation] = useState(false);
-  const [locationExpanded, setLocationExpanded] = useState(true);
-  const [dangerZoneExpanded, setDangerZoneExpanded] = useState(false);
+  const [locationExpanded, setLocationExpanded] = usePersistedState("locations:location:expanded", true);
+  const [dangerZoneExpanded, setDangerZoneExpanded] = usePersistedState("locations:danger:expanded", false);
   const [dangerSelectedId, setDangerSelectedId] = useState<number | null>(null);
   const [deleteStep, setDeleteStep] = useState<"idle" | "confirm">("idle");
   const [deleting, setDeleting] = useState(false);
@@ -256,7 +258,7 @@ export default function AdminLocationsScreen() {
             />
           </Pressable>
 
-          {locationExpanded && (
+          <AnimatedAccordion expanded={locationExpanded}>
             <View style={[styles.secForm, { borderTopColor: borderColor, gap: 12 }]}>
               {restaurants.length > 0 ? (
                 <View style={{ gap: 12 }}>
@@ -370,7 +372,7 @@ export default function AdminLocationsScreen() {
                 </View>
               )}
             </View>
-          )}
+          </AnimatedAccordion>
         </View>
       </View>
 
@@ -409,7 +411,7 @@ export default function AdminLocationsScreen() {
             />
           </Pressable>
 
-          {dangerZoneExpanded && (
+          <AnimatedAccordion expanded={dangerZoneExpanded}>
             <View style={[styles.secForm, { borderTopColor: borderColor, gap: 16 }]}>
               {allRestaurants.length > 0 && (
                 <ScrollView
@@ -684,7 +686,7 @@ export default function AdminLocationsScreen() {
                 </View>
               )}
             </View>
-          )}
+          </AnimatedAccordion>
         </View>
       </View>
 

--- a/openresto-frontend/components/admin/settings/BrandSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/BrandSettingsCard.tsx
@@ -9,6 +9,7 @@ import { COLORS } from "@/theme/theme";
 import { saveBrandSettings, uploadHeroImage, deleteHeroImage } from "@/api/admin";
 import { useBrand } from "@/context/BrandContext";
 import { FAVICON_ICONS, buildFaviconDataUri } from "@/constants/faviconIcons";
+import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 import { styles } from "./settings.styles";
 
 const MAX_HERO_MB = 5;
@@ -119,7 +120,7 @@ export function BrandSettingsCard({
         <Ionicons name={expanded ? "chevron-up" : "chevron-down"} size={18} color={mutedColor} />
       </Pressable>
 
-      {expanded && (
+      <AnimatedAccordion expanded={expanded}>
         <View style={[styles.secForm, { borderTopColor: borderColor }]}>
           <View style={styles.field}>
             <View
@@ -291,7 +292,7 @@ export function BrandSettingsCard({
             {saving ? "Saving…" : "Save"}
           </Button>
         </View>
-      )}
+      </AnimatedAccordion>
     </View>
   );
 }

--- a/openresto-frontend/components/admin/settings/EmailSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/EmailSettingsCard.tsx
@@ -14,6 +14,7 @@ import {
   type EmailFailureDto,
 } from "@/api/admin";
 import { useBrand } from "@/context/BrandContext";
+import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 import { styles } from "./settings.styles";
 
 // Design CSS var mappings:
@@ -753,7 +754,7 @@ export function EmailSettingsCard({
         <Ionicons name={expanded ? "chevron-up" : "chevron-down"} size={18} color={mutedColor} />
       </Pressable>
 
-      {expanded && (
+      <AnimatedAccordion expanded={expanded}>
         <View style={[styles.secForm, { borderTopColor: borderColor, gap: 20 }]}>
           {/* Provider grid */}
           {providerGrid}
@@ -820,7 +821,7 @@ export function EmailSettingsCard({
             </Button>
           </View>
         </View>
-      )}
+      </AnimatedAccordion>
     </View>
   );
 }

--- a/openresto-frontend/components/admin/settings/HighlightsCard.tsx
+++ b/openresto-frontend/components/admin/settings/HighlightsCard.tsx
@@ -14,6 +14,7 @@ import {
   adminDeleteHighlight,
   AdminHighlightDto,
 } from "@/api/admin";
+import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 import { styles } from "./settings.styles";
 
 const ICON_OPTIONS = [
@@ -161,7 +162,7 @@ export function HighlightsCard({
         <Ionicons name={expanded ? "chevron-up" : "chevron-down"} size={18} color={mutedColor} />
       </Pressable>
 
-      {expanded && (
+      <AnimatedAccordion expanded={expanded}>
         <View style={[styles.secForm, { borderTopColor: borderColor, gap: 12 }]}>
           <Pressable
             onPress={startNew}
@@ -287,7 +288,7 @@ export function HighlightsCard({
             </View>
           )}
         </View>
-      )}
+      </AnimatedAccordion>
     </View>
   );
 }

--- a/openresto-frontend/components/admin/settings/PushNotificationsCard.tsx
+++ b/openresto-frontend/components/admin/settings/PushNotificationsCard.tsx
@@ -180,92 +180,97 @@ export function PushNotificationsCard() {
       </Pressable>
 
       <AnimatedAccordion expanded={expanded}>
-        {pushState !== "loading" && (<View style={[styles.secForm, { borderTopColor: borderColor }]}>
-          {isUnconfigured ? (
-            <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 10 }}>
-              <Ionicons
-                name="warning-outline"
-                size={16}
-                color={COLORS.warning}
-                style={{ marginTop: 1 }}
-              />
-              <ThemedText style={{ fontSize: 13, color: mutedColor, flex: 1, lineHeight: 19 }}>
-                Push notifications require VAPID keys to be configured in the server environment
-                (VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY). Contact your administrator to set these
-                up.
-              </ThemedText>
-            </View>
-          ) : isDenied ? (
-            <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 10 }}>
-              <Ionicons
-                name="information-circle-outline"
-                size={16}
-                color={COLORS.warning}
-                style={{ marginTop: 1 }}
-              />
-              <ThemedText style={{ fontSize: 13, color: mutedColor, flex: 1, lineHeight: 19 }}>
-                Push notifications are blocked by your browser. Open your browser&apos;s site
-                settings to allow notifications, then reload this page.
-              </ThemedText>
-            </View>
-          ) : pushState === "unavailable" ? (
-            <ThemedText style={{ fontSize: 13, color: mutedColor, lineHeight: 19 }}>
-              Push notifications are not supported in this browser.
-            </ThemedText>
-          ) : (
-            <View style={{ gap: 12 }}>
+        {pushState !== "loading" && (
+          <View style={[styles.secForm, { borderTopColor: borderColor }]}>
+            {isUnconfigured ? (
+              <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 10 }}>
+                <Ionicons
+                  name="warning-outline"
+                  size={16}
+                  color={COLORS.warning}
+                  style={{ marginTop: 1 }}
+                />
+                <ThemedText style={{ fontSize: 13, color: mutedColor, flex: 1, lineHeight: 19 }}>
+                  Push notifications require VAPID keys to be configured in the server environment
+                  (VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY). Contact your administrator to set these
+                  up.
+                </ThemedText>
+              </View>
+            ) : isDenied ? (
+              <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 10 }}>
+                <Ionicons
+                  name="information-circle-outline"
+                  size={16}
+                  color={COLORS.warning}
+                  style={{ marginTop: 1 }}
+                />
+                <ThemedText style={{ fontSize: 13, color: mutedColor, flex: 1, lineHeight: 19 }}>
+                  Push notifications are blocked by your browser. Open your browser&apos;s site
+                  settings to allow notifications, then reload this page.
+                </ThemedText>
+              </View>
+            ) : pushState === "unavailable" ? (
               <ThemedText style={{ fontSize: 13, color: mutedColor, lineHeight: 19 }}>
-                {isActive
-                  ? "You will receive push notifications for new bookings, cancellations, and capacity alerts across all locations."
-                  : "Enable push notifications to receive real-time alerts for new bookings, cancellations, and when a location is nearly full."}
+                Push notifications are not supported in this browser.
               </ThemedText>
+            ) : (
+              <View style={{ gap: 12 }}>
+                <ThemedText style={{ fontSize: 13, color: mutedColor, lineHeight: 19 }}>
+                  {isActive
+                    ? "You will receive push notifications for new bookings, cancellations, and capacity alerts across all locations."
+                    : "Enable push notifications to receive real-time alerts for new bookings, cancellations, and when a location is nearly full."}
+                </ThemedText>
 
-              {errorMsg && (
-                <ThemedText style={{ fontSize: 13, color: COLORS.error }}>{errorMsg}</ThemedText>
-              )}
-
-              <Pressable
-                onPress={isActive ? handleDisable : handleEnable}
-                disabled={working}
-                style={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: 8,
-                  paddingVertical: 10,
-                  paddingHorizontal: 16,
-                  borderRadius: BORDER_RADIUS.md,
-                  borderWidth: 1,
-                  borderColor: isActive ? COLORS.error : primaryColor,
-                  backgroundColor: isActive
-                    ? hexToRgba(COLORS.error, isDark ? 0.1 : 0.06)
-                    : hexToRgba(primaryColor, isDark ? 0.12 : 0.08),
-                  opacity: working ? 0.6 : 1,
-                  alignSelf: "flex-start",
-                }}
-              >
-                {working && (
-                  <ActivityIndicator size="small" color={isActive ? COLORS.error : primaryColor} />
+                {errorMsg && (
+                  <ThemedText style={{ fontSize: 13, color: COLORS.error }}>{errorMsg}</ThemedText>
                 )}
-                <ThemedText
+
+                <Pressable
+                  onPress={isActive ? handleDisable : handleEnable}
+                  disabled={working}
                   style={{
-                    fontSize: 14,
-                    fontWeight: "600",
-                    color: isActive ? COLORS.error : primaryColor,
+                    flexDirection: "row",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: 8,
+                    paddingVertical: 10,
+                    paddingHorizontal: 16,
+                    borderRadius: BORDER_RADIUS.md,
+                    borderWidth: 1,
+                    borderColor: isActive ? COLORS.error : primaryColor,
+                    backgroundColor: isActive
+                      ? hexToRgba(COLORS.error, isDark ? 0.1 : 0.06)
+                      : hexToRgba(primaryColor, isDark ? 0.12 : 0.08),
+                    opacity: working ? 0.6 : 1,
+                    alignSelf: "flex-start",
                   }}
                 >
-                  {working
-                    ? isActive
-                      ? "Disabling…"
-                      : "Enabling…"
-                    : isActive
-                      ? "Disable push notifications"
-                      : "Enable push notifications"}
-                </ThemedText>
-              </Pressable>
-            </View>
-          )}
-        </View>)}
+                  {working && (
+                    <ActivityIndicator
+                      size="small"
+                      color={isActive ? COLORS.error : primaryColor}
+                    />
+                  )}
+                  <ThemedText
+                    style={{
+                      fontSize: 14,
+                      fontWeight: "600",
+                      color: isActive ? COLORS.error : primaryColor,
+                    }}
+                  >
+                    {working
+                      ? isActive
+                        ? "Disabling…"
+                        : "Enabling…"
+                      : isActive
+                        ? "Disable push notifications"
+                        : "Enable push notifications"}
+                  </ThemedText>
+                </Pressable>
+              </View>
+            )}
+          </View>
+        )}
       </AnimatedAccordion>
     </View>
   );

--- a/openresto-frontend/components/admin/settings/PushNotificationsCard.tsx
+++ b/openresto-frontend/components/admin/settings/PushNotificationsCard.tsx
@@ -8,6 +8,7 @@ import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
 import { getVapidPublicKey, subscribePush, unsubscribePush } from "@/api/notifications";
 import { fetchRestaurants } from "@/api/restaurants";
+import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 import { styles } from "./settings.styles";
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
@@ -178,8 +179,8 @@ export function PushNotificationsCard() {
         )}
       </Pressable>
 
-      {expanded && pushState !== "loading" && (
-        <View style={[styles.secForm, { borderTopColor: borderColor }]}>
+      <AnimatedAccordion expanded={expanded}>
+        {pushState !== "loading" && (<View style={[styles.secForm, { borderTopColor: borderColor }]}>
           {isUnconfigured ? (
             <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 10 }}>
               <Ionicons
@@ -264,8 +265,8 @@ export function PushNotificationsCard() {
               </Pressable>
             </View>
           )}
-        </View>
-      )}
+        </View>)}
+      </AnimatedAccordion>
     </View>
   );
 }

--- a/openresto-frontend/components/admin/settings/SecurityCard.tsx
+++ b/openresto-frontend/components/admin/settings/SecurityCard.tsx
@@ -8,6 +8,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { COLORS } from "@/theme/theme";
 import { getPvqStatus, setupPvq, changePassword, PvqStatus } from "@/api/auth";
 import { useBrand } from "@/context/BrandContext";
+import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 import { styles } from "./settings.styles";
 
 export function SecurityCard({
@@ -88,7 +89,7 @@ export function SecurityCard({
         <Ionicons name={expanded ? "chevron-up" : "chevron-down"} size={18} color={mutedColor} />
       </Pressable>
 
-      {expanded && (
+      <AnimatedAccordion expanded={expanded}>
         <>
           {/* PVQ status row */}
           <View style={[styles.secRow, { borderTopColor: borderColor }]}>
@@ -233,7 +234,7 @@ export function SecurityCard({
             </View>
           )}
         </>
-      )}
+      </AnimatedAccordion>
     </View>
   );
 }

--- a/openresto-frontend/components/common/AnimatedAccordion.tsx
+++ b/openresto-frontend/components/common/AnimatedAccordion.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, type ReactNode } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import { Animated } from "react-native";
 
 export function AnimatedAccordion({
@@ -8,7 +8,7 @@ export function AnimatedAccordion({
   expanded: boolean;
   children: ReactNode;
 }) {
-  const anim = useRef(new Animated.Value(expanded ? 1 : 0)).current;
+  const [anim] = useState(() => new Animated.Value(expanded ? 1 : 0));
 
   useEffect(() => {
     Animated.timing(anim, {

--- a/openresto-frontend/components/common/AnimatedAccordion.tsx
+++ b/openresto-frontend/components/common/AnimatedAccordion.tsx
@@ -1,0 +1,32 @@
+import { useRef, useEffect, type ReactNode } from "react";
+import { Animated } from "react-native";
+
+export function AnimatedAccordion({
+  expanded,
+  children,
+}: {
+  expanded: boolean;
+  children: ReactNode;
+}) {
+  const anim = useRef(new Animated.Value(expanded ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: expanded ? 1 : 0,
+      duration: 180,
+      useNativeDriver: false,
+    }).start();
+  }, [expanded, anim]);
+
+  return (
+    <Animated.View
+      style={{
+        overflow: "hidden",
+        maxHeight: anim.interpolate({ inputRange: [0, 1], outputRange: [0, 3000] }),
+        opacity: anim,
+      }}
+    >
+      {children}
+    </Animated.View>
+  );
+}

--- a/openresto-frontend/components/common/AnimatedAccordion.tsx
+++ b/openresto-frontend/components/common/AnimatedAccordion.tsx
@@ -9,14 +9,26 @@ export function AnimatedAccordion({
   children: ReactNode;
 }) {
   const [anim] = useState(() => new Animated.Value(expanded ? 1 : 0));
+  const [mounted, setMounted] = useState(expanded);
 
   useEffect(() => {
-    Animated.timing(anim, {
-      toValue: expanded ? 1 : 0,
-      duration: 180,
-      useNativeDriver: false,
-    }).start();
+    if (expanded) {
+      setMounted(true);
+      Animated.timing(anim, {
+        toValue: 1,
+        duration: 180,
+        useNativeDriver: false,
+      }).start();
+    } else {
+      Animated.timing(anim, {
+        toValue: 0,
+        duration: 180,
+        useNativeDriver: false,
+      }).start(() => setMounted(false));
+    }
   }, [expanded, anim]);
+
+  if (!mounted) return null;
 
   return (
     <Animated.View

--- a/openresto-frontend/jest-mocks/AnimatedAccordion.js
+++ b/openresto-frontend/jest-mocks/AnimatedAccordion.js
@@ -1,0 +1,5 @@
+const React = require("react");
+function AnimatedAccordion({ expanded, children }) {
+  return expanded ? children : null;
+}
+module.exports = { AnimatedAccordion };

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -65,6 +65,7 @@
     ],
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/jest-mocks/styleMock.js",
+      "^@/components/common/AnimatedAccordion$": "<rootDir>/jest-mocks/AnimatedAccordion.js",
       "^@/(.*)$": "<rootDir>/$1"
     },
     "collectCoverageFrom": [


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `AnimatedAccordion` shared component (180ms ease, `maxHeight` + `opacity` animation) for smooth expand/collapse
- Apply animation to all 5 settings cards (Brand, Highlights, Email, Push, Security) and both accordions on the Locations page
- Persist Location Manager and Archive/Delete accordion states in `localStorage` via `usePersistedState` (same hook used by settings cards)

## Test plan

- [x] Open `/settings` — all cards start expanded, collapse/expand with smooth animation
- [x] Open `/locations` — Location Manager starts expanded, Archive/Delete starts collapsed; both animate smoothly
- [ ] Collapse a card, refresh page — card stays collapsed (localStorage persistence works)
- [x] Confirm accordion states are independent between settings and locations pages

https://claude.ai/code/session_01QMQpJ42tXjTJtktTRPTdiL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMQpJ42tXjTJtktTRPTdiL)_