### PR TITLE
Hide timezone hint when viewer's device matches restaurant tz

### DIFF
--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -12,7 +12,7 @@ import HoldStatusBanner from "./HoldStatusBanner";
 import PopularTimesPicker from "./PopularTimesPicker";
 import { fetchAvailability, TimeSlotDto } from "@/api/availability";
 import { useAppTheme } from "@/hooks/use-app-theme";
-import { getNowInTimezone, formatCurrentTimeInTimezone } from "@/utils/date";
+import { getNowInTimezone, formatCurrentTimeInTimezone, isViewerInTimezone } from "@/utils/date";
 import { isValidEmail } from "@/utils/validation";
 import { getHoursForDate, HoursSource } from "@/utils/openingHours";
 import { isWalkInOnlyOnDate, walkInDaysLabel } from "@/utils/walkIn";
@@ -366,7 +366,7 @@ export default function BookingForm({
         </View>
       </View>
 
-      {restaurant.timezone && (
+      {restaurant.timezone && !isViewerInTimezone(timezone) && (
         <ThemedText style={[styles.timezoneHint, { color: colors.muted }]}>
           All times are in {timezone.replace(/_/g, " ")} (currently {restaurantCurrentTime} there)
         </ThemedText>

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -138,6 +138,7 @@ jest.mock("@/components/common/DatePicker", () => ({
 jest.mock("@/utils/date", () => ({
   getNowInTimezone: jest.fn(() => ({ dateStr: "2026-06-23", hours: 10, minutes: 0 })),
   formatCurrentTimeInTimezone: jest.fn(() => "10:00 AM"),
+  isViewerInTimezone: jest.fn(() => false),
 }));
 
 jest.mock("@/components/common/Select", () => ({

--- a/openresto-frontend/tests/utils/date.test.ts
+++ b/openresto-frontend/tests/utils/date.test.ts
@@ -3,6 +3,7 @@ import {
   isTodayInTimezone,
   getNowInTimezone,
   formatCurrentTimeInTimezone,
+  isViewerInTimezone,
 } from "@/utils/date";
 
 describe("date utility - convertLocalToUtc", () => {
@@ -175,5 +176,51 @@ describe("date utility - isTodayInTimezone", () => {
     const now = new Date().toISOString();
     const result = isTodayInTimezone(now, "");
     expect(typeof result).toBe("boolean");
+  });
+});
+
+describe("date utility - isViewerInTimezone", () => {
+  const realDateTimeFormat = Intl.DateTimeFormat;
+
+  afterEach(() => {
+    // Restore the real Intl.DateTimeFormat after each test
+    global.Intl.DateTimeFormat = realDateTimeFormat;
+  });
+
+  function mockDeviceTimezone(deviceTz: string | undefined) {
+    const mock = jest.fn(() => ({
+      resolvedOptions: () => ({ timeZone: deviceTz }),
+    })) as unknown as typeof Intl.DateTimeFormat;
+    global.Intl.DateTimeFormat = mock as never;
+  }
+
+  it("returns true when device timezone matches the restaurant's", () => {
+    mockDeviceTimezone("America/Toronto");
+    expect(isViewerInTimezone("America/Toronto")).toBe(true);
+  });
+
+  it("returns false when device timezone differs from the restaurant's", () => {
+    mockDeviceTimezone("Europe/London");
+    expect(isViewerInTimezone("America/Toronto")).toBe(false);
+  });
+
+  it("returns false for an empty timezone", () => {
+    mockDeviceTimezone("America/Toronto");
+    expect(isViewerInTimezone("")).toBe(false);
+  });
+
+  it("returns false when resolvedOptions() has no timeZone", () => {
+    mockDeviceTimezone(undefined);
+    expect(isViewerInTimezone("America/Toronto")).toBe(false);
+  });
+
+  it("falls back to false if resolvedOptions() throws", () => {
+    const throwing = jest.fn(() => ({
+      resolvedOptions: () => {
+        throw new Error("unsupported");
+      },
+    })) as unknown as typeof Intl.DateTimeFormat;
+    global.Intl.DateTimeFormat = throwing as never;
+    expect(isViewerInTimezone("America/Toronto")).toBe(false);
   });
 });

--- a/openresto-frontend/utils/date.ts
+++ b/openresto-frontend/utils/date.ts
@@ -83,6 +83,22 @@ export function convertLocalToUtc(date: string, time: string, timezone: string):
 }
 
 /**
+ * Returns true when the viewer's device timezone matches the given IANA
+ * timezone, e.g. to hide a "times shown in X" hint from local customers.
+ * Resolves the device timezone via Intl; any failure resolves to false so
+ * the hint stays visible (the safe default for an unknown comparison).
+ */
+export function isViewerInTimezone(timezone: string): boolean {
+  if (!timezone) return false;
+  try {
+    const deviceTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return !!deviceTz && deviceTz === timezone;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks if a UTC date string represents "today" in a specific timezone.
  */
 export function isTodayInTimezone(utcDateStr: string, timezone: string): boolean {


### PR DESCRIPTION
## Summary
Closes #181.

The booking form shows an "All times are in X (currently Y there)" hint so customers booking a restaurant in a different timezone understand the displayed times. For customers already in the restaurant's own timezone, this note is redundant noise.

## Changes
- Add `isViewerInTimezone(timezone)` to `utils/date.ts` — compares the viewer's device timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) against the restaurant's stored IANA timezone. Fails safe to `false` (keep showing the hint) on any error.
- Gate the timezone hint in `BookingForm.tsx:369` on `!isViewerInTimezone(timezone)`, so it only renders for out-of-timezone viewers.
- Add 5 unit tests covering the helper (match, mismatch, empty tz, missing resolved tz, throwing `resolvedOptions`).
- Update `BookingForm.test.tsx`'s `@/utils/date` mock to expose the new export.

## Note on the issue
The issue's investigation comment said no timezone note existed — it does, at `BookingForm.tsx:369-372`. This PR implements the hide behavior as the title requests.

## Test plan
- [x] `npx jest tests/utils/date.test.ts` — 28 pass (5 new)
- [x] `npx jest` full suite — 1780 pass across 140 suites
- [x] `oxlint` + `prettier --check` on changed files — 0 errors