### PR TITLE
test: achieve 100% unit test coverage (backend batch 2 — 5 files)

### DIFF
--- a/OpenRestoApi.Tests/Controllers/AvailabilityControllerUnitTests.cs
+++ b/OpenRestoApi.Tests/Controllers/AvailabilityControllerUnitTests.cs
@@ -24,4 +24,37 @@ public class AvailabilityControllerUnitTests
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(500, objectResult.StatusCode);
     }
+
+    [Fact]
+    public async Task Get_ReturnsNotFound_WhenServiceThrowsArgumentException()
+    {
+        var mockService = new Mock<AvailabilityService>(null!, null!, null!);
+        mockService.Setup(s => s.GetAvailabilityAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ThrowsAsync(new ArgumentException("Restaurant not found"));
+
+        var controller = new AvailabilityController(mockService.Object);
+
+        var result = await controller.Get(999, DateTime.Now, 2);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(
+            "Restaurant not found",
+            notFound.Value!.GetType().GetProperty("message")!.GetValue(notFound.Value));
+    }
+
+    [Fact]
+    public async Task Get_ReturnsOk_OnSuccess()
+    {
+        var mockService = new Mock<AvailabilityService>(null!, null!, null!);
+        var response = new OpenRestoApi.Core.Application.DTOs.AvailabilityResponseDto { Slots = [] };
+        mockService.Setup(s => s.GetAvailabilityAsync(1, It.IsAny<DateTime>(), 2))
+            .ReturnsAsync(response);
+
+        var controller = new AvailabilityController(mockService.Object);
+
+        var result = await controller.Get(1, DateTime.Now, 2);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
 }

--- a/OpenRestoApi.Tests/Controllers/HoldsControllerUnitTests.cs
+++ b/OpenRestoApi.Tests/Controllers/HoldsControllerUnitTests.cs
@@ -139,6 +139,198 @@ public class HoldsControllerUnitTests
     }
 
     [Fact]
+    public async Task PlaceHold_ReturnsBadRequest_ForPastDate()
+    {
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "00:00",
+                CloseTime = "23:59",
+            });
+
+        var result = await _controller.PlaceHold(
+            new PlaceHoldRequest { Date = DateTime.UtcNow.AddDays(-1) });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_ReturnsBadRequest_WhenBookingsArePaused()
+    {
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "00:00",
+                CloseTime = "23:59",
+                BookingsPausedUntil = DateTime.UtcNow.AddDays(7),
+            });
+
+        var testDate = DateTime.UtcNow.Date.AddDays(1).AddHours(12);
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_ReturnsConflict_WhenAlreadyBooked()
+    {
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "00:00",
+                CloseTime = "23:59",
+            });
+        _mockBookingRepo.Setup(b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ReturnsAsync(true);
+
+        var testDate = DateTime.UtcNow.Date.AddDays(1).AddHours(12);
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<ConflictObjectResult>(result);
+        _mockService.Verify(
+            s => s.PlaceHold(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PlaceHold_FallsBackToUtc_WhenTimezoneIsInvalid()
+    {
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "Not/A/Real/Timezone",
+                OpenTime = "00:00",
+                CloseTime = "23:59",
+            });
+        _mockBookingRepo.Setup(b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ReturnsAsync(false);
+        _mockService.Setup(s => s.PlaceHold(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>()))
+            .Returns(new HoldResult("hold-1", DateTime.UtcNow.AddMinutes(5)));
+
+        // Unspecified-kind date forces the timezone-conversion branch.
+        var testDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(1).AddHours(12), DateTimeKind.Unspecified);
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_ReturnsBadRequest_WhenDayNotInOpenDays()
+    {
+        DateTime testDate = DateTime.UtcNow.Date.AddDays(1).AddHours(12);
+        int isoDay = (int)testDate.DayOfWeek == 0 ? 7 : (int)testDate.DayOfWeek;
+        string otherDay = isoDay == 1 ? "2" : "1";
+
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "00:00",
+                CloseTime = "23:59",
+                OpenDays = otherDay,
+            });
+
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_UsesDefaultHours_WhenStoredTimesAreUnparseable()
+    {
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "",
+                CloseTime = "",
+            });
+        _mockBookingRepo.Setup(b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ReturnsAsync(false);
+        _mockService.Setup(s => s.PlaceHold(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>()))
+            .Returns(new HoldResult("hold-1", DateTime.UtcNow.AddMinutes(5)));
+
+        // Falls back to the default 09:00-22:00 window, so noon is within hours.
+        var testDate = DateTime.UtcNow.Date.AddDays(1).AddHours(12);
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_HandlesOvernightHours_WhenRequestedTimeIsBeforeMidnightClose()
+    {
+        // Open 18:00, close 02:00 (after midnight) — 23:00 should be within hours.
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "18:00",
+                CloseTime = "02:00",
+            });
+        _mockBookingRepo.Setup(b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ReturnsAsync(false);
+        _mockService.Setup(s => s.PlaceHold(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>()))
+            .Returns(new HoldResult("hold-1", DateTime.UtcNow.AddMinutes(5)));
+
+        var testDate = DateTime.UtcNow.Date.AddDays(1).AddHours(23);
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_ReturnsBadRequest_OutsideOvernightHoursWindow()
+    {
+        // Open 18:00, close 02:00 — noon falls outside both segments of the window.
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "18:00",
+                CloseTime = "02:00",
+            });
+
+        var testDate = DateTime.UtcNow.Date.AddDays(1).AddHours(12);
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_TreatsEqualOpenAndCloseTimes_AsAlwaysOpen()
+    {
+        _mockRestaurantRepo.Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new OpenRestoApi.Core.Domain.Restaurant
+            {
+                Id = 1,
+                Timezone = "UTC",
+                OpenTime = "00:00",
+                CloseTime = "00:00",
+            });
+        _mockBookingRepo.Setup(b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ReturnsAsync(false);
+        _mockService.Setup(s => s.PlaceHold(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>()))
+            .Returns(new HoldResult("hold-1", DateTime.UtcNow.AddMinutes(5)));
+
+        var testDate = DateTime.UtcNow.Date.AddDays(1).AddHours(3);
+        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = testDate });
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
     public async Task PlaceHold_ReturnsBadRequest_WhenDateFallsOnWalkInDay()
     {
         // Tomorrow's ISO day (1=Mon … 7=Sun) is marked walk-in only.

--- a/OpenRestoApi.Tests/Integration/RestaurantsControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/RestaurantsControllerTests.cs
@@ -169,6 +169,26 @@ public class RestaurantsControllerTests(TestWebAppFactory factory) : IClassFixtu
     }
 
     [Fact]
+    public async Task UpdateRestaurant_ReturnsBadRequest_ForInvalidBookingDuration()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        int restaurantId = db.Restaurants.First().Id;
+
+        HttpResponseMessage response = await client.PutAsJsonAsync($"/api/restaurants/{restaurantId}", new
+        {
+            name = "Still A Valid Name",
+            defaultBookingDurationMinutes = 999,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("DefaultBookingDurationMinutes", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
     public async Task UpdateSection_WithAuth_Succeeds()
     {
         HttpClient client = _factory.CreateAuthenticatedClient();

--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -983,4 +983,114 @@ public class AdminServiceTests : IDisposable
         Booking? futureBooking = await _db.Bookings.FindAsync(2);
         Assert.Null(futureBooking!.EndTime);
     }
+
+    [Fact]
+    public async Task PauseRestaurantBookingsAsync_ReturnsFalse_WhenRestaurantNotFound()
+    {
+        AdminService svc = CreateService();
+        bool result = await svc.PauseRestaurantBookingsAsync(999, 60);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task PauseRestaurantBookingsAsync_SetsBookingsPausedUntil()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        bool result = await svc.PauseRestaurantBookingsAsync(1, 60);
+
+        Assert.True(result);
+        Restaurant restaurant = await _db.Restaurants.SingleAsync(r => r.Id == 1);
+        Assert.NotNull(restaurant.BookingsPausedUntil);
+        Assert.True(restaurant.BookingsPausedUntil > DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task UnpauseRestaurantBookingsAsync_ReturnsFalse_WhenRestaurantNotFound()
+    {
+        AdminService svc = CreateService();
+        bool result = await svc.UnpauseRestaurantBookingsAsync(999);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task UnpauseRestaurantBookingsAsync_ClearsBookingsPausedUntil()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+        await svc.PauseRestaurantBookingsAsync(1, 60);
+
+        bool result = await svc.UnpauseRestaurantBookingsAsync(1);
+
+        Assert.True(result);
+        Restaurant restaurant = await _db.Restaurants.SingleAsync(r => r.Id == 1);
+        Assert.Null(restaurant.BookingsPausedUntil);
+    }
+
+    [Fact]
+    public async Task ExtendAllActiveBookingsAsync_ReturnsNull_WhenRestaurantNotFound()
+    {
+        AdminService svc = CreateService();
+        List<BookingDetailDto>? result = await svc.ExtendAllActiveBookingsAsync(999, 30);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_CountsPausedRestaurants()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+        Restaurant restaurant = await _db.Restaurants.SingleAsync(r => r.Id == 1);
+        restaurant.BookingsPausedUntil = DateTime.UtcNow.AddHours(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(1, overview.PausedRestaurantsCount);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_DoesNotCountRestaurants_WithExpiredPause()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+        Restaurant restaurant = await _db.Restaurants.SingleAsync(r => r.Id == 1);
+        restaurant.BookingsPausedUntil = DateTime.UtcNow.AddHours(-1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(0, overview.PausedRestaurantsCount);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_UpcomingFilter_BehavesLikeActive()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> upcoming = await svc.GetBookingsAsync(1, null, "upcoming");
+        List<BookingDetailDto> active = await svc.GetBookingsAsync(1, null, "active");
+
+        Assert.Equal(active.Count, upcoming.Count);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_UnrecognizedStatus_DefaultsToActive()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> unrecognized = await svc.GetBookingsAsync(1, null, "not-a-real-status");
+        List<BookingDetailDto> active = await svc.GetBookingsAsync(1, null, "active");
+
+        Assert.Equal(active.Count, unrecognized.Count);
+    }
 }

--- a/OpenRestoApi.Tests/Services/BrandServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BrandServiceTests.cs
@@ -143,4 +143,86 @@ public class BrandServiceTests
         Assert.Null(result.CopyrightText);
     }
 
+    [Fact]
+    public async Task SaveAsync_Throws_WhenInvalidFaviconIcon()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_Throws_WhenInvalidFaviconIcon));
+        var svc = CreateService(db);
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => svc.SaveAsync(null, null, null, faviconIcon: "not-a-real-icon"));
+    }
+
+    [Fact]
+    public async Task SaveAsync_Persists_WebsiteUrl_Trimmed()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_Persists_WebsiteUrl_Trimmed));
+        var svc = CreateService(db);
+        await svc.SaveAsync(null, null, null, websiteUrl: "  https://example.com  ");
+        BrandSettings result = await svc.GetAsync();
+        Assert.Equal("https://example.com", result.WebsiteUrl);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Clears_WebsiteUrl_WhenBlankPassed()
+    {
+        using AppDbContext db = CreateDb(nameof(SaveAsync_Clears_WebsiteUrl_WhenBlankPassed));
+        var svc = CreateService(db);
+        await svc.SaveAsync(null, null, null, websiteUrl: "https://example.com");
+        await svc.SaveAsync(null, null, null, websiteUrl: "   ");
+        BrandSettings result = await svc.GetAsync();
+        Assert.Null(result.WebsiteUrl);
+    }
+
+    [Fact]
+    public void GetWebsiteUrl_ReturnsBrandWebsiteUrl_WhenSet()
+    {
+        var svc = CreateService(CreateDb(nameof(GetWebsiteUrl_ReturnsBrandWebsiteUrl_WhenSet)));
+        string result = svc.GetWebsiteUrl(new BrandSettings { WebsiteUrl = "https://brand.example.com" });
+        Assert.Equal("https://brand.example.com", result);
+    }
+
+    [Fact]
+    public void GetWebsiteUrl_FallsBackToConfig_WhenBrandUrlMissing()
+    {
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["Website:Url"]).Returns("https://configured.example.com");
+        var svc = new BrandService(CreateDb(nameof(GetWebsiteUrl_FallsBackToConfig_WhenBrandUrlMissing)), config.Object);
+
+        string result = svc.GetWebsiteUrl(null);
+
+        Assert.Equal("https://configured.example.com", result);
+    }
+
+    [Fact]
+    public void GetWebsiteUrl_FallsBackToFirstCorsOrigin_WhenConfigMissing()
+    {
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["Cors:Origins"]).Returns("https://cors-a.example.com, https://cors-b.example.com");
+        var svc = new BrandService(CreateDb(nameof(GetWebsiteUrl_FallsBackToFirstCorsOrigin_WhenConfigMissing)), config.Object);
+
+        string result = svc.GetWebsiteUrl(null);
+
+        Assert.Equal("https://cors-a.example.com", result);
+    }
+
+    [Fact]
+    public void GetWebsiteUrl_FallsBackToLocalhost_WhenNothingConfigured()
+    {
+        var svc = CreateService(CreateDb(nameof(GetWebsiteUrl_FallsBackToLocalhost_WhenNothingConfigured)));
+        string result = svc.GetWebsiteUrl(null);
+        Assert.Equal("http://localhost:8081", result);
+    }
+
+    [Fact]
+    public async Task GetWebsiteUrlAsync_UsesPersistedBrandSettings()
+    {
+        using AppDbContext db = CreateDb(nameof(GetWebsiteUrlAsync_UsesPersistedBrandSettings));
+        db.Set<BrandSettings>().Add(new BrandSettings { WebsiteUrl = "https://persisted.example.com" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        string result = await svc.GetWebsiteUrlAsync();
+
+        Assert.Equal("https://persisted.example.com", result);
+    }
 }


### PR DESCRIPTION
## Summary

Second backend coverage batch (follows #201), targeting the next lowest-coverage controllers and services.

### Files brought to (or near) 100% branch coverage

| File | Coverage before | After |
|---|---|---|
| `Controllers/AvailabilityController.cs` | 76.9% | 100% |
| `Controllers/HoldsController.cs` | 79.6% | 100% |
| `Controllers/RestaurantsController.cs` | 91.8% | 100% |
| `Core/Application/Services/BrandService.cs` | 84.4% | 98.7% |
| `Core/Application/Services/AdminService.cs` | 91.0% | 93.1% |

### What was added

- **`AvailabilityController`**: the `ArgumentException` → 404 catch branch and the success (200) path — only the generic-exception → 500 path was previously tested.
- **`HoldsController`**: the remaining `PlaceHold` guard branches (past date, paused bookings, already-booked conflict, invalid-timezone fallback) plus every branch of the private `IsTimeWithinOpeningHours` helper — day-not-in-`OpenDays`, unparseable stored open/close times falling back to the 09:00-22:00 default, overnight hours (close < open) both inside and outside the window, and close == open treated as always-open.
- **`RestaurantsController`**: the `ArgumentException` → 400 branch of `Put` (invalid `DefaultBookingDurationMinutes`) — a real end-to-end integration test through `TestWebAppFactory` rather than a mock, since the validation lives in `RestaurantManagementService`.
- **`BrandService`**: the invalid-favicon-icon rejection, the `websiteUrl` set/trim/clear branches in `SaveAsync`, and all four fallback tiers of `GetWebsiteUrl`/`GetWebsiteUrlAsync` (brand-configured, `IConfiguration`, first CORS origin, and the `http://localhost:8081` default).
- **`AdminService`**: `Pause`/`Unpause`/`ExtendAllActiveBookings`'s restaurant-not-found branches (all three were entirely untested), `Pause`/`Unpause`'s happy paths (also untested), `GetOverviewAsync`'s paused-restaurant counting (both active and expired-pause cases), and `NormalizeStatus`'s `"upcoming"` and unrecognized-status default arms via `GetBookingsAsync`.

### What was investigated but not touched

- **`NotificationService.SendPushAsync`** (the file's one remaining large gap): it constructs a `WebPushClient` directly inline and makes real outbound HTTP calls, with no injected abstraction to mock. Covering it properly would need a production refactor (introducing an `IWebPushClient`/`IPushSender` seam) rather than a coverage-only change, so left alone this round.
- **`AdminService.AdminUpdateBookingAsync`/`GetBookingsAsync`** still have some remaining gaps — too broad in scope for this batch, candidate for a future one.

### Coverage before / after (full backend suite)

| | Line | Branch | Method |
|---|---|---|---|
| Before | 91.05% | 78.90% | 94.82% |
| After | 92.20% | 81.10% | 94.96% |

### Tests added

29 new tests (732 → 761). All pass.

## Test plan

- [x] `dotnet test` — 761/761 passing
- [x] `dotnet build --configuration Release` (matching CI) — clean of new warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014ehn9GCo5jd3rHwAo5y1UF)_