### PR TITLE
test: cover BookingFilterRepository, AdminController.PatchRestaurant, ServiceCollectionExtensions, EmailFailureRepository, and EmailSettingsController

### DIFF
--- a/OpenRestoApi.Tests/Controllers/AdminControllerUnitTests.cs
+++ b/OpenRestoApi.Tests/Controllers/AdminControllerUnitTests.cs
@@ -170,4 +170,33 @@ public class AdminControllerUnitTests
             () => _controller.AdminUpdateBooking(1, new AdminUpdateBookingRequest()));
         Assert.Equal("This update would cause a conflict with an existing booking.", ex.Message);
     }
+
+    [Fact]
+    public async Task PatchRestaurant_ArchivesSuccessfully_ReturnsNoContent()
+    {
+        _mockAdminService.Setup(s => s.SetArchivedAsync(1, true)).ReturnsAsync(true);
+
+        var result = await _controller.PatchRestaurant(1, new AdminRestaurantPatchRequest { IsArchived = true });
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task PatchRestaurant_ReturnsNotFound_WhenRestaurantMissing()
+    {
+        _mockAdminService.Setup(s => s.SetArchivedAsync(999, false)).ReturnsAsync(false);
+
+        var result = await _controller.PatchRestaurant(999, new AdminRestaurantPatchRequest { IsArchived = false });
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task PatchRestaurant_DoesNotCallSetArchived_WhenIsArchivedNull()
+    {
+        var result = await _controller.PatchRestaurant(1, new AdminRestaurantPatchRequest { IsArchived = null });
+
+        Assert.IsType<NoContentResult>(result);
+        _mockAdminService.Verify(s => s.SetArchivedAsync(It.IsAny<int>(), It.IsAny<bool>()), Times.Never);
+    }
 }

--- a/OpenRestoApi.Tests/Controllers/EmailSettingsControllerUnitTests.cs
+++ b/OpenRestoApi.Tests/Controllers/EmailSettingsControllerUnitTests.cs
@@ -83,13 +83,24 @@ public class EmailSettingsControllerUnitTests
     [Fact]
     public async Task GetFailures_ReturnsOk_WithMappedResponse()
     {
+        DateTime attemptedAt = DateTime.UtcNow;
         var failures = new List<EmailFailure>
         {
-            new() { Id = 1, BookingRef = "ABC", RecipientEmail = "a@a.com", ErrorMessage = "err", AttemptedAt = DateTime.UtcNow }
+            new() { Id = 1, BookingRef = "ABC", RecipientEmail = "a@a.com", ErrorMessage = "err", AttemptedAt = attemptedAt }
         };
         _mockService.Setup(s => s.GetFailuresAsync()).ReturnsAsync(failures);
 
         var result = await _controller.GetFailures();
-        Assert.IsType<OkObjectResult>(result);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        // Force enumeration of the deferred Select() to exercise the mapping itself
+        // (a bare IsType<OkObjectResult> assertion never enumerates the IEnumerable).
+        var mapped = Assert.IsAssignableFrom<IEnumerable<EmailFailureResponse>>(okResult.Value).ToList();
+        Assert.Single(mapped);
+        Assert.Equal(1, mapped[0].Id);
+        Assert.Equal("ABC", mapped[0].BookingRef);
+        Assert.Equal("a@a.com", mapped[0].RecipientEmail);
+        Assert.Equal("err", mapped[0].ErrorMessage);
+        Assert.Equal(attemptedAt, mapped[0].AttemptedAt);
     }
 }

--- a/OpenRestoApi.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/OpenRestoApi.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -66,6 +66,29 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddCustomAuthentication_Throws_WhenJwtKeyMissing()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        Environment.SetEnvironmentVariable("JWT_KEY", null);
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => services.AddCustomAuthentication(config));
+        Assert.Contains("Jwt:Key must be set", ex.Message);
+    }
+
+    [Fact]
+    public void AddCustomAuthentication_Throws_WhenJwtKeyTooShort()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Jwt:Key"] = "too-short" })
+            .Build();
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => services.AddCustomAuthentication(config));
+        Assert.Contains("at least 32 characters", ex.Message);
+    }
+
+    [Fact]
     public void AddProjectDependencies_RegistersExpectedServices()
     {
         var services = new ServiceCollection();
@@ -107,6 +130,21 @@ public class ServiceCollectionExtensionsTests
         using IServiceScope scope = provider.CreateScope();
         IHoldService scopedHoldService = scope.ServiceProvider.GetRequiredService<IHoldService>();
         Assert.Same(holdService, scopedHoldService);
+    }
+
+    [Fact]
+    public void AddProjectDependencies_ConfiguresSessionCookieOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddProjectDependencies();
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        // Resolving IOptions<SessionOptions> triggers the AddSession(...) configure delegate.
+        var sessionOptions = provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Builder.SessionOptions>>().Value;
+
+        Assert.Equal(TimeSpan.FromSeconds(10), sessionOptions.IdleTimeout);
+        Assert.True(sessionOptions.Cookie.HttpOnly);
+        Assert.True(sessionOptions.Cookie.IsEssential);
     }
 
     [Fact]

--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -287,6 +287,36 @@ public class AdminServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetBookingsAsync_EmailFilter_IsCaseInsensitiveAndPartial()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "A", CustomerEmail = "Alice@Example.com" });
+        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "B", CustomerEmail = "bob@example.com" });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> results = await svc.GetBookingsAsync(1, null, "all", email: "alice");
+
+        Assert.Single(results);
+        Assert.Equal("A", results[0].BookingRef);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_BookingRefFilter_IsCaseInsensitiveAndPartial()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "ABC123" });
+        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "XYZ789" });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> results = await svc.GetBookingsAsync(1, null, "all", bookingRef: "abc");
+
+        Assert.Single(results);
+        Assert.Equal("ABC123", results[0].BookingRef);
+    }
+
+    [Fact]
     public async Task GetBookingAsync_ReturnsNull_WhenNotFound()
     {
         AdminService svc = CreateService();

--- a/OpenRestoApi.Tests/Services/EmailSettingsServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/EmailSettingsServiceTests.cs
@@ -161,4 +161,32 @@ public class EmailSettingsServiceTests
         var svc = CreateService(db, emailMock: emailMock);
         Assert.False(await svc.TestConnectionAsync());
     }
+
+    [Fact]
+    public async Task GetFailuresAsync_ReturnsMostRecentFirst()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetFailuresAsync_ReturnsMostRecentFirst));
+        DateTime now = DateTime.UtcNow;
+        db.Set<EmailFailure>().Add(new EmailFailure { BookingRef = "OLD", RecipientEmail = "a@a.com", ErrorMessage = "err1", AttemptedAt = now.AddMinutes(-10) });
+        db.Set<EmailFailure>().Add(new EmailFailure { BookingRef = "NEW", RecipientEmail = "b@b.com", ErrorMessage = "err2", AttemptedAt = now });
+        await db.SaveChangesAsync();
+
+        var svc = CreateService(db);
+        IReadOnlyList<EmailFailure> failures = await svc.GetFailuresAsync();
+
+        Assert.Equal(2, failures.Count);
+        Assert.Equal("NEW", failures[0].BookingRef);
+        Assert.Equal("OLD", failures[1].BookingRef);
+    }
+
+    [Fact]
+    public async Task GetFailuresAsync_ReturnsEmpty_WhenNoneRecorded()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetFailuresAsync_ReturnsEmpty_WhenNoneRecorded));
+        var svc = CreateService(db);
+
+        IReadOnlyList<EmailFailure> failures = await svc.GetFailuresAsync();
+
+        Assert.Empty(failures);
+    }
 }

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingFilterRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingFilterRepository.cs
@@ -62,6 +62,8 @@ internal class BookingFilterRepository(AppDbContext db) : IBookingFilterReposito
             }
             else
             {
+                // The `_` arm is unreachable: NormalizeStatus only ever returns "active", "past",
+                // "cancelled", or "all", all of which are already handled above.
                 q = normalized switch
                 {
                     "cancelled" => q.Where(b => b.IsCancelled),
@@ -89,6 +91,8 @@ internal class BookingFilterRepository(AppDbContext db) : IBookingFilterReposito
             {
                 DateTime globalCutoff = nowUtc.AddMinutes(-Booking.GridGraceMinutes);
 
+                // The `_` arm is unreachable: NormalizeStatus only ever returns "active", "past",
+                // "cancelled", or "all", all of which are already handled above.
                 q = normalized switch
                 {
                     "cancelled" => q.Where(b => b.IsCancelled),


### PR DESCRIPTION
## Summary

Third batch (5 files) in a series of PRs working toward 100% unit test coverage (see #214 and #215 for the first two batches). This PR targets the next 5 backend files with the largest remaining coverage gaps after #214 landed most of them.

**All 5 files now at or near 100% coverage** (1010 → 1020 tests, all passing).

### Files covered

| File | Before | After |
|---|---|---|
| `Infrastructure/Persistence/Repositories/BookingFilterRepository.cs` | 86.1% | 97.6% |
| `Controllers/AdminController.cs` (`PatchRestaurant`) | 0% | 100% |
| `Extensions/ServiceCollectionExtensions.cs` | 95.4% | 100% |
| `Infrastructure/Persistence/Repositories/EmailFailureRepository.cs` (`GetRecentAsync`) | 0% | 100% |
| `Controllers/EmailSettingsController.cs` (`EmailFailureResponse`) | 0% | 100% |

### What changed

- **`BookingFilterRepository.cs`** — added `AdminService.GetBookingsAsync` tests exercising the `email` and `bookingRef` filter branches, which no existing test passed through. Added inline comments on the two `_ =>` default switch arms in `QueryAsync` documenting they're unreachable dead code (`NormalizeStatus` only ever returns `"active"`/`"past"`/`"cancelled"`/`"all"`, all already handled by named arms).
- **`AdminController.PatchRestaurant`** — added archive-success, not-found, and `IsArchived == null` no-op tests (mocking `AdminService.SetArchivedAsync`, following the existing `AdminControllerUnitTests` Moq pattern).
- **`ServiceCollectionExtensions.cs`** — added tests for `AddCustomAuthentication`'s missing/too-short JWT key throw paths, and a test that resolves `IOptions<SessionOptions>` to force the `AddSession(...)` configure delegate to actually run (it's otherwise never invoked anywhere, since the app never calls `UseSession()` — the delegate only executes when something resolves the options).
- **`EmailFailureRepository.GetRecentAsync`** — added `EmailSettingsService.GetFailuresAsync` tests (most-recent-first ordering + empty-list case); no test previously exercised this method end-to-end.
- **`EmailSettingsController.EmailFailureResponse`** — strengthened the existing `GetFailures_ReturnsOk_WithMappedResponse` test. It previously asserted only the `ActionResult` type and never enumerated the controller's deferred `.Select(...)`, so the `EmailFailureResponse` mapping itself never ran. It now asserts on the mapped values, which forces enumeration.

**Bonus:** #214's `BookingNotificationService` push-flow tests already gave full coverage to `AdminNotificationRepository` and `AdminPushSubscriptionRepository` (both were on the original gap list), so they weren't targeted again here.

### Intentionally excluded

`BookingFilterRepository.cs` has 2 remaining uncovered lines — the `_ =>` default arms in the two `normalized switch` blocks in `QueryAsync`. Documented inline (see above) as unreachable: `NormalizeStatus` maps every input to `"active"`, `"past"`, `"cancelled"`, or `"all"`, and each of those has its own named switch arm, so the default arm can never execute.

## Test plan

- [x] `dotnet build openresto.sln --configuration Release` — 0 errors
- [x] `dotnet test OpenRestoApi.Tests/OpenRestoApi.Tests.csproj --configuration Release` — 1020/1020 passing
- [x] Verified per-file coverage deltas via `dotnet test --collect:"XPlat Code Coverage"` + cobertura report parsing


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rt2Vy9gEY3vTnbdbpJkVUv)_