### PR TITLE
Anchor footer to viewport bottom and match page background

### DIFF
--- a/openresto-frontend/app/(user)/book/[restaurantId].tsx
+++ b/openresto-frontend/app/(user)/book/[restaurantId].tsx
@@ -119,6 +119,7 @@ export default function BookScreen() {
       <ScrollView
         ref={scrollRef}
         style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
         onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
         scrollEventThrottle={100}
       >
@@ -169,6 +170,7 @@ export default function BookScreen() {
 const styles = StyleSheet.create({
   root: { flex: 1 },
   scroll: { flex: 1 },
+  scrollContent: { flexGrow: 1 },
   center: { flex: 1, justifyContent: "center", alignItems: "center" },
   page: {
     maxWidth: Platform.OS === "web" ? 860 : 560,

--- a/openresto-frontend/app/(user)/index.tsx
+++ b/openresto-frontend/app/(user)/index.tsx
@@ -80,181 +80,185 @@ export default function HomeScreen() {
         onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
         scrollEventThrottle={100}
       >
-        {/* ── Hero ── */}
-        <View
-          style={[
-            styles.hero,
-            {
-              backgroundColor: surface,
-              borderBottomColor: border,
-              ...(!hasHero &&
-                Platform.OS === "web" &&
-                ({
-                  background: isDark
-                    ? `radial-gradient(80% 90% at 90% 10%, ${accentSoft}, transparent 60%), radial-gradient(60% 80% at 10% 100%, rgba(${accentR},${accentG},${accentB},0.12), transparent 60%), linear-gradient(180deg, ${surface} 0%, ${bg} 100%)`
-                    : `radial-gradient(80% 90% at 90% 10%, ${accentSoft}, transparent 60%), linear-gradient(180deg, ${surface} 0%, ${bg} 100%)`,
-                } as object)),
-            },
-          ]}
-        >
-          {hasHero && (
-            <>
-              <img
-                src={brand.headerImageUrl!}
-                aria-hidden
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  width: "100%",
-                  height: "100%",
-                  objectFit: "cover",
-                  objectPosition: "center",
-                  pointerEvents: "none",
-                }}
-              />
+        <View style={{ flex: 1 }}>
+          {/* ── Hero ── */}
+          <View
+            style={[
+              styles.hero,
+              {
+                backgroundColor: surface,
+                borderBottomColor: border,
+                ...(!hasHero &&
+                  Platform.OS === "web" &&
+                  ({
+                    background: isDark
+                      ? `radial-gradient(80% 90% at 90% 10%, ${accentSoft}, transparent 60%), radial-gradient(60% 80% at 10% 100%, rgba(${accentR},${accentG},${accentB},0.12), transparent 60%), linear-gradient(180deg, ${surface} 0%, ${bg} 100%)`
+                      : `radial-gradient(80% 90% at 90% 10%, ${accentSoft}, transparent 60%), linear-gradient(180deg, ${surface} 0%, ${bg} 100%)`,
+                  } as object)),
+              },
+            ]}
+          >
+            {hasHero && (
+              <>
+                <img
+                  src={brand.headerImageUrl!}
+                  aria-hidden
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "cover",
+                    objectPosition: "center",
+                    pointerEvents: "none",
+                  }}
+                />
+                <View
+                  style={[
+                    { position: "absolute", top: 0, left: 0, right: 0, bottom: 0 },
+                    {
+                      background: `linear-gradient(160deg, rgba(${accentR},${accentG},${accentB},0.30) 0%, rgba(0,0,0,0.40) 100%)`,
+                    } as object,
+                  ]}
+                  pointerEvents="none"
+                />
+              </>
+            )}
+            <View style={[styles.heroInner, isMobile && { paddingHorizontal: 20 }]}>
               <View
                 style={[
-                  { position: "absolute", top: 0, left: 0, right: 0, bottom: 0 },
-                  {
-                    background: `linear-gradient(160deg, rgba(${accentR},${accentG},${accentB},0.30) 0%, rgba(0,0,0,0.40) 100%)`,
-                  } as object,
+                  styles.heroTextPill,
+                  hasHero && {
+                    backgroundColor: surface,
+                    borderColor: border,
+                    borderRadius: 12,
+                    borderWidth: 1,
+                    padding: 16,
+                  },
                 ]}
-                pointerEvents="none"
-              />
-            </>
-          )}
-          <View style={[styles.heroInner, isMobile && { paddingHorizontal: 20 }]}>
-            <View
-              style={[
-                styles.heroTextPill,
-                hasHero && {
-                  backgroundColor: surface,
-                  borderColor: border,
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  padding: 16,
-                },
-              ]}
-            >
-              <ThemedText style={[styles.heroTitle, isMobile && { fontSize: 40, lineHeight: 44 }]}>
-                {brand.appName}
-              </ThemedText>
-              <ThemedText style={[styles.heroSub, { color: mutedColor }]}>
-                Scroll down to pick a location below, choose a time, enter your email address, and
-                you're booked!
-              </ThemedText>
+              >
+                <ThemedText
+                  style={[styles.heroTitle, isMobile && { fontSize: 40, lineHeight: 44 }]}
+                >
+                  {brand.appName}
+                </ThemedText>
+                <ThemedText style={[styles.heroSub, { color: mutedColor }]}>
+                  Scroll down to pick a location below, choose a time, enter your email address, and
+                  you're booked!
+                </ThemedText>
+              </View>
             </View>
-          </View>
 
-          {/* ── Highlights ── */}
-          <View style={[styles.highlights, isMobile && { paddingHorizontal: 20 }]}>
-            <View style={styles.highlightsHead}>
-              <ThemedText
-                style={[
-                  styles.highlightsLabel,
-                  { color: hasHero ? "rgba(255,255,255,0.92)" : mutedColor },
-                  hasHero && ({ textShadow: heroTextShadow } as object),
-                ]}
-              >
-                Restaurant highlights
-              </ThemedText>
-              <ThemedText
-                style={[
-                  styles.highlightsBy,
-                  { color: hasHero ? "rgba(255,255,255,0.82)" : mutedColor },
-                  hasHero && ({ textShadow: heroTextShadow } as object),
-                ]}
-              >
-                Curated by the owner
-              </ThemedText>
-            </View>
-            <View
-              style={[
-                styles.highlightsGrid,
-                numHighlightCols > 1 && { flexDirection: "row", flexWrap: "wrap" },
-              ]}
-            >
-              {highlights.map((h) => (
-                <View
-                  key={h.id}
+            {/* ── Highlights ── */}
+            <View style={[styles.highlights, isMobile && { paddingHorizontal: 20 }]}>
+              <View style={styles.highlightsHead}>
+                <ThemedText
                   style={[
-                    styles.highlightCard,
-                    { backgroundColor: surface, borderColor: border },
-                    numHighlightCols > 1 && {
-                      width:
-                        numHighlightCols === 2
-                          ? ("calc(50% - 6px)" as unknown as number)
-                          : ("calc(25% - 9px)" as unknown as number),
-                      minWidth: 200,
-                    },
+                    styles.highlightsLabel,
+                    { color: hasHero ? "rgba(255,255,255,0.92)" : mutedColor },
+                    hasHero && ({ textShadow: heroTextShadow } as object),
                   ]}
                 >
-                  <View style={styles.highlightHeader}>
-                    <View
-                      style={[
-                        styles.highlightIconBox,
-                        { backgroundColor: `rgba(${accentR},${accentG},${accentB},0.18)` },
-                      ]}
-                    >
-                      <Ionicons
-                        name={h.iconKey as ComponentProps<typeof Ionicons>["name"]}
-                        size={16}
-                        color={primaryColor}
-                      />
+                  Restaurant highlights
+                </ThemedText>
+                <ThemedText
+                  style={[
+                    styles.highlightsBy,
+                    { color: hasHero ? "rgba(255,255,255,0.82)" : mutedColor },
+                    hasHero && ({ textShadow: heroTextShadow } as object),
+                  ]}
+                >
+                  Curated by the owner
+                </ThemedText>
+              </View>
+              <View
+                style={[
+                  styles.highlightsGrid,
+                  numHighlightCols > 1 && { flexDirection: "row", flexWrap: "wrap" },
+                ]}
+              >
+                {highlights.map((h) => (
+                  <View
+                    key={h.id}
+                    style={[
+                      styles.highlightCard,
+                      { backgroundColor: surface, borderColor: border },
+                      numHighlightCols > 1 && {
+                        width:
+                          numHighlightCols === 2
+                            ? ("calc(50% - 6px)" as unknown as number)
+                            : ("calc(25% - 9px)" as unknown as number),
+                        minWidth: 200,
+                      },
+                    ]}
+                  >
+                    <View style={styles.highlightHeader}>
+                      <View
+                        style={[
+                          styles.highlightIconBox,
+                          { backgroundColor: `rgba(${accentR},${accentG},${accentB},0.18)` },
+                        ]}
+                      >
+                        <Ionicons
+                          name={h.iconKey as ComponentProps<typeof Ionicons>["name"]}
+                          size={16}
+                          color={primaryColor}
+                        />
+                      </View>
+                      <ThemedText style={styles.highlightTitle}>{h.title}</ThemedText>
                     </View>
-                    <ThemedText style={styles.highlightTitle}>{h.title}</ThemedText>
+                    <ThemedText style={[styles.highlightBody, { color: mutedColor }]}>
+                      {h.body}
+                    </ThemedText>
                   </View>
-                  <ThemedText style={[styles.highlightBody, { color: mutedColor }]}>
-                    {h.body}
-                  </ThemedText>
-                </View>
-              ))}
+                ))}
+              </View>
             </View>
+          </View>
+
+          {/* ── Main body ── */}
+          <View style={[styles.body, isMobile && { paddingHorizontal: 16 }]}>
+            <View style={styles.sectionHead}>
+              <ThemedText style={styles.sectionTitle}>Our locations</ThemedText>
+            </View>
+
+            {loading ? (
+              <ActivityIndicator
+                testID="loading-screen"
+                style={styles.spinner}
+                size="large"
+                color={primaryColor}
+              />
+            ) : (
+              <View
+                style={[styles.grid, numColumns > 1 && { flexDirection: "row", flexWrap: "wrap" }]}
+              >
+                {restaurants.map((r, i) => (
+                  <View
+                    key={r.id}
+                    style={[
+                      styles.cardWrapper,
+                      numColumns > 1 && {
+                        width:
+                          numColumns === 2
+                            ? ("calc(50% - 9px)" as unknown as number)
+                            : ("calc(33.333% - 12px)" as unknown as number),
+                        minWidth: 320,
+                      },
+                    ]}
+                  >
+                    <RestaurantCard restaurant={r} index={i} party={party} />
+                  </View>
+                ))}
+              </View>
+            )}
           </View>
         </View>
 
-        {/* ── Main body ── */}
-        <View style={[styles.body, isMobile && { paddingHorizontal: 16 }]}>
-          <View style={styles.sectionHead}>
-            <ThemedText style={styles.sectionTitle}>Our locations</ThemedText>
-          </View>
-
-          {loading ? (
-            <ActivityIndicator
-              testID="loading-screen"
-              style={styles.spinner}
-              size="large"
-              color={primaryColor}
-            />
-          ) : (
-            <View
-              style={[styles.grid, numColumns > 1 && { flexDirection: "row", flexWrap: "wrap" }]}
-            >
-              {restaurants.map((r, i) => (
-                <View
-                  key={r.id}
-                  style={[
-                    styles.cardWrapper,
-                    numColumns > 1 && {
-                      width:
-                        numColumns === 2
-                          ? ("calc(50% - 9px)" as unknown as number)
-                          : ("calc(33.333% - 12px)" as unknown as number),
-                      minWidth: 320,
-                    },
-                  ]}
-                >
-                  <RestaurantCard restaurant={r} index={i} party={party} />
-                </View>
-              ))}
-            </View>
-          )}
-        </View>
-
-        <Footer />
+        <Footer backgroundColor={bg} />
       </ScrollView>
 
       <ScrollToTopFab scrollY={scrollY} onPress={scrollToTop} />

--- a/openresto-frontend/app/(user)/lookup.tsx
+++ b/openresto-frontend/app/(user)/lookup.tsx
@@ -575,7 +575,7 @@ function BookingResultCard({
 
 const styles = StyleSheet.create({
   root: { flex: 1 },
-  scrollContent: { paddingBottom: 60 },
+  scrollContent: { flexGrow: 1, paddingBottom: 60 },
   header: { alignItems: "center", gap: 8, marginTop: 8, marginBottom: 20 },
   title: { fontSize: 28, fontWeight: "800", letterSpacing: -0.6, marginTop: 8 },
   subtitle: { fontSize: 15, textAlign: "center", lineHeight: 22 },

--- a/openresto-frontend/app/(user)/restaurant/[id].tsx
+++ b/openresto-frontend/app/(user)/restaurant/[id].tsx
@@ -66,6 +66,7 @@ export default function RestaurantScreen() {
       <ScrollView
         ref={scrollRef}
         style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
         onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
         scrollEventThrottle={100}
       >
@@ -90,6 +91,7 @@ export default function RestaurantScreen() {
 const styles = StyleSheet.create({
   root: { flex: 1 },
   scroll: { flex: 1 },
+  scrollContent: { flexGrow: 1 },
   center: { flex: 1, justifyContent: "center", alignItems: "center" },
   page: {
     maxWidth: 720,

--- a/openresto-frontend/components/layout/Footer.tsx
+++ b/openresto-frontend/components/layout/Footer.tsx
@@ -8,7 +8,12 @@ import { useAppTheme } from "@/hooks/use-app-theme";
 import { SPACING } from "@/theme/theme";
 import { fetchSocialLinks, SocialLinkDto } from "@/api/restaurants";
 
-export default function Footer() {
+interface FooterProps {
+  /** Override the footer's background so it matches a page that doesn't use the default themed page color. */
+  backgroundColor?: string;
+}
+
+export default function Footer({ backgroundColor }: FooterProps) {
   const { brand, colors } = useAppTheme();
   const { width } = useWindowDimensions();
   const isMobile = width < 600;
@@ -24,7 +29,13 @@ export default function Footer() {
     brand.copyrightText?.trim() || `© ${year} ${brand.appName}. All rights reserved.`;
 
   return (
-    <ThemedView style={[styles.footer, { borderTopColor: colors.border }]}>
+    <ThemedView
+      style={[
+        styles.footer,
+        { borderTopColor: colors.border },
+        backgroundColor && { backgroundColor },
+      ]}
+    >
       <View style={[styles.inner, isMobile && styles.innerMobile]}>
         <ThemedText style={[styles.copyright, { color: colors.muted }]}>{copyright}</ThemedText>
 


### PR DESCRIPTION
## Summary

Follow-up to #203 addressing two more issues found on the "My Bookings" (lookup) page after that merge:

- **Footer not anchored to the bottom on short pages** — the footer only ever appeared directly after a page's content, so on sparse screens (My Bookings before you search, for example) it floated up mid-page, leaving a large gap of bare background below it instead of sitting at the bottom of the viewport. Fixed with the standard flex "sticky footer" pattern: each screen's `ScrollView` content container now has `flexGrow: 1`, and the main content area inside it has `flex: 1`, so short content still expands to push the footer down to the bottom of the viewport — while pages with enough content to fill or exceed the viewport keep scrolling exactly as before (the footer only comes into view once you actually scroll to the end).

- **Footer background didn't match the page** — most pages already share the same default page background as `Footer` (both resolve to the app's `colors.page`), so this was really only visible on the home page, which uses its own custom cream/dark background rather than the shared default. Added an optional `backgroundColor` prop to `Footer` and pass the home page's own background color into it, so there's no visible seam between the page content and the footer band.

## Frontend changes

- `components/layout/Footer.tsx`: accepts an optional `backgroundColor` prop, applied on top of the themed default.
- `app/(user)/index.tsx`: wraps its main content in a `flex: 1` `View` and passes its custom `bg` color to `<Footer backgroundColor={bg} />`.
- `app/(user)/lookup.tsx`: `scrollContent` style now includes `flexGrow: 1` (the content itself was already wrapped by `PageContainer`, which has its own `flex: 1`).
- `app/(user)/book/[restaurantId].tsx` and `app/(user)/restaurant/[id].tsx`: added a `scrollContent` style (`{ flexGrow: 1 }`) to their `ScrollView`'s `contentContainerStyle`, which they didn't set before.
- `app/(user)/booking-confirmation/[bookingRef].tsx` needed no changes — it already had `flexGrow: 1` on its content container and a `PageContainer`-wrapped body.

## Test plan

- [x] `dotnet test` — 761/761 passing
- [x] `npm test` — 1444/1444 passing (no test changes needed — the flex/background changes don't affect any assertions)
- [x] `npm run check` (prettier + eslint) — clean
- [x] Verified in a running dev stack: the lookup page's footer now sits flush at the bottom of a 900px-tall viewport instead of floating up after the short form; same for the restaurant-detail page. Rendered the home page at an artificially tall viewport (to defeat RN Web's inner-scrollview clipping in a screenshot) and confirmed the footer band now blends seamlessly into the page's cream background with no visible seam, while still anchoring to the true bottom when content is short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmeqgX65Fo3TgRFc1gEKJ)_