### PR TITLE
purge-bookings: wipe and restore uploaded media

### DIFF
--- a/scripts/purge-bookings.sh
+++ b/scripts/purge-bookings.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Deletes all bookings and customer PII, then resets admin credentials from .env.
-# Safe to run against a live container — preserves all restaurant config.
+# Wipes all uploaded media and restores from scripts/media-snapshot/ if it exists.
+# Preserves all restaurant config (via config-snapshot.sql).
+#
+# BEFORE RUNNING: snapshot your current uploaded media so it gets restored afterwards:
+#
+#   mkdir -p scripts/media-snapshot
+#   CONTAINER=$(docker compose -f docker-compose.vps.yml ps -q backend | head -1)
+#   docker cp "$CONTAINER:/app/wwwroot/media/." scripts/media-snapshot/
+#
+# Commit scripts/media-snapshot/ alongside config-snapshot.sql to keep both in sync.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/purge-bookings.sh
+++ b/scripts/purge-bookings.sh
@@ -39,6 +39,11 @@ log "Purging bookings and PII..."
 docker exec "$CONTAINER" sqlite3 "$DB" "$SQL"
 log "Purge done. Bookings remaining: $(docker exec "$CONTAINER" sqlite3 "$DB" 'SELECT COUNT(*) FROM Bookings;')"
 
+# --- Purge uploaded media ---
+log "Purging uploaded media..."
+docker exec "$CONTAINER" sh -c 'find /app/wwwroot/media -maxdepth 1 -type f -delete'
+log "Media purged. Files remaining: $(docker exec "$CONTAINER" sh -c 'find /app/wwwroot/media -maxdepth 1 -type f | wc -l')"
+
 # --- Reset admin credentials from .env ---
 if [[ ! -f "$ENV_FILE" ]]; then
   log "WARNING: .env not found at $ENV_FILE — skipping credential reset."
@@ -202,4 +207,19 @@ if [[ -f "$SNAPSHOT" ]]; then
   log "Config restored. Restaurants: $(docker exec "$CONTAINER" sqlite3 "$DB" 'SELECT COUNT(*) FROM Restaurants;')"
 else
   log "WARNING: config-snapshot.sql not found — skipping config restore."
+fi
+
+# --- Restore media snapshot ---
+MEDIA_SNAPSHOT="$SCRIPT_DIR/media-snapshot"
+if [[ -d "$MEDIA_SNAPSHOT" ]]; then
+  log "Restoring media snapshot..."
+  FILE_COUNT=0
+  for f in "$MEDIA_SNAPSHOT"/*; do
+    [[ -f "$f" ]] || continue
+    docker cp "$f" "$CONTAINER:/app/wwwroot/media/"
+    FILE_COUNT=$((FILE_COUNT + 1))
+  done
+  log "Media restored. Files copied: $FILE_COUNT"
+else
+  log "WARNING: media-snapshot/ not found at $MEDIA_SNAPSHOT — skipping media restore."
 fi

--- a/scripts/purge-bookings.sh
+++ b/scripts/purge-bookings.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # Deletes all bookings and customer PII, then resets admin credentials from .env.
-# Wipes all uploaded media and restores from scripts/media-snapshot/ if it exists.
+# Wipes all uploaded media and restores from data/media-snapshot/ if it exists.
 # Preserves all restaurant config (via config-snapshot.sql).
 #
-# BEFORE RUNNING: snapshot your current uploaded media so it gets restored afterwards:
+# BEFORE RUNNING: snapshot your current uploaded media so it gets restored afterwards.
+# The snapshot lives in ./data/media-snapshot/ (the bind-mounted data directory —
+# persists across code updates and redeploys, no git commit needed):
 #
-#   mkdir -p scripts/media-snapshot
+#   mkdir -p data/media-snapshot
 #   CONTAINER=$(docker compose -f docker-compose.vps.yml ps -q backend | head -1)
-#   docker cp "$CONTAINER:/app/wwwroot/media/." scripts/media-snapshot/
+#   docker cp "$CONTAINER:/app/wwwroot/media/." data/media-snapshot/
 #
-# Commit scripts/media-snapshot/ alongside config-snapshot.sql to keep both in sync.
+# Run this once from your docker-compose.vps.yml directory before the first purge.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -219,7 +221,7 @@ else
 fi
 
 # --- Restore media snapshot ---
-MEDIA_SNAPSHOT="$SCRIPT_DIR/media-snapshot"
+MEDIA_SNAPSHOT="$SCRIPT_DIR/../data/media-snapshot"
 if [[ -d "$MEDIA_SNAPSHOT" ]]; then
   log "Restoring media snapshot..."
   FILE_COUNT=0


### PR DESCRIPTION
## Summary

- After the DB purge step, delete all files from `/app/wwwroot/media` inside the backend container using `find -maxdepth 1 -type f -delete`
- At the end of the script (alongside `config-snapshot.sql` restore), copy files from `scripts/media-snapshot/` into the container via `docker cp` — same opt-in pattern as the SQL config snapshot; logs a warning and skips gracefully if the directory doesn't exist

## How to use the media snapshot

Place the image files you want restored (e.g. `hero.jpg`, `location-1.webp`) in `scripts/media-snapshot/`. The script will copy them verbatim into `/app/wwwroot/media/` on every purge run.

## Test plan

- [ ] Run `purge-bookings.sh` with no `scripts/media-snapshot/` directory — confirm "WARNING: media-snapshot/ not found" is logged and script exits cleanly
- [ ] Add image files to `scripts/media-snapshot/`, run again — confirm files appear in the container at `/app/wwwroot/media/` and log reports the correct count
- [ ] Verify pre-existing media files are gone after the purge step (count drops to 0 before restore)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119RDKaWhTEuZtyxXnYZW4Z)_