### PR TITLE
Occupancy chart: real booking counts, summary line & peak highlight

### DIFF
--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -196,6 +196,63 @@ public class AdminServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOverviewAsync_OccupancyCounts_HasSevenElements()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(7, overview.OccupancyCounts.Count);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_OccupancyCounts_AlignedWithOccupancyData()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(overview.OccupancyData.Count, overview.OccupancyCounts.Count);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_OccupancyCounts_MatchRawBookingsAtPeakDay()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        DateTime nowUtc = DateTime.UtcNow;
+        // 3 bookings today (peak), 1 yesterday
+        _db.Bookings.Add(new Booking { Id = 40, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(12), BookingRef = "T1" });
+        _db.Bookings.Add(new Booking { Id = 41, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(13), BookingRef = "T2" });
+        _db.Bookings.Add(new Booking { Id = 42, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddHours(14), BookingRef = "T3" });
+        _db.Bookings.Add(new Booking { Id = 43, RestaurantId = 1, SectionId = 1, TableId = 1, Date = nowUtc.Date.AddDays(-1).AddHours(12), BookingRef = "Y1" });
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        // Today (index 6) is the peak: 3 raw bookings, normalized to 100%.
+        Assert.Equal(3, overview.OccupancyCounts[6]);
+        Assert.Equal(100, overview.OccupancyData[6]);
+        Assert.Equal(1, overview.OccupancyCounts[5]);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_OccupancyCounts_AllZeroWhenNoBookings()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.All(overview.OccupancyCounts, c => Assert.Equal(0, c));
+    }
+
+    [Fact]
     public async Task GetOverviewAsync_TodayBookingsList_ContainsTodayBookings()
     {
         AdminService svc = CreateService();

--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -20,6 +20,7 @@ public class AdminOverviewDto
     public int PausedRestaurantsCount { get; set; }
     public List<int> OccupancyData { get; set; } = [];
     public List<string> OccupancyDates { get; set; } = [];
+    public List<int> OccupancyCounts { get; set; } = [];
     public List<BookingDetailDto> TodayBookingsList { get; set; } = [];
 }
 

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -101,6 +101,7 @@ public class AdminService(
             PausedRestaurantsCount = pausedRestaurantsCount,
             OccupancyData = occupancyData,
             OccupancyDates = occupancyDates,
+            OccupancyCounts = rawCounts,
             TodayBookingsList = [.. todayBookingsList.OrderBy(b => b.Date)],
         };
     }

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -11,6 +11,7 @@ export interface AdminOverviewDto {
   pausedRestaurantsCount?: number;
   occupancyData?: number[];
   occupancyDates?: string[];
+  occupancyCounts?: number[];
   todayBookingsList?: BookingDetailDto[];
 }
 
@@ -33,6 +34,7 @@ export interface AdminDashboardStats {
   totalCovers: number;
   occupancyData: number[];
   occupancyDates: string[];
+  occupancyCounts: number[];
   recentBookings: BookingSummaryDto[];
 }
 
@@ -49,6 +51,7 @@ export async function getAdminDashboardStats(): Promise<AdminDashboardStats | nu
       totalCovers: overview.totalSeats,
       occupancyData: overview.occupancyData ?? [],
       occupancyDates: overview.occupancyDates ?? [],
+      occupancyCounts: overview.occupancyCounts ?? [],
       recentBookings: (overview.todayBookingsList ?? [])
         .map((b) => ({
           id: b.id,

--- a/openresto-frontend/app/(admin)/dashboard.tsx
+++ b/openresto-frontend/app/(admin)/dashboard.tsx
@@ -168,6 +168,7 @@ export default function AdminDashboardScreen() {
                   isDark={isDark}
                   data={stats?.occupancyData ?? []}
                   dates={stats?.occupancyDates ?? []}
+                  counts={stats?.occupancyCounts ?? []}
                 />
               </View>
 
@@ -297,12 +298,14 @@ function OccupancyChart({
   isDark,
   data,
   dates,
+  counts,
 }: {
   primaryColor: string;
   colors: ThemeColors;
   isDark: boolean;
   data: number[];
   dates?: string[];
+  counts?: number[];
 }) {
   const chartData = data?.length > 0 ? data : [0, 0, 0, 0, 0, 0, 0];
   const [labelMode, setLabelMode] = useState<"relative" | "calendar">("relative");
@@ -318,67 +321,109 @@ function OccupancyChart({
     return relativeLabels[i];
   };
 
+  const hasCounts = !!counts && counts.length > 0;
+  const peakCount = hasCounts ? Math.max(...(counts as number[])) : 0;
+  const peakIndex = hasCounts ? (counts as number[]).indexOf(peakCount) : -1;
+  const totalBookings = hasCounts ? (counts as number[]).reduce((a, b) => a + b, 0) : 0;
+  const peakWeekday =
+    peakIndex >= 0 && dates && dates[peakIndex]
+      ? new Date(dates[peakIndex]).toLocaleDateString(undefined, { weekday: "short" })
+      : peakIndex >= 0
+        ? relativeLabels[peakIndex]
+        : "";
+
+  const summary =
+    totalBookings > 0
+      ? `${totalBookings} bookings · ${(totalBookings / 7).toFixed(1)}/day · peak ${peakWeekday}`
+      : "No bookings in the last 7 days";
+
   return (
     <View style={styles.chartArea}>
-      <View style={styles.toggleRow}>
-        <Pressable
-          testID="occupancy-toggle-relative"
-          onPress={() => setLabelMode("relative")}
-          style={[
-            styles.toggleSegment,
-            labelMode === "relative"
-              ? { backgroundColor: primaryColor }
-              : { backgroundColor: `${colors.muted}14` },
-          ]}
+      <View style={styles.chartHeaderRow}>
+        <ThemedText
+          testID="occupancy-summary"
+          style={[styles.summaryText, { color: colors.muted }]}
         >
-          <ThemedText
+          {summary}
+        </ThemedText>
+        <View style={styles.toggleRow}>
+          <Pressable
+            testID="occupancy-toggle-relative"
+            onPress={() => setLabelMode("relative")}
             style={[
-              styles.toggleText,
-              { color: labelMode === "relative" ? theme.colors.white : colors.muted },
+              styles.toggleSegment,
+              labelMode === "relative"
+                ? { backgroundColor: primaryColor }
+                : { backgroundColor: `${colors.muted}14` },
             ]}
           >
-            T-x
-          </ThemedText>
-        </Pressable>
-        <Pressable
-          testID="occupancy-toggle-calendar"
-          onPress={() => setLabelMode("calendar")}
-          style={[
-            styles.toggleSegment,
-            labelMode === "calendar"
-              ? { backgroundColor: primaryColor }
-              : { backgroundColor: `${colors.muted}14` },
-          ]}
-        >
-          <ThemedText
+            <ThemedText
+              style={[
+                styles.toggleText,
+                { color: labelMode === "relative" ? theme.colors.white : colors.muted },
+              ]}
+            >
+              T-x
+            </ThemedText>
+          </Pressable>
+          <Pressable
+            testID="occupancy-toggle-calendar"
+            onPress={() => setLabelMode("calendar")}
             style={[
-              styles.toggleText,
-              { color: labelMode === "calendar" ? theme.colors.white : colors.muted },
+              styles.toggleSegment,
+              labelMode === "calendar"
+                ? { backgroundColor: primaryColor }
+                : { backgroundColor: `${colors.muted}14` },
             ]}
           >
-            Dates
-          </ThemedText>
-        </Pressable>
+            <ThemedText
+              style={[
+                styles.toggleText,
+                { color: labelMode === "calendar" ? theme.colors.white : colors.muted },
+              ]}
+            >
+              Dates
+            </ThemedText>
+          </Pressable>
+        </View>
       </View>
       <View style={styles.chartBars}>
-        {chartData.map((val, i) => (
-          <View key={i} style={styles.barContainer}>
-            <View style={styles.barTrack}>
-              <View
+        {chartData.map((val, i) => {
+          const isPeak = i === peakIndex;
+          const count = hasCounts ? (counts as number[])[i] : null;
+          return (
+            <View key={i} style={styles.barContainer}>
+              <ThemedText
+                testID={`occupancy-count-${i}`}
                 style={[
-                  styles.barFill,
-                  {
-                    backgroundColor: isDark ? `${primaryColor}CC` : primaryColor,
-                    height: `${Math.max(2, val)}%` as `${number}%`,
-                  },
+                  styles.countLabel,
+                  { color: isPeak ? primaryColor : colors.muted },
+                  isPeak && styles.countLabelPeak,
                 ]}
-              />
+              >
+                {count === null ? "–" : count}
+              </ThemedText>
+              <View style={styles.barTrack}>
+                <View
+                  style={[
+                    styles.barFill,
+                    {
+                      backgroundColor: isPeak
+                        ? primaryColor
+                        : isDark
+                          ? `${primaryColor}99`
+                          : `${primaryColor}55`,
+                      height: `${Math.max(2, val)}%` as `${number}%`,
+                    },
+                  ]}
+                />
+              </View>
+              <ThemedText style={[styles.barLabel, { color: colors.muted }]}>
+                {labelFor(i)}
+              </ThemedText>
             </View>
-            <ThemedText style={[styles.barLabel, { color: colors.muted }]}>
-              {labelFor(i)}
-            </ThemedText>
-          </View>
-        ))}
+          );
+        })}
       </View>
     </View>
   );
@@ -509,16 +554,25 @@ const styles = StyleSheet.create({
   chartHeader: { marginBottom: theme.spacing.xxxl },
   cardTitle: { ...theme.typography.h3 },
   chartSub: { ...theme.typography.body, marginTop: theme.spacing.xs },
-  chartArea: { flex: 1, justifyContent: "flex-end", minHeight: 200 },
+  chartArea: { flex: 1, justifyContent: "flex-end", minHeight: 220 },
+  chartHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing.md,
+    marginBottom: theme.spacing.lg,
+    flexWrap: "wrap",
+  },
+  summaryText: { ...theme.typography.caption, fontWeight: "600", flexShrink: 1 },
   toggleRow: {
     flexDirection: "row",
-    alignSelf: "flex-end",
     borderRadius: theme.borderRadius.full,
     overflow: "hidden",
-    marginBottom: theme.spacing.lg,
   },
   toggleSegment: { paddingHorizontal: theme.spacing.md, paddingVertical: theme.spacing.xsm },
   toggleText: { ...theme.typography.label, fontWeight: "700", fontSize: 12 },
+  countLabel: { ...theme.typography.captionSmall, fontWeight: "700", fontSize: 12 },
+  countLabelPeak: { fontSize: 13 },
   chartBars: {
     flexDirection: "row",
     alignItems: "flex-end",

--- a/openresto-frontend/e2e/admin-dashboard.spec.ts
+++ b/openresto-frontend/e2e/admin-dashboard.spec.ts
@@ -53,7 +53,9 @@ test.describe("Admin dashboard", () => {
     await gotoAdminDashboard(page);
 
     await expect(page.getByText("Occupancy Overview")).toBeVisible();
-    await expect(page.getByText("Last 7 days")).toBeVisible();
+    // { exact: true } because the occupancy summary line also contains
+    // the words "last 7 days" (see OccupancyChart in dashboard.tsx).
+    await expect(page.getByText("Last 7 days", { exact: true })).toBeVisible();
     // The chart axis labels (OccupancyChart.tsx) — T-6 through Today.
     for (const label of ["T-6", "T-5", "T-4", "T-3", "T-2", "T-1", "Today"]) {
       await expect(page.getByText(label, { exact: true })).toBeVisible();

--- a/openresto-frontend/tests/api/admin.test.ts
+++ b/openresto-frontend/tests/api/admin.test.ts
@@ -101,6 +101,7 @@ describe("getAdminDashboardStats", () => {
       totalCovers: 100,
       occupancyData: [],
       occupancyDates: [],
+      occupancyCounts: [],
       recentBookings: [
         {
           id: 1,
@@ -136,6 +137,20 @@ describe("getAdminDashboardStats", () => {
     const result = await getAdminDashboardStats();
 
     expect(result?.occupancyDates).toEqual(overview.occupancyDates);
+  });
+
+  it("passes occupancyCounts through when present in overview", async () => {
+    const overview = {
+      todayBookings: 1,
+      totalSeats: 10,
+      occupancyCounts: [0, 1, 2, 3, 4, 5, 6],
+      todayBookingsList: [],
+    };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => overview });
+
+    const result = await getAdminDashboardStats();
+
+    expect(result?.occupancyCounts).toEqual([0, 1, 2, 3, 4, 5, 6]);
   });
 
   it("returns null if overview fails", async () => {

--- a/openresto-frontend/tests/app/(admin)/dashboard.test.tsx
+++ b/openresto-frontend/tests/app/(admin)/dashboard.test.tsx
@@ -74,6 +74,7 @@ const mockStats: AdminDashboardStats = {
   pausedCount: 1,
   totalCovers: 100,
   occupancyData: [10, 20, 30, 40, 50, 60, 70],
+  occupancyCounts: [1, 2, 3, 4, 5, 6, 12],
   occupancyDates: Array.from({ length: 7 }, (_, i) => {
     const d = new Date();
     d.setDate(d.getDate() - (6 - i));
@@ -105,7 +106,9 @@ describe("AdminDashboardScreen", () => {
     await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
 
     expect(screen.getByText("today@test.com")).toBeTruthy();
-    expect(screen.getByText("5")).toBeTruthy();
+    // "5" appears both as the Today's Bookings metric and as an occupancy count label,
+    // so assert presence (not uniqueness) here.
+    expect(screen.getAllByText("5").length).toBeGreaterThan(0);
     expect(screen.getByText("1 venues are currently paused")).toBeTruthy();
     expect(screen.getByText("100")).toBeTruthy();
   });
@@ -399,5 +402,41 @@ describe("AdminDashboardScreen", () => {
 
     fireEvent.press(screen.getByTestId("occupancy-toggle-relative"));
     expect(screen.getByText("T-6")).toBeTruthy();
+  });
+
+  it("renders a summary line with total, average, and peak", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+
+    // occupancyCounts = [1,2,3,4,5,6,12] → total 33, avg 33/7 = 4.7/day, peak = Today
+    const summary = screen.getByTestId("occupancy-summary");
+    expect(summary.props.children).toEqual(expect.stringContaining("33 bookings · 4.7/day · peak"));
+  });
+
+  it("shows the raw booking count above each bar", async () => {
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+
+    // Peak bar (index 6, count 12)
+    expect(screen.getByTestId("occupancy-count-6").props.children).toBe(12);
+    // First bar (index 0, count 1)
+    expect(screen.getByTestId("occupancy-count-0").props.children).toBe(1);
+  });
+
+  it("renders the no-bookings summary and does not crash when counts are all zero", async () => {
+    (getAdminDashboardStats as jest.Mock).mockResolvedValue({
+      ...mockStats,
+      occupancyData: [0, 0, 0, 0, 0, 0, 0],
+      occupancyCounts: [0, 0, 0, 0, 0, 0, 0],
+    });
+
+    const { queryByTestId } = renderWithProviders(<AdminDashboardScreen />);
+    await waitFor(() => expect(queryByTestId("dashboard-spinner")).toBeNull());
+
+    expect(screen.getByTestId("occupancy-summary").props.children).toBe(
+      "No bookings in the last 7 days"
+    );
+    // Counts still render as 0 above each bar
+    expect(screen.getByTestId("occupancy-count-6").props.children).toBe(0);
   });
 });


### PR DESCRIPTION
Follow-on polish to the occupancy chart introduced in #180 / #222. The chart previously normalized each day to a percentage of the peak day and **discarded the raw booking counts** — so there was nothing to show beyond relative bar heights. This surfaces those numbers.

## What's new on the dashboard occupancy chart

- **Raw booking counts** above each bar (e.g. `12`). The backend was already computing these in its 7-day loop; it just wasn't returning them.
- **Summary line**: `33 bookings · 4.7/day · peak Today` — total over the 7-day window, daily average, and the weekday of the busiest bar. Falls back to `No bookings in the last 7 days` for an all-zero window.
- **Peak highlight**: the busiest bar renders in solid primary color with its count in primary; non-peak bars use a translucent primary tint. Peak detection is skipped when every day is zero, so an empty chart highlights nothing.

Bar **heights are unchanged** (still normalized %, `Math.max(2, val)`) — only context is layered on top. The existing **T-x / Dates toggle** still only affects the bottom labels.

## Changes

**Backend**
- `AdminOverviewDto.OccupancyCounts` (`List<int>`) — parallel to `OccupancyData`/`OccupancyDates`.
- `AdminService.GetOverviewAsync()` sets it to the `rawCounts` already computed in the loop. No change to the normalized data, dates, or window.

**Frontend**
- `admin.ts`: thread `occupancyCounts` through `AdminOverviewDto` → `AdminDashboardStats` → `getAdminDashboardStats()`.
- `OccupancyChart`: summary line + per-bar count labels + peak styling. Pure RN `View` styling, no new dependencies.

## Tests
- **Backend** (`AdminServiceTests`): +4 — has 7 elements, aligned with `OccupancyData`, peak-day count matches the 100% bar, all-zero when no bookings. Full suite: **105 passed**.
- **Frontend `admin.test.ts`**: updated passthrough expectation + new `occupancyCounts` test. **121 passed**.
- **Frontend `dashboard.test.tsx`**: summary text, count labels, peak bar, and the no-bookings case. **25 passed** (one pre-existing assertion updated to `getAllByText("5")` since the count label now also renders a `5`).