### PR TITLE
Add shared email base template with branding for all email types

### DIFF
--- a/OpenRestoApi.Tests/Infrastructure/EmailTemplateBuilderTests.cs
+++ b/OpenRestoApi.Tests/Infrastructure/EmailTemplateBuilderTests.cs
@@ -1,0 +1,125 @@
+using OpenRestoApi.Infrastructure.Email;
+
+namespace OpenRestoApi.Tests.Infrastructure;
+
+public class EmailTemplateBuilderTests
+{
+    [Fact]
+    public void Wrap_ContainsSharedShell()
+    {
+        string html = EmailTemplateBuilder.Wrap("#0a7ea4", "MyApp", "https://example.com", "<tr><td>header</td></tr>", "<tr><td>body</td></tr>");
+
+        Assert.Contains("<!DOCTYPE html>", html);
+        Assert.Contains("background-color:#f9fafb", html);
+        Assert.Contains("max-width:520px", html);
+        Assert.Contains("header", html);
+        Assert.Contains("body", html);
+    }
+
+    [Fact]
+    public void Wrap_Footer_ContainsWebsiteUrlAndCopyright()
+    {
+        string html = EmailTemplateBuilder.Wrap("#0a7ea4", "MyApp", "https://example.com/", "", "");
+
+        Assert.Contains("example.com", html);
+        Assert.Contains("MyApp", html);
+        Assert.Contains("&copy;", html);
+        Assert.Contains(DateTime.UtcNow.Year.ToString(), html);
+    }
+
+    [Fact]
+    public void Wrap_StripsTrailingSlashFromUrl()
+    {
+        string html = EmailTemplateBuilder.Wrap("#0a7ea4", "MyApp", "https://example.com/", "", "");
+
+        Assert.Contains("href=\"https://example.com\"", html);
+    }
+
+    [Fact]
+    public void Wrap_HtmlEncodesAppName()
+    {
+        string html = EmailTemplateBuilder.Wrap("#0a7ea4", "My <App>", "https://example.com", "", "");
+
+        Assert.Contains("My &lt;App&gt;", html);
+        Assert.DoesNotContain("My <App>", html);
+    }
+
+    [Fact]
+    public void BannerHeader_ContainsImageAndTitle()
+    {
+        string html = EmailTemplateBuilder.BannerHeader("https://cdn.example.com/photo.jpg", "My Restaurant", "My Restaurant", "Booking Confirmed");
+
+        Assert.Contains("https://cdn.example.com/photo.jpg", html);
+        Assert.Contains("width:100%", html);
+        Assert.Contains("height:200px", html);
+        Assert.Contains("object-fit:cover", html);
+        Assert.Contains("My Restaurant", html);
+        Assert.Contains("Booking Confirmed", html);
+    }
+
+    [Fact]
+    public void BannerHeader_EmptySubtitle_OmitsSubtitleElement()
+    {
+        string html = EmailTemplateBuilder.BannerHeader("https://cdn.example.com/photo.jpg", "Alt", "Title", "");
+
+        Assert.DoesNotContain("<p style='margin:8px", html);
+    }
+
+    [Fact]
+    public void BannerHeader_HtmlEncodesAltAndTitle()
+    {
+        string html = EmailTemplateBuilder.BannerHeader("https://x.com/img.jpg", "Alt <b>text</b>", "Title <b>text</b>", "Sub");
+
+        Assert.Contains("Alt &lt;b&gt;text&lt;/b&gt;", html);
+        Assert.Contains("Title &lt;b&gt;text&lt;/b&gt;", html);
+    }
+
+    [Fact]
+    public void IconHeader_ContainsIconAndTitle()
+    {
+        string html = EmailTemplateBuilder.IconHeader("https://example.com/api/brand/pwa-icon.svg", "MyApp", "Restaurant Name", "Booking Confirmed");
+
+        Assert.Contains("https://example.com/api/brand/pwa-icon.svg", html);
+        Assert.Contains("width:72px", html);
+        Assert.Contains("height:72px", html);
+        Assert.Contains("border-radius:12px", html);
+        Assert.Contains("Restaurant Name", html);
+        Assert.Contains("Booking Confirmed", html);
+    }
+
+    [Fact]
+    public void IconHeader_EmptySubtitle_OmitsSubtitleElement()
+    {
+        string html = EmailTemplateBuilder.IconHeader("https://example.com/icon.svg", "App", "Title", "");
+
+        Assert.DoesNotContain("<p style='margin:8px", html);
+    }
+
+    [Fact]
+    public void IconHeader_HtmlEncodesAltAndTitle()
+    {
+        string html = EmailTemplateBuilder.IconHeader("https://x.com/icon.svg", "Alt <x>", "Title <x>", "Sub");
+
+        Assert.Contains("Alt &lt;x&gt;", html);
+        Assert.Contains("Title &lt;x&gt;", html);
+    }
+
+    [Fact]
+    public void TextHeader_ContainsAppNameInPrimaryColor()
+    {
+        string html = EmailTemplateBuilder.TextHeader("My Restaurant", "#ff5500");
+
+        Assert.Contains("My Restaurant", html);
+        Assert.Contains("#ff5500", html);
+        Assert.Contains("border-bottom:3px solid #ff5500", html);
+    }
+
+    [Fact]
+    public void TextHeader_HtmlEncodesAppName()
+    {
+        string html = EmailTemplateBuilder.TextHeader("My <App>", "#0a7ea4");
+
+        Assert.Contains("My &lt;App&gt;", html);
+        Assert.DoesNotContain("My <App>", html);
+    }
+}

--- a/OpenRestoApi/Controllers/AdminController.cs
+++ b/OpenRestoApi/Controllers/AdminController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Interfaces;
 using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Infrastructure.Email;
 
 namespace OpenRestoApi.Controllers;
 
@@ -176,7 +177,10 @@ public class AdminController(AdminService adminService, IEmailService emailServi
                 string appName = brand.AppName ?? "Open Resto";
                 string primaryColor = brand.PrimaryColor ?? "#0a7ea4";
                 string websiteUrl = _brand.GetWebsiteUrl(brand).TrimEnd('/');
-                htmlBody = WrapInBrandedEmail(req.Body, appName, primaryColor, websiteUrl);
+                string iconUrl = !string.IsNullOrEmpty(brand.FaviconIcon)
+                    ? $"{websiteUrl}/api/brand/pwa-icon.svg"
+                    : "";
+                htmlBody = WrapInBrandedEmail(req.Body, appName, primaryColor, websiteUrl, iconUrl);
             }
             await _email.SendEmailAsync(booking.CustomerEmail, req.Subject, htmlBody);
             return Ok(new MessageResponse { Message = $"Email sent to {booking.CustomerEmail}." });
@@ -191,44 +195,24 @@ public class AdminController(AdminService adminService, IEmailService emailServi
         }
     }
 
-    private static string WrapInBrandedEmail(string content, string appName, string primaryColor, string websiteUrl)
+    private static string WrapInBrandedEmail(string content, string appName, string primaryColor, string websiteUrl, string iconUrl = "")
     {
         bool isHtmlFragment = content.TrimStart().StartsWith('<');
         string innerHtml = isHtmlFragment
             ? content
             : System.Net.WebUtility.HtmlEncode(content).Replace("\n", "<br>").Replace("\r", "");
 
-        return $"""
-            <!DOCTYPE html>
-            <html>
-            <head>
-              <meta charset="utf-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            </head>
-            <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-              <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f9fafb;padding:32px 16px;">
-                <tr><td align="center">
-                  <table width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -1px rgba(0,0,0,0.06);border:1px solid #e5e7eb;">
-                    <tr><td style="padding:32px 40px 24px;text-align:center;border-bottom:3px solid {primaryColor};">
-                      <h1 style="margin:0;font-size:20px;font-weight:700;color:{primaryColor};">{System.Net.WebUtility.HtmlEncode(appName)}</h1>
-                    </td></tr>
-                    <tr><td style="padding:32px 40px;font-size:15px;line-height:1.7;color:#111827;">
-                      {innerHtml}
-                    </td></tr>
-                    <tr><td style="padding:0 40px 32px;border-top:1px solid #f0f0f0;text-align:center;">
-                      <p style="margin:24px 0 4px;font-size:13px;color:#6b7280;">
-                        <a href="{websiteUrl}" style="color:{primaryColor};text-decoration:none;">{websiteUrl.Replace("http://","").Replace("https://","")}</a>
-                      </p>
-                      <p style="margin:0;font-size:12px;color:#9ca3af;">
-                        &copy; {DateTime.UtcNow.Year} {System.Net.WebUtility.HtmlEncode(appName)}
-                      </p>
-                    </td></tr>
-                  </table>
-                </td></tr>
-              </table>
-            </body>
-            </html>
+        string headerHtml = !string.IsNullOrEmpty(iconUrl)
+            ? EmailTemplateBuilder.IconHeader(iconUrl, appName, appName, "")
+            : EmailTemplateBuilder.TextHeader(appName, primaryColor);
+
+        string contentHtml = $"""
+            <tr><td style="padding:32px 40px;font-size:15px;line-height:1.7;color:#111827;">
+              {innerHtml}
+            </td></tr>
             """;
+
+        return EmailTemplateBuilder.Wrap(primaryColor, appName, websiteUrl, headerHtml, contentHtml);
     }
 
     [HttpPost("bookings/{id}/restore")]

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -1,8 +1,10 @@
 using System.Globalization;
+using System.Net;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Interfaces;
 using OpenRestoApi.Core.Application.Mappings;
 using OpenRestoApi.Core.Domain;
+using OpenRestoApi.Infrastructure.Email;
 using OpenRestoApi.Infrastructure.Persistence;
 
 namespace OpenRestoApi.Core.Application.Services;
@@ -226,24 +228,37 @@ public class BookingService(
         string cleanWebsiteUrl = websiteUrl.TrimEnd('/');
         string lookupUrl = $"{cleanWebsiteUrl}/booking-confirmation/{Uri.EscapeDataString(booking.BookingRef ?? "")}?email={Uri.EscapeDataString(booking.CustomerEmail ?? "")}";
 
-        string headerImageSrc = !string.IsNullOrEmpty(restaurant.ImageUrl)
-            ? (restaurant.ImageUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+        // Choose header: full-width banner for restaurant photos, small icon for brand SVG, plain text otherwise
+        string headerHtml;
+        if (!string.IsNullOrEmpty(restaurant.ImageUrl))
+        {
+            string imageSrc = restaurant.ImageUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
                 ? restaurant.ImageUrl
-                : $"{cleanWebsiteUrl}/{restaurant.ImageUrl.TrimStart('/')}")
-            : !string.IsNullOrEmpty(brand.FaviconIcon)
-                ? $"{cleanWebsiteUrl}/api/brand/pwa-icon.svg"
-                : "";
-        string headerImageHtml = string.IsNullOrEmpty(headerImageSrc)
-            ? ""
-            : $"<img src='{headerImageSrc}' alt='{System.Net.WebUtility.HtmlEncode(appName)}' style='max-height:120px;margin-bottom:16px;display:block;margin-left:auto;margin-right:auto;border-radius:8px;'>";
+                : $"{cleanWebsiteUrl}/{restaurant.ImageUrl.TrimStart('/')}";
+            headerHtml = EmailTemplateBuilder.BannerHeader(imageSrc, restaurant.Name, restaurant.Name, "Booking Confirmed");
+        }
+        else if (!string.IsNullOrEmpty(brand.FaviconIcon))
+        {
+            headerHtml = EmailTemplateBuilder.IconHeader(
+                $"{cleanWebsiteUrl}/api/brand/pwa-icon.svg", appName, restaurant.Name, "Booking Confirmed");
+        }
+        else
+        {
+            headerHtml = $"""
+                <tr><td style="padding:40px 40px 24px;text-align:center;background-color:#ffffff;">
+                  <h1 style="margin:0;font-size:24px;font-weight:700;color:#111827;">{WebUtility.HtmlEncode(restaurant.Name)}</h1>
+                  <p style="margin:8px 0 0;font-size:16px;color:#6b7280;">Booking Confirmed</p>
+                </td></tr>
+                """;
+        }
 
         string directionsHtml = string.IsNullOrWhiteSpace(restaurant.Address)
             ? ""
             : $"""
                <div style='margin-top:16px;padding-top:16px;border-top:1px solid #f0f0f0;'>
                  <p style='margin:0 0 8px;font-size:14px;color:#6b7280;'>Location</p>
-                 <p style='margin:0 0 12px;font-size:15px;color:#111827;'>{System.Net.WebUtility.HtmlEncode(restaurant.Address)}</p>
-                 <a href='https://www.google.com/maps/search/?api=1&query={Uri.EscapeDataString(restaurant.Address)}' 
+                 <p style='margin:0 0 12px;font-size:15px;color:#111827;'>{WebUtility.HtmlEncode(restaurant.Address)}</p>
+                 <a href='https://www.google.com/maps/search/?api=1&query={Uri.EscapeDataString(restaurant.Address)}'
                     style='color:{primaryColor};text-decoration:none;font-size:14px;font-weight:600;'>Get directions &rarr;</a>
                </div>
                """;
@@ -253,86 +268,59 @@ public class BookingService(
             : $"""
                <tr>
                  <td style='padding:12px 0;color:#6b7280;font-size:14px;vertical-align:top;'>Special requests</td>
-                 <td style='padding:12px 0;font-size:14px;color:#111827;'>{System.Net.WebUtility.HtmlEncode(booking.SpecialRequests)}</td>
+                 <td style='padding:12px 0;font-size:14px;color:#111827;'>{WebUtility.HtmlEncode(booking.SpecialRequests)}</td>
                </tr>
                """;
 
-        return $"""
-            <!DOCTYPE html>
-            <html>
-            <head>
-              <meta charset="utf-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            </head>
-            <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-              <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f9fafb;padding:32px 16px;">
-                <tr><td align="center">
-                  <table width="100%" max-width="520" cellpadding="0" cellspacing="0" style="max-width:520px;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -1px rgba(0,0,0,0.06);border:1px solid #e5e7eb;">
-                    <!-- Header -->
-                    <tr><td style="padding:40px 40px 32px;text-align:center;background-color:#ffffff;">
-                      {headerImageHtml}
-                      <h1 style="margin:0;font-size:24px;font-weight:700;color:#111827;">{System.Net.WebUtility.HtmlEncode(restaurant.Name)}</h1>
-                      <p style="margin:8px 0 0;font-size:16px;color:#6b7280;">Booking Confirmed</p>
-                    </td></tr>
+        string greetingName = string.IsNullOrWhiteSpace(booking.CustomerName)
+            ? "You're all set!"
+            : $"You're all set, {WebUtility.HtmlEncode(booking.CustomerName)}!";
 
-                    <!-- Confirmation Hero -->
-                    <tr><td style="padding:0 40px;">
-                      <div style="background-color:{primaryColor}10;border-radius:12px;padding:24px;text-align:center;border:1px solid {primaryColor}20;">
-                        <p style="margin:0;font-size:18px;font-weight:600;color:{primaryColor};">{(string.IsNullOrWhiteSpace(booking.CustomerName) ? "You're all set!" : $"You're all set, {System.Net.WebUtility.HtmlEncode(booking.CustomerName)}!")}</p>
-                        <p style="margin:4px 0 0;font-size:14px;color:{primaryColor};opacity:0.8;">We're looking forward to seeing you.</p>
-                      </div>
-                    </td></tr>
+        string contentHtml = $"""
+            <!-- Confirmation Hero -->
+            <tr><td style="padding:0 40px;">
+              <div style="background-color:{primaryColor}10;border-radius:12px;padding:24px;text-align:center;border:1px solid {primaryColor}20;">
+                <p style="margin:0;font-size:18px;font-weight:600;color:{primaryColor};">{greetingName}</p>
+                <p style="margin:4px 0 0;font-size:14px;color:{primaryColor};opacity:0.8;">We're looking forward to seeing you.</p>
+              </div>
+            </td></tr>
 
-                    <!-- Details -->
-                    <tr><td style="padding:32px 40px;">
-                      <table width="100%" cellpadding="0" cellspacing="0">
-                        <tr>
-                          <td style="padding:12px 0;color:#6b7280;font-size:14px;width:100px;">Reference</td>
-                          <td style="padding:12px 0;font-size:14px;font-weight:700;color:#111827;letter-spacing:0.05em;">{System.Net.WebUtility.HtmlEncode(booking.BookingRef ?? "")}</td>
-                        </tr>
-                        <tr>
-                          <td style="padding:12px 0;color:#6b7280;font-size:14px;">Date</td>
-                          <td style="padding:12px 0;font-size:14px;color:#111827;">{dateStr}</td>
-                        </tr>
-                        <tr>
-                          <td style="padding:12px 0;color:#6b7280;font-size:14px;">Time</td>
-                          <td style="padding:12px 0;font-size:14px;color:#111827;">{timeStr}</td>
-                        </tr>
-                        <tr>
-                          <td style="padding:12px 0;color:#6b7280;font-size:14px;">Guests</td>
-                          <td style="padding:12px 0;font-size:14px;color:#111827;">{booking.Seats} {(booking.Seats == 1 ? "guest" : "guests")}</td>
-                        </tr>
-                        {specialReqsHtml}
-                      </table>
-
-                      {directionsHtml}
-                    </td></tr>
-
-                    <!-- CTA -->
-                    <tr><td style="padding:0 40px 32px;text-align:center;">
-                      <a href="{lookupUrl}" style="display:inline-block;background-color:{primaryColor};color:#ffffff;padding:14px 28px;border-radius:8px;text-decoration:none;font-weight:600;font-size:15px;box-shadow:0 2px 4px rgba(0,0,0,0.1);">Manage your booking</a>
-                      <p style="margin:16px 0 0;font-size:13px;color:#9ca3af;">
-                        Or visit: <a href="{cleanWebsiteUrl}" style="color:{primaryColor};text-decoration:none;">{cleanWebsiteUrl.Replace("http://", "").Replace("https://", "")}</a>
-                      </p>
-                    </td></tr>
-
-                    <!-- Footer Info -->
-                    <tr><td style="padding:0 40px 40px;">
-                      <div style="padding-top:24px;border-top:1px solid #f0f0f0;text-align:center;">
-                        <p style="margin:0 0 8px;font-size:14px;color:#6b7280;line-height:1.5;">
-                          Need to change or cancel your reservation?
-                        </p>
-                        <p style="margin:0;font-size:12px;color:#9ca3af;">
-                          &copy; {DateTime.UtcNow.Year} {appName}
-                        </p>
-                      </div>
-                    </td></tr>
-                  </table>
-                </td></tr>
+            <!-- Details -->
+            <tr><td style="padding:32px 40px;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="padding:12px 0;color:#6b7280;font-size:14px;width:100px;">Reference</td>
+                  <td style="padding:12px 0;font-size:14px;font-weight:700;color:#111827;letter-spacing:0.05em;">{WebUtility.HtmlEncode(booking.BookingRef ?? "")}</td>
+                </tr>
+                <tr>
+                  <td style="padding:12px 0;color:#6b7280;font-size:14px;">Date</td>
+                  <td style="padding:12px 0;font-size:14px;color:#111827;">{dateStr}</td>
+                </tr>
+                <tr>
+                  <td style="padding:12px 0;color:#6b7280;font-size:14px;">Time</td>
+                  <td style="padding:12px 0;font-size:14px;color:#111827;">{timeStr}</td>
+                </tr>
+                <tr>
+                  <td style="padding:12px 0;color:#6b7280;font-size:14px;">Guests</td>
+                  <td style="padding:12px 0;font-size:14px;color:#111827;">{booking.Seats} {(booking.Seats == 1 ? "guest" : "guests")}</td>
+                </tr>
+                {specialReqsHtml}
               </table>
-            </body>
-            </html>
+              {directionsHtml}
+            </td></tr>
+
+            <!-- CTA -->
+            <tr><td style="padding:0 40px 32px;text-align:center;">
+              <a href="{lookupUrl}" style="display:inline-block;background-color:{primaryColor};color:#ffffff;padding:14px 28px;border-radius:8px;text-decoration:none;font-weight:600;font-size:15px;box-shadow:0 2px 4px rgba(0,0,0,0.1);">Manage your booking</a>
+            </td></tr>
+
+            <!-- Cancellation note -->
+            <tr><td style="padding:0 40px 32px;text-align:center;">
+              <p style="margin:0;font-size:14px;color:#6b7280;line-height:1.5;">Need to change or cancel your reservation?<br>Use the link above or visit our website.</p>
+            </td></tr>
             """;
+
+        return EmailTemplateBuilder.Wrap(primaryColor, appName, cleanWebsiteUrl, headerHtml, contentHtml);
     }
 
     public virtual async Task<bool> CancelBookingAsync(string bookingRef, string email)

--- a/OpenRestoApi/Infrastructure/Email/EmailTemplateBuilder.cs
+++ b/OpenRestoApi/Infrastructure/Email/EmailTemplateBuilder.cs
@@ -1,0 +1,102 @@
+using System.Net;
+
+namespace OpenRestoApi.Infrastructure.Email;
+
+public static class EmailTemplateBuilder
+{
+    /// <summary>
+    /// Wraps header + content HTML in the shared branded email shell (outer table, card, footer).
+    /// </summary>
+    public static string Wrap(
+        string primaryColor,
+        string appName,
+        string websiteUrl,
+        string headerHtml,
+        string contentHtml)
+    {
+        string cleanUrl = websiteUrl.TrimEnd('/');
+        string displayUrl = cleanUrl.Replace("https://", "").Replace("http://", "");
+        int year = DateTime.UtcNow.Year;
+
+        return $"""
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            </head>
+            <body style="margin:0;padding:0;background-color:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f9fafb;padding:32px 16px;">
+                <tr><td align="center">
+                  <table width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -1px rgba(0,0,0,0.06);border:1px solid #e5e7eb;">
+                    {headerHtml}
+                    {contentHtml}
+                    <tr><td style="padding:0 40px 32px;border-top:1px solid #f0f0f0;text-align:center;">
+                      <p style="margin:24px 0 4px;font-size:13px;color:#6b7280;">
+                        <a href="{cleanUrl}" style="color:{primaryColor};text-decoration:none;">{displayUrl}</a>
+                      </p>
+                      <p style="margin:0;font-size:12px;color:#9ca3af;">
+                        &copy; {year} {WebUtility.HtmlEncode(appName)}
+                      </p>
+                    </td></tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            """;
+    }
+
+    /// <summary>
+    /// Full-width restaurant banner photo header (landscape image, cropped to fixed height).
+    /// Use when the restaurant has a photo uploaded.
+    /// </summary>
+    public static string BannerHeader(string imageUrl, string altText, string title, string subtitle)
+    {
+        string subtitleHtml = string.IsNullOrEmpty(subtitle) ? "" :
+            $"<p style='margin:8px 0 0;font-size:16px;color:#6b7280;'>{WebUtility.HtmlEncode(subtitle)}</p>";
+        return $"""
+            <tr><td style="padding:0;text-align:center;background-color:#ffffff;">
+              <img src="{imageUrl}" alt="{WebUtility.HtmlEncode(altText)}"
+                   width="520"
+                   style="width:100%;max-width:520px;height:200px;object-fit:cover;display:block;">
+              <div style="padding:24px 40px 20px;">
+                <h1 style="margin:0;font-size:24px;font-weight:700;color:#111827;">{WebUtility.HtmlEncode(title)}</h1>
+                {subtitleHtml}
+              </div>
+            </td></tr>
+            """;
+    }
+
+    /// <summary>
+    /// Small square brand icon (72 × 72 px) centered above the title.
+    /// Use when there's no restaurant photo but a brand favicon icon is set.
+    /// </summary>
+    public static string IconHeader(string iconUrl, string altText, string title, string subtitle)
+    {
+        string subtitleHtml = string.IsNullOrEmpty(subtitle) ? "" :
+            $"<p style='margin:8px 0 0;font-size:16px;color:#6b7280;'>{WebUtility.HtmlEncode(subtitle)}</p>";
+        return $"""
+            <tr><td style="padding:40px 40px 24px;text-align:center;background-color:#ffffff;">
+              <img src="{iconUrl}" alt="{WebUtility.HtmlEncode(altText)}"
+                   width="72" height="72"
+                   style="width:72px;height:72px;display:block;margin:0 auto 16px;border-radius:12px;">
+              <h1 style="margin:0;font-size:24px;font-weight:700;color:#111827;">{WebUtility.HtmlEncode(title)}</h1>
+              {subtitleHtml}
+            </td></tr>
+            """;
+    }
+
+    /// <summary>
+    /// Text-only header with the app name styled in the primary brand colour.
+    /// Fallback when no image or icon is available.
+    /// </summary>
+    public static string TextHeader(string appName, string primaryColor)
+    {
+        return $"""
+            <tr><td style="padding:32px 40px 24px;text-align:center;border-bottom:3px solid {primaryColor};">
+              <h1 style="margin:0;font-size:20px;font-weight:700;color:{primaryColor};">{WebUtility.HtmlEncode(appName)}</h1>
+            </td></tr>
+            """;
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts a new `EmailTemplateBuilder` static class (`Infrastructure/Email/`) with `Wrap()`, `BannerHeader()`, `IconHeader()`, and `TextHeader()` helpers — a single source of truth for the outer email shell (card, colours, footer)
- **Booking confirmation emails** now differentiate image types: restaurant photos render as a full-width 200 px banner at the top of the card; brand favicon icons render as a small 72×72 centred tile; falls back to text-only when neither is set
- **Admin custom emails** now inherit the same base template and pick up the brand favicon icon header (if configured) instead of the plain text-only header they had before
- Both email types share the identical outer wrapper, card border/shadow, and footer (website URL + copyright)

## Test plan

- [ ] Send a booking confirmation for a restaurant **with** a photo → banner image fills the card top at 200 px height
- [ ] Send a booking confirmation for a restaurant **without** a photo but with a favicon icon set → 72×72 brand icon appears centred above the restaurant name
- [ ] Send a booking confirmation with neither → text-only header, no broken image
- [ ] Send an admin custom email (POST `/api/admin/bookings/{id}/email`) → branded wrapper with icon header if favicon is set, text header otherwise
- [ ] Verify footer shows website URL + copyright in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Br8T8TeuwDx4Cobs72d1D

---
_Generated by [Claude Code](https://claude.ai/code/session_015Br8T8TeuwDx4Cobs72d1D)_