### PR TITLE
Fill card space with an every-day hint for fully walk-in-only locations

### DIFF
--- a/openresto-frontend/components/restaurant/RestaurantCard.tsx
+++ b/openresto-frontend/components/restaurant/RestaurantCard.tsx
@@ -178,7 +178,12 @@ export default function RestaurantCard({
   const walkInToday =
     !walkInLocation &&
     isWalkInOnlyOnDay(restaurant, getRestaurantNow(restaurant.timezone ?? "UTC").isoDay);
-  const walkInDaysList = !walkInLocation ? walkInDaysLabel(restaurant) : null;
+  const walkInDaysList = walkInLocation ? null : walkInDaysLabel(restaurant);
+  const walkInDaysHintText = walkInLocation
+    ? "This location is walk-in only every day of the week"
+    : walkInDaysList
+      ? `Walk-ins only on ${walkInDaysList}`
+      : null;
   const todayHours = getHoursForDay(
     restaurant,
     getRestaurantNow(restaurant.timezone ?? "UTC").isoDay
@@ -392,11 +397,11 @@ export default function RestaurantCard({
         )}
 
         {/* Walk-in days hint (always visible, independent of today) */}
-        {walkInDaysList && (
+        {walkInDaysHintText && (
           <View style={styles.walkInDaysRow} testID="walk-in-days-hint">
             <Ionicons name="walk-outline" size={11} color={mutedColor} />
             <ThemedText style={[styles.walkInDaysText, { color: mutedColor }]}>
-              Walk-ins only on {walkInDaysList}
+              {walkInDaysHintText}
             </ThemedText>
           </View>
         )}

--- a/openresto-frontend/tests/components/RestaurantCard.test.tsx
+++ b/openresto-frontend/tests/components/RestaurantCard.test.tsx
@@ -135,11 +135,12 @@ describe("RestaurantCard", () => {
       expect(screen.getByText("Walk-ins only on Saturdays and Sundays")).toBeTruthy();
     });
 
-    it("does not show the days hint for a fully walk-in-only location", () => {
+    it("shows an every-day hint for a fully walk-in-only location, ignoring walkInDays", () => {
       render(
         <RestaurantCard restaurant={{ ...restaurant, walkInOnly: true, walkInDays: "6,7" }} />
       );
-      expect(screen.queryByTestId("walk-in-days-hint")).toBeNull();
+      expect(screen.getByTestId("walk-in-days-hint")).toBeTruthy();
+      expect(screen.getByText("This location is walk-in only every day of the week")).toBeTruthy();
     });
 
     it("does not show the days hint when no walk-in days are configured", () => {


### PR DESCRIPTION
Follow-up to #176 / #193 / #194 (both merged).

## Summary

For fully walk-in-only locations (`WalkInOnly: true`), the public restaurant card looked sparse compared to locations with specific walk-in days, since the "which days" hint only rendered when `WalkInDays` was set. This adds a matching line for the full-week case: "This location is walk-in only every day of the week", shown in the same slot as the per-day hint so card layout stays consistent between the two modes.

## Test plan

- [x] `npm test` — full suite passes (105 suites / 1306 tests); updated the existing "does not show the days hint for a fully walk-in-only location" test since the behavior is now intentionally the opposite
- [x] `npm run check` (prettier + eslint) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FLDcfmTpqBsP2ZDFque5o

---
_Generated by [Claude Code](https://claude.ai/code/session_013FLDcfmTpqBsP2ZDFque5o)_