### PR TITLE
Occupancy overview: toggle between T-x and calendar date view

### DIFF
--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -148,6 +148,54 @@ public class AdminServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOverviewAsync_OccupancyDates_HasSevenElements()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(7, overview.OccupancyDates.Count);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_OccupancyDates_LastIsToday()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(DateTime.UtcNow.Date.ToString("yyyy-MM-dd"), overview.OccupancyDates[6]);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_OccupancyDates_AreIsoDateFormat()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.All(overview.OccupancyDates, d => Assert.Matches(@"^\d{4}-\d{2}-\d{2}$", d));
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_OccupancyDates_AlignedWithOccupancyData()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(overview.OccupancyData.Count, overview.OccupancyDates.Count);
+    }
+
+    [Fact]
     public async Task GetOverviewAsync_TodayBookingsList_ContainsTodayBookings()
     {
         AdminService svc = CreateService();

--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -19,6 +19,7 @@ public class AdminOverviewDto
     public int ActiveHoldsCount { get; set; }
     public int PausedRestaurantsCount { get; set; }
     public List<int> OccupancyData { get; set; } = [];
+    public List<string> OccupancyDates { get; set; } = [];
     public List<BookingDetailDto> TodayBookingsList { get; set; } = [];
 }
 

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -73,13 +73,17 @@ public class AdminService(
 
         // Calculate Occupancy Data (Last 7 days) — raw counts first, then normalize to 0-100
         // relative to the peak day so the busiest day fills the chart and others are proportional.
+        // OccupancyDates carries the ISO calendar date (yyyy-MM-dd) for each bar so the client can
+        // toggle between the T-x relative labels and actual calendar dates (see issue #180).
         List<int> rawCounts = [];
+        List<string> occupancyDates = [];
         for (int i = 6; i >= 0; i--)
         {
             DateTime dayStart = DateTime.SpecifyKind(nowUtc.Date.AddDays(-i), DateTimeKind.Utc);
             DateTime dayEnd = dayStart.AddDays(1);
             int dayBookings = await _bookingRepository.CountActiveByDayAsync(dayStart, dayEnd);
             rawCounts.Add(dayBookings);
+            occupancyDates.Add(dayStart.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
         }
 
         int maxCount = rawCounts.Count > 0 ? rawCounts.Max() : 0;
@@ -96,6 +100,7 @@ public class AdminService(
             ActiveHoldsCount = _holdService.GetActiveHoldsCount(),
             PausedRestaurantsCount = pausedRestaurantsCount,
             OccupancyData = occupancyData,
+            OccupancyDates = occupancyDates,
             TodayBookingsList = [.. todayBookingsList.OrderBy(b => b.Date)],
         };
     }

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -10,6 +10,7 @@ export interface AdminOverviewDto {
   activeHoldsCount?: number;
   pausedRestaurantsCount?: number;
   occupancyData?: number[];
+  occupancyDates?: string[];
   todayBookingsList?: BookingDetailDto[];
 }
 
@@ -31,6 +32,7 @@ export interface AdminDashboardStats {
   pausedCount: number;
   totalCovers: number;
   occupancyData: number[];
+  occupancyDates: string[];
   recentBookings: BookingSummaryDto[];
 }
 
@@ -46,6 +48,7 @@ export async function getAdminDashboardStats(): Promise<AdminDashboardStats | nu
       pausedCount: overview.pausedRestaurantsCount ?? 0,
       totalCovers: overview.totalSeats,
       occupancyData: overview.occupancyData ?? [],
+      occupancyDates: overview.occupancyDates ?? [],
       recentBookings: (overview.todayBookingsList ?? [])
         .map((b) => ({
           id: b.id,

--- a/openresto-frontend/app/(admin)/dashboard.tsx
+++ b/openresto-frontend/app/(admin)/dashboard.tsx
@@ -167,6 +167,7 @@ export default function AdminDashboardScreen() {
                   colors={colors}
                   isDark={isDark}
                   data={stats?.occupancyData ?? []}
+                  dates={stats?.occupancyDates ?? []}
                 />
               </View>
 
@@ -295,15 +296,70 @@ function OccupancyChart({
   colors,
   isDark,
   data,
+  dates,
 }: {
   primaryColor: string;
   colors: ThemeColors;
   isDark: boolean;
   data: number[];
+  dates?: string[];
 }) {
   const chartData = data?.length > 0 ? data : [0, 0, 0, 0, 0, 0, 0];
+  const [labelMode, setLabelMode] = useState<"relative" | "calendar">("relative");
+
+  const relativeLabels = ["T-6", "T-5", "T-4", "T-3", "T-2", "T-1", "Today"];
+  const formatCalendar = (iso: string) =>
+    new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+
+  const labelFor = (i: number) => {
+    if (labelMode === "calendar" && dates && dates[i]) {
+      return i === 6 ? "Today" : formatCalendar(dates[i]);
+    }
+    return relativeLabels[i];
+  };
+
   return (
     <View style={styles.chartArea}>
+      <View style={styles.toggleRow}>
+        <Pressable
+          testID="occupancy-toggle-relative"
+          onPress={() => setLabelMode("relative")}
+          style={[
+            styles.toggleSegment,
+            labelMode === "relative"
+              ? { backgroundColor: primaryColor }
+              : { backgroundColor: `${colors.muted}14` },
+          ]}
+        >
+          <ThemedText
+            style={[
+              styles.toggleText,
+              { color: labelMode === "relative" ? theme.colors.white : colors.muted },
+            ]}
+          >
+            T-x
+          </ThemedText>
+        </Pressable>
+        <Pressable
+          testID="occupancy-toggle-calendar"
+          onPress={() => setLabelMode("calendar")}
+          style={[
+            styles.toggleSegment,
+            labelMode === "calendar"
+              ? { backgroundColor: primaryColor }
+              : { backgroundColor: `${colors.muted}14` },
+          ]}
+        >
+          <ThemedText
+            style={[
+              styles.toggleText,
+              { color: labelMode === "calendar" ? theme.colors.white : colors.muted },
+            ]}
+          >
+            Dates
+          </ThemedText>
+        </Pressable>
+      </View>
       <View style={styles.chartBars}>
         {chartData.map((val, i) => (
           <View key={i} style={styles.barContainer}>
@@ -319,7 +375,7 @@ function OccupancyChart({
               />
             </View>
             <ThemedText style={[styles.barLabel, { color: colors.muted }]}>
-              {["T-6", "T-5", "T-4", "T-3", "T-2", "T-1", "Today"][i]}
+              {labelFor(i)}
             </ThemedText>
           </View>
         ))}
@@ -454,6 +510,15 @@ const styles = StyleSheet.create({
   cardTitle: { ...theme.typography.h3 },
   chartSub: { ...theme.typography.body, marginTop: theme.spacing.xs },
   chartArea: { flex: 1, justifyContent: "flex-end", minHeight: 200 },
+  toggleRow: {
+    flexDirection: "row",
+    alignSelf: "flex-end",
+    borderRadius: theme.borderRadius.full,
+    overflow: "hidden",
+    marginBottom: theme.spacing.lg,
+  },
+  toggleSegment: { paddingHorizontal: theme.spacing.md, paddingVertical: theme.spacing.xsm },
+  toggleText: { ...theme.typography.label, fontWeight: "700", fontSize: 12 },
   chartBars: {
     flexDirection: "row",
     alignItems: "flex-end",

--- a/openresto-frontend/tests/api/admin.test.ts
+++ b/openresto-frontend/tests/api/admin.test.ts
@@ -100,6 +100,7 @@ describe("getAdminDashboardStats", () => {
       pausedCount: 0,
       totalCovers: 100,
       occupancyData: [],
+      occupancyDates: [],
       recentBookings: [
         {
           id: 1,
@@ -113,6 +114,28 @@ describe("getAdminDashboardStats", () => {
         },
       ],
     });
+  });
+
+  it("passes occupancyDates through when present in overview", async () => {
+    const overview = {
+      todayBookings: 1,
+      totalSeats: 10,
+      occupancyDates: [
+        "2026-07-07",
+        "2026-07-08",
+        "2026-07-09",
+        "2026-07-10",
+        "2026-07-11",
+        "2026-07-12",
+        "2026-07-13",
+      ],
+      todayBookingsList: [],
+    };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => overview });
+
+    const result = await getAdminDashboardStats();
+
+    expect(result?.occupancyDates).toEqual(overview.occupancyDates);
   });
 
   it("returns null if overview fails", async () => {

--- a/openresto-frontend/tests/app/(admin)/dashboard.test.tsx
+++ b/openresto-frontend/tests/app/(admin)/dashboard.test.tsx
@@ -74,6 +74,11 @@ const mockStats: AdminDashboardStats = {
   pausedCount: 1,
   totalCovers: 100,
   occupancyData: [10, 20, 30, 40, 50, 60, 70],
+  occupancyDates: Array.from({ length: 7 }, (_, i) => {
+    const d = new Date();
+    d.setDate(d.getDate() - (6 - i));
+    return d.toISOString().slice(0, 10);
+  }),
   recentBookings: [
     {
       id: 10,
@@ -353,5 +358,46 @@ describe("AdminDashboardScreen", () => {
     fireEvent.press(screen.getByTestId("action-modal-close"));
 
     await waitFor(() => expect(getAdminDashboardStats).toHaveBeenCalledTimes(2));
+  });
+
+  it("defaults to the T-x relative occupancy labels", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+
+    expect(screen.getByText("T-6")).toBeTruthy();
+    expect(screen.getByText("Today")).toBeTruthy();
+  });
+
+  it("swaps to calendar date labels when the Dates toggle is pressed", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+
+    // Sanity: relative label present before toggling
+    expect(screen.getByText("T-6")).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId("occupancy-toggle-calendar"));
+
+    // T-6 should be replaced by the oldest calendar date; Today remains.
+    expect(screen.queryByText("T-6")).toBeNull();
+    expect(screen.getByText("Today")).toBeTruthy();
+    // The oldest bar's date (6 days ago) should render as a short month/day.
+    const oldest = new Date();
+    oldest.setDate(oldest.getDate() - 6);
+    const oldestLabel = oldest.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+    expect(screen.getByText(oldestLabel)).toBeTruthy();
+  });
+
+  it("restores T-x labels when switching back to relative mode", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+
+    fireEvent.press(screen.getByTestId("occupancy-toggle-calendar"));
+    expect(screen.queryByText("T-6")).toBeNull();
+
+    fireEvent.press(screen.getByTestId("occupancy-toggle-relative"));
+    expect(screen.getByText("T-6")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #180

## Summary
Adds a view-mode toggle to the admin dashboard's occupancy chart so admins can switch between the existing relative-day labels (T-6 … Today) and actual calendar dates (e.g. "Jul 7"). The default view stays T-x, so existing admins see no change unless they toggle.

## Changes
**Backend**
- `AdminOverviewDto` gains `OccupancyDates` (`List<string>`), parallel to the existing `OccupancyData`.
- `AdminService.GetOverviewAsync()` populates it in the same 7-day loop with ISO `yyyy-MM-dd` strings (invariant culture, server-UTC day — consistent with how counts are computed). No change to the counts or the 7-day window.

**Frontend**
- `admin.ts`: thread `occupancyDates` through `AdminOverviewDto` → `AdminDashboardStats` → `getAdminDashboardStats()`.
- `OccupancyChart`: two-segment toggle (T-x / Dates) in the chart header. In calendar mode the last bar still reads "Today"; earlier bars show `new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" })`. Falls back to relative labels if dates are missing. Bar fill/height logic is untouched — only labels change.

## Acceptance criteria
- [x] `AdminService.GetOverviewAsync()` returns date strings alongside the existing counts
- [x] `OccupancyChart` has a toggle between "T-x" and "calendar date" label modes
- [x] Switching modes only changes bar labels, not the underlying data or bar values
- [x] Default view mode matches today's behavior (T-x)

## Tests
- Backend (`AdminServiceTests`): 4 new tests — has 7 elements, last is today, all match ISO format, aligned with `OccupancyData`. Full suite: 101 passed.
- Frontend `admin.test.ts`: updated passthrough expectation + new `occupancyDates` test. 120 passed.
- Frontend `dashboard.test.tsx`: default labels, toggle to calendar (T-6 → formatted date, Today preserved), restore to relative. 22 passed.

Labeled `_v1.1 — SHOULD_` per the issue.