### PR TITLE
Shrink footer padding further

### DIFF
--- a/openresto-frontend/components/layout/Footer.tsx
+++ b/openresto-frontend/components/layout/Footer.tsx
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
     width: "100%",
     alignSelf: "center",
     paddingHorizontal: 28,
-    paddingVertical: 10,
+    paddingVertical: 6,
   },
   innerMobile: {
     justifyContent: "center",
@@ -114,8 +114,8 @@ const styles = StyleSheet.create({
     gap: SPACING.sm,
   },
   socialBtn: {
-    width: 20,
-    height: 20,
+    width: 18,
+    height: 18,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -123,7 +123,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 4,
-    height: 20,
+    height: 18,
   },
   adminText: {
     fontSize: 12,


### PR DESCRIPTION
## Summary

Small follow-up to #204 — position and background were confirmed correct, but the footer band itself was still visually too tall on the My Bookings (lookup) page.

Reduced `Footer.tsx`'s vertical padding (`paddingVertical: 10 → 6`) and the social/admin icon row height (`20 → 18`), bringing the total footer height from ~40px down to ~31px (measured via the rendered `getBoundingClientRect()`), about a 25% reduction.

## Test plan

- [x] `npm test` — 1444/1444 passing
- [x] `npm run check` (prettier + eslint) — clean
- [x] Verified in a running dev stack on the lookup page — footer now reads as a proper thin bar instead of an oversized band, copyright/social icons/admin link all still legible and properly aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpmeqgX65Fo3TgRFc1gEKJ)_