### PR TITLE
Use restaurant image in emails; show 'Opens in X hours' on home page

### DIFF
--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -519,6 +519,128 @@ public class BookingServiceTests
     }
 
     [Fact]
+    public async Task CreateBookingAsync_EmailHtml_ContainsRestaurantImage_WhenImageUrlSet()
+    {
+        using AppDbContext db = CreateDb(nameof(CreateBookingAsync_EmailHtml_ContainsRestaurantImage_WhenImageUrlSet));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Pic Restaurant", ImageUrl = "https://cdn.example.com/photo.jpg" });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        db.SaveChanges();
+        db.Set<EmailSettings>().Add(new EmailSettings
+        {
+            Host = "smtp.test.com", Port = 587, Username = "u", EncryptedPassword = "enc",
+            SendBookingConfirmations = true,
+        });
+        db.SaveChanges();
+
+        string? capturedBody = null;
+        var emailServiceMock = new Mock<IEmailService>();
+        emailServiceMock
+            .Setup(e => e.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string, string>((_, _, body) => capturedBody = body)
+            .Returns(Task.CompletedTask);
+
+        var emailSettingsService = new Mock<EmailSettingsService>(null!, null!, null!);
+        emailSettingsService.Setup(s => s.GetAsync()).ReturnsAsync(
+            await db.Set<EmailSettings>().FirstAsync());
+
+        BookingService svc = CreateService(db, emailService: emailServiceMock.Object,
+            emailSettingsService: emailSettingsService.Object);
+
+        await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1, SectionId = 1, TableId = 1,
+            CustomerEmail = "guest@example.com", Seats = 2,
+            Date = new DateTime(2026, 8, 1, 19, 0, 0, DateTimeKind.Utc),
+        });
+
+        Assert.NotNull(capturedBody);
+        Assert.Contains("https://cdn.example.com/photo.jpg", capturedBody);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_EmailHtml_ContainsFaviconSvg_WhenNoRestaurantImageButFaviconSet()
+    {
+        using AppDbContext db = CreateDb(nameof(CreateBookingAsync_EmailHtml_ContainsFaviconSvg_WhenNoRestaurantImageButFaviconSet));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Icon Restaurant" });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        db.Set<BrandSettings>().Add(new BrandSettings { FaviconIcon = "utensils" });
+        db.SaveChanges();
+        db.Set<EmailSettings>().Add(new EmailSettings
+        {
+            Host = "smtp.test.com", Port = 587, Username = "u", EncryptedPassword = "enc",
+            SendBookingConfirmations = true,
+        });
+        db.SaveChanges();
+
+        string? capturedBody = null;
+        var emailServiceMock = new Mock<IEmailService>();
+        emailServiceMock
+            .Setup(e => e.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string, string>((_, _, body) => capturedBody = body)
+            .Returns(Task.CompletedTask);
+
+        var emailSettingsService = new Mock<EmailSettingsService>(null!, null!, null!);
+        emailSettingsService.Setup(s => s.GetAsync()).ReturnsAsync(
+            await db.Set<EmailSettings>().FirstAsync());
+
+        BookingService svc = CreateService(db, emailService: emailServiceMock.Object,
+            emailSettingsService: emailSettingsService.Object);
+
+        await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1, SectionId = 1, TableId = 1,
+            CustomerEmail = "guest@example.com", Seats = 2,
+            Date = new DateTime(2026, 8, 1, 19, 0, 0, DateTimeKind.Utc),
+        });
+
+        Assert.NotNull(capturedBody);
+        Assert.Contains("/api/brand/pwa-icon.svg", capturedBody);
+        Assert.DoesNotContain("cdn.example.com", capturedBody);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_EmailHtml_HasNoImage_WhenNeitherRestaurantImageNorFaviconSet()
+    {
+        using AppDbContext db = CreateDb(nameof(CreateBookingAsync_EmailHtml_HasNoImage_WhenNeitherRestaurantImageNorFaviconSet));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Plain Restaurant" });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        db.SaveChanges();
+        db.Set<EmailSettings>().Add(new EmailSettings
+        {
+            Host = "smtp.test.com", Port = 587, Username = "u", EncryptedPassword = "enc",
+            SendBookingConfirmations = true,
+        });
+        db.SaveChanges();
+
+        string? capturedBody = null;
+        var emailServiceMock = new Mock<IEmailService>();
+        emailServiceMock
+            .Setup(e => e.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string, string>((_, _, body) => capturedBody = body)
+            .Returns(Task.CompletedTask);
+
+        var emailSettingsService = new Mock<EmailSettingsService>(null!, null!, null!);
+        emailSettingsService.Setup(s => s.GetAsync()).ReturnsAsync(
+            await db.Set<EmailSettings>().FirstAsync());
+
+        BookingService svc = CreateService(db, emailService: emailServiceMock.Object,
+            emailSettingsService: emailSettingsService.Object);
+
+        await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1, SectionId = 1, TableId = 1,
+            CustomerEmail = "guest@example.com", Seats = 2,
+            Date = new DateTime(2026, 8, 1, 19, 0, 0, DateTimeKind.Utc),
+        });
+
+        Assert.NotNull(capturedBody);
+        Assert.DoesNotContain("<img", capturedBody);
+    }
+
+    [Fact]
     public async Task CreateBookingAsync_DoesNotSendEmail_WhenConfirmationsDisabled()
     {
         using AppDbContext db = CreateDb(nameof(CreateBookingAsync_DoesNotSendEmail_WhenConfirmationsDisabled));

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -226,14 +226,16 @@ public class BookingService(
         string cleanWebsiteUrl = websiteUrl.TrimEnd('/');
         string lookupUrl = $"{cleanWebsiteUrl}/booking-confirmation/{Uri.EscapeDataString(booking.BookingRef ?? "")}?email={Uri.EscapeDataString(booking.CustomerEmail ?? "")}";
 
-        string headerImageSrc = string.IsNullOrEmpty(brand.HeaderImageUrl)
-            ? ""
-            : brand.HeaderImageUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                ? brand.HeaderImageUrl
-                : $"{cleanWebsiteUrl}/{brand.HeaderImageUrl.TrimStart('/')}";
+        string headerImageSrc = !string.IsNullOrEmpty(restaurant.ImageUrl)
+            ? (restaurant.ImageUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? restaurant.ImageUrl
+                : $"{cleanWebsiteUrl}/{restaurant.ImageUrl.TrimStart('/')}")
+            : !string.IsNullOrEmpty(brand.FaviconIcon)
+                ? $"{cleanWebsiteUrl}/api/brand/pwa-icon.svg"
+                : "";
         string headerImageHtml = string.IsNullOrEmpty(headerImageSrc)
             ? ""
-            : $"<img src='{headerImageSrc}' alt='{System.Net.WebUtility.HtmlEncode(appName)}' style='max-height:48px;margin-bottom:16px;display:block;margin-left:auto;margin-right:auto;'>";
+            : $"<img src='{headerImageSrc}' alt='{System.Net.WebUtility.HtmlEncode(appName)}' style='max-height:120px;margin-bottom:16px;display:block;margin-left:auto;margin-right:auto;border-radius:8px;'>";
 
         string directionsHtml = string.IsNullOrWhiteSpace(restaurant.Address)
             ? ""

--- a/openresto-frontend/components/restaurant/RestaurantCard.tsx
+++ b/openresto-frontend/components/restaurant/RestaurantCard.tsx
@@ -76,6 +76,25 @@ function parseDayOfWeek(day: string): number {
   return 0;
 }
 
+function opensLaterToday(openTime: string, timezone: string, openDays: string): string | null {
+  const [oh, om] = openTime.split(":").map(Number);
+  const { totalMins, isoDay } = getRestaurantNow(timezone || "UTC");
+  const openDaysList =
+    openDays
+      ?.split(",")
+      .map((d) => parseDayOfWeek(d.trim()))
+      .filter((d) => d > 0) ?? [1, 2, 3, 4, 5, 6, 7];
+  if (openDaysList.length > 0 && !openDaysList.includes(isoDay)) return null;
+  const openMins = oh * 60 + (om || 0);
+  if (totalMins >= openMins) return null;
+  const diffMins = openMins - totalMins;
+  const diffHours = Math.floor(diffMins / 60);
+  const diffRemMins = diffMins % 60;
+  if (diffHours >= 1 && diffRemMins === 0) return `Opens in ${diffHours}h`;
+  if (diffHours >= 1) return `Opens in ${diffHours}h ${diffRemMins}m`;
+  return `Opens in ${diffMins}m`;
+}
+
 function isOpenNow(
   openTime: string,
   closeTime: string,
@@ -252,7 +271,13 @@ export default function RestaurantCard({
           >
             {open && <View style={styles.badgeDot} />}
             <ThemedText style={styles.badgeText}>
-              {open ? `Open till ${restaurant.closeTime}` : "Closed"}
+              {open
+                ? `Open till ${restaurant.closeTime}`
+                : (opensLaterToday(
+                    restaurant.openTime,
+                    restaurant.timezone ?? "UTC",
+                    restaurant.openDays
+                  ) ?? "Closed")}
             </ThemedText>
           </View>
         </View>

--- a/openresto-frontend/components/restaurant/RestaurantCard.tsx
+++ b/openresto-frontend/components/restaurant/RestaurantCard.tsx
@@ -79,11 +79,10 @@ function parseDayOfWeek(day: string): number {
 function opensLaterToday(openTime: string, timezone: string, openDays: string): string | null {
   const [oh, om] = openTime.split(":").map(Number);
   const { totalMins, isoDay } = getRestaurantNow(timezone || "UTC");
-  const openDaysList =
-    openDays
-      ?.split(",")
-      .map((d) => parseDayOfWeek(d.trim()))
-      .filter((d) => d > 0) ?? [1, 2, 3, 4, 5, 6, 7];
+  const openDaysList = openDays
+    ?.split(",")
+    .map((d) => parseDayOfWeek(d.trim()))
+    .filter((d) => d > 0) ?? [1, 2, 3, 4, 5, 6, 7];
   if (openDaysList.length > 0 && !openDaysList.includes(isoDay)) return null;
   const openMins = oh * 60 + (om || 0);
   if (totalMins >= openMins) return null;

--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -8313,6 +8313,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/openresto-frontend/tests/components/restaurant/RestaurantCard.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/RestaurantCard.test.tsx
@@ -115,14 +115,70 @@ describe("RestaurantCard", () => {
     await waitFor(() => expect(screen.getByText("dog friendly")).toBeTruthy());
   });
 
-  it("shows Closed badge when restaurant is closed", async () => {
+  it("shows Closed badge when restaurant is closed for the day (past close time)", async () => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date("2026-01-01T14:00:00Z")); // fixed noon UTC — outside 23:00-23:59 window
+    // 23:59 UTC — past the 23:00-23:59 window so the day's service is over
+    jest.setSystemTime(new Date("2026-01-01T23:59:30Z"));
     try {
       render(
         <RestaurantCard restaurant={{ ...mockRestaurant, openTime: "23:00", closeTime: "23:59" }} />
       );
       await waitFor(() => expect(screen.queryByText("Closed")).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("shows 'Opens in Xh' badge when opening is an exact number of hours away", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T10:00:00Z")); // Monday 10:00 UTC
+    try {
+      render(
+        <RestaurantCard restaurant={{ ...mockRestaurant, openTime: "14:00", closeTime: "22:00" }} />
+      );
+      await waitFor(() => expect(screen.getByText("Opens in 4h")).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("shows 'Opens in Xh Ym' badge when opening is hours and minutes away", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T10:00:00Z")); // Monday 10:00 UTC
+    try {
+      render(
+        <RestaurantCard restaurant={{ ...mockRestaurant, openTime: "14:30", closeTime: "22:00" }} />
+      );
+      await waitFor(() => expect(screen.getByText("Opens in 4h 30m")).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("shows 'Opens in Xm' badge when opening is less than an hour away", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T10:00:00Z")); // Monday 10:00 UTC
+    try {
+      render(
+        <RestaurantCard restaurant={{ ...mockRestaurant, openTime: "10:30", closeTime: "22:00" }} />
+      );
+      await waitFor(() => expect(screen.getByText("Opens in 30m")).toBeTruthy());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("shows 'Opens in' when openDays has all-unknown day names and time is before opening", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T10:00:00Z")); // Monday 10:00 UTC
+    try {
+      render(
+        <RestaurantCard
+          restaurant={{ ...mockRestaurant, openDays: "xyz", openTime: "14:00", closeTime: "22:00" }}
+        />
+      );
+      // openDaysList is empty → day check skipped → shows "Opens in 4h"
+      await waitFor(() => expect(screen.getByText("Opens in 4h")).toBeTruthy());
     } finally {
       jest.useRealTimers();
     }


### PR DESCRIPTION
## Summary

- **Email header image**: confirmation emails now use the restaurant's own photo (`restaurant.ImageUrl`) instead of the brand header image. Falls back to the brand favicon SVG (`/api/brand/pwa-icon.svg`) when the restaurant has no image and a favicon icon is configured. Falls back to no image otherwise. Also bumped max-height to 120px and added `border-radius: 8px`.
- **Home page "Opens in X hours"**: restaurant cards now show `Opens in 4h`, `Opens in 4h 30m`, or `Opens in 30m` when the restaurant is closed at time of viewing but scheduled to open later that same day. Still shows `Closed` when today is not an open day or the day's service has ended.

## Test plan

- [ ] Backend: 3 new `BookingServiceTests` covering restaurant image URL (absolute), favicon SVG fallback, and no-image case
- [ ] Frontend: updated "Closed badge" test to use a post-close-time timestamp; 4 new `RestaurantCard` tests covering each "Opens in" format variant and the empty-openDays edge case
- [ ] CI frontend/backend coverage should hold or improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qz6cD9kHDPTvfdVnv9Fkmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz6cD9kHDPTvfdVnv9Fkmj)_