### PR TITLE
Fix email confirmation: header image, manage booking link, and admin email formatting

### DIFF
--- a/OpenRestoApi.Tests/Integration/AdminControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/AdminControllerTests.cs
@@ -432,6 +432,48 @@ public class AdminControllerTests(TestWebAppFactory factory) : IClassFixture<Tes
     }
 
     [Fact]
+    public async Task SendEmail_ValidBooking_ReturnsOk_WithPlainTextBody()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        (int r, int s, int t) = GetSeededIds();
+        HttpResponseMessage createResp = await client.PostAsJsonAsync("/api/admin/bookings", new
+        {
+            restaurantId = r, sectionId = s, tableId = t,
+            date = DateTime.UtcNow.AddDays(310).ToString("yyyy-MM-ddT12:00:00"),
+            customerEmail = "emailtest@test.com", seats = 2
+        });
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        int id = (await createResp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetInt32();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync($"/api/admin/bookings/{id}/email",
+            new { subject = "Test message", body = "Hello, this is a test." });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("emailtest@test.com", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task SendEmail_ValidBooking_ReturnsOk_WithHtmlBody()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        (int r, int s, int t) = GetSeededIds();
+        HttpResponseMessage createResp = await client.PostAsJsonAsync("/api/admin/bookings", new
+        {
+            restaurantId = r, sectionId = s, tableId = t,
+            date = DateTime.UtcNow.AddDays(311).ToString("yyyy-MM-ddT12:00:00"),
+            customerEmail = "htmltest@test.com", seats = 2
+        });
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        int id = (await createResp.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetInt32();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync($"/api/admin/bookings/{id}/email",
+            new { subject = "HTML message", body = "<p>Hello</p><p>This is a test.</p>" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task GetRestaurants_ReturnsOk()
     {
         HttpClient client = _factory.CreateAuthenticatedClient();

--- a/OpenRestoApi.Tests/Integration/HoldsControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/HoldsControllerTests.cs
@@ -27,7 +27,7 @@ public class HoldsControllerTests(TestWebAppFactory factory) : IClassFixture<Tes
         HttpClient client = _factory.CreateClient();
         (int restaurantId, int sectionId, int tableId) = GetSeededIds();
 
-        var date = "2026-10-10T12:00:00"; // A Saturday
+        var date = "2027-10-09T12:00:00"; // A Saturday, far enough ahead to avoid collision with relative-date tests
 
         HttpResponseMessage response = await client.PostAsJsonAsync("/api/holds", new
         {

--- a/OpenRestoApi/Controllers/AdminController.cs
+++ b/OpenRestoApi/Controllers/AdminController.cs
@@ -9,11 +9,12 @@ namespace OpenRestoApi.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Roles = "Admin")]
-public class AdminController(AdminService adminService, IEmailService emailService) : ControllerBase
+public class AdminController(AdminService adminService, IEmailService emailService, BrandService? brandService = null) : ControllerBase
 {
     public enum bookingStatus { active, cancelled, all, past, upcoming }
     private readonly AdminService _adminService = adminService;
     private readonly IEmailService _email = emailService;
+    private readonly BrandService? _brand = brandService;
 
     [HttpGet("overview")]
     public async Task<IActionResult> Overview()
@@ -167,7 +168,17 @@ public class AdminController(AdminService adminService, IEmailService emailServi
 
         try
         {
-            await _email.SendEmailAsync(booking.CustomerEmail, req.Subject, req.Body);
+            string htmlBody = req.Body;
+            if (_brand != null && !req.Body.TrimStart().StartsWith("<!DOCTYPE", StringComparison.OrdinalIgnoreCase)
+                               && !req.Body.TrimStart().StartsWith("<html", StringComparison.OrdinalIgnoreCase))
+            {
+                var brand = await _brand.GetAsync();
+                string appName = brand.AppName ?? "Open Resto";
+                string primaryColor = brand.PrimaryColor ?? "#0a7ea4";
+                string websiteUrl = _brand.GetWebsiteUrl().TrimEnd('/');
+                htmlBody = WrapInBrandedEmail(req.Body, appName, primaryColor, websiteUrl);
+            }
+            await _email.SendEmailAsync(booking.CustomerEmail, req.Subject, htmlBody);
             return Ok(new MessageResponse { Message = $"Email sent to {booking.CustomerEmail}." });
         }
         catch (InvalidOperationException ex)
@@ -178,6 +189,46 @@ public class AdminController(AdminService adminService, IEmailService emailServi
         {
             return BadRequest(new MessageResponse { Message = $"Failed to send: {ex.Message}" });
         }
+    }
+
+    private static string WrapInBrandedEmail(string content, string appName, string primaryColor, string websiteUrl)
+    {
+        bool isHtmlFragment = content.TrimStart().StartsWith('<');
+        string innerHtml = isHtmlFragment
+            ? content
+            : System.Net.WebUtility.HtmlEncode(content).Replace("\n", "<br>").Replace("\r", "");
+
+        return $"""
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            </head>
+            <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f9fafb;padding:32px 16px;">
+                <tr><td align="center">
+                  <table width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -1px rgba(0,0,0,0.06);border:1px solid #e5e7eb;">
+                    <tr><td style="padding:32px 40px 24px;text-align:center;border-bottom:3px solid {primaryColor};">
+                      <h1 style="margin:0;font-size:20px;font-weight:700;color:{primaryColor};">{System.Net.WebUtility.HtmlEncode(appName)}</h1>
+                    </td></tr>
+                    <tr><td style="padding:32px 40px;font-size:15px;line-height:1.7;color:#111827;">
+                      {innerHtml}
+                    </td></tr>
+                    <tr><td style="padding:0 40px 32px;border-top:1px solid #f0f0f0;text-align:center;">
+                      <p style="margin:24px 0 4px;font-size:13px;color:#6b7280;">
+                        <a href="{websiteUrl}" style="color:{primaryColor};text-decoration:none;">{websiteUrl.Replace("http://","").Replace("https://","")}</a>
+                      </p>
+                      <p style="margin:0;font-size:12px;color:#9ca3af;">
+                        &copy; {DateTime.UtcNow.Year} {System.Net.WebUtility.HtmlEncode(appName)}
+                      </p>
+                    </td></tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            """;
     }
 
     [HttpPost("bookings/{id}/restore")]

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -224,11 +224,16 @@ public class BookingService(
         string primaryColor = brand.PrimaryColor ?? "#0a7ea4";
         string appName = brand.AppName ?? "Open Resto";
         string cleanWebsiteUrl = websiteUrl.TrimEnd('/');
-        string lookupUrl = $"{cleanWebsiteUrl}/lookup";
+        string lookupUrl = $"{cleanWebsiteUrl}/booking-confirmation/{Uri.EscapeDataString(booking.BookingRef ?? "")}?email={Uri.EscapeDataString(booking.CustomerEmail ?? "")}";
 
-        string headerImageHtml = string.IsNullOrEmpty(brand.HeaderImageUrl)
+        string headerImageSrc = string.IsNullOrEmpty(brand.HeaderImageUrl)
             ? ""
-            : $"<img src='{brand.HeaderImageUrl}' alt='{appName}' style='max-height:48px;margin-bottom:16px;'>";
+            : brand.HeaderImageUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? brand.HeaderImageUrl
+                : $"{cleanWebsiteUrl}/{brand.HeaderImageUrl.TrimStart('/')}";
+        string headerImageHtml = string.IsNullOrEmpty(headerImageSrc)
+            ? ""
+            : $"<img src='{headerImageSrc}' alt='{System.Net.WebUtility.HtmlEncode(appName)}' style='max-height:48px;margin-bottom:16px;display:block;margin-left:auto;margin-right:auto;'>";
 
         string directionsHtml = string.IsNullOrWhiteSpace(restaurant.Address)
             ? ""


### PR DESCRIPTION
## Summary

- **Header image broken**: `HeaderImageUrl` is stored as a relative path (e.g. `/media/logo.png`). Email clients can't resolve relative URLs, so the image never loaded. Now prepends the configured website URL to make it absolute when the URL is relative.
- **"Manage your booking" link broken**: The link pointed to `/lookup`, forcing customers to manually enter their booking ref and email. Now links directly to `/booking-confirmation/{ref}?email={email}` so clicking opens their specific booking immediately.
- **Admin email from booking page lacked formatting**: When admins sent a custom email from the booking detail popup, the body was sent as raw text/HTML with no wrapper. It now gets wrapped in a branded HTML email template matching the auto-confirmation style — app name header with brand color, styled content area, and a footer with the website URL and copyright. Full HTML documents (starting with `<!DOCTYPE` or `<html>`) are passed through unchanged; HTML fragments are used as-is; plain text is escaped and has newlines converted to `<br>`.

## Test plan

- [ ] Send a booking confirmation and verify the header image loads in the email client
- [ ] Click "Manage your booking" in a confirmation email — should land on the booking detail page pre-filled, not the blank lookup form
- [ ] From admin → booking detail popup → Email guest: send a plain-text message and verify it arrives with the branded header/footer; send an HTML fragment and verify same; send a full `<!DOCTYPE html>` body and verify it passes through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qz6cD9kHDPTvfdVnv9Fkmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz6cD9kHDPTvfdVnv9Fkmj)_