### PR TITLE
Surface backend hold rejection reason in the UI

### DIFF
--- a/openresto-frontend/api/holds.ts
+++ b/openresto-frontend/api/holds.ts
@@ -14,15 +14,31 @@ export interface HoldResponse {
   secondsRemaining: number;
 }
 
-export async function createHold(request: HoldRequest): Promise<HoldResponse | null> {
+/** Successful hold. */
+export type HoldSuccess = { ok: true; hold: HoldResponse };
+/** Hold rejected (409 already-held, or 400 past-time / paused / closed / walk-in). */
+export type HoldFailure = { ok: false; message: string };
+export type HoldResult = HoldSuccess | HoldFailure;
+
+const GENERIC_UNAVAILABLE = "Table not available for this date. Please choose another.";
+
+export async function createHold(request: HoldRequest): Promise<HoldResult> {
   try {
     const res = await post("/holds", request);
-    if (res.status === 409) return null;
-    if (!res.ok) throw new Error("Failed to place hold");
-    return await res.json();
+
+    if (res.ok) {
+      return { ok: true, hold: await res.json() };
+    }
+
+    // 409 (already held/booked) and 400 (past time, paused, closed, walk-in)
+    // both carry a descriptive { message } from the backend — surface it
+    // instead of discarding it so the customer sees the real reason.
+    const body = await res.json().catch(() => ({}));
+    return { ok: false, message: body?.message ?? GENERIC_UNAVAILABLE };
   } catch (err) {
+    // Network failure or non-JSON body — fall back to a generic message.
     console.error("createHold error:", err);
-    return null;
+    return { ok: false, message: GENERIC_UNAVAILABLE };
   }
 }
 

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -137,14 +137,15 @@ export default function BookingForm({
     return eligible[0]?.id ?? pool[0]?.id;
   }
 
-  const { holdStatus, secondsLeft, holdId, setHoldStatus, releaseCurrentHold } = useTableHold({
-    restaurantId: restaurant.id,
-    sections: restaurant.sections,
-    tableId,
-    date,
-    time,
-    email: customerEmail,
-  });
+  const { holdStatus, holdMessage, secondsLeft, holdId, setHoldStatus, releaseCurrentHold } =
+    useTableHold({
+      restaurantId: restaurant.id,
+      sections: restaurant.sections,
+      tableId,
+      date,
+      time,
+      email: customerEmail,
+    });
 
   // Fetch availability when date/seats change
   useEffect(() => {
@@ -425,6 +426,7 @@ export default function BookingForm({
               holdStatus={holdStatus}
               secondsLeft={secondsLeft}
               hasSelection={!!tableId && !!date && !!time}
+              holdMessage={holdMessage}
               onRefresh={onRefresh}
             />
           </View>

--- a/openresto-frontend/components/booking/HoldStatusBanner.tsx
+++ b/openresto-frontend/components/booking/HoldStatusBanner.tsx
@@ -8,6 +8,8 @@ interface HoldStatusBannerProps {
   holdStatus: HoldStatus;
   secondsLeft: number;
   hasSelection: boolean;
+  /** Specific rejection reason from the backend (e.g. past time, closed). Falls back to a generic line when absent. */
+  holdMessage?: string | null;
   onRefresh?: () => void;
 }
 
@@ -15,6 +17,7 @@ export default function HoldStatusBanner({
   holdStatus,
   secondsLeft,
   hasSelection,
+  holdMessage,
   onRefresh,
 }: HoldStatusBannerProps) {
   const { colors, isDark } = useAppTheme();
@@ -46,7 +49,7 @@ export default function HoldStatusBanner({
       return (
         <ThemedView style={styles.holdRow}>
           <ThemedText style={[styles.holdUnavailable, { color: colors.error }]}>
-            ✗ Table not available for this date. Please choose another.
+            ✗ {holdMessage ?? "Table not available for this date. Please choose another."}
           </ThemedText>
         </ThemedView>
       );

--- a/openresto-frontend/components/booking/useTableHold.ts
+++ b/openresto-frontend/components/booking/useTableHold.ts
@@ -19,6 +19,7 @@ export interface UseTableHoldParams {
 export interface UseTableHoldResult {
   hold: HoldResponse | null;
   holdStatus: HoldStatus;
+  holdMessage: string | null;
   secondsLeft: number;
   holdId: string | null;
   setHoldStatus: (status: HoldStatus) => void;
@@ -35,6 +36,7 @@ export function useTableHold({
 }: UseTableHoldParams): UseTableHoldResult {
   const [hold, setHold] = useState<HoldResponse | null>(null);
   const [holdStatus, setHoldStatus] = useState<HoldStatus>("idle");
+  const [holdMessage, setHoldMessage] = useState<string | null>(null);
   const [secondsLeft, setSecondsLeft] = useState(0);
   const [holdId, setHoldId] = useState<string | null>(null);
 
@@ -76,6 +78,7 @@ export function useTableHold({
     }
     setHold(null);
     setHoldStatus("idle");
+    setHoldMessage(null);
     clearCountdown();
   }
 
@@ -117,20 +120,23 @@ export function useTableHold({
         currentHoldId: previousHoldId ?? undefined,
       });
 
-      if (result) {
+      if (result.ok) {
         // Backend atomically released previousHoldId and placed the new hold
-        currentHoldId.current = result.holdId;
-        setHoldId(result.holdId);
-        setHold(result);
+        currentHoldId.current = result.hold.holdId;
+        setHoldId(result.hold.holdId);
+        setHold(result.hold);
+        setHoldMessage(null);
         setHoldStatus("held");
-        startCountdown(result.expiresAt);
+        startCountdown(result.hold.expiresAt);
       } else {
-        // Table is held by someone else — release our previous hold and surface unavailable
+        // Hold rejected (already-held, past time, paused, closed, walk-in).
+        // Release our previous hold and surface the backend's reason.
         if (previousHoldId) releaseHold(previousHoldId);
         currentHoldId.current = null;
         setHoldId(null);
         setHold(null);
         clearCountdown();
+        setHoldMessage(result.message);
         setHoldStatus("unavailable");
       }
     }, HOLD_DEBOUNCE_MS);
@@ -159,6 +165,7 @@ export function useTableHold({
   return {
     hold,
     holdStatus,
+    holdMessage,
     secondsLeft,
     holdId,
     setHoldStatus,

--- a/openresto-frontend/tests/api/holds.test.ts
+++ b/openresto-frontend/tests/api/holds.test.ts
@@ -28,32 +28,63 @@ describe("createHold", () => {
     });
 
     const result = await createHold(request);
-    expect(result).toEqual(holdResp);
+    expect(result).toEqual({ ok: true, hold: holdResp });
     const [url, opts] = mockFetch.mock.calls[0];
     expect(url).toContain("/api/holds");
     expect(opts.method).toBe("POST");
     expect(JSON.parse(opts.body)).toEqual(request);
   });
 
-  it("returns null on 409 (table already held)", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 409 });
+  it("surfaces backend message on 400 past-time rejection", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ message: "Cannot hold a table for a past time." }),
+    });
 
     const result = await createHold(request);
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, message: "Cannot hold a table for a past time." });
   });
 
-  it("returns null on server error", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+  it("surfaces backend message on 409 (table already held)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ message: "This table is already booked for that time." }),
+    });
 
     const result = await createHold(request);
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, message: "This table is already booked for that time." });
   });
 
-  it("returns null on network failure", async () => {
+  it("falls back to generic message when 4xx has no body", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => {
+        throw new Error("no json");
+      },
+    });
+
+    const result = await createHold(request);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Table not available for this date. Please choose another.");
+    }
+  });
+
+  it("returns generic failure on server error", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+
+    const result = await createHold(request);
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns generic failure on network failure", async () => {
     mockFetch.mockRejectedValueOnce(new Error("offline"));
 
     const result = await createHold(request);
-    expect(result).toBeNull();
+    expect(result.ok).toBe(false);
   });
 });
 

--- a/openresto-frontend/tests/components/HoldStatusBanner.test.tsx
+++ b/openresto-frontend/tests/components/HoldStatusBanner.test.tsx
@@ -31,9 +31,22 @@ describe("HoldStatusBanner", () => {
     expect(screen.getByText(/Table held - expires in 3:05/)).toBeTruthy();
   });
 
-  it("shows unavailable message", () => {
+  it("shows generic unavailable message when no holdMessage is provided", () => {
     render(<HoldStatusBanner holdStatus="unavailable" secondsLeft={0} hasSelection={true} />);
     expect(screen.getByText(/Table not available/)).toBeTruthy();
+  });
+
+  it("shows the backend holdMessage when provided", () => {
+    render(
+      <HoldStatusBanner
+        holdStatus="unavailable"
+        secondsLeft={0}
+        hasSelection={true}
+        holdMessage="Cannot hold a table for a past time."
+      />
+    );
+    expect(screen.getByText(/Cannot hold a table for a past time/)).toBeTruthy();
+    expect(screen.queryByText(/Table not available/)).toBeNull();
   });
 
   it("shows expired message with refresh button", () => {

--- a/openresto-frontend/tests/hooks/useTableHold.test.ts
+++ b/openresto-frontend/tests/hooks/useTableHold.test.ts
@@ -53,9 +53,12 @@ describe("useTableHold", () => {
   it("transitions to pending then held after debounce when tableId is set", async () => {
     const expiresAt = new Date(Date.now() + 120_000).toISOString();
     mockCreateHold.mockResolvedValueOnce({
-      holdId: "hold-1",
-      expiresAt,
-      secondsRemaining: 120,
+      ok: true,
+      hold: {
+        holdId: "hold-1",
+        expiresAt,
+        secondsRemaining: 120,
+      },
     });
 
     const params = { ...defaultParams, tableId: 100 };
@@ -81,8 +84,11 @@ describe("useTableHold", () => {
     expect(result.current.hold?.holdId).toBe("hold-1");
   });
 
-  it("sets unavailable status when createHold returns null", async () => {
-    mockCreateHold.mockResolvedValueOnce(null);
+  it("sets unavailable status when createHold fails", async () => {
+    mockCreateHold.mockResolvedValueOnce({
+      ok: false,
+      message: "Cannot hold a table for a past time.",
+    });
 
     const params = { ...defaultParams, tableId: 100 };
     const { result } = renderHook(() => useTableHold(params));
@@ -92,15 +98,19 @@ describe("useTableHold", () => {
     });
 
     expect(result.current.holdStatus).toBe("unavailable");
+    expect(result.current.holdMessage).toBe("Cannot hold a table for a past time.");
   });
 
   it("countdown decreases secondsLeft and expires to idle", async () => {
     // Hold expires in 3 seconds for fast test
     const expiresAt = new Date(Date.now() + 3_000).toISOString();
     mockCreateHold.mockResolvedValueOnce({
-      holdId: "hold-2",
-      expiresAt,
-      secondsRemaining: 3,
+      ok: true,
+      hold: {
+        holdId: "hold-2",
+        expiresAt,
+        secondsRemaining: 3,
+      },
     });
 
     const params = { ...defaultParams, tableId: 100 };
@@ -124,9 +134,12 @@ describe("useTableHold", () => {
 
   it("releases hold on unmount", async () => {
     mockCreateHold.mockResolvedValueOnce({
-      holdId: "hold-cleanup",
-      expiresAt: new Date(Date.now() + 120_000).toISOString(),
-      secondsRemaining: 120,
+      ok: true,
+      hold: {
+        holdId: "hold-cleanup",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
     });
 
     const params = { ...defaultParams, tableId: 100 };
@@ -145,9 +158,12 @@ describe("useTableHold", () => {
 
   it("releaseCurrentHold resets state and calls releaseHold", async () => {
     mockCreateHold.mockResolvedValueOnce({
-      holdId: "hold-manual",
-      expiresAt: new Date(Date.now() + 120_000).toISOString(),
-      secondsRemaining: 120,
+      ok: true,
+      hold: {
+        holdId: "hold-manual",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
     });
 
     const params = { ...defaultParams, tableId: 100 };
@@ -170,9 +186,12 @@ describe("useTableHold", () => {
 
   it("re-triggers hold when date changes, passing currentHoldId for atomic replace", async () => {
     mockCreateHold.mockResolvedValueOnce({
-      holdId: "hold-date-1",
-      expiresAt: new Date(Date.now() + 120_000).toISOString(),
-      secondsRemaining: 120,
+      ok: true,
+      hold: {
+        holdId: "hold-date-1",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
     });
 
     const { result, rerender } = renderHook((props: UseTableHoldParams) => useTableHold(props), {
@@ -190,9 +209,12 @@ describe("useTableHold", () => {
     const newProps = { ...defaultParams, tableId: 100, date: "2026-06-16" };
 
     mockCreateHold.mockResolvedValueOnce({
-      holdId: "hold-date-2",
-      expiresAt: new Date(Date.now() + 120_000).toISOString(),
-      secondsRemaining: 120,
+      ok: true,
+      hold: {
+        holdId: "hold-date-2",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
     });
 
     rerender(newProps);
@@ -216,9 +238,12 @@ describe("useTableHold", () => {
 
   it("releases previous hold explicitly when createHold fails", async () => {
     mockCreateHold.mockResolvedValueOnce({
-      holdId: "hold-fail-1",
-      expiresAt: new Date(Date.now() + 120_000).toISOString(),
-      secondsRemaining: 120,
+      ok: true,
+      hold: {
+        holdId: "hold-fail-1",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
     });
 
     const { result, rerender } = renderHook((props: UseTableHoldParams) => useTableHold(props), {
@@ -232,7 +257,10 @@ describe("useTableHold", () => {
     expect(result.current.holdStatus).toBe("held");
 
     // Second attempt fails — table taken by someone else
-    mockCreateHold.mockResolvedValueOnce(null);
+    mockCreateHold.mockResolvedValueOnce({
+      ok: false,
+      message: "This table is already held by another user.",
+    });
     rerender({ ...defaultParams, tableId: 100, date: "2026-06-16" });
 
     await act(async () => {


### PR DESCRIPTION
## Summary
Closes #213.

When a table hold is rejected, the backend returns a descriptive message (e.g. "Cannot hold a table for a past time.", "The restaurant is closed at the requested time.", "This table is already booked for that time."). The frontend was discarding it on both the `409` and rejected (`400`) paths, so customers always saw a generic "Table not available" — even when the real cause was a past-time request (most commonly from a timezone edge case where a slot tips into the past between page load and selection).

The final `createBooking()` 409 path already surfaces `body.message` correctly; this fix brings the earlier, automatic hold step in line.

## Changes
- **`api/holds.ts`** — `createHold()` now returns a discriminated `HoldResult` (`{ ok: true, hold } | { ok: false, message }`), reading `body.message` from both `409` and `400` responses. Falls back to a generic message on network failure or missing body.
- **`components/booking/useTableHold.ts`** — consumes the new shape; stores a `holdMessage` alongside status and exposes it; clears it on release.
- **`components/booking/HoldStatusBanner.tsx`** — renders `holdMessage` in the `unavailable` case when present, keeping the existing generic line as the fallback.
- **`components/booking/BookingForm.tsx`** — passes `holdMessage` through to the banner.
- Tests updated for the new return shape, plus new cases: 400 past-time message, 409 already-held message, missing-body fallback, banner rendering the custom message.

## Acceptance criteria (from #213)
- [x] `createHold()` returns the backend's actual `message` text for both `409` and rejected (`400`) responses, not a generic fallback
- [x] The hold-unavailable UI shows the real rejection reason instead of always showing "Table not available for this date."
- [x] Other hold-rejection reasons (already-booked, already-held, closed, walk-in-only) are handled without regressing to a raw/ugly error state — they all flow through the same `message` path with their backend-provided text

## Out of scope (per #213)
- No backend changes — past-time detection and its 5-min grace period are already correct
- `createBooking()` 409 path left untouched — already correct

## Test plan
- [x] `npx jest` full suite — 1778 pass across 140 suites
- [x] `oxlint` on changed files — 0 errors / 0 warnings
- [x] `prettier --check` on changed files — all clean