### PR TITLE
nginx: add proper caching headers across all envs

### DIFF
--- a/nginx-vps/default.conf.template
+++ b/nginx-vps/default.conf.template
@@ -28,7 +28,13 @@ server {
     error_log /dev/stderr warn;
 
     gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/json application/javascript text/xml
+               application/xml image/svg+xml font/woff font/woff2
+               application/font-woff application/font-woff2;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -43,9 +49,17 @@ server {
 
     client_max_body_size 10M;
 
+    # Block dotfiles
+    location ~ /\.(?!well-known).* {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
     location /api/ {
         limit_req zone=api burst=20 nodelay;
         include /etc/nginx/conf.d/security-headers.conf;
+        proxy_hide_header Cache-Control;
         add_header Cache-Control "no-store, max-age=0" always;
         proxy_pass http://backend:8080;
         error_page 404 500 502 503 504 = @api_error;
@@ -56,9 +70,20 @@ server {
         return 500 '{"error": "Internal Server Error", "message": "Service unavailable"}';
     }
 
+    # Expo static assets — content-hashed filenames, safe to cache indefinitely
+    location /_expo/static/ {
+        limit_req zone=general burst=50 nodelay;
+        include /etc/nginx/conf.d/security-headers.conf;
+        proxy_hide_header Cache-Control;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        proxy_pass http://frontend:8081;
+    }
+
     location / {
         limit_req zone=general burst=50 nodelay;
         include /etc/nginx/conf.d/security-headers.conf;
+        proxy_hide_header Cache-Control;
+        add_header Cache-Control "no-cache" always;
         proxy_pass http://frontend:8081;
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,13 @@ http {
 
     # Gzip
     gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/json application/javascript text/xml
+               application/xml image/svg+xml font/woff font/woff2
+               application/font-woff application/font-woff2;
 
     # Rate limiting zones
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
@@ -55,7 +61,26 @@ http {
         location /api/ {
             limit_req zone=api burst=20 nodelay;
 
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "no-store, max-age=0" always;
+
             proxy_pass http://backend:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_hide_header X-Powered-By;
+            proxy_hide_header Server;
+        }
+
+        # Expo static assets — content-hashed filenames, safe to cache indefinitely
+        location /_expo/static/ {
+            limit_req zone=general burst=50 nodelay;
+
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+
+            proxy_pass http://frontend:8081;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -67,6 +92,9 @@ http {
         # Frontend
         location / {
             limit_req zone=general burst=50 nodelay;
+
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "no-cache" always;
 
             proxy_pass http://frontend:8081;
             proxy_set_header Host $host;

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -9,7 +9,13 @@ server {
     error_log /dev/stderr warn;
 
     gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/json application/javascript text/xml
+               application/xml image/svg+xml font/woff font/woff2
+               application/font-woff application/font-woff2;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -65,9 +71,20 @@ server {
         proxy_pass http://$backend_host:${BACKEND_PORT};
     }
 
+    # Expo static assets — content-hashed filenames, safe to cache indefinitely
+    location /_expo/static/ {
+        include /etc/nginx/conf.d/security-headers.conf;
+        proxy_hide_header Cache-Control;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+
+        set $frontend_host ${FRONTEND_HOST};
+        proxy_pass http://$frontend_host:${FRONTEND_PORT};
+    }
+
     # API — Proxy to Backend
     location /api/ {
         include /etc/nginx/conf.d/security-headers.conf;
+        proxy_hide_header Cache-Control;
         add_header Cache-Control "no-store, max-age=0" always;
 
         # Variable must be just the host for runtime DNS resolution to work
@@ -85,6 +102,8 @@ server {
     # Frontend — Proxy to Static Server
     location / {
         include /etc/nginx/conf.d/security-headers.conf;
+        proxy_hide_header Cache-Control;
+        add_header Cache-Control "no-cache" always;
 
         set $frontend_host ${FRONTEND_HOST};
         proxy_pass http://$frontend_host:${FRONTEND_PORT};


### PR DESCRIPTION
## Summary

- Add `/_expo/static/` location with `Cache-Control: public, max-age=31536000, immutable` so browsers permanently cache Expo's content-hashed JS/CSS bundles
- Add `Cache-Control: no-cache` to the root `/` location so the app shell HTML is always revalidated rather than served stale
- Add `proxy_hide_header Cache-Control` in frontend and API locations to prevent duplicate `Cache-Control` headers when the upstream also sets its own
- Expand gzip settings across all three configs: `gzip_vary`, `gzip_comp_level 6`, `gzip_min_length 1000`, `gzip_proxied any`, and SVG/font MIME types
- Add dotfile blocking to `nginx-vps/` (was already present in `nginx/`)

## What changed and why

Previously the frontend proxy location (`/`) sent no `Cache-Control` header at all, so browsers applied their own heuristics (often caching based on `Last-Modified`). The Expo static bundles under `/_expo/static/` also had no dedicated location, so they fell through to the same uncacheable default.

Expo content-hashes every JS/CSS chunk filename on build, making those assets safe to cache indefinitely (`immutable`). The HTML entry point must not be cached so users always get the latest app shell pointing to the new hashed filenames.

## Files changed

| File | Change |
|---|---|
| `nginx/default.conf.template` | Docker/Railway env — gzip improvements, new `/_expo/static/` block, `no-cache` on `/` |
| `nginx-vps/default.conf.template` | VPS TLS env — same + dotfile blocking |
| `nginx.conf` | Standalone env — same caching and gzip improvements |

## Test plan

- [x] `docker compose up` and verify `/_expo/static/*.js` response includes `Cache-Control: public, max-age=31536000, immutable`
- [x] Verify `/` response includes `Cache-Control: no-cache`
- [x] Verify `/api/` response includes `Cache-Control: no-store, max-age=0`
- [x] Verify `/media/` response still includes `Cache-Control: public, no-transform` with `expires 30d`
- [x] Confirm gzip is active: `curl -H "Accept-Encoding: gzip" -I http://localhost:5062/` includes `Content-Encoding: gzip` and `Vary: Accept-Encoding`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvqGzJq4LuCMvXFnt8iR39

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvqGzJq4LuCMvXFnt8iR39)_