### PR TITLE
test: achieve 100% unit test coverage (batch 1 of N)

### DIFF
--- a/openresto-frontend/tests/api/notifications.test.ts
+++ b/openresto-frontend/tests/api/notifications.test.ts
@@ -1,0 +1,280 @@
+import {
+  getNotifications,
+  getUnreadCount,
+  markRead,
+  markAllRead,
+  getVapidPublicKey,
+  subscribePush,
+  unsubscribePush,
+  deleteNotification,
+  deleteNotifications,
+  deleteAllNotifications,
+} from "@/api/notifications";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("getNotifications", () => {
+  it("returns page data on success with all params", async () => {
+    const data = { items: [], totalCount: 0 };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => data });
+
+    const result = await getNotifications({
+      restaurantId: 1,
+      type: "BookingCreated",
+      unreadOnly: true,
+      page: 2,
+      pageSize: 10,
+    });
+
+    expect(result).toEqual(data);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/notifications");
+    expect(url).toContain("restaurantId=1");
+    expect(url).toContain("type=BookingCreated");
+    expect(url).toContain("unreadOnly=true");
+    expect(url).toContain("page=2");
+    expect(url).toContain("pageSize=10");
+  });
+
+  it("returns page data with no params (no query string)", async () => {
+    const data = { items: [{ id: 1 }], totalCount: 1 };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => data });
+
+    const result = await getNotifications({});
+    expect(result).toEqual(data);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).not.toContain("?");
+  });
+
+  it("returns null when response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    const result = await getNotifications({});
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    const result = await getNotifications({});
+    expect(result).toBeNull();
+  });
+
+  it("omits optional params when falsy", async () => {
+    const data = { items: [], totalCount: 0 };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => data });
+
+    await getNotifications({ unreadOnly: false, type: "" });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).not.toContain("unreadOnly");
+    expect(url).not.toContain("type");
+  });
+});
+
+describe("getUnreadCount", () => {
+  it("returns count from response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ count: 5 }) });
+    const result = await getUnreadCount();
+    expect(result).toBe(5);
+  });
+
+  it("appends restaurantId when provided", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ count: 3 }) });
+    const result = await getUnreadCount(42);
+    expect(result).toBe(3);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("restaurantId=42");
+  });
+
+  it("returns 0 when response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    const result = await getUnreadCount();
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    const result = await getUnreadCount();
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 when count is missing from response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    const result = await getUnreadCount();
+    expect(result).toBe(0);
+  });
+});
+
+describe("markRead", () => {
+  it("patches the correct endpoint", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await markRead(7);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/notifications/7/read");
+    expect(opts.method).toBe("PATCH");
+  });
+
+  it("does not throw on error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    await expect(markRead(7)).resolves.toBeUndefined();
+  });
+});
+
+describe("markAllRead", () => {
+  it("patches the correct endpoint with restaurantId", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await markAllRead(3);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/notifications/read-all");
+    expect(url).toContain("restaurantId=3");
+    expect(opts.method).toBe("PATCH");
+  });
+
+  it("does not throw on error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    await expect(markAllRead(3)).resolves.toBeUndefined();
+  });
+});
+
+describe("getVapidPublicKey", () => {
+  it("returns publicKey on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ publicKey: "abc123" }),
+    });
+    const result = await getVapidPublicKey();
+    expect(result).toBe("abc123");
+  });
+
+  it("returns null on 204 (no vapid key configured)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 204 });
+    const result = await getVapidPublicKey();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when response is not ok (non-204)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    const result = await getVapidPublicKey();
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    const result = await getVapidPublicKey();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when publicKey is missing from response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+    const result = await getVapidPublicKey();
+    expect(result).toBeNull();
+  });
+});
+
+describe("subscribePush", () => {
+  it("posts to the correct endpoint with body", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    const sub = { endpoint: "https://push.example.com/sub", p256dh: "key1", auth: "auth1" };
+    await subscribePush(5, sub);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/push/subscribe");
+    expect(url).toContain("restaurantId=5");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body)).toEqual(sub);
+  });
+
+  it("does not throw on error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    await expect(
+      subscribePush(5, { endpoint: "x", p256dh: "y", auth: "z" })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("unsubscribePush", () => {
+  it("sends DELETE to the correct endpoint", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await unsubscribePush("https://push.example.com/sub");
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/push/subscribe");
+    expect(opts.method).toBe("DELETE");
+  });
+
+  it("does not throw on error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    await expect(unsubscribePush("https://push.example.com/sub")).resolves.toBeUndefined();
+  });
+});
+
+describe("deleteNotification", () => {
+  it("sends DELETE to the correct endpoint", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await deleteNotification(99);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/notifications/99");
+    expect(opts.method).toBe("DELETE");
+  });
+
+  it("does not throw on error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    await expect(deleteNotification(99)).resolves.toBeUndefined();
+  });
+});
+
+describe("deleteNotifications", () => {
+  it("sends DELETE with array body", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await deleteNotifications([1, 2, 3]);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/notifications");
+    expect(opts.method).toBe("DELETE");
+    expect(JSON.parse(opts.body)).toEqual([1, 2, 3]);
+  });
+
+  it("does not throw on error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    await expect(deleteNotifications([1])).resolves.toBeUndefined();
+  });
+});
+
+describe("deleteAllNotifications", () => {
+  it("sends DELETE with all query params", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await deleteAllNotifications({ restaurantId: 2, type: "BookingCancelled", unreadOnly: true });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/admin/notifications/all");
+    expect(url).toContain("restaurantId=2");
+    expect(url).toContain("type=BookingCancelled");
+    expect(url).toContain("unreadOnly=true");
+    expect(opts.method).toBe("DELETE");
+  });
+
+  it("sends DELETE with no query string when no params", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await deleteAllNotifications({});
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).not.toContain("?");
+  });
+
+  it("does not throw on error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+    await expect(deleteAllNotifications({})).resolves.toBeUndefined();
+  });
+
+  it("omits falsy optional params", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await deleteAllNotifications({ unreadOnly: false, type: "" });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).not.toContain("unreadOnly");
+    expect(url).not.toContain("type");
+  });
+});

--- a/openresto-frontend/tests/components/admin/bookings/BookingActionButtons.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingActionButtons.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { BookingActionButtons } from "@/components/admin/bookings/BookingActionButtons";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: () => ({ primaryColor: "#0a7ea4", appName: "Open Resto" }),
+}));
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+const baseProps = {
+  isCancelled: false,
+  uncancelling: false,
+  deleting: false,
+  mutedColor: "#888",
+  onUncancel: jest.fn(),
+  onCancel: jest.fn(),
+  onPurge: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("BookingActionButtons", () => {
+  describe("non-cancelled booking", () => {
+    it("shows Cancel Booking button", () => {
+      render(<BookingActionButtons {...baseProps} />);
+      expect(screen.getByText("Cancel Booking")).toBeTruthy();
+    });
+
+    it("shows Permanently Delete (GDPR) button", () => {
+      render(<BookingActionButtons {...baseProps} />);
+      expect(screen.getByText("Permanently Delete (GDPR)")).toBeTruthy();
+    });
+
+    it("does not show Restore Booking button", () => {
+      render(<BookingActionButtons {...baseProps} />);
+      expect(screen.queryByText("Restore Booking")).toBeNull();
+    });
+
+    it("calls onCancel when Cancel Booking is pressed", () => {
+      render(<BookingActionButtons {...baseProps} />);
+      fireEvent.press(screen.getByText("Cancel Booking"));
+      expect(baseProps.onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onPurge when Permanently Delete is pressed", () => {
+      render(<BookingActionButtons {...baseProps} />);
+      fireEvent.press(screen.getByText("Permanently Delete (GDPR)"));
+      expect(baseProps.onPurge).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onCancel when deleting (disabled)", () => {
+      render(<BookingActionButtons {...baseProps} deleting />);
+      fireEvent.press(screen.getByText("Cancelling…"));
+      expect(baseProps.onCancel).not.toHaveBeenCalled();
+    });
+
+    it("shows Cancelling… text when deleting", () => {
+      render(<BookingActionButtons {...baseProps} deleting />);
+      expect(screen.getByText("Cancelling…")).toBeTruthy();
+    });
+  });
+
+  describe("cancelled booking", () => {
+    const cancelledProps = { ...baseProps, isCancelled: true };
+
+    it("shows Restore Booking button", () => {
+      render(<BookingActionButtons {...cancelledProps} />);
+      expect(screen.getByText("Restore Booking")).toBeTruthy();
+    });
+
+    it("does not show Cancel Booking button", () => {
+      render(<BookingActionButtons {...cancelledProps} />);
+      expect(screen.queryByText("Cancel Booking")).toBeNull();
+    });
+
+    it("calls onUncancel when Restore Booking is pressed", () => {
+      render(<BookingActionButtons {...cancelledProps} />);
+      fireEvent.press(screen.getByText("Restore Booking"));
+      expect(baseProps.onUncancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onUncancel when uncancelling (disabled)", () => {
+      render(<BookingActionButtons {...cancelledProps} uncancelling />);
+      fireEvent.press(screen.getByText("Restoring…"));
+      expect(baseProps.onUncancel).not.toHaveBeenCalled();
+    });
+
+    it("shows Restoring… text when uncancelling", () => {
+      render(<BookingActionButtons {...cancelledProps} uncancelling />);
+      expect(screen.getByText("Restoring…")).toBeTruthy();
+    });
+  });
+
+  describe("purge button", () => {
+    it("does not call onPurge when deleting (disabled)", () => {
+      render(<BookingActionButtons {...baseProps} deleting />);
+      fireEvent.press(screen.getByText("Permanently Delete (GDPR)"));
+      expect(baseProps.onPurge).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/openresto-frontend/tests/components/admin/settings/PushNotificationsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/PushNotificationsCard.test.tsx
@@ -40,6 +40,9 @@ const mockSubscribePush = notificationsApi.subscribePush as jest.Mock;
 const mockUnsubscribePush = notificationsApi.unsubscribePush as jest.Mock;
 const mockFetchRestaurants = restaurantsApi.fetchRestaurants as jest.Mock;
 
+// Use global as Record to avoid bare `navigator`/`window` which may not exist in the node test env
+const g = global as Record<string, unknown>;
+
 // Build a fake push subscription
 function makeSub(endpoint = "https://push.example.com/sub") {
   const buffer = new ArrayBuffer(16);
@@ -60,25 +63,31 @@ function makeSW(existingSub: ReturnType<typeof makeSub> | null = null) {
   };
 }
 
+function setNavigatorSW(sw: ReturnType<typeof makeSW> | null) {
+  if (!g.navigator || typeof g.navigator !== "object") {
+    Object.defineProperty(global, "navigator", {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+  }
+  const nav = g.navigator as Record<string, unknown>;
+  if (sw) {
+    nav.serviceWorker = { ready: Promise.resolve(sw) };
+  } else {
+    delete nav.serviceWorker;
+  }
+}
+
 function setupWebEnvironment(hasServiceWorker = true, hasPushManager = true) {
   Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
 
-  if (hasServiceWorker) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (navigator as unknown as Record<string, unknown>).serviceWorker = {
-      ready: Promise.resolve(makeSW()),
-    };
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (navigator as unknown as Record<string, unknown>).serviceWorker;
-  }
+  setNavigatorSW(hasServiceWorker ? makeSW() : null);
 
   if (hasPushManager) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as unknown as Record<string, unknown>).PushManager = {};
+    g.PushManager = {};
   } else {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as unknown as Record<string, unknown>).PushManager;
+    delete g.PushManager;
   }
 }
 
@@ -193,10 +202,7 @@ describe("PushNotificationsCard", () => {
   describe("web platform - inactive (no existing subscription)", () => {
     it("shows inactive status text when no existing subscription", async () => {
       const sw = makeSW(null);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (navigator as unknown as Record<string, unknown>).serviceWorker = {
-        ready: Promise.resolve(sw),
-      };
+      setNavigatorSW(sw);
 
       render(<PushNotificationsCard />);
 
@@ -207,10 +213,7 @@ describe("PushNotificationsCard", () => {
 
     it("shows Enable push notifications button", async () => {
       const sw = makeSW(null);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (navigator as unknown as Record<string, unknown>).serviceWorker = {
-        ready: Promise.resolve(sw),
-      };
+      setNavigatorSW(sw);
 
       render(<PushNotificationsCard />);
 
@@ -223,10 +226,7 @@ describe("PushNotificationsCard", () => {
   describe("web platform - active (existing subscription)", () => {
     it("shows active status text when subscription exists", async () => {
       const sw = makeSW(makeSub());
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (navigator as unknown as Record<string, unknown>).serviceWorker = {
-        ready: Promise.resolve(sw),
-      };
+      setNavigatorSW(sw);
 
       render(<PushNotificationsCard />);
 
@@ -237,10 +237,7 @@ describe("PushNotificationsCard", () => {
 
     it("shows Disable push notifications button when active", async () => {
       const sw = makeSW(makeSub());
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (navigator as unknown as Record<string, unknown>).serviceWorker = {
-        ready: Promise.resolve(sw),
-      };
+      setNavigatorSW(sw);
 
       render(<PushNotificationsCard />);
 
@@ -253,10 +250,7 @@ describe("PushNotificationsCard", () => {
   describe("handleEnable", () => {
     async function renderInactive() {
       const sw = makeSW(null);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (navigator as unknown as Record<string, unknown>).serviceWorker = {
-        ready: Promise.resolve(sw),
-      };
+      setNavigatorSW(sw);
       render(<PushNotificationsCard />);
       await waitFor(() => {
         expect(screen.getByText("Enable push notifications")).toBeTruthy();
@@ -323,10 +317,7 @@ describe("PushNotificationsCard", () => {
     async function renderActive() {
       const existingSub = makeSub();
       const sw = makeSW(existingSub);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (navigator as unknown as Record<string, unknown>).serviceWorker = {
-        ready: Promise.resolve(sw),
-      };
+      setNavigatorSW(sw);
       render(<PushNotificationsCard />);
       await waitFor(() => {
         expect(screen.getByText("Disable push notifications")).toBeTruthy();

--- a/openresto-frontend/tests/components/admin/settings/PushNotificationsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/PushNotificationsCard.test.tsx
@@ -156,9 +156,7 @@ describe("PushNotificationsCard", () => {
       render(<PushNotificationsCard />);
 
       await waitFor(() => {
-        expect(
-          screen.getByText(/Push notifications require VAPID keys/)
-        ).toBeTruthy();
+        expect(screen.getByText(/Push notifications require VAPID keys/)).toBeTruthy();
       });
     });
   });
@@ -187,9 +185,7 @@ describe("PushNotificationsCard", () => {
       render(<PushNotificationsCard />);
 
       await waitFor(() => {
-        expect(
-          screen.getByText("Notifications blocked — enable in browser settings")
-        ).toBeTruthy();
+        expect(screen.getByText("Notifications blocked — enable in browser settings")).toBeTruthy();
       });
     });
   });
@@ -205,9 +201,7 @@ describe("PushNotificationsCard", () => {
       render(<PushNotificationsCard />);
 
       await waitFor(() => {
-        expect(
-          screen.getByText("Enable to receive real-time booking alerts")
-        ).toBeTruthy();
+        expect(screen.getByText("Enable to receive real-time booking alerts")).toBeTruthy();
       });
     });
 
@@ -237,9 +231,7 @@ describe("PushNotificationsCard", () => {
       render(<PushNotificationsCard />);
 
       await waitFor(() => {
-        expect(
-          screen.getByText("Push notifications active for all locations")
-        ).toBeTruthy();
+        expect(screen.getByText("Push notifications active for all locations")).toBeTruthy();
       });
     });
 

--- a/openresto-frontend/tests/components/admin/settings/PushNotificationsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/PushNotificationsCard.test.tsx
@@ -1,0 +1,390 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { Platform } from "react-native";
+import { PushNotificationsCard } from "@/components/admin/settings/PushNotificationsCard";
+import * as notificationsApi from "@/api/notifications";
+import * as restaurantsApi from "@/api/restaurants";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: () => ({ primaryColor: "#0a7ea4", appName: "Open Resto" }),
+}));
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+jest.mock("@/hooks/use-persisted-state", () => ({
+  usePersistedState: (_key: string, defaultValue: unknown) => {
+    const { useState } = require("react");
+    return useState(defaultValue);
+  },
+}));
+
+jest.mock("@/api/notifications", () => ({
+  getVapidPublicKey: jest.fn(),
+  subscribePush: jest.fn(),
+  unsubscribePush: jest.fn(),
+}));
+
+jest.mock("@/api/restaurants", () => ({
+  fetchRestaurants: jest.fn(),
+}));
+
+// Typed shortcuts
+const mockGetVapidPublicKey = notificationsApi.getVapidPublicKey as jest.Mock;
+const mockSubscribePush = notificationsApi.subscribePush as jest.Mock;
+const mockUnsubscribePush = notificationsApi.unsubscribePush as jest.Mock;
+const mockFetchRestaurants = restaurantsApi.fetchRestaurants as jest.Mock;
+
+// Build a fake push subscription
+function makeSub(endpoint = "https://push.example.com/sub") {
+  const buffer = new ArrayBuffer(16);
+  return {
+    endpoint,
+    getKey: jest.fn().mockReturnValue(buffer),
+    unsubscribe: jest.fn().mockResolvedValue(true),
+  };
+}
+
+// Build a fake service worker with pushManager
+function makeSW(existingSub: ReturnType<typeof makeSub> | null = null) {
+  return {
+    pushManager: {
+      getSubscription: jest.fn().mockResolvedValue(existingSub),
+      subscribe: jest.fn().mockResolvedValue(makeSub()),
+    },
+  };
+}
+
+function setupWebEnvironment(hasServiceWorker = true, hasPushManager = true) {
+  Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+
+  if (hasServiceWorker) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (navigator as unknown as Record<string, unknown>).serviceWorker = {
+      ready: Promise.resolve(makeSW()),
+    };
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as unknown as Record<string, unknown>).serviceWorker;
+  }
+
+  if (hasPushManager) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as unknown as Record<string, unknown>).PushManager = {};
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as unknown as Record<string, unknown>).PushManager;
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+
+  // Default: web with push support available, inactive subscription
+  setupWebEnvironment();
+  mockGetVapidPublicKey.mockResolvedValue("test-vapid-key");
+  mockFetchRestaurants.mockResolvedValue([{ id: 1, name: "Location A" }]);
+  mockSubscribePush.mockResolvedValue(undefined);
+  mockUnsubscribePush.mockResolvedValue(undefined);
+
+  // Default Notification: default permission
+  Object.defineProperty(global, "Notification", {
+    value: {
+      permission: "default",
+      requestPermission: jest.fn().mockResolvedValue("granted"),
+    },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+});
+
+describe("PushNotificationsCard", () => {
+  describe("non-web platform", () => {
+    it("renders null on native platform", async () => {
+      Object.defineProperty(Platform, "OS", { value: "ios", configurable: true });
+      mockGetVapidPublicKey.mockResolvedValue("key");
+
+      const { toJSON } = render(<PushNotificationsCard />);
+
+      // Initially renders null (vapidKey === undefined)
+      expect(toJSON()).toBeNull();
+
+      // After effects fire, still returns null for native unavailable
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe("web platform - unconfigured (no VAPID key)", () => {
+    it("shows Push Notifications heading after loading", async () => {
+      mockGetVapidPublicKey.mockResolvedValue(null);
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Push Notifications")).toBeTruthy();
+      });
+    });
+
+    it("shows VAPID keys not configured status text", async () => {
+      mockGetVapidPublicKey.mockResolvedValue(null);
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("VAPID keys not configured")).toBeTruthy();
+      });
+    });
+
+    it("shows unconfigured message in expanded body", async () => {
+      mockGetVapidPublicKey.mockResolvedValue(null);
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Push notifications require VAPID keys/)
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("web platform - unavailable (no PushManager)", () => {
+    it("shows unavailable status when PushManager missing", async () => {
+      setupWebEnvironment(true, false);
+      mockGetVapidPublicKey.mockResolvedValue("key");
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Not supported in this browser")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("web platform - denied", () => {
+    it("shows denied status when Notification permission is denied", async () => {
+      Object.defineProperty(global, "Notification", {
+        value: { permission: "denied", requestPermission: jest.fn() },
+        configurable: true,
+        writable: true,
+      });
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Notifications blocked — enable in browser settings")
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("web platform - inactive (no existing subscription)", () => {
+    it("shows inactive status text when no existing subscription", async () => {
+      const sw = makeSW(null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigator as unknown as Record<string, unknown>).serviceWorker = {
+        ready: Promise.resolve(sw),
+      };
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Enable to receive real-time booking alerts")
+        ).toBeTruthy();
+      });
+    });
+
+    it("shows Enable push notifications button", async () => {
+      const sw = makeSW(null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigator as unknown as Record<string, unknown>).serviceWorker = {
+        ready: Promise.resolve(sw),
+      };
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Enable push notifications")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("web platform - active (existing subscription)", () => {
+    it("shows active status text when subscription exists", async () => {
+      const sw = makeSW(makeSub());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigator as unknown as Record<string, unknown>).serviceWorker = {
+        ready: Promise.resolve(sw),
+      };
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Push notifications active for all locations")
+        ).toBeTruthy();
+      });
+    });
+
+    it("shows Disable push notifications button when active", async () => {
+      const sw = makeSW(makeSub());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigator as unknown as Record<string, unknown>).serviceWorker = {
+        ready: Promise.resolve(sw),
+      };
+
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Disable push notifications")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("handleEnable", () => {
+    async function renderInactive() {
+      const sw = makeSW(null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigator as unknown as Record<string, unknown>).serviceWorker = {
+        ready: Promise.resolve(sw),
+      };
+      render(<PushNotificationsCard />);
+      await waitFor(() => {
+        expect(screen.getByText("Enable push notifications")).toBeTruthy();
+      });
+      return sw;
+    }
+
+    it("enables push and transitions to active on success", async () => {
+      const sw = await renderInactive();
+      (sw.pushManager.subscribe as jest.Mock).mockResolvedValue(makeSub());
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable push notifications"));
+      });
+
+      await waitFor(() => {
+        expect(mockSubscribePush).toHaveBeenCalled();
+        expect(screen.getByText("Push notifications active for all locations")).toBeTruthy();
+      });
+    });
+
+    it("shows denied state when requestPermission returns denied", async () => {
+      await renderInactive();
+      (global.Notification.requestPermission as jest.Mock).mockResolvedValue("denied");
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable push notifications"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Notifications blocked — enable in browser settings")).toBeTruthy();
+      });
+    });
+
+    it("does nothing when permission is dismissed (not granted, not denied)", async () => {
+      await renderInactive();
+      (global.Notification.requestPermission as jest.Mock).mockResolvedValue("default");
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable push notifications"));
+      });
+
+      // Should stay inactive
+      await waitFor(() => {
+        expect(screen.getByText("Enable push notifications")).toBeTruthy();
+      });
+    });
+
+    it("shows error message when subscribe throws", async () => {
+      const sw = await renderInactive();
+      (sw.pushManager.subscribe as jest.Mock).mockRejectedValue(new Error("subscribe failed"));
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable push notifications"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to enable push notifications.")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("handleDisable", () => {
+    async function renderActive() {
+      const existingSub = makeSub();
+      const sw = makeSW(existingSub);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigator as unknown as Record<string, unknown>).serviceWorker = {
+        ready: Promise.resolve(sw),
+      };
+      render(<PushNotificationsCard />);
+      await waitFor(() => {
+        expect(screen.getByText("Disable push notifications")).toBeTruthy();
+      });
+      return { sw, existingSub };
+    }
+
+    it("disables push and transitions to inactive on success", async () => {
+      const { existingSub } = await renderActive();
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Disable push notifications"));
+      });
+
+      await waitFor(() => {
+        expect(existingSub.unsubscribe).toHaveBeenCalled();
+        expect(mockUnsubscribePush).toHaveBeenCalledWith(existingSub.endpoint);
+        expect(screen.getByText("Enable push notifications")).toBeTruthy();
+      });
+    });
+
+    it("shows error message when unsubscribe throws", async () => {
+      const { existingSub } = await renderActive();
+      existingSub.unsubscribe.mockRejectedValue(new Error("unsubscribe failed"));
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Disable push notifications"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to disable push notifications.")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("expand/collapse", () => {
+    it("toggles collapse when header is pressed", async () => {
+      mockGetVapidPublicKey.mockResolvedValue(null);
+      render(<PushNotificationsCard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Push Notifications")).toBeTruthy();
+      });
+
+      // Press header to collapse
+      fireEvent.press(screen.getByText("Push Notifications"));
+      // Press again to expand
+      fireEvent.press(screen.getByText("Push Notifications"));
+
+      expect(screen.getByText("Push Notifications")).toBeTruthy();
+    });
+  });
+});

--- a/openresto-frontend/tests/components/common/AnimatedAccordion.test.tsx
+++ b/openresto-frontend/tests/components/common/AnimatedAccordion.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, act } from "@testing-library/react-native";
+import { Animated } from "react-native";
+
+// Import from the real file using a relative path to bypass the moduleNameMapper mock
+// (moduleNameMapper maps @/components/common/AnimatedAccordion to jest-mocks/AnimatedAccordion.js)
+import { AnimatedAccordion } from "../../../components/common/AnimatedAccordion";
+
+// Capture animation start callbacks so tests can trigger them synchronously
+let capturedStartCallback: (() => void) | undefined;
+
+const timingSpy = jest.spyOn(Animated, "timing").mockImplementation(
+  (_value, _config) =>
+    ({
+      start: (cb?: () => void) => {
+        capturedStartCallback = cb;
+      },
+    }) as unknown as Animated.CompositeAnimation
+);
+
+beforeEach(() => {
+  capturedStartCallback = undefined;
+  timingSpy.mockClear();
+});
+
+describe("AnimatedAccordion", () => {
+  it("renders null when initially collapsed (expanded=false)", () => {
+    const { toJSON } = render(
+      <AnimatedAccordion expanded={false}>
+        <></>
+      </AnimatedAccordion>
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders children inside Animated.View when initially expanded", () => {
+    const { toJSON } = render(
+      <AnimatedAccordion expanded>
+        <></>
+      </AnimatedAccordion>
+    );
+    expect(toJSON()).not.toBeNull();
+  });
+
+  it("animates to value 1 when initially expanded", () => {
+    render(
+      <AnimatedAccordion expanded>
+        <></>
+      </AnimatedAccordion>
+    );
+    const calls = timingSpy.mock.calls;
+    expect(calls.some(([, config]) => config.toValue === 1)).toBe(true);
+  });
+
+  it("mounts and shows children when expanded changes from false to true", () => {
+    const { rerender, toJSON } = render(
+      <AnimatedAccordion expanded={false}>
+        <></>
+      </AnimatedAccordion>
+    );
+    expect(toJSON()).toBeNull();
+
+    act(() => {
+      rerender(
+        <AnimatedAccordion expanded>
+          <></>
+        </AnimatedAccordion>
+      );
+    });
+
+    expect(toJSON()).not.toBeNull();
+  });
+
+  it("animates to value 0 when collapsing", () => {
+    timingSpy.mockClear();
+
+    const { rerender } = render(
+      <AnimatedAccordion expanded>
+        <></>
+      </AnimatedAccordion>
+    );
+
+    act(() => {
+      rerender(
+        <AnimatedAccordion expanded={false}>
+          <></>
+        </AnimatedAccordion>
+      );
+    });
+
+    const calls = timingSpy.mock.calls;
+    expect(calls.some(([, config]) => config.toValue === 0)).toBe(true);
+  });
+
+  it("unmounts (returns null) after collapse animation completes", () => {
+    const { rerender, toJSON } = render(
+      <AnimatedAccordion expanded>
+        <></>
+      </AnimatedAccordion>
+    );
+    expect(toJSON()).not.toBeNull();
+
+    act(() => {
+      rerender(
+        <AnimatedAccordion expanded={false}>
+          <></>
+        </AnimatedAccordion>
+      );
+    });
+
+    // Component is still mounted until animation finishes
+    expect(toJSON()).not.toBeNull();
+
+    // Trigger animation completion callback → setMounted(false)
+    act(() => {
+      capturedStartCallback?.();
+    });
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it("stays mounted if re-expanded before collapse animation completes", () => {
+    const { rerender, toJSON } = render(
+      <AnimatedAccordion expanded>
+        <></>
+      </AnimatedAccordion>
+    );
+
+    act(() => {
+      rerender(
+        <AnimatedAccordion expanded={false}>
+          <></>
+        </AnimatedAccordion>
+      );
+    });
+
+    // Re-expand before the collapse animation fires its callback
+    act(() => {
+      rerender(
+        <AnimatedAccordion expanded>
+          <></>
+        </AnimatedAccordion>
+      );
+    });
+
+    // Even if the old callback fires, it should not unmount
+    act(() => {
+      capturedStartCallback?.();
+    });
+
+    expect(toJSON()).not.toBeNull();
+  });
+});

--- a/openresto-frontend/tests/hooks/use-persisted-state.test.ts
+++ b/openresto-frontend/tests/hooks/use-persisted-state.test.ts
@@ -1,0 +1,107 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { Platform } from "react-native";
+import { usePersistedState } from "@/hooks/use-persisted-state";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(global, "localStorage", { value: localStorageMock });
+
+beforeEach(() => {
+  localStorageMock.clear();
+  jest.clearAllMocks();
+  // Default to web platform
+  Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+});
+
+describe("usePersistedState (web)", () => {
+  it("returns defaultValue when localStorage has no entry", () => {
+    const { result } = renderHook(() => usePersistedState("test-key", 42));
+    expect(result.current[0]).toBe(42);
+  });
+
+  it("returns stored value when localStorage has a valid entry", () => {
+    localStorageMock.getItem.mockReturnValueOnce(JSON.stringify(99));
+    const { result } = renderHook(() => usePersistedState("test-key", 0));
+    expect(result.current[0]).toBe(99);
+  });
+
+  it("persists value to localStorage on state change", () => {
+    const { result } = renderHook(() => usePersistedState("my-key", "initial"));
+
+    act(() => {
+      result.current[1]("updated");
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith("my-key", JSON.stringify("updated"));
+    expect(result.current[0]).toBe("updated");
+  });
+
+  it("returns defaultValue when localStorage.getItem throws", () => {
+    localStorageMock.getItem.mockImplementationOnce(() => {
+      throw new Error("storage error");
+    });
+    const { result } = renderHook(() => usePersistedState("bad-key", "default"));
+    expect(result.current[0]).toBe("default");
+  });
+
+  it("returns defaultValue when stored JSON is invalid", () => {
+    localStorageMock.getItem.mockReturnValueOnce("not-valid-json{{{");
+    const { result } = renderHook(() => usePersistedState("bad-json-key", "fallback"));
+    expect(result.current[0]).toBe("fallback");
+  });
+
+  it("handles object default values", () => {
+    const defaultObj = { count: 0, label: "test" };
+    const { result } = renderHook(() => usePersistedState("obj-key", defaultObj));
+    expect(result.current[0]).toEqual(defaultObj);
+  });
+
+  it("silently ignores localStorage.setItem errors", () => {
+    localStorageMock.setItem.mockImplementationOnce(() => {
+      throw new Error("quota exceeded");
+    });
+    const { result } = renderHook(() => usePersistedState("err-key", 0));
+    // Should not throw
+    act(() => {
+      result.current[1](1);
+    });
+    expect(result.current[0]).toBe(1);
+  });
+});
+
+describe("usePersistedState (native)", () => {
+  beforeEach(() => {
+    Object.defineProperty(Platform, "OS", { value: "ios", configurable: true });
+  });
+
+  it("returns defaultValue without accessing localStorage", () => {
+    const { result } = renderHook(() => usePersistedState("native-key", "native-default"));
+    expect(result.current[0]).toBe("native-default");
+    expect(localStorageMock.getItem).not.toHaveBeenCalled();
+  });
+
+  it("does not persist to localStorage when state changes", () => {
+    const { result } = renderHook(() => usePersistedState("native-key", 0));
+
+    act(() => {
+      result.current[1](5);
+    });
+
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    expect(result.current[0]).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for 5 previously untested or poorly-covered frontend files.

### Coverage before → after

| File | Before | After |
|------|--------|-------|
| `api/notifications.ts` | 10.6% stmts | **100%** |
| `components/admin/bookings/BookingActionButtons.tsx` | 0% | **100%** |
| `components/common/AnimatedAccordion.tsx` | 0% | **100%** |
| `hooks/use-persisted-state.ts` | 53.84% stmts / 33.33% branch | **100%** |
| `components/admin/settings/PushNotificationsCard.tsx` | 0% | **100% lines / 97.84% stmts** |

### Tests added: 77 new tests across 5 files

- **`tests/api/notifications.test.ts`** (31 tests) — covers all 10 API functions including success, error, network failure, and query-param permutations
- **`tests/components/admin/bookings/BookingActionButtons.test.tsx`** (13 tests) — cancelled vs non-cancelled state, all three buttons, disabled states
- **`tests/components/common/AnimatedAccordion.test.tsx`** (7 tests) — mount/unmount lifecycle, animation direction, callback-triggered unmount; imports via relative path to bypass `moduleNameMapper` mock
- **`tests/hooks/use-persisted-state.test.ts`** (9 tests) — web/native platform paths, localStorage read/write/error handling
- **`tests/components/admin/settings/PushNotificationsCard.test.tsx`** (17 tests) — all push-state variants (unconfigured, unavailable, denied, inactive, active), enable/disable flows, error handling

### Intentionally excluded lines
- `PushNotificationsCard.tsx` lines 73, 96–122, 146, 175 — minor unreachable branches: `vapidKey` guard inside `handleEnable` (unreachable when button is visible), push-key null-check after a mocked subscribe, "loading" ternary text (component returns null before rendering while loading), and `ActivityIndicator` during initial load state

## Test plan
- [x] All 5 new test files pass independently
- [x] Full suite of 100 test files (1108 tests) passes with no regressions
- [x] Coverage confirmed via `npm test -- --coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011n5PJoqpX3C4ZFKGKQSBFW

---
_Generated by [Claude Code](https://claude.ai/code/session_011n5PJoqpX3C4ZFKGKQSBFW)_