### PR TITLE
test: achieve 100% unit test coverage (batches 11 & 12 — 10 files)

### DIFF
--- a/openresto-frontend/components/common/Select.tsx
+++ b/openresto-frontend/components/common/Select.tsx
@@ -42,12 +42,11 @@ export default function Select({
         animationType="fade"
         transparent={true}
         visible={modalVisible}
-        /* istanbul ignore next */
         onRequestClose={() => setModalVisible(false)}
       >
         <Pressable
+          testID="select-backdrop"
           style={styles.backdrop}
-          /* istanbul ignore next */
           onPress={() => setModalVisible(false)}
         >
           <ThemedView style={[styles.modalView, { borderColor }]}>

--- a/openresto-frontend/components/common/TimePicker.tsx
+++ b/openresto-frontend/components/common/TimePicker.tsx
@@ -6,7 +6,7 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { getThemeColors, COLORS, FORM_SIZES, BORDER_RADIUS } from "@/theme/theme";
 import { useBrand } from "@/context/BrandContext";
 
-function generateTimeOptions(
+export function generateTimeOptions(
   minTime = "09:00",
   maxTime = "22:00"
 ): { label: string; value: string }[] {
@@ -56,7 +56,11 @@ export default function TimePicker({
         visible={modalVisible}
         onRequestClose={() => setModalVisible(false)}
       >
-        <Pressable style={styles.backdrop} onPress={() => setModalVisible(false)}>
+        <Pressable
+          testID="time-picker-backdrop"
+          style={styles.backdrop}
+          onPress={() => setModalVisible(false)}
+        >
           <ThemedView style={[styles.modalView, { borderColor }]}>
             <ThemedText type="bodyBold" style={styles.modalTitle}>
               Select a time

--- a/openresto-frontend/tests/components/AlertModal.test.tsx
+++ b/openresto-frontend/tests/components/AlertModal.test.tsx
@@ -4,20 +4,15 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react-native";
 import AlertModal from "@/components/common/AlertModal";
-import { BrandProvider } from "@/context/BrandContext";
+import { useBrand } from "@/context/BrandContext";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { Modal } from "react-native";
-
-// Polyfill fetch
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({ appName: "Open Resto", primaryColor: "#0a7ea4" }),
-  })
-) as jest.Mock;
 
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: jest.fn(() => "light"),
+}));
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: jest.fn(() => ({ appName: "Open Resto", primaryColor: "#0a7ea4" })),
 }));
 
 describe("AlertModal", () => {
@@ -30,18 +25,17 @@ describe("AlertModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useColorScheme as jest.Mock).mockReturnValue("light");
+    (useBrand as jest.Mock).mockReturnValue({ appName: "Open Resto", primaryColor: "#0a7ea4" });
   });
 
-  const renderWithBrand = (ui: React.ReactElement) => render(<BrandProvider>{ui}</BrandProvider>);
-
   it("renders title and message when visible", () => {
-    renderWithBrand(<AlertModal {...defaultProps} title="Alert" />);
+    render(<AlertModal {...defaultProps} title="Alert" />);
     expect(screen.getByText("Alert")).toBeTruthy();
     expect(screen.getByText("Something happened")).toBeTruthy();
   });
 
   it("calls onClose when backdrop pressed", () => {
-    renderWithBrand(<AlertModal {...defaultProps} />);
+    render(<AlertModal {...defaultProps} />);
     // backdrop is the outer Pressable in AlertModal.tsx
     const backdrop = screen.getByText("Something happened").parent?.parent;
     fireEvent.press(backdrop as any);
@@ -50,7 +44,13 @@ describe("AlertModal", () => {
 
   it("renders in dark mode", () => {
     (useColorScheme as jest.Mock).mockReturnValue("dark");
-    renderWithBrand(<AlertModal {...defaultProps} />);
+    render(<AlertModal {...defaultProps} />);
+    expect(screen.getByText("OK")).toBeTruthy();
+  });
+
+  it("falls back to the default button color when the brand has no primary color", () => {
+    (useBrand as jest.Mock).mockReturnValue({ appName: "Open Resto", primaryColor: "" });
+    render(<AlertModal {...defaultProps} />);
     expect(screen.getByText("OK")).toBeTruthy();
   });
 });

--- a/openresto-frontend/tests/components/ConfirmModal.test.tsx
+++ b/openresto-frontend/tests/components/ConfirmModal.test.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react-native";
 import ConfirmModal from "@/components/common/ConfirmModal";
+import { useBrand } from "@/context/BrandContext";
 
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
+}));
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: jest.fn(() => ({ appName: "Open Resto", primaryColor: "#0a7ea4" })),
 }));
 
 jest.mock("expo-haptics", () => ({
@@ -23,6 +28,7 @@ describe("ConfirmModal", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (useBrand as jest.Mock).mockReturnValue({ appName: "Open Resto", primaryColor: "#0a7ea4" });
   });
 
   it("renders title and message when visible", () => {
@@ -59,5 +65,17 @@ describe("ConfirmModal", () => {
     render(<ConfirmModal {...defaultProps} cancelLabel="Nope" />);
     fireEvent.press(screen.getByText("Nope"));
     expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a destructive confirm button", () => {
+    render(<ConfirmModal {...defaultProps} destructive confirmLabel="Delete" />);
+    fireEvent.press(screen.getByText("Delete"));
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the default primary color when the brand has none", () => {
+    (useBrand as jest.Mock).mockReturnValue({ appName: "Open Resto", primaryColor: "" });
+    render(<ConfirmModal {...defaultProps} confirmLabel="OK" />);
+    expect(screen.getByText("OK")).toBeTruthy();
   });
 });

--- a/openresto-frontend/tests/components/RestaurantDetails.test.tsx
+++ b/openresto-frontend/tests/components/RestaurantDetails.test.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
 import RestaurantDetails from "@/components/restaurant/RestaurantDetails";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 
 jest.mock("@/hooks/use-color-scheme", () => ({
-  useColorScheme: () => "light",
+  useColorScheme: jest.fn(() => "light"),
 }));
 
 jest.mock("@expo/vector-icons", () => ({
@@ -73,6 +74,12 @@ describe("RestaurantDetails", () => {
     render(<RestaurantDetails restaurant={noAddress} />);
     expect(screen.getByText("Sushi Spot")).toBeTruthy();
     expect(screen.queryByText(/456 Ocean Ave/)).toBeNull();
+  });
+
+  it("renders table chips with the dark-mode background", () => {
+    (useColorScheme as jest.Mock).mockReturnValueOnce("dark");
+    render(<RestaurantDetails restaurant={restaurant} />);
+    expect(screen.getByText("A1")).toBeTruthy();
   });
 
   it("renders table fallback name when table.name is null", () => {

--- a/openresto-frontend/tests/components/Select.test.tsx
+++ b/openresto-frontend/tests/components/Select.test.tsx
@@ -2,11 +2,14 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react-native";
+import { render, screen, fireEvent, act } from "@testing-library/react-native";
+import { Modal } from "react-native";
 import Select from "@/components/common/Select";
+import { useBrand } from "@/context/BrandContext";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 
 jest.mock("@/context/BrandContext", () => ({
-  useBrand: () => ({ appName: "Test App", primaryColor: "#000" }),
+  useBrand: jest.fn(() => ({ appName: "Test App", primaryColor: "#000" })),
 }));
 
 jest.mock("expo-haptics", () => ({
@@ -14,7 +17,7 @@ jest.mock("expo-haptics", () => ({
 }));
 
 jest.mock("@/hooks/use-color-scheme", () => ({
-  useColorScheme: () => "light",
+  useColorScheme: jest.fn(() => "light"),
 }));
 
 describe("Select", () => {
@@ -23,6 +26,10 @@ describe("Select", () => {
     { label: "Option 2", value: "2" },
   ];
   const onSelect = jest.fn();
+
+  beforeEach(() => {
+    (useColorScheme as jest.Mock).mockReturnValue("light");
+  });
 
   it("renders with selected option", () => {
     render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
@@ -47,12 +54,16 @@ describe("Select", () => {
     expect(screen.getByText("Select an option")).toBeTruthy();
   });
 
-  it("renders in dark mode", () => {
-    const mockUseColorScheme = jest.fn(() => "dark");
-    jest.doMock("@/hooks/use-color-scheme", () => ({ useColorScheme: mockUseColorScheme }));
+  it("defaults to light when useColorScheme returns nothing", () => {
+    (useColorScheme as jest.Mock).mockReturnValue(undefined);
     render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
     expect(screen.getByText("Option 1")).toBeTruthy();
-    jest.dontMock("@/hooks/use-color-scheme");
+  });
+
+  it("renders in dark mode", () => {
+    (useColorScheme as jest.Mock).mockReturnValue("dark");
+    render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
+    expect(screen.getByText("Option 1")).toBeTruthy();
   });
 
   it("shows checkmark on selected item inside modal", () => {
@@ -60,5 +71,48 @@ describe("Select", () => {
     fireEvent.press(screen.getByText("Option 1"));
     // Inside the modal, the selected item shows a checkmark
     expect(screen.getByText("✓")).toBeTruthy();
+  });
+
+  it("renders the item separator in dark mode when the modal is open", () => {
+    (useColorScheme as jest.Mock).mockReturnValue("dark");
+    render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
+    fireEvent.press(screen.getByText("Option 1"));
+    expect(screen.getByText("Option 2")).toBeTruthy();
+  });
+
+  it("closes the modal when the backdrop is pressed", () => {
+    render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
+    fireEvent.press(screen.getByText("Option 1"));
+    expect(screen.getByText("Option 2")).toBeTruthy();
+    fireEvent.press(screen.getByTestId("select-backdrop"));
+    expect(screen.queryByText("Option 2")).toBeNull();
+  });
+
+  it("closes the modal when onRequestClose fires (e.g. Android back button)", () => {
+    render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
+    fireEvent.press(screen.getByText("Option 1"));
+    expect(screen.getByText("Option 2")).toBeTruthy();
+    act(() => {
+      screen.UNSAFE_getByType(Modal).props.onRequestClose();
+    });
+    expect(screen.queryByText("Option 2")).toBeNull();
+  });
+
+  it("falls back to the default primary color when the brand has none", () => {
+    (useBrand as jest.Mock).mockReturnValueOnce({ appName: "Test App", primaryColor: "" });
+    render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
+    expect(screen.getByText("Option 1")).toBeTruthy();
+  });
+
+  it("highlights the trigger border when hovered", () => {
+    render(<Select selectedValue="1" options={options} onSelect={onSelect} />);
+    let node = screen.getByText("Option 1").parent;
+    while (node && typeof node.props?.style !== "function") {
+      node = node.parent;
+    }
+    const styleFn = node?.props.style as (state: { hovered: boolean }) => unknown;
+    expect(typeof styleFn).toBe("function");
+    const hoveredStyle = styleFn({ hovered: true });
+    expect(hoveredStyle).toContainEqual({ borderColor: "#000" });
   });
 });

--- a/openresto-frontend/tests/components/TimePicker.test.tsx
+++ b/openresto-frontend/tests/components/TimePicker.test.tsx
@@ -2,11 +2,13 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react-native";
-import TimePicker from "@/components/common/TimePicker";
+import { render, screen, fireEvent, act } from "@testing-library/react-native";
+import { Modal } from "react-native";
+import TimePicker, { generateTimeOptions } from "@/components/common/TimePicker";
+import { useBrand } from "@/context/BrandContext";
 
 jest.mock("@/context/BrandContext", () => ({
-  useBrand: () => ({ appName: "Test App", primaryColor: "#000" }),
+  useBrand: jest.fn(() => ({ appName: "Test App", primaryColor: "#000" })),
 }));
 
 jest.mock("@/hooks/use-color-scheme", () => ({
@@ -46,19 +48,54 @@ describe("TimePicker Native", () => {
     expect(screen.getByText("Select a time")).toBeTruthy();
   });
 
-  it("closes modal when backdrop is pressed", () => {
-    render(<TimePicker selectedTime="09:00" onSelect={onSelect} />);
-    fireEvent.press(screen.getByText("09:00"));
-    // Modal is open — press backdrop to close
-    const backdrop = screen.getByText("Select a time");
-    // backdrop is the Pressable container; pressing the modal title area closes via onRequestClose
-    expect(backdrop).toBeTruthy();
-  });
-
   it("shows checkmark for currently selected time option", () => {
     render(<TimePicker selectedTime="09:00" onSelect={onSelect} />);
     fireEvent.press(screen.getByText("09:00"));
     // The selected option renders a checkmark
     expect(screen.getByText("✓")).toBeTruthy();
+  });
+
+  it("closes the modal when the backdrop is pressed", () => {
+    render(<TimePicker selectedTime="09:00" onSelect={onSelect} />);
+    fireEvent.press(screen.getByText("09:00"));
+    expect(screen.getByText("Select a time")).toBeTruthy();
+    fireEvent.press(screen.getByTestId("time-picker-backdrop"));
+    expect(screen.queryByText("Select a time")).toBeNull();
+  });
+
+  it("closes the modal when onRequestClose fires (e.g. Android back button)", () => {
+    render(<TimePicker selectedTime="09:00" onSelect={onSelect} />);
+    fireEvent.press(screen.getByText("09:00"));
+    expect(screen.getByText("Select a time")).toBeTruthy();
+    act(() => {
+      screen.UNSAFE_getByType(Modal).props.onRequestClose();
+    });
+    expect(screen.queryByText("Select a time")).toBeNull();
+  });
+
+  it("falls back to the default primary color when the brand has none", () => {
+    (useBrand as jest.Mock).mockReturnValueOnce({ appName: "Test App", primaryColor: "" });
+    render(<TimePicker selectedTime="09:00" onSelect={onSelect} />);
+    expect(screen.getByText("09:00")).toBeTruthy();
+  });
+
+  it("highlights the trigger border when hovered", () => {
+    render(<TimePicker selectedTime="09:00" onSelect={onSelect} />);
+    let node = screen.getByText("09:00").parent;
+    while (node && typeof node.props?.style !== "function") {
+      node = node.parent;
+    }
+    const styleFn = node?.props.style as (state: { hovered: boolean }) => unknown;
+    expect(typeof styleFn).toBe("function");
+    const hoveredStyle = styleFn({ hovered: true });
+    expect(hoveredStyle).toContainEqual({ borderColor: "#000" });
+  });
+});
+
+describe("generateTimeOptions", () => {
+  it("defaults to a 09:00-22:00 range when called with no arguments", () => {
+    const options = generateTimeOptions();
+    expect(options[0]).toEqual({ label: "09:00", value: "09:00" });
+    expect(options[options.length - 1]).toEqual({ label: "22:00", value: "22:00" });
   });
 });

--- a/openresto-frontend/tests/components/admin/bookings/NewBookingModal.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/NewBookingModal.test.tsx
@@ -16,10 +16,9 @@ jest.mock("@/api/admin", () => ({
   adminCreateBooking: jest.fn(),
 }));
 
-jest.mock("@/context/BrandContext", () => {
-  const brand = { primaryColor: "#0a7ea4", appName: "Open Resto" };
-  return { useBrand: () => brand };
-});
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: jest.fn(() => ({ primaryColor: "#0a7ea4", appName: "Open Resto" })),
+}));
 
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
@@ -76,6 +75,19 @@ jest.mock("@/components/common/DatePicker", () => {
         >
           <Text>Select Past Date</Text>
         </Pressable>
+        <Pressable
+          testID="date-picker-future"
+          onPress={() => {
+            const d = new Date();
+            d.setDate(d.getDate() + 7);
+            const y = d.getFullYear();
+            const m = String(d.getMonth() + 1).padStart(2, "0");
+            const day = String(d.getDate()).padStart(2, "0");
+            onSelect(`${y}-${m}-${day}`);
+          }}
+        >
+          <Text>Select Future Date</Text>
+        </Pressable>
       </View>
     ),
   };
@@ -116,8 +128,12 @@ jest.mock("@/components/common/Button", () => {
   const { Pressable, Text } = require("react-native");
   return {
     __esModule: true,
+    // Note: `disabled` is surfaced via accessibilityState (not the native
+    // `disabled` prop) so tests can still press through it to exercise the
+    // component's own validity guard, mirroring how an accessibility tool
+    // (or a stale re-render) could invoke onPress while disabled.
     default: ({ onPress, children, disabled }: any) => (
-      <Pressable onPress={onPress} disabled={disabled}>
+      <Pressable onPress={onPress} accessibilityState={{ disabled }}>
         <Text>{children}</Text>
       </Pressable>
     ),
@@ -209,6 +225,13 @@ describe("NewBookingModal", () => {
     render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
     await waitFor(() => expect(screen.getByText("Test Restaurant")).toBeTruthy());
     fireEvent.press(screen.getByText("Test Restaurant"));
+    expect(screen.getByText("New Booking")).toBeTruthy();
+  });
+
+  it("handles table change", async () => {
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByText("Table 2 (2 seats)")).toBeTruthy());
+    fireEvent.press(screen.getByText("Table 2 (2 seats)"));
     expect(screen.getByText("New Booking")).toBeTruthy();
   });
 
@@ -328,5 +351,163 @@ describe("NewBookingModal", () => {
     // The submitted date is genuinely in the past.
     expect(new Date(payload.date).getTime()).toBeLessThan(Date.now());
     expect(onCreated).toHaveBeenCalledWith(77);
+  });
+
+  it("selects a future date without applying the back-date special-casing", async () => {
+    (adminApi.adminCreateBooking as jest.Mock).mockResolvedValue({ id: 88 });
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByPlaceholderText("guest@example.com")).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId("date-picker-future"));
+    fireEvent.changeText(screen.getByPlaceholderText("guest@example.com"), "test@example.com");
+
+    await act(async () => {
+      fireEvent.press(screen.getByText("Create Booking"));
+    });
+    await waitFor(() => expect(adminApi.adminCreateBooking).toHaveBeenCalled());
+
+    const payload = (adminApi.adminCreateBooking as jest.Mock).mock.calls[0][0];
+    expect(new Date(payload.date).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("computes the next slot within opening hours, rounding minutes up to :30", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T14:20:00Z"));
+    try {
+      render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+      await waitFor(() => expect(screen.getByTestId("time-picker")).toBeTruthy());
+      expect(screen.getByTestId("time-picker").props.children).toBe("14:30");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("computes the next slot within opening hours, rounding minutes up to :45", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T14:35:00Z"));
+    try {
+      render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+      await waitFor(() => expect(screen.getByTestId("time-picker")).toBeTruthy());
+      expect(screen.getByTestId("time-picker").props.children).toBe("14:45");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("rolls over to the next hour when minutes round up past :45", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T14:50:00Z"));
+    try {
+      render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+      await waitFor(() => expect(screen.getByTestId("time-picker")).toBeTruthy());
+      expect(screen.getByTestId("time-picker").props.children).toBe("15:00");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("falls back to the default primary color when the brand has none", async () => {
+    const { useBrand } = require("@/context/BrandContext");
+    (useBrand as jest.Mock).mockReturnValueOnce({ primaryColor: "", appName: "Open Resto" });
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByText("New Booking")).toBeTruthy());
+  });
+
+  it("handles an empty restaurant list", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([]);
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByTestId("time-picker")).toBeTruthy());
+    expect(screen.getByPlaceholderText("guest@example.com")).toBeTruthy();
+  });
+
+  it("handles a restaurant with no sections", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      { ...mockRestaurants[0], sections: [] },
+    ]);
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByText("Test Restaurant")).toBeTruthy());
+    expect(screen.getByPlaceholderText("guest@example.com")).toBeTruthy();
+  });
+
+  it("falls back to a generic table label when a table has no name", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      {
+        ...mockRestaurants[0],
+        sections: [
+          {
+            id: 10,
+            name: "Main",
+            tables: [{ id: 100, seats: 4 }],
+          },
+        ],
+      },
+    ]);
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByText("Table 100 (4 seats)")).toBeTruthy());
+  });
+
+  it("does not submit while the form is invalid", async () => {
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByPlaceholderText("guest@example.com")).toBeTruthy());
+    fireEvent.press(screen.getByText("Create Booking"));
+    expect(adminApi.adminCreateBooking).not.toHaveBeenCalled();
+  });
+
+  it("does not call onCreated/onClose when the booking result is falsy", async () => {
+    (adminApi.adminCreateBooking as jest.Mock).mockResolvedValue(null);
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByPlaceholderText("guest@example.com")).toBeTruthy());
+    fireEvent.changeText(screen.getByPlaceholderText("guest@example.com"), "test@example.com");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Create Booking"));
+    });
+    await waitFor(() => expect(adminApi.adminCreateBooking).toHaveBeenCalled());
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows a generic error message when the rejection is not an Error instance", async () => {
+    (adminApi.adminCreateBooking as jest.Mock).mockRejectedValue("network down");
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByPlaceholderText("guest@example.com")).toBeTruthy());
+    fireEvent.changeText(screen.getByPlaceholderText("guest@example.com"), "test@example.com");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Create Booking"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Failed to create booking.")).toBeTruthy();
+    });
+  });
+
+  it("falls back to noon when the resolved opening hour is an empty string", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      { ...mockRestaurants[0], openTime: "", openHours: null },
+    ]);
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByText("Test Restaurant")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("date-picker-past"));
+    await waitFor(() => expect(screen.getByTestId("time-picker").props.children).toBe("12:00"));
+  });
+
+  it("resolves default opening hours when no restaurant is selected", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([]);
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByTestId("date-picker-past")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("date-picker-past"));
+    expect(screen.getByTestId("date-picker")).toBeTruthy();
+  });
+
+  it("submits the trimmed guest name when provided", async () => {
+    (adminApi.adminCreateBooking as jest.Mock).mockResolvedValue({ id: 55 });
+    render(<NewBookingModal visible onClose={onClose} onCreated={onCreated} />);
+    await waitFor(() => expect(screen.getByPlaceholderText("guest@example.com")).toBeTruthy());
+    fireEvent.changeText(screen.getByPlaceholderText("guest@example.com"), "test@example.com");
+    fireEvent.changeText(screen.getByPlaceholderText("Full name"), "  Jane Doe  ");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Create Booking"));
+    });
+    await waitFor(() => expect(adminApi.adminCreateBooking).toHaveBeenCalled());
+    const payload = (adminApi.adminCreateBooking as jest.Mock).mock.calls[0][0];
+    expect(payload.customerName).toBe("Jane Doe");
   });
 });

--- a/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
 import { TableRow } from "@/components/admin/settings/TableRow";
 import * as restaurantsApi from "@/api/restaurants";
+import { useBrand } from "@/context/BrandContext";
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -16,10 +17,9 @@ jest.mock("@/utils/colors", () => ({
   hexToRgba: (hex: string, _opacity: number) => hex,
 }));
 
-jest.mock("@/context/BrandContext", () => {
-  const brand = { primaryColor: "#0a7ea4", appName: "Open Resto" };
-  return { useBrand: () => brand };
-});
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: jest.fn(() => ({ primaryColor: "#0a7ea4", appName: "Open Resto" })),
+}));
 
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
@@ -174,6 +174,87 @@ describe("TableRow", () => {
   it("renders tableIcon with seats=10 (albums-outline branch)", () => {
     render(<TableRow {...baseProps} table={{ ...baseTable, seats: 10 }} />);
     expect(screen.getByText("10")).toBeTruthy();
+  });
+
+  it("falls back to the default primary color when the brand has none", () => {
+    (useBrand as jest.Mock).mockReturnValueOnce({ primaryColor: "", appName: "Open Resto" });
+    render(<TableRow {...baseProps} />);
+    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
+    act(() => {
+      fireEvent.press(accessible[0]);
+    });
+    expect(screen.getByText("Save")).toBeTruthy();
+  });
+
+  it("seeds the edit form and delete confirmation with the table id when name is null", async () => {
+    (baseProps.confirmAction as jest.Mock).mockResolvedValue(false);
+    render(<TableRow {...baseProps} table={{ ...baseTable, name: null }} />);
+    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
+    act(() => {
+      fireEvent.press(accessible[0]);
+    });
+    expect(screen.getByDisplayValue("")).toBeTruthy();
+    expect(screen.getByText("EDITING · Table 5")).toBeTruthy();
+    fireEvent.press(screen.getByText("Cancel"));
+
+    const accessibleAfterCancel = screen.UNSAFE_getAllByProps({ accessible: true });
+    await act(async () => {
+      fireEvent.press(accessibleAfterCancel[2]);
+    });
+    expect(baseProps.confirmAction).toHaveBeenCalledWith('Delete table "Table 5"?');
+  });
+
+  it("does not call onDeleted when deleteTable resolves falsy", async () => {
+    (baseProps.confirmAction as jest.Mock).mockResolvedValue(true);
+    (restaurantsApi.deleteTable as jest.Mock).mockResolvedValue(false);
+    render(<TableRow {...baseProps} />);
+    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
+    await act(async () => {
+      fireEvent.press(accessible[2]);
+    });
+    expect(restaurantsApi.deleteTable).toHaveBeenCalledWith(1, 2, 5);
+    expect(baseProps.onDeleted).not.toHaveBeenCalled();
+  });
+
+  it("renders the edit-mode background in dark mode", () => {
+    render(<TableRow {...baseProps} isDark />);
+    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
+    act(() => {
+      fireEvent.press(accessible[0]);
+    });
+    expect(screen.getByText("Save")).toBeTruthy();
+  });
+
+  it("saves with an undefined name when the name field is cleared", async () => {
+    const updatedTable = { id: 5, name: null, seats: 4 };
+    (restaurantsApi.updateTable as jest.Mock).mockResolvedValue(updatedTable);
+    render(<TableRow {...baseProps} />);
+    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
+    act(() => {
+      fireEvent.press(accessible[0]);
+    });
+    fireEvent.changeText(screen.getByDisplayValue("T1"), "   ");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    expect(restaurantsApi.updateTable).toHaveBeenCalledWith(1, 2, 5, {
+      name: undefined,
+      seats: 4,
+    });
+  });
+
+  it("stays in edit mode when updateTable resolves falsy", async () => {
+    (restaurantsApi.updateTable as jest.Mock).mockResolvedValue(null);
+    render(<TableRow {...baseProps} />);
+    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
+    act(() => {
+      fireEvent.press(accessible[0]);
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    expect(baseProps.onUpdated).not.toHaveBeenCalled();
+    expect(screen.getByText("Save")).toBeTruthy();
   });
 
   it("shows saving state while updating", async () => {

--- a/openresto-frontend/tests/components/booking/CalendarActions.test.tsx
+++ b/openresto-frontend/tests/components/booking/CalendarActions.test.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react-native";
 import CalendarActions from "@/components/booking/CalendarActions";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
 }));
 
 jest.mock("@/hooks/use-color-scheme", () => ({
-  useColorScheme: () => "light",
+  useColorScheme: jest.fn(() => "light"),
 }));
 
 jest.mock("@/utils/calendar", () => ({
@@ -85,6 +86,18 @@ describe("CalendarActions", () => {
 
   it("renders with specialRequests prop", () => {
     render(<CalendarActions {...baseProps} specialRequests="window seat" />);
+    expect(screen.getByText("Google Calendar")).toBeTruthy();
+  });
+
+  it("renders compact variant in dark mode", () => {
+    (useColorScheme as jest.Mock).mockReturnValueOnce("dark");
+    render(<CalendarActions {...baseProps} variant="compact" />);
+    expect(screen.getByText("Google")).toBeTruthy();
+  });
+
+  it("renders full variant in dark mode", () => {
+    (useColorScheme as jest.Mock).mockReturnValueOnce("dark");
+    render(<CalendarActions {...baseProps} />);
     expect(screen.getByText("Google Calendar")).toBeTruthy();
   });
 });

--- a/openresto-frontend/tests/utils/scrollIntoView.test.ts
+++ b/openresto-frontend/tests/utils/scrollIntoView.test.ts
@@ -1,0 +1,78 @@
+import { Platform } from "react-native";
+import { scrollIntoView } from "@/utils/scrollIntoView";
+
+describe("scrollIntoView", () => {
+  const originalPlatform = Platform.OS;
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+    jest.restoreAllMocks();
+  });
+
+  it("does nothing when the target ref has no current value", () => {
+    Platform.OS = "web";
+    const targetRef = { current: null };
+    const scrollRef = { current: null };
+    expect(() => scrollIntoView(targetRef as any, scrollRef as any)).not.toThrow();
+  });
+
+  it("calls the DOM scrollIntoView on web with the given block, default behavior", () => {
+    Platform.OS = "web";
+    const domScrollIntoView = jest.fn();
+    const targetRef = { current: { scrollIntoView: domScrollIntoView } };
+    const scrollRef = { current: null };
+
+    scrollIntoView(targetRef as any, scrollRef as any, "center");
+
+    expect(domScrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+  });
+
+  it("defaults block to 'start' on web when omitted, and is a no-op when scrollIntoView is unavailable", () => {
+    Platform.OS = "web";
+    const targetRef = { current: {} };
+    const scrollRef = { current: null };
+
+    expect(() => scrollIntoView(targetRef as any, scrollRef as any)).not.toThrow();
+  });
+
+  it("returns early on native when findNodeHandle can't resolve a node", () => {
+    Platform.OS = "ios";
+    jest.spyOn(require("react-native"), "findNodeHandle").mockReturnValue(null);
+    const measureLayout = jest.fn();
+    const targetRef = { current: { measureLayout } };
+    const scrollRef = { current: {} };
+
+    scrollIntoView(targetRef as any, scrollRef as any);
+
+    expect(measureLayout).not.toHaveBeenCalled();
+  });
+
+  it("measures against the scroll view and scrolls to the clamped offset on success", () => {
+    Platform.OS = "android";
+    jest.spyOn(require("react-native"), "findNodeHandle").mockReturnValue(42);
+    const scrollTo = jest.fn();
+    const measureLayout = jest.fn((_node, onSuccess, onFail) => {
+      onSuccess(0, 200);
+      onFail();
+    });
+    const targetRef = { current: { measureLayout } };
+    const scrollRef = { current: { scrollTo } };
+
+    scrollIntoView(targetRef as any, scrollRef as any);
+
+    expect(measureLayout).toHaveBeenCalledWith(42, expect.any(Function), expect.any(Function));
+    expect(scrollTo).toHaveBeenCalledWith({ y: 184, animated: true });
+  });
+
+  it("clamps negative offsets to 0 and is a no-op when the scroll ref has no current value", () => {
+    Platform.OS = "android";
+    jest.spyOn(require("react-native"), "findNodeHandle").mockReturnValue(42);
+    const measureLayout = jest.fn((_node, onSuccess) => {
+      onSuccess(0, 5);
+    });
+    const targetRef = { current: { measureLayout } };
+    const scrollRef = { current: null };
+
+    expect(() => scrollIntoView(targetRef as any, scrollRef as any)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Continues the ongoing unit-test-coverage effort (batches 1–10 already merged). This PR closes the remaining **branch**-coverage gaps in 10 frontend files across two batches, picked from the largest gaps in `npm test -- --coverage`. Statement/line coverage was already high across the repo; the gaps were almost entirely untested conditional branches (dark-mode ternaries, `||`/`??` fallback defaults, and error/edge-case paths), so each fix is a small, targeted test rather than a rewrite.

Note: this environment's egress policy blocks `builds.dotnet.microsoft.com`, so the .NET SDK could not be installed and the backend (`OpenRestoApi.Tests`) could not be run or touched this round — this PR is frontend (Jest) only.

### Files brought to 100% branch coverage

**Batch 11:**

| File | Branch coverage before | After |
|---|---|---|
| `utils/scrollIntoView.ts` | 57.14% | 100% |
| `components/booking/CalendarActions.tsx` | 78.57% | 100% |
| `components/common/AlertModal.tsx` | 75.00% | 100% |
| `components/admin/bookings/NewBookingModal.tsx` | 71.42% | 100% |
| `components/admin/settings/TableRow.tsx` | 73.33% | 100% |

**Batch 12:**

| File | Branch coverage before | After |
|---|---|---|
| `components/common/Select.tsx` | 78.94% | 100% |
| `components/common/ConfirmModal.tsx` | 90.00% | 100% |
| `components/restaurant/RestaurantDetails.tsx` | 83.33% | 100% |
| `components/common/TimePicker.tsx` | 77.77% | 100% |

(batch 12 is 4 components + `generateTimeOptions`, the private helper exported out of `TimePicker.tsx` and tested directly — see below)

### What was added

**Batch 11:**
- **`utils/scrollIntoView.ts`**: new dedicated unit test file — this cross-platform helper previously had no direct test, only indirect exercise through component tests. Covers the null-ref no-op, the web `scrollIntoView` call, the native `findNodeHandle`-returns-null early return, and both `measureLayout` callbacks.
- **`CalendarActions.tsx`**: dark-mode render tests for both variants — the `isDark ? … : …` tint ternaries were only ever exercised under the light-mode mock.
- **`AlertModal.tsx`**: converted the `BrandContext` mock to a mockable `jest.fn()` and added a test for the `brand.primaryColor || COLORS.primary` fallback.
- **`NewBookingModal.tsx`**: the biggest gap — tests for the internal `nextSlotTime()` minute-rounding buckets under fake timers, the in-hours vs. out-of-hours branch, a forward-date case, an empty restaurant list, a sectionless restaurant, a nameless table, the `!isValid` submit guard, a falsy booking result, a non-`Error` rejection, and the trimmed-guest-name branch.
- **`TableRow.tsx`**: primary-color fallback, null-name edit/delete seeding, a falsy `deleteTable` result, dark-mode edit styling, saving with a whitespace-only name, and a falsy `updateTable` result.

**Batch 12:**
- **`Select.tsx`**: `??`-defaulted color scheme, dark-mode item separator, closing via backdrop press and via `onRequestClose`, the primary-color fallback, and the hovered-trigger style. Removed two `/* istanbul ignore next */` comments that turned out to be non-functional (comment-based ignores don't reliably attach to arrow functions in JSX attribute position) in favor of real tests, and added a `testID` to the backdrop `Pressable` since `Pressable`'s module reference wasn't stable for `UNSAFE_getAllByType` in this test environment.
- **`ConfirmModal.tsx`**: added a `BrandContext` mock (there wasn't one) plus tests for the `destructive` variant and the primary-color fallback.
- **`RestaurantDetails.tsx`**: dark-mode render test for the table-chip background tint.
- **`TimePicker.tsx`**: exported the previously-private `generateTimeOptions` helper and tested its default range directly (its default parameters were unreachable through the component, which always resolves its own prop defaults first). Same backdrop/`onRequestClose`/hover/fallback tests as `Select.tsx`.

### Coverage before / after (full frontend suite)

| | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| Before batch 11 | 97.15% | 86.74% | 96.98% | 98.37% |
| After batch 11 | 97.30% | 87.74% | 97.18% | 98.43% |
| After batch 12 | 97.39% | 88.05% | 97.57% | 98.54% |

### Tests added

43 new tests total (1394 → 1437). All 117 suites pass.

### Excluded lines

None — every gap closed in this PR was reachable and is now exercised; no `/* istanbul ignore */` directives were added (two non-functional ones were removed and replaced with real tests, see `Select.tsx` above).

## Test plan

- [x] `npm test -- --coverage` — 1437/1437 passing, all 9 target files at 100% branch coverage (`TimePicker.tsx` also at 100% funcs/lines)
- [x] `npm run check` (prettier + eslint) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
