### PR TITLE
test(backend): add EmailSettingsService and RestaurantManagementService coverage

### DIFF
--- a/OpenRestoApi.Tests/Services/EmailSettingsServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/EmailSettingsServiceTests.cs
@@ -1,0 +1,167 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Domain;
+using OpenRestoApi.Infrastructure.Email;
+using OpenRestoApi.Infrastructure.Persistence;
+
+namespace OpenRestoApi.Tests.Services;
+
+public class EmailSettingsServiceTests
+{
+    private static AppDbContext CreateDb(string name)
+    {
+        DbContextOptions<AppDbContext> opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options;
+        return new AppDbContext(opts);
+    }
+
+    private static EmailSettingsService CreateService(AppDbContext db, Mock<CredentialProtector>? protectorMock = null, Mock<IEmailService>? emailMock = null)
+    {
+        protectorMock ??= new Mock<CredentialProtector>(Mock.Of<IDataProtectionProvider>());
+        emailMock ??= new Mock<IEmailService>();
+        return new EmailSettingsService(db, protectorMock.Object, emailMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsNull_WhenNoSettings()
+    {
+        using AppDbContext db = CreateDb(nameof(GetAsync_ReturnsNull_WhenNoSettings));
+        var svc = CreateService(db);
+        Assert.Null(await svc.GetAsync());
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsExistingSettings()
+    {
+        using AppDbContext db = CreateDb(nameof(GetAsync_ReturnsExistingSettings));
+        db.Set<EmailSettings>().Add(new EmailSettings { Host = "smtp.example.com", Port = 587 });
+        await db.SaveChangesAsync();
+
+        var svc = CreateService(db);
+        EmailSettings? result = await svc.GetAsync();
+        Assert.NotNull(result);
+        Assert.Equal("smtp.example.com", result.Host);
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesNewSettings_WhenNoneExist()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_CreatesNewSettings_WhenNoneExist));
+        var svc = CreateService(db);
+        await svc.SaveAsync("smtp.test.com", 465, "user@test.com", null, true, null, null);
+
+        EmailSettings? result = await db.Set<EmailSettings>().FirstOrDefaultAsync();
+        Assert.NotNull(result);
+        Assert.Equal("smtp.test.com", result.Host);
+        Assert.Equal(465, result.Port);
+        Assert.Equal("user@test.com", result.Username);
+        Assert.True(result.EnableSsl);
+    }
+
+    [Fact]
+    public async Task SaveAsync_UpdatesExistingSettings()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_UpdatesExistingSettings));
+        db.Set<EmailSettings>().Add(new EmailSettings { Host = "old.host", Port = 587 });
+        await db.SaveChangesAsync();
+
+        var svc = CreateService(db);
+        await svc.SaveAsync("new.host", 465, "new@user.com", null, false, null, null);
+
+        EmailSettings? result = await db.Set<EmailSettings>().FirstOrDefaultAsync();
+        Assert.Equal("new.host", result!.Host);
+        Assert.Equal(465, result.Port);
+        Assert.False(result.EnableSsl);
+    }
+
+    [Fact]
+    public async Task SaveAsync_EncryptsPassword_WhenProvided()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_EncryptsPassword_WhenProvided));
+        var protectorMock = new Mock<CredentialProtector>(Mock.Of<IDataProtectionProvider>());
+        protectorMock.Setup(p => p.Encrypt("secret")).Returns("encrypted-secret");
+
+        var svc = CreateService(db, protectorMock);
+        await svc.SaveAsync("smtp.test.com", 587, "user", "secret", true, null, null);
+
+        EmailSettings? result = await db.Set<EmailSettings>().FirstOrDefaultAsync();
+        Assert.Equal("encrypted-secret", result!.EncryptedPassword);
+        protectorMock.Verify(p => p.Encrypt("secret"), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SkipsEncryption_WhenPasswordIsMask()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_SkipsEncryption_WhenPasswordIsMask));
+        db.Set<EmailSettings>().Add(new EmailSettings { Host = "smtp", Port = 587, EncryptedPassword = "existing-encrypted" });
+        await db.SaveChangesAsync();
+
+        var protectorMock = new Mock<CredentialProtector>(Mock.Of<IDataProtectionProvider>());
+        var svc = CreateService(db, protectorMock);
+        await svc.SaveAsync("smtp", 587, "user", "••••••••", true, null, null);
+
+        protectorMock.Verify(p => p.Encrypt(It.IsAny<string>()), Times.Never);
+        EmailSettings? result = await db.Set<EmailSettings>().FirstOrDefaultAsync();
+        Assert.Equal("existing-encrypted", result!.EncryptedPassword);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SkipsEncryption_WhenPasswordIsNull()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_SkipsEncryption_WhenPasswordIsNull));
+        var protectorMock = new Mock<CredentialProtector>(Mock.Of<IDataProtectionProvider>());
+        var svc = CreateService(db, protectorMock);
+        await svc.SaveAsync("smtp.test.com", 587, "user", null, true, null, null);
+
+        protectorMock.Verify(p => p.Encrypt(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsFromNameAndFromEmail()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_PersistsFromNameAndFromEmail));
+        var svc = CreateService(db);
+        await svc.SaveAsync("smtp.test.com", 587, "user", null, true, "My Restaurant", "no-reply@myrestaurant.com");
+
+        EmailSettings? result = await db.Set<EmailSettings>().FirstOrDefaultAsync();
+        Assert.Equal("My Restaurant", result!.FromName);
+        Assert.Equal("no-reply@myrestaurant.com", result.FromEmail);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SetsSendBookingConfirmations()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_SetsSendBookingConfirmations));
+        var svc = CreateService(db);
+        await svc.SaveAsync("smtp.test.com", 587, "user", null, true, null, null, sendBookingConfirmations: true);
+
+        EmailSettings? result = await db.Set<EmailSettings>().FirstOrDefaultAsync();
+        Assert.True(result!.SendBookingConfirmations);
+    }
+
+    [Fact]
+    public async Task TestConnectionAsync_ReturnsTrue_WhenServiceSucceeds()
+    {
+        using AppDbContext db = CreateDb(nameof(TestConnectionAsync_ReturnsTrue_WhenServiceSucceeds));
+        var emailMock = new Mock<IEmailService>();
+        emailMock.Setup(e => e.TestConnectionAsync()).ReturnsAsync(true);
+
+        var svc = CreateService(db, emailMock: emailMock);
+        Assert.True(await svc.TestConnectionAsync());
+    }
+
+    [Fact]
+    public async Task TestConnectionAsync_ReturnsFalse_WhenServiceFails()
+    {
+        using AppDbContext db = CreateDb(nameof(TestConnectionAsync_ReturnsFalse_WhenServiceFails));
+        var emailMock = new Mock<IEmailService>();
+        emailMock.Setup(e => e.TestConnectionAsync()).ReturnsAsync(false);
+
+        var svc = CreateService(db, emailMock: emailMock);
+        Assert.False(await svc.TestConnectionAsync());
+    }
+}

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -124,4 +124,158 @@ public class RestaurantManagementServiceTests
         var svc = new RestaurantManagementService(db);
         Assert.False(await svc.DeleteTableAsync(1, 1, 1));
     }
+
+    [Fact]
+    public async Task GetAllAsync_ExcludesArchivedRestaurants()
+    {
+        using AppDbContext db = CreateDb(nameof(GetAllAsync_ExcludesArchivedRestaurants));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Active" });
+        db.Restaurants.Add(new Restaurant { Id = 2, Name = "Archived", IsArchived = true });
+        await db.SaveChangesAsync();
+        var svc = new RestaurantManagementService(db);
+        List<RestaurantDto> result = await svc.GetAllAsync();
+        Assert.Single(result);
+        Assert.Equal("Active", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsDto_WhenFound()
+    {
+        using AppDbContext db = CreateDb(nameof(GetByIdAsync_ReturnsDto_WhenFound));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Found", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = new RestaurantManagementService(db);
+        RestaurantDto? result = await svc.GetByIdAsync(1);
+        Assert.NotNull(result);
+        Assert.Equal("Found", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenArchived()
+    {
+        using AppDbContext db = CreateDb(nameof(GetByIdAsync_ReturnsNull_WhenArchived));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Archived", IsArchived = true });
+        await db.SaveChangesAsync();
+        var svc = new RestaurantManagementService(db);
+        Assert.Null(await svc.GetByIdAsync(1));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SplitsTags()
+    {
+        using AppDbContext db = CreateDb(nameof(UpdateAsync_SplitsTags));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = new RestaurantManagementService(db);
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest { Tags = "Italian, Pizza, Casual" });
+        Assert.Equal(3, result!.Tags.Length);
+        Assert.Contains("Italian", result.Tags);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_HandlesEmptyTags()
+    {
+        using AppDbContext db = CreateDb(nameof(UpdateAsync_HandlesEmptyTags));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Tags = "old", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = new RestaurantManagementService(db);
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest { Tags = "" });
+        Assert.Empty(result!.Tags);
+    }
+
+    [Fact]
+    public async Task AddSectionAsync_ReturnsSection_WhenRestaurantExists()
+    {
+        using AppDbContext db = CreateDb(nameof(AddSectionAsync_ReturnsSection_WhenRestaurantExists));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        await db.SaveChangesAsync();
+        var svc = new RestaurantManagementService(db);
+        SectionDto? result = await svc.AddSectionAsync(1, "Patio");
+        Assert.NotNull(result);
+        Assert.Equal("Patio", result.Name);
+        Assert.Empty(result.Tables);
+    }
+
+    [Fact]
+    public async Task UpdateSectionAsync_UpdatesName_WhenFound()
+    {
+        using AppDbContext db = CreateDb(nameof(UpdateSectionAsync_UpdatesName_WhenFound));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "Old", RestaurantId = 1 });
+        await db.SaveChangesAsync();
+        var svc = new RestaurantManagementService(db);
+        SectionDto? result = await svc.UpdateSectionAsync(1, 1, "New");
+        Assert.NotNull(result);
+        Assert.Equal("New", result.Name);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_ReturnsTrue_AndNullsBookings()
+    {
+        using AppDbContext db = CreateDb(nameof(DeleteSectionAsync_ReturnsTrue_AndNullsBookings));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Seats = 4, SectionId = 1 });
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, TableId = 1, SectionId = 1, Date = DateTime.UtcNow, BookingRef = "REF1" });
+        await db.SaveChangesAsync();
+
+        var svc = new RestaurantManagementService(db);
+        bool result = await svc.DeleteSectionAsync(1, 1);
+
+        Assert.True(result);
+        Booking? booking = await db.Bookings.FindAsync(1);
+        Assert.Null(booking!.TableId);
+        Assert.Null(booking.SectionId);
+        Assert.False(await db.Sections.AnyAsync(s => s.Id == 1));
+    }
+
+    [Fact]
+    public async Task AddTableAsync_ReturnsTable_WhenSectionExists()
+    {
+        using AppDbContext db = CreateDb(nameof(AddTableAsync_ReturnsTable_WhenSectionExists));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        await db.SaveChangesAsync();
+
+        var svc = new RestaurantManagementService(db);
+        TableDto? result = await svc.AddTableAsync(1, 1, "T1", 4);
+        Assert.NotNull(result);
+        Assert.Equal("T1", result.Name);
+        Assert.Equal(4, result.Seats);
+    }
+
+    [Fact]
+    public async Task UpdateTableAsync_UpdatesNameAndSeats_WhenFound()
+    {
+        using AppDbContext db = CreateDb(nameof(UpdateTableAsync_UpdatesNameAndSeats_WhenFound));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "Old", Seats = 2, SectionId = 1 });
+        await db.SaveChangesAsync();
+
+        var svc = new RestaurantManagementService(db);
+        TableDto? result = await svc.UpdateTableAsync(1, 1, 1, "New", 6);
+        Assert.NotNull(result);
+        Assert.Equal("New", result.Name);
+        Assert.Equal(6, result.Seats);
+    }
+
+    [Fact]
+    public async Task DeleteTableAsync_ReturnsTrue_AndNullsBookings()
+    {
+        using AppDbContext db = CreateDb(nameof(DeleteTableAsync_ReturnsTrue_AndNullsBookings));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Seats = 4, SectionId = 1 });
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, TableId = 1, SectionId = 1, Date = DateTime.UtcNow, BookingRef = "REF1" });
+        await db.SaveChangesAsync();
+
+        var svc = new RestaurantManagementService(db);
+        bool result = await svc.DeleteTableAsync(1, 1, 1);
+
+        Assert.True(result);
+        Booking? booking = await db.Bookings.FindAsync(1);
+        Assert.Null(booking!.TableId);
+        Assert.False(await db.Tables.AnyAsync(t => t.Id == 1));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `EmailSettingsServiceTests` covering all 3 public methods: `GetAsync` (null/existing), `SaveAsync` (create new, update existing, password encryption, mask/null skip, FromName/FromEmail persistence, SendBookingConfirmations), and `TestConnectionAsync` (true/false delegation to `IEmailService`).
- Expand `RestaurantManagementServiceTests` with happy-path tests for all 11 methods: archive filtering in `GetAllAsync`/`GetByIdAsync`, Tags comma-splitting in `UpdateAsync`, section/table CRUD success paths, and cascade null-out on section/table delete (verifies affected `Booking` rows have `TableId`/`SectionId` set to null).

## Test plan

- [ ] CI backend tests pass (`dotnet test`)
- [ ] New tests cover previously-untested happy paths and cascade behaviour
- [ ] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rD9NwD3TzU8jL2XuSrYqe

---
_Generated by [Claude Code](https://claude.ai/code/session_017rD9NwD3TzU8jL2XuSrYqe)_