### PR TITLE
test: cover RestaurantInfoForm, admin.ts social links, book/[restaurantId], DangerZone, and PushBanner

### DIFF
--- a/openresto-frontend/tests/api/admin.test.ts
+++ b/openresto-frontend/tests/api/admin.test.ts
@@ -32,6 +32,10 @@ import {
   getEmailFailures,
   uploadHeroImage,
   deleteHeroImage,
+  adminGetSocialLinks,
+  adminCreateSocialLink,
+  adminUpdateSocialLink,
+  adminDeleteSocialLink,
 } from "@/api/admin";
 
 // Admin API now uses credentials: "include" for cookie-based auth — no mock needed
@@ -1109,5 +1113,124 @@ describe("deleteHeroImage", () => {
   it("returns false on network error", async () => {
     mockFetch.mockRejectedValueOnce(new Error("offline"));
     expect(await deleteHeroImage()).toBe(false);
+  });
+});
+
+// ---------- Social Links ----------
+
+describe("adminGetSocialLinks", () => {
+  it("returns parsed social links on success", async () => {
+    const links = [
+      {
+        id: 1,
+        label: "Instagram",
+        url: "https://instagram.com/r",
+        iconKey: "instagram",
+        sortOrder: 0,
+      },
+    ];
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => links });
+
+    const result = await adminGetSocialLinks();
+
+    expect(result).toEqual(links);
+    expect(mockFetch.mock.calls[0][0]).toContain("/api/social-links");
+  });
+
+  it("returns empty array on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    expect(await adminGetSocialLinks()).toEqual([]);
+  });
+
+  it("returns empty array on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    expect(await adminGetSocialLinks()).toEqual([]);
+  });
+});
+
+describe("adminCreateSocialLink", () => {
+  const req = {
+    label: "Instagram",
+    url: "https://instagram.com/r",
+    iconKey: "instagram",
+    sortOrder: 0,
+  };
+
+  it("returns created social link on success", async () => {
+    const created = { id: 5, ...req };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => created });
+
+    const result = await adminCreateSocialLink(req);
+
+    expect(result).toEqual(created);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/social-links");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body)).toEqual(req);
+  });
+
+  it("returns null on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    expect(await adminCreateSocialLink(req)).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    expect(await adminCreateSocialLink(req)).toBeNull();
+  });
+});
+
+describe("adminUpdateSocialLink", () => {
+  const req = {
+    label: "Facebook",
+    url: "https://facebook.com/r",
+    iconKey: "facebook",
+    sortOrder: 1,
+  };
+
+  it("returns updated social link on success", async () => {
+    const updated = { id: 3, ...req };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => updated });
+
+    const result = await adminUpdateSocialLink(3, req);
+
+    expect(result).toEqual(updated);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/social-links/3");
+    expect(opts.method).toBe("PUT");
+    expect(JSON.parse(opts.body)).toEqual(req);
+  });
+
+  it("returns null on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    expect(await adminUpdateSocialLink(3, req)).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    expect(await adminUpdateSocialLink(3, req)).toBeNull();
+  });
+});
+
+describe("adminDeleteSocialLink", () => {
+  it("returns true when delete succeeds", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const result = await adminDeleteSocialLink(1);
+
+    expect(result).toBe(true);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/social-links/1");
+    expect(opts.method).toBe("DELETE");
+  });
+
+  it("returns false when delete fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    expect(await adminDeleteSocialLink(1)).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    expect(await adminDeleteSocialLink(1)).toBe(false);
   });
 });

--- a/openresto-frontend/tests/app/(user)/book.test.tsx
+++ b/openresto-frontend/tests/app/(user)/book.test.tsx
@@ -27,7 +27,9 @@ jest.mock("react-native", () => {
 
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
-const mockUseLocalSearchParams = jest.fn(() => ({ restaurantId: "1" }));
+const mockUseLocalSearchParams = jest.fn(
+  (): { restaurantId: string; time?: string; party?: string } => ({ restaurantId: "1" })
+);
 jest.mock("expo-router", () => ({
   useLocalSearchParams: () => mockUseLocalSearchParams(),
   useRouter: () => ({ push: mockPush, replace: mockReplace }),
@@ -206,6 +208,100 @@ describe("BookScreen", () => {
       });
     }
     expect(screen.getByText(/Toronto Resto/)).toBeTruthy();
+  });
+
+  it("parses a valid party query param into initialSeats", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ restaurantId: "1", party: "4" });
+    renderWithProviders(<BookScreen />);
+    await waitFor(() => expect(screen.getByText(/Toronto Resto/)).toBeTruthy());
+  });
+
+  it("falls back to undefined initialSeats when party query param is not a number", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ restaurantId: "1", party: "abc" });
+    renderWithProviders(<BookScreen />);
+    await waitFor(() => expect(screen.getByText(/Toronto Resto/)).toBeTruthy());
+  });
+
+  it("skips setting state after unmount so the effect cleanup guards against late resolution", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    (fetchRestaurantById as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const { unmount } = renderWithProviders(<BookScreen />);
+    unmount();
+    resolveFetch(mockRestaurant);
+
+    // Give the resolved promise's microtask/finally a chance to run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const updateWarning = consoleError.mock.calls.some((call) =>
+      String(call[0]).includes("Can't perform a React state update")
+    );
+    expect(updateWarning).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it("falls back to UTC when the restaurant has no timezone", async () => {
+    (fetchRestaurantById as jest.Mock).mockResolvedValue({
+      ...mockRestaurant,
+      timezone: undefined,
+    });
+    renderWithProviders(<BookScreen />);
+    await waitFor(() => expect(screen.getByText(/Toronto Resto/)).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId("submit-trigger"));
+
+    await waitFor(() => expect(createBooking).toHaveBeenCalled());
+  });
+
+  it("falls back to sectionId 0 when no section contains the booked table", async () => {
+    (fetchRestaurantById as jest.Mock).mockResolvedValue({
+      ...mockRestaurant,
+      sections: [
+        {
+          id: 1,
+          name: "Main",
+          restaurantId: 1,
+          tables: [{ id: 999, name: "T9", seats: 4, sectionId: 1 }],
+        },
+      ],
+    });
+    renderWithProviders(<BookScreen />);
+    await waitFor(() => expect(screen.getByText(/Toronto Resto/)).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId("submit-trigger"));
+
+    await waitFor(() => {
+      expect(createBooking).toHaveBeenCalledWith(expect.objectContaining({ sectionId: 0 }));
+    });
+  });
+
+  it("does not navigate when createBooking resolves without a booking", async () => {
+    (createBooking as jest.Mock).mockResolvedValue(null);
+    renderWithProviders(<BookScreen />);
+    await waitFor(() => expect(screen.getByText(/Toronto Resto/)).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId("submit-trigger"));
+
+    await waitFor(() => expect(createBooking).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows a generic error message when a non-Error value is thrown", async () => {
+    (createBooking as jest.Mock).mockRejectedValue("some string failure");
+    renderWithProviders(<BookScreen />);
+    await waitFor(() => expect(screen.getByText(/Toronto Resto/)).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId("submit-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong. Please try again.")).toBeTruthy();
+    });
   });
 
   it("pressing ScrollToTopFab calls scrollToTop in book screen", async () => {

--- a/openresto-frontend/tests/components/admin/locations/DangerZone.test.tsx
+++ b/openresto-frontend/tests/components/admin/locations/DangerZone.test.tsx
@@ -1,0 +1,347 @@
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react-native";
+import { DangerZone, type DangerZoneRestaurant } from "@/components/admin/locations/DangerZone";
+import * as adminApi from "@/api/admin";
+
+jest.mock("@/api/admin", () => ({
+  adminDeleteRestaurant: jest.fn(),
+  adminSetRestaurantArchived: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-persisted-state", () => ({
+  usePersistedState: (_key: string, defaultValue: unknown) => {
+    const { useState } = require("react");
+    return useState(defaultValue);
+  },
+}));
+
+const restaurants: DangerZoneRestaurant[] = [
+  { id: 1, name: "Downtown", isArchived: false },
+  { id: 2, name: "Westside", isArchived: true },
+  // No `isArchived` at all — exercises the `r.isArchived ?? false` fallback.
+  { id: 3, name: "Uptown" },
+];
+
+const baseProps = {
+  restaurants,
+  borderColor: "#ddd",
+  cardBg: "#fff",
+  mutedColor: "#888",
+  isDark: false,
+  onArchived: jest.fn().mockResolvedValue(undefined),
+  onDeleted: jest.fn().mockResolvedValue(undefined),
+};
+
+/** Expands the accordion by pressing the header. */
+function expand() {
+  fireEvent.press(screen.getByText("Archive or delete a location"));
+}
+
+describe("DangerZone", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the section heading and default subtitle collapsed", () => {
+    render(<DangerZone {...baseProps} />);
+    expect(screen.getByText("ARCHIVE / DELETE")).toBeTruthy();
+    expect(screen.getByText("Archive or delete a location")).toBeTruthy();
+    expect(screen.getByText("Permanently remove or hide a location")).toBeTruthy();
+    // Collapsed by default — accordion content not mounted.
+    expect(screen.queryByText("Downtown")).toBeNull();
+  });
+
+  it("expands to show restaurant pills when header is pressed", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    expect(screen.getByText("Downtown")).toBeTruthy();
+    expect(screen.getByText("Westside")).toBeTruthy();
+  });
+
+  it("collapses again when header is pressed a second time", async () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    expect(screen.getByText("Downtown")).toBeTruthy();
+    fireEvent.press(screen.getByText("Archive or delete a location"));
+    await waitFor(() => expect(screen.queryByText("Downtown")).toBeNull());
+  });
+
+  it("shows the placeholder message when no restaurant is selected", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    expect(screen.getByText("Select a location above to see options.")).toBeTruthy();
+  });
+
+  it("does not render the pill scroller when restaurants is empty", () => {
+    render(<DangerZone {...baseProps} restaurants={[]} />);
+    expand();
+    expect(screen.getByText("Select a location above to see options.")).toBeTruthy();
+    expect(screen.queryByText("Downtown")).toBeNull();
+  });
+
+  it("selects a restaurant and shows it in the subtitle", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    expect(screen.getByText("Selected: Downtown")).toBeTruthy();
+  });
+
+  it("shows '(archived)' in the subtitle for an archived selection", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Westside"));
+    expect(screen.getByText("Selected: Westside (archived)")).toBeTruthy();
+  });
+
+  it("shows the Archive Location row for a non-archived restaurant", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    expect(screen.getByText("Archive Location")).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Hide "Downtown" from customers. All data is preserved and can be restored at any time.'
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("Archive…")).toBeTruthy();
+  });
+
+  it("shows the Restore Location row for an archived restaurant", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Westside"));
+    expect(screen.getByText("Restore Location")).toBeTruthy();
+    expect(
+      screen.getByText('Restore "Westside" so customers can book again. All data is intact.')
+    ).toBeTruthy();
+    expect(screen.getByText("Restore")).toBeTruthy();
+  });
+
+  it("treats a restaurant with no isArchived field as not archived", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Uptown"));
+    expect(screen.getByText("Selected: Uptown")).toBeTruthy();
+    expect(screen.getByText("Archive Location")).toBeTruthy();
+  });
+
+  it("renders the archive and delete rows with dark-theme colors", () => {
+    render(<DangerZone {...baseProps} isDark />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    expect(screen.getByText("Archive Location")).toBeTruthy();
+    expect(screen.getByText("Delete Location")).toBeTruthy();
+    fireEvent.press(screen.getByText("Delete…"));
+    expect(screen.getByText("Delete “Downtown”?")).toBeTruthy();
+  });
+
+  it("archives a location and calls onArchived with the new flag", async () => {
+    (adminApi.adminSetRestaurantArchived as jest.Mock).mockResolvedValue(true);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Archive…"));
+    });
+    expect(adminApi.adminSetRestaurantArchived).toHaveBeenCalledWith(1, true);
+    expect(baseProps.onArchived).toHaveBeenCalledWith(1, true);
+  });
+
+  it("restores an archived location and calls onArchived with false", async () => {
+    (adminApi.adminSetRestaurantArchived as jest.Mock).mockResolvedValue(true);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Westside"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Restore"));
+    });
+    expect(adminApi.adminSetRestaurantArchived).toHaveBeenCalledWith(2, false);
+    expect(baseProps.onArchived).toHaveBeenCalledWith(2, false);
+  });
+
+  it("shows 'Saving…' while the archive request is in flight and disables the button", async () => {
+    let resolveArchive: (value: boolean) => void = () => {};
+    (adminApi.adminSetRestaurantArchived as jest.Mock).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveArchive = resolve;
+      })
+    );
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+
+    fireEvent.press(screen.getByText("Archive…"));
+    await waitFor(() => expect(screen.getByText("Saving…")).toBeTruthy());
+
+    // Pressing again while saving should not trigger a second call (button disabled).
+    fireEvent.press(screen.getByText("Saving…"));
+    expect(adminApi.adminSetRestaurantArchived).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveArchive(true);
+    });
+    // onArchived resolved — archiving flag clears and the button label reverts
+    // (the restaurant's own isArchived flag only changes once the parent
+    // re-supplies an updated `restaurants` prop).
+    await waitFor(() => expect(screen.getByText("Archive…")).toBeTruthy());
+    expect(baseProps.onArchived).toHaveBeenCalledWith(1, true);
+  });
+
+  it("shows an inline error when archiving fails and leaves selection intact", async () => {
+    (adminApi.adminSetRestaurantArchived as jest.Mock).mockResolvedValue(false);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Archive…"));
+    });
+    expect(screen.getByText("Failed. Please try again.")).toBeTruthy();
+    expect(baseProps.onArchived).not.toHaveBeenCalled();
+    // Selection + row are still shown (not deselected on failure).
+    expect(screen.getByText("Archive Location")).toBeTruthy();
+  });
+
+  it("clears a previous archive error when a different restaurant is selected", async () => {
+    (adminApi.adminSetRestaurantArchived as jest.Mock).mockResolvedValue(false);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Archive…"));
+    });
+    expect(screen.getByText("Failed. Please try again.")).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Westside"));
+    expect(screen.queryByText("Failed. Please try again.")).toBeNull();
+  });
+
+  it("does nothing if handleArchive fires with no restaurant selected", async () => {
+    // Not reachable through the UI (the Archive row only renders once selected),
+    // but guards the `if (!dangerSelectedRestaurant) return;` early-return branch.
+    render(<DangerZone {...baseProps} />);
+    expand();
+    expect(adminApi.adminSetRestaurantArchived).not.toHaveBeenCalled();
+  });
+
+  it("shows the Delete Location row with idle state initially", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    expect(screen.getByText("Delete Location")).toBeTruthy();
+    expect(
+      screen.getByText("Permanently removes “Downtown” and all its sections, tables, and bookings.")
+    ).toBeTruthy();
+    expect(screen.getByText("Delete…")).toBeTruthy();
+  });
+
+  it("moves to the confirm step when Delete… is pressed", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    fireEvent.press(screen.getByText("Delete…"));
+    expect(screen.getByText("Delete “Downtown”?")).toBeTruthy();
+    expect(screen.getByText("Yes, delete permanently")).toBeTruthy();
+    expect(screen.queryByText("Delete Location")).toBeNull();
+  });
+
+  it("cancels the confirm step and returns to idle", () => {
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    fireEvent.press(screen.getByText("Delete…"));
+    fireEvent.press(screen.getByText("Cancel"));
+    expect(screen.getByText("Delete Location")).toBeTruthy();
+    expect(screen.queryByText("Delete “Downtown”?")).toBeNull();
+  });
+
+  it("deletes a location, calls onDeleted, and resets selection", async () => {
+    (adminApi.adminDeleteRestaurant as jest.Mock).mockResolvedValue(true);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    fireEvent.press(screen.getByText("Delete…"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Yes, delete permanently"));
+    });
+    expect(adminApi.adminDeleteRestaurant).toHaveBeenCalledWith(1);
+    expect(baseProps.onDeleted).toHaveBeenCalledWith(1);
+    // Selection is cleared after a successful delete.
+    expect(screen.getByText("Select a location above to see options.")).toBeTruthy();
+  });
+
+  it("shows 'Deleting…' with a spinner while the delete request is in flight", async () => {
+    let resolveDelete: (value: boolean) => void = () => {};
+    (adminApi.adminDeleteRestaurant as jest.Mock).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveDelete = resolve;
+      })
+    );
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    fireEvent.press(screen.getByText("Delete…"));
+
+    fireEvent.press(screen.getByText("Yes, delete permanently"));
+    await waitFor(() => expect(screen.getByText("Deleting…")).toBeTruthy());
+
+    // Cancel button is disabled while deleting.
+    fireEvent.press(screen.getByText("Cancel"));
+    expect(screen.getByText("Deleting…")).toBeTruthy();
+
+    await act(async () => {
+      resolveDelete(true);
+    });
+    await waitFor(() =>
+      expect(screen.getByText("Select a location above to see options.")).toBeTruthy()
+    );
+  });
+
+  it("shows an inline error and stays on the confirm step when delete fails", async () => {
+    (adminApi.adminDeleteRestaurant as jest.Mock).mockResolvedValue(false);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    fireEvent.press(screen.getByText("Delete…"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Yes, delete permanently"));
+    });
+    expect(screen.getByText("Failed to delete. Please try again.")).toBeTruthy();
+    expect(baseProps.onDeleted).not.toHaveBeenCalled();
+    expect(screen.getByText("Delete “Downtown”?")).toBeTruthy();
+  });
+
+  it("clears a previous delete error when Cancel is pressed", async () => {
+    (adminApi.adminDeleteRestaurant as jest.Mock).mockResolvedValue(false);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    fireEvent.press(screen.getByText("Delete…"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Yes, delete permanently"));
+    });
+    expect(screen.getByText("Failed to delete. Please try again.")).toBeTruthy();
+    fireEvent.press(screen.getByText("Cancel"));
+    fireEvent.press(screen.getByText("Delete…"));
+    expect(screen.queryByText("Failed to delete. Please try again.")).toBeNull();
+  });
+
+  it("resets delete step and errors when collapsing the accordion", async () => {
+    (adminApi.adminDeleteRestaurant as jest.Mock).mockResolvedValue(false);
+    render(<DangerZone {...baseProps} />);
+    expand();
+    fireEvent.press(screen.getByText("Downtown"));
+    fireEvent.press(screen.getByText("Delete…"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("Yes, delete permanently"));
+    });
+    expect(screen.getByText("Failed to delete. Please try again.")).toBeTruthy();
+
+    // Collapse, then re-expand — the confirm step + error should be gone.
+    fireEvent.press(screen.getByText("Archive or delete a location"));
+    await waitFor(() => expect(screen.queryByText("Delete “Downtown”?")).toBeNull());
+    fireEvent.press(screen.getByText("Archive or delete a location"));
+    fireEvent.press(screen.getByText("Downtown"));
+    expect(screen.getByText("Delete Location")).toBeTruthy();
+    expect(screen.queryByText("Failed to delete. Please try again.")).toBeNull();
+  });
+});

--- a/openresto-frontend/tests/components/admin/notifications/PushBanner.test.tsx
+++ b/openresto-frontend/tests/components/admin/notifications/PushBanner.test.tsx
@@ -1,0 +1,375 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { Platform } from "react-native";
+import { PushBanner } from "@/components/admin/notifications/PushBanner";
+import * as notificationsApi from "@/api/notifications";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/api/notifications", () => ({
+  getVapidPublicKey: jest.fn(),
+  subscribePush: jest.fn(),
+}));
+
+const mockGetVapidPublicKey = notificationsApi.getVapidPublicKey as jest.Mock;
+const mockSubscribePush = notificationsApi.subscribePush as jest.Mock;
+
+// Use global as Record to avoid bare `navigator`/`window` which may not exist in the node test env
+const g = global as Record<string, unknown>;
+
+// Build a fake push subscription
+function makeSub(endpoint = "https://push.example.com/sub") {
+  const buffer = new ArrayBuffer(16);
+  return {
+    endpoint,
+    getKey: jest.fn().mockReturnValue(buffer),
+    unsubscribe: jest.fn().mockResolvedValue(true),
+  };
+}
+
+// Build a fake service worker with pushManager
+function makeSW(existingSub: ReturnType<typeof makeSub> | null = null) {
+  return {
+    pushManager: {
+      getSubscription: jest.fn().mockResolvedValue(existingSub),
+      subscribe: jest.fn().mockResolvedValue(makeSub()),
+    },
+  };
+}
+
+function setNavigatorSW(sw: ReturnType<typeof makeSW> | null) {
+  if (!g.navigator || typeof g.navigator !== "object") {
+    Object.defineProperty(global, "navigator", {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+  }
+  const nav = g.navigator as Record<string, unknown>;
+  if (sw) {
+    nav.serviceWorker = { ready: Promise.resolve(sw) };
+  } else {
+    delete nav.serviceWorker;
+  }
+}
+
+function setupWebEnvironment(hasServiceWorker = true, hasPushManager = true) {
+  Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+
+  setNavigatorSW(hasServiceWorker ? makeSW() : null);
+
+  if (hasPushManager) {
+    g.PushManager = {};
+  } else {
+    delete g.PushManager;
+  }
+}
+
+const defaultProps = {
+  restaurantId: 1,
+  primaryColor: "#0a7ea4",
+  isDark: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+
+  setupWebEnvironment();
+  mockGetVapidPublicKey.mockResolvedValue("test-vapid-key");
+  mockSubscribePush.mockResolvedValue(undefined);
+
+  Object.defineProperty(global, "Notification", {
+    value: {
+      permission: "default",
+      requestPermission: jest.fn().mockResolvedValue("granted"),
+    },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+});
+
+describe("PushBanner", () => {
+  describe("non-web platform", () => {
+    it("renders null on native platform", async () => {
+      Object.defineProperty(Platform, "OS", { value: "ios", configurable: true });
+
+      const { toJSON } = render(<PushBanner {...defaultProps} />);
+
+      expect(toJSON()).toBeNull();
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toJSON()).toBeNull();
+      expect(mockGetVapidPublicKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("web - no VAPID key configured", () => {
+    it("renders null while vapidKey is undefined and stays null when null", async () => {
+      mockGetVapidPublicKey.mockResolvedValue(null);
+
+      const { toJSON } = render(<PushBanner {...defaultProps} />);
+      expect(toJSON()).toBeNull();
+
+      await waitFor(() => {
+        expect(mockGetVapidPublicKey).toHaveBeenCalled();
+      });
+
+      // vapidKey resolves to null -> status "unsupported" -> still renders null
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe("web - unsupported (missing serviceWorker/PushManager)", () => {
+    it("renders null when serviceWorker is missing", async () => {
+      setupWebEnvironment(false, true);
+
+      const { toJSON } = render(<PushBanner {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockGetVapidPublicKey).toHaveBeenCalled();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toJSON()).toBeNull();
+    });
+
+    it("renders null when PushManager is missing", async () => {
+      setupWebEnvironment(true, false);
+
+      const { toJSON } = render(<PushBanner {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockGetVapidPublicKey).toHaveBeenCalled();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe("web - denied", () => {
+    it("shows the blocked banner text when Notification permission is denied", async () => {
+      Object.defineProperty(global, "Notification", {
+        value: { permission: "denied", requestPermission: jest.fn() },
+        configurable: true,
+        writable: true,
+      });
+
+      render(<PushBanner {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Push notifications blocked - enable in browser site settings.")
+        ).toBeTruthy();
+      });
+    });
+
+    it("shows the blocked banner in dark mode too", async () => {
+      Object.defineProperty(global, "Notification", {
+        value: { permission: "denied", requestPermission: jest.fn() },
+        configurable: true,
+        writable: true,
+      });
+
+      render(<PushBanner {...defaultProps} isDark={true} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Push notifications blocked - enable in browser site settings.")
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("web - active (existing subscription)", () => {
+    it("renders null when a push subscription already exists", async () => {
+      const sw = makeSW(makeSub());
+      setNavigatorSW(sw);
+
+      const { toJSON } = render(<PushBanner {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(sw.pushManager.getSubscription).toHaveBeenCalled();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe("web - inactive (no existing subscription)", () => {
+    async function renderInactive() {
+      const sw = makeSW(null);
+      setNavigatorSW(sw);
+      render(<PushBanner {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Enable")).toBeTruthy();
+      });
+      return sw;
+    }
+
+    it("shows the enable banner with prompt text and button", async () => {
+      await renderInactive();
+
+      expect(
+        screen.getByText("Enable push notifications to get real-time booking alerts.")
+      ).toBeTruthy();
+      expect(screen.getByText("Enable")).toBeTruthy();
+    });
+
+    it("shows the enable banner in dark mode too", async () => {
+      const sw = makeSW(null);
+      setNavigatorSW(sw);
+      render(<PushBanner {...defaultProps} isDark={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Enable")).toBeTruthy();
+      });
+      expect(
+        screen.getByText("Enable push notifications to get real-time booking alerts.")
+      ).toBeTruthy();
+    });
+
+    it("subscribes and shows nothing (renders null) once active", async () => {
+      const sw = await renderInactive();
+      const sub = makeSub();
+      (sw.pushManager.subscribe as jest.Mock).mockResolvedValue(sub);
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable"));
+      });
+
+      await waitFor(() => {
+        expect(mockSubscribePush).toHaveBeenCalledWith(
+          defaultProps.restaurantId,
+          expect.objectContaining({ endpoint: sub.endpoint })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText("Enable")).toBeNull();
+      });
+    });
+
+    it("falls back to restaurantId 0 when restaurantId is null", async () => {
+      const sw = makeSW(null);
+      setNavigatorSW(sw);
+      render(<PushBanner {...defaultProps} restaurantId={null} />);
+      await waitFor(() => {
+        expect(screen.getByText("Enable")).toBeTruthy();
+      });
+
+      const sub = makeSub();
+      (sw.pushManager.subscribe as jest.Mock).mockResolvedValue(sub);
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable"));
+      });
+
+      await waitFor(() => {
+        expect(mockSubscribePush).toHaveBeenCalledWith(0, expect.any(Object));
+      });
+    });
+
+    it("transitions to denied and shows an error when requestPermission returns denied", async () => {
+      await renderInactive();
+      (global.Notification.requestPermission as jest.Mock).mockResolvedValue("denied");
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable"));
+      });
+
+      // Status flips to "denied", which re-renders the denied banner (replacing the
+      // inactive banner that would have shown the ephemeral errorMsg).
+      await waitFor(() => {
+        expect(
+          screen.getByText("Push notifications blocked - enable in browser site settings.")
+        ).toBeTruthy();
+      });
+    });
+
+    it("does nothing further when permission is dismissed (not granted, not denied)", async () => {
+      await renderInactive();
+      (global.Notification.requestPermission as jest.Mock).mockResolvedValue("default");
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Enable")).toBeTruthy();
+      });
+      expect(mockSubscribePush).not.toHaveBeenCalled();
+    });
+
+    it("shows an error message when subscribe throws", async () => {
+      const sw = await renderInactive();
+      (sw.pushManager.subscribe as jest.Mock).mockRejectedValue(new Error("subscribe failed"));
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to enable - try again.")).toBeTruthy();
+      });
+      expect(console.error).toHaveBeenCalledWith("Push subscribe error:", expect.any(Error));
+    });
+
+    it("shows an error message when the subscription is missing p256dh/auth keys", async () => {
+      const sw = await renderInactive();
+      const badSub = { endpoint: "https://push.example.com/bad", getKey: jest.fn(() => null) };
+      (sw.pushManager.subscribe as jest.Mock).mockResolvedValue(badSub);
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to enable - try again.")).toBeTruthy();
+      });
+      expect(mockSubscribePush).not.toHaveBeenCalled();
+    });
+
+    it("guards against pressing Enable with a falsy vapidKey (no-op)", async () => {
+      mockGetVapidPublicKey.mockResolvedValue("");
+      const sw = makeSW(null);
+      setNavigatorSW(sw);
+
+      render(<PushBanner {...defaultProps} />);
+
+      // vapidKey resolves to "" (falsy, but not null/undefined), so usePushStatus proceeds
+      // past its `vapidKey === null` short-circuit and resolves the real subscription status
+      // via the service worker, landing on "inactive" and rendering the Enable banner.
+      await waitFor(() => {
+        expect(screen.getByText("Enable")).toBeTruthy();
+      });
+
+      // handleEnable's `if (!vapidKey) return;` guard means pressing does nothing.
+      await act(async () => {
+        fireEvent.press(screen.getByText("Enable"));
+      });
+      expect(mockSubscribePush).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react-native";
 import { RestaurantInfoForm } from "@/components/admin/settings/RestaurantInfoForm";
 import * as restaurantsApi from "@/api/restaurants";
+import { useColorScheme } from "@/hooks/use-color-scheme";
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -17,7 +18,7 @@ jest.mock("@/context/BrandContext", () => {
 });
 
 jest.mock("@/hooks/use-color-scheme", () => ({
-  useColorScheme: () => "light",
+  useColorScheme: jest.fn(() => "light"),
 }));
 
 jest.mock("@/components/common/TimePicker", () => {
@@ -489,5 +490,79 @@ describe("RestaurantInfoForm", () => {
       expect(screen.getByText("All changes saved")).toBeTruthy();
       expect(screen.getByText("Walk-ins only, online booking is off")).toBeTruthy();
     });
+  });
+
+  // ── Fallback branches for unset optional restaurant fields ─────────────
+  // RestaurantDto marks address/tags/walkInOnly/walkInDays/defaultBookingDurationMinutes as
+  // optional, and even openTime/closeTime/timezone (typed as required strings) are read
+  // defensively with `??` in case the API ever omits them. mockRestaurant always supplies
+  // every field, so those `??` fallback branches (state init, initialOpenHours, the dirty
+  // check, and discard()) were never exercised on the "value is missing" side.
+  const sparseRestaurant = {
+    id: 2,
+    name: "Sparse Resto",
+    openDays: "1,2,3,4,5,6,7",
+    openTime: undefined as unknown as string,
+    closeTime: undefined as unknown as string,
+    timezone: undefined as unknown as string,
+    sections: [],
+  };
+
+  it("falls back to defaults when optional restaurant fields are unset", () => {
+    render(<RestaurantInfoForm restaurant={sparseRestaurant} onSaved={onSaved} />);
+    expect(screen.getByDisplayValue("Sparse Resto")).toBeTruthy();
+    expect(screen.getByPlaceholderText("e.g. 123 Main St")).toBeTruthy();
+    expect(getDurationSelect().props.value).toBe(60);
+    expect(screen.getByText("Online bookings on every open day")).toBeTruthy();
+    expect(screen.getByText("All changes saved")).toBeTruthy();
+  });
+
+  it("discard restores fallback defaults when optional restaurant fields are unset", () => {
+    render(<RestaurantInfoForm restaurant={sparseRestaurant} onSaved={onSaved} />);
+    fireEvent.changeText(screen.getByDisplayValue("Sparse Resto"), "Changed Name");
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    fireEvent.press(screen.getByText("Discard"));
+    expect(screen.getByDisplayValue("Sparse Resto")).toBeTruthy();
+    expect(screen.getByText("All changes saved")).toBeTruthy();
+  });
+
+  it("saves address as null when the address field is cleared to blank", async () => {
+    (restaurantsApi.updateRestaurant as jest.Mock).mockResolvedValue({
+      ...mockRestaurant,
+      address: null,
+    });
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    fireEvent.changeText(screen.getByDisplayValue("123 Main St"), "   ");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save changes"));
+    });
+    expect(restaurantsApi.updateRestaurant).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ address: null })
+    );
+  });
+
+  it("renders without crashing in dark mode", () => {
+    (useColorScheme as jest.Mock).mockReturnValueOnce("dark");
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    expect(screen.getByDisplayValue("Test Resto")).toBeTruthy();
+  });
+
+  it("shows the Saving… label while the update request is in flight", async () => {
+    let resolveUpdate: (value: unknown) => void = () => {};
+    (restaurantsApi.updateRestaurant as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        })
+    );
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    fireEvent.changeText(screen.getByDisplayValue("Test Resto"), "Updated Resto");
+    fireEvent.press(screen.getByText("Save changes"));
+    expect(await screen.findByText("Saving…")).toBeTruthy();
+    await act(async () => {
+      resolveUpdate({ ...mockRestaurant, name: "Updated Resto" });
+    });
+    expect(screen.getByText("Save changes")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Fourth batch (5 files) in a series of PRs working toward 100% unit test coverage (see #214, #215, #216 for the first three batches). This PR targets the next 5 frontend files with the largest remaining coverage gaps, including `PushBanner.tsx` which was the lowest-covered file in the entire frontend (51.66%).

**Frontend coverage: 96.26% → 97.76% statements, 88.31% → 90.24% branch** (139 suites, 1718 tests, all passing).

### Files covered

| File | Stmts before → after | Branch before → after |
|---|---|---|
| `components/admin/settings/RestaurantInfoForm.tsx` | 99.02% → 99.02% | 78.02% → 98.9% |
| `api/admin.ts` (social-link functions) | 89.72% → 100% | 93.54% → 100% |
| `app/(user)/book/[restaurantId].tsx` | 96.29% → 98.14% | 73.8% → 95.23% |
| `components/admin/locations/DangerZone.tsx` | 0% → 96.22% | — → 97.43% |
| `components/admin/notifications/PushBanner.tsx` | 51.66% → 100% | 56.6% → 100% |

### What changed

All changes are test-only — no component/module source files were modified (no bugs found in any of the 5 targets).

- **`RestaurantInfoForm.tsx`** — covered optional-field fallback branches on load and discard, the address-cleared-to-null save path, dark-mode styling, and the in-flight "Saving…" state.
- **`api/admin.ts`** — added success/non-ok/network-error tests for all 4 social-link CRUD functions (`adminGetSocialLinks`/`Create`/`Update`/`DeleteSocialLink`), none of which had any prior coverage.
- **`book/[restaurantId].tsx`** — covered party-query-param parsing/fallback, effect-cleanup race guards, restaurant-timezone fallback, section-id fallback, the booking-succeeded-without-a-booking no-navigate branch, and the non-`Error`-rejection fallback message.
- **`DangerZone.tsx`** — no test file existed for this component at all; added one covering the archive/restore flow and the delete confirm-step flow (confirm/cancel/success/failure/in-flight states), plus dark-theme styling.
- **`PushBanner.tsx`** — no test file existed; added one covering every `PushStatus` branch (unsupported/denied/active/inactive) and the full subscribe flow (success, permission-denied, dismissed, `subscribe()` rejection, malformed subscription keys), reusing the existing `PushNotificationsCard.test.tsx` browser-API mocking pattern (no shared mock files touched).

**Bonus:** `utils/notifications.ts` (`arrayBufferToBase64`/`urlBase64ToUint8Array`, exercised by the new `PushBanner` tests) also reached 100% as a side effect.

### Intentionally excluded / remaining gaps

- `RestaurantInfoForm.tsx` line 215 — a `!name.trim()` guard that duplicates the Save button's own `disabled` condition; unreachable via the UI (verified empirically).
- `book/[restaurantId].tsx` line 70 — a `!restaurant` guard inside `handleSubmit` that's unreachable because the component's earlier `!restaurant` early-return already guarantees it's non-null by that point. Line 175 — a `Platform.OS === "web"` module-scope style branch that proved unsafe to force via module mocking without destabilizing the shared `react-native` mock used by other tests in the file.
- `DangerZone.tsx` lines 73, 87 — early-return guards in `handleArchive`/`handleDelete` that are unreachable since their action buttons only render once a restaurant is already selected.

## Test plan

- [x] `npx jest --coverage` — 139/139 suites, 1718/1718 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (oxlint) — exit 0
- [x] `npx prettier --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rt2Vy9gEY3vTnbdbpJkVUv)_