### PR TITLE
Make footer a real page footer and fix admin link alignment

### DIFF
--- a/openresto-frontend/app/(user)/_layout.tsx
+++ b/openresto-frontend/app/(user)/_layout.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { Platform, View } from "react-native";
 import { Slot, Stack, useRouter, useSegments } from "expo-router";
 import Navbar from "@/components/layout/Navbar";
-import Footer from "@/components/layout/Footer";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { focusTarget } from "@/utils/focusRegistry";
 import KeyboardShortcutsHelp from "@/components/common/KeyboardShortcutsHelp";
@@ -39,10 +38,7 @@ export default function UserLayout() {
     return (
       <View style={{ flex: 1 }}>
         <Navbar />
-        <View style={{ flex: 1 }}>
-          <Slot />
-        </View>
-        <Footer />
+        <Slot />
         <KeyboardShortcutsHelp
           visible={showShortcutsHelp}
           scope="user"

--- a/openresto-frontend/app/(user)/book/[restaurantId].tsx
+++ b/openresto-frontend/app/(user)/book/[restaurantId].tsx
@@ -14,6 +14,7 @@ import { convertLocalToUtc } from "@/utils/date";
 import BookingSkeleton from "@/components/booking/BookingSkeleton";
 import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 import WalkInNotice from "@/components/booking/WalkInNotice";
+import Footer from "@/components/layout/Footer";
 
 export default function BookScreen() {
   const {
@@ -157,6 +158,8 @@ export default function BookScreen() {
             </>
           )}
         </PageContainer>
+
+        <Footer />
       </ScrollView>
       <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
     </ThemedView>

--- a/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
+++ b/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
@@ -22,6 +22,7 @@ import BookingConfirmationSkeleton from "@/components/booking/BookingConfirmatio
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import ScrollToTopFab from "@/components/common/ScrollToTopFab";
+import Footer from "@/components/layout/Footer";
 import * as Haptics from "expo-haptics";
 
 export default function BookingConfirmationScreen() {
@@ -437,6 +438,8 @@ export default function BookingConfirmationScreen() {
           onConfirm={handleCancelBooking}
           onCancel={() => !cancelling && setShowCancelConfirm(false)}
         />
+
+        <Footer />
       </ScrollView>
       <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
     </View>

--- a/openresto-frontend/app/(user)/index.tsx
+++ b/openresto-frontend/app/(user)/index.tsx
@@ -15,6 +15,7 @@ import RestaurantCard from "@/components/restaurant/RestaurantCard";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { Ionicons } from "@expo/vector-icons";
 import ScrollToTopFab from "@/components/common/ScrollToTopFab";
+import Footer from "@/components/layout/Footer";
 
 // Module-level cache so data survives route changes — prevents hero layout shift on back-navigation.
 let _cachedRestaurants: RestaurantDto[] | null = null;
@@ -252,6 +253,8 @@ export default function HomeScreen() {
             </View>
           )}
         </View>
+
+        <Footer />
       </ScrollView>
 
       <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />

--- a/openresto-frontend/app/(user)/lookup.tsx
+++ b/openresto-frontend/app/(user)/lookup.tsx
@@ -38,6 +38,7 @@ import BookingDetailRows from "@/components/booking/BookingDetailRows";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { buildCalendarUrls } from "@/utils/calendar";
 import ScrollToTopFab from "@/components/common/ScrollToTopFab";
+import Footer from "@/components/layout/Footer";
 
 export default function LookupScreen() {
   const [refInput, setRefInput] = useState("");
@@ -267,6 +268,8 @@ export default function LookupScreen() {
             />
           )}
         </PageContainer>
+
+        <Footer />
       </ScrollView>
 
       <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />

--- a/openresto-frontend/app/(user)/restaurant/[id].tsx
+++ b/openresto-frontend/app/(user)/restaurant/[id].tsx
@@ -10,6 +10,7 @@ import Button from "@/components/common/Button";
 import RestaurantSkeleton from "@/components/restaurant/RestaurantSkeleton";
 import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 import WalkInNotice from "@/components/booking/WalkInNotice";
+import Footer from "@/components/layout/Footer";
 
 export default function RestaurantScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -78,6 +79,8 @@ export default function RestaurantScreen() {
             </Link>
           )}
         </PageContainer>
+
+        <Footer />
       </ScrollView>
       <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />
     </ThemedView>

--- a/openresto-frontend/components/layout/Footer.tsx
+++ b/openresto-frontend/components/layout/Footer.tsx
@@ -11,7 +11,7 @@ import { fetchSocialLinks, SocialLinkDto } from "@/api/restaurants";
 export default function Footer() {
   const { brand, colors } = useAppTheme();
   const { width } = useWindowDimensions();
-  const isMobile = width < 768;
+  const isMobile = width < 600;
 
   const [socialLinks, setSocialLinks] = useState<SocialLinkDto[]>([]);
 
@@ -28,7 +28,7 @@ export default function Footer() {
       <View style={[styles.inner, isMobile && styles.innerMobile]}>
         <ThemedText style={[styles.copyright, { color: colors.muted }]}>{copyright}</ThemedText>
 
-        <View style={[styles.right, isMobile && styles.rightMobile]}>
+        <View style={styles.right}>
           {socialLinks.length > 0 && (
             <View style={styles.social}>
               {socialLinks.map((link) => (
@@ -42,7 +42,7 @@ export default function Footer() {
                 >
                   <Ionicons
                     name={link.iconKey as ComponentProps<typeof Ionicons>["name"]}
-                    size={18}
+                    size={16}
                     color={colors.muted}
                   />
                 </Pressable>
@@ -54,10 +54,9 @@ export default function Footer() {
             <Pressable
               accessibilityRole="link"
               accessibilityLabel="Restaurant admin"
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              style={({ hovered }: any) => [styles.adminBtn, hovered && { opacity: 0.65 }]}
+              style={styles.adminBtn}
             >
-              <Ionicons name="settings-outline" size={14} color={colors.muted} />
+              <Ionicons name="settings-outline" size={13} color={colors.muted} />
               <ThemedText style={[styles.adminText, { color: colors.muted }]}>Admin</ThemedText>
             </Pressable>
           </Link>
@@ -77,30 +76,26 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     flexWrap: "wrap",
-    gap: SPACING.sm,
+    rowGap: 6,
+    columnGap: SPACING.md,
     maxWidth: 1320,
     width: "100%",
     alignSelf: "center",
     paddingHorizontal: 28,
-    paddingVertical: SPACING.sm,
+    paddingVertical: 10,
   },
   innerMobile: {
-    flexDirection: "column",
-    alignItems: "flex-start",
-    paddingHorizontal: 12,
-    gap: SPACING.xs,
+    justifyContent: "center",
+    paddingHorizontal: 16,
   },
   copyright: {
     fontSize: 12,
+    lineHeight: 16,
   },
   right: {
     flexDirection: "row",
     alignItems: "center",
-    gap: SPACING.lg,
-  },
-  rightMobile: {
-    width: "100%",
-    justifyContent: "space-between",
+    gap: SPACING.md,
   },
   social: {
     flexDirection: "row",
@@ -108,8 +103,8 @@ const styles = StyleSheet.create({
     gap: SPACING.sm,
   },
   socialBtn: {
-    width: 26,
-    height: 26,
+    width: 20,
+    height: 20,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -117,9 +112,11 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 4,
+    height: 20,
   },
   adminText: {
     fontSize: 12,
+    lineHeight: 16,
     fontWeight: "500",
   },
 });

--- a/openresto-frontend/tests/app/(user)/book.test.tsx
+++ b/openresto-frontend/tests/app/(user)/book.test.tsx
@@ -10,6 +10,11 @@ import { AppThemeProvider } from "@/context/ThemeContext";
 import { BrandProvider } from "@/context/BrandContext";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
+jest.mock("@/components/layout/Footer", () => {
+  const { View } = require("react-native");
+  return { __esModule: true, default: () => <View testID="mock-footer" /> };
+});
+
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
 }));

--- a/openresto-frontend/tests/app/(user)/booking-confirmation.test.tsx
+++ b/openresto-frontend/tests/app/(user)/booking-confirmation.test.tsx
@@ -22,6 +22,11 @@ global.fetch = jest.fn(() =>
   })
 ) as jest.Mock;
 
+jest.mock("@/components/layout/Footer", () => {
+  const { View } = require("react-native");
+  return { __esModule: true, default: () => <View testID="mock-footer" /> };
+});
+
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
 }));

--- a/openresto-frontend/tests/app/(user)/index.test.tsx
+++ b/openresto-frontend/tests/app/(user)/index.test.tsx
@@ -16,6 +16,11 @@ global.fetch = jest.fn(() =>
   })
 ) as jest.Mock;
 
+jest.mock("@/components/layout/Footer", () => {
+  const { View } = require("react-native");
+  return { __esModule: true, default: () => <View testID="mock-footer" /> };
+});
+
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: jest.fn(() => null),
 }));

--- a/openresto-frontend/tests/app/(user)/lookup.test.tsx
+++ b/openresto-frontend/tests/app/(user)/lookup.test.tsx
@@ -21,6 +21,11 @@ global.fetch = jest.fn(() =>
 ) as jest.Mock;
 
 // Mock Modal to always render children
+jest.mock("@/components/layout/Footer", () => {
+  const { View } = require("react-native");
+  return { __esModule: true, default: () => <View testID="mock-footer" /> };
+});
+
 jest.mock("react-native", () => {
   const rn = jest.requireActual("react-native");
   rn.Modal = ({ children, visible }: any) => (visible ? children : null);

--- a/openresto-frontend/tests/app/(user)/restaurant.test.tsx
+++ b/openresto-frontend/tests/app/(user)/restaurant.test.tsx
@@ -16,6 +16,11 @@ global.fetch = jest.fn(() =>
   })
 ) as jest.Mock;
 
+jest.mock("@/components/layout/Footer", () => {
+  const { View } = require("react-native");
+  return { __esModule: true, default: () => <View testID="mock-footer" /> };
+});
+
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
 }));


### PR DESCRIPTION
## Summary

Follow-up to #198/#199 addressing feedback that the footer was still behaving wrong after those merges:

- **"Footer is still sticky" / "I want a page footer, not an app footer"** — the previous layout wrapped `<Slot />` in its own `flex: 1` box and rendered `<Footer />` as a sibling after it inside the shared `(user)/_layout.tsx`. That pins the footer to the bottom of the viewport (an app-shell bar), not to the bottom of each page's content. Fixed by removing `Footer` from the shared layout entirely and rendering it as the last element inside each screen's own `ScrollView` (home, restaurant detail, book, lookup, booking confirmation) — it now scrolls away with the page and only comes into view once you actually scroll to the bottom of that page's content, like a normal website footer.

- **"Admin icon and text don't look aligned"** — root-caused this properly by inspecting the actual rendered DOM instead of guessing again: the admin link's `Pressable` used a function-based `style` prop (`({ hovered }) => [...]`) for a hover-opacity effect, while wrapped in `<Link asChild>`. `asChild` forwards `style` straight onto the rendered `<a>` element, and a plain DOM/RN-Web element can't invoke a style *function* — so it silently dropped, meaning `flexDirection: row` never applied and the icon rendered stacked above the text instead of beside it. `Navbar.tsx`'s own `Link`+`Pressable` links (the brand name link, nav links) already avoid this by using static style objects; the footer's admin link now does the same. Confirmed via the rendered `outerHTML` before/after — `flex-direction: row; align-items: center; gap: 4px` is now actually present on the element.

- **"Still way too big vertically"** — on top of the smaller padding from #199, `ThemedText`'s default style carries `lineHeight: 24` (sized for 16px text), which was still applied since the footer's text styles only overrode `fontSize`. That alone reserved 24px of line-box height per text line regardless of the 12px font size. Added explicit `lineHeight: 16` to both the copyright and admin text styles, which — combined with the layout fix above collapsing the icon+text back to one line — brings the footer down to a normal, compact single-line bar.

## Frontend changes

- `app/(user)/_layout.tsx`: removed the `Footer` import/render and the `flex:1` wrapper around `<Slot />`, reverting to the original simple `<Navbar /><Slot />` structure.
- `components/layout/Footer.tsx`: admin link's `Pressable` now uses a static `style` object instead of a hover-function; added `lineHeight` to text styles; slightly retuned spacing.
- Added `<Footer />` as the last element inside the `ScrollView` in `index.tsx`, `book/[restaurantId].tsx`, `restaurant/[id].tsx`, `lookup.tsx`, and `booking-confirmation/[bookingRef].tsx`.
- Updated the five corresponding page-level test files to mock `@/components/layout/Footer` (matching how these files already mock other heavy child components), since some of them mock `expo-router` without exporting `Link`, which the real `Footer` needs.

## Test plan

- [x] `dotnet test` — 732/732 passing (unaffected, backend-only PRs from other work already included)
- [x] `npm test` — 1444/1444 passing
- [x] `npm run check` (prettier + eslint) — clean
- [x] Verified in a running dev stack by rendering the home page at a very tall viewport (so RN Web's inner `ScrollView` doesn't clip) and confirming: the footer sits directly after the actual page content (not glued to the visual bottom of a short page), the browser viewport at normal height shows no footer without scrolling, and — via `page.evaluate(...outerHTML)` — the admin link's computed style now actually includes `flex-direction: row` where before the fix it had no layout styles at all
- [x] Confirmed the same single-line, properly-aligned footer on a 390px mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmeqgX65Fo3TgRFc1gEKJ)_