### PR TITLE
chore: dependency audit — no vulnerabilities, lock file metadata fix

### DIFF
--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -8313,6 +8313,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Dependency Audit — June 24 2026

Full audit of all npm and NuGet dependencies across the repo. **No security vulnerabilities found.**

---

### Security Findings

#### npm (root + frontend)
`npm audit` returned **0 vulnerabilities** across both workspaces (1,136 packages scanned in frontend, 306 in root).

#### NuGet (.NET 10 backend)
All Microsoft.AspNetCore.* and EF Core packages are pinned at **10.0.9**, which is the June 2026 security release — already patched for:

| CVE | Severity | Description | Fixed in | Status |
|-----|----------|-------------|----------|--------|
| CVE-2026-40372 | CVSS 9.1 | ASP.NET Core DataProtection EoP — HMAC over wrong data allows auth cookie forgery | 10.0.7 | ✅ Patched (using 10.0.9) |
| CVE-2026-45591 | CVSS 7.5 | ASP.NET Core DoS via deeply nested MessagePack in SignalR/Blazor | 10.0.9 | ✅ Patched |
| CVE-2026-45491 | CVSS 6.8 | System.Formats.Tar path traversal EoP | 10.0.9 | ✅ Patched |
| GHSA-9j88-vvj5-vhgr | Medium | MailKit STARTTLS response injection (SASL downgrade) | 4.16.0 | ✅ Patched (using 4.17.0) |

> **Note on CVE-2026-40372**: This project uses `DataProtection` for encrypted booking cookies (`Infrastructure/Cookies/`). The transitive `Microsoft.AspNetCore.DataProtection` version is determined by the SDK 10.0.9 platform — already safe. No key rotation needed.

---

### Available Updates (non-security)

#### npm — patch updates (already applied in lock file via `npm install --package-lock-only`)

| Package | In package.json | Installed (lock) | Latest in range |
|---------|----------------|-----------------|-----------------|
| expo-router | ~56.2.9 | 56.2.11 | 56.2.11 ✅ |
| expo-constants | ~56.0.17 | 56.0.18 | 56.0.18 ✅ |
| expo-font | ~56.0.5 | 56.0.7 | 56.0.7 ✅ |
| expo-image | ~56.0.10 | 56.0.11 | 56.0.11 ✅ |

Lock file was already current for all expo packages.

#### npm — updates held back (need manual decision)

| Package | Current | Latest | Type | Reason to hold |
|---------|---------|--------|------|---------------|
| react-native | 0.85.3 | 0.86.0 | minor | Must track Expo SDK upgrade, not standalone |
| react-native-reanimated | 4.3.1 | 4.5.0 | minor | Expo SDK 56 bundles 4.3.1; 4.5.0 requires worklets 0.10.x |
| react-native-worklets | 0.8.3 | 0.10.0 | minor | Paired with reanimated; update together with SDK bump |
| eslint | ^9.20.1 | 10.5.0 | **major** | ESLint 10 has config format changes; needs migration |
| concurrently | ^9.2.1 | 10.0.3 | **major** | Major version; review API changes before upgrading |

#### NuGet — all up to date

| Package | Version | Latest |
|---------|---------|--------|
| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.9 | 10.0.9 ✅ |
| Microsoft.EntityFrameworkCore | 10.0.9 | 10.0.9 ✅ |
| Magick.NET-Q8-AnyCPU | 14.14.0 | 14.14.0 ✅ |
| MailKit | 4.17.0 | 4.17.0 ✅ |
| System.IdentityModel.Tokens.Jwt | 8.19.1 | 8.19.1 ✅ |
| Riok.Mapperly | 4.3.1 | 4.3.1 ✅ |
| WebPush | 1.0.13 | 1.0.13 ✅ |
| Moq | 4.20.72 | 4.20.72 ✅ |
| xunit | 2.9.3 | 2.9.3 ✅ |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.6.0 ✅ |

---

### Change in this PR

- `openresto-frontend/package-lock.json`: corrects `fsevents` metadata flag (`"dev": true`) — cosmetic only, no version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tPhsSYEEDkCSzeQZaVF59

---
_Generated by [Claude Code](https://claude.ai/code/session_012tPhsSYEEDkCSzeQZaVF59)_