### PR TITLE
fix(web): cap #root height at viewport to prevent sticky-footer gap

### DIFF
--- a/openresto-frontend/app/+html.tsx
+++ b/openresto-frontend/app/+html.tsx
@@ -34,6 +34,16 @@ export default function Root({ children }: PropsWithChildren) {
           }}
         />
         <ScrollViewStyleReset />
+        {/* ScrollViewStyleReset sizes #root off body's (percentage) height, so third-party
+            wrappers that pad body (e.g. a proxy-injected banner) can inflate it past the
+            viewport and push the sticky footer down (issue #226). Cap #root at the real
+            viewport height so the flex chain stays correct regardless of body's own size. */}
+        <style
+          id="root-viewport-height-cap"
+          dangerouslySetInnerHTML={{
+            __html: `#root { max-height: 100vh; max-height: 100dvh; }`,
+          }}
+        />
       </head>
       <body>{children}</body>
     </html>


### PR DESCRIPTION
## Summary

- `expo-router`'s `ScrollViewStyleReset` sizes `#root` with `height: 100%`, derived from `body`'s box. Third-party layers that pad `body` (e.g. the demo site's nginx `sub_filter`-injected banner, which reserves space via `body { padding-bottom: 40px !important; }`) can inflate that percentage chain past the actual viewport, and since the sticky-footer layout (`app/(user)/index.tsx` and siblings) is a nested `flex: 1` chain rooted at `#root`, the excess bubbles down and pushes the footer below the last content section with extra blank space.
- Adds a `<style>` override in `app/+html.tsx`, right after `ScrollViewStyleReset`, that caps `#root` at `100vh`/`100dvh` (dvh preferred, vh as fallback) directly against the viewport instead of `body`'s own rendered size.
- This only adds a *ceiling* — it doesn't touch `height`, so the existing padding-driven space reservation for the banner (which already works correctly for normal `body` padding) is untouched. It only kicks in if `#root` would otherwise render taller than the viewport.

## Test plan

- [x] `npm run check` (prettier + oxlint) passes with no new warnings/errors.
- [x] Built the static web export (`expo export -p web`) and served it locally; verified with a scripted Playwright/Chromium check across several viewport heights (450–1200px) that:
  - Injecting a simulated `body { padding-bottom: 40px !important; }` (mirroring the nginx demo-banner injection) still shifts the footer up by exactly 40px, matching pre-fix behavior — no regression to the existing space reservation.
  - Forcing `#root` to render taller than the viewport (simulating the reported gap) is correctly capped back down to the viewport height by the fix.
  - Long-page internal scrolling (RN Web `ScrollView`) still works correctly with the cap applied — content isn't clipped, footer remains reachable by scrolling.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U256CtHZBuXRJeecsuc1c1

---
_Generated by [Claude Code](https://claude.ai/code/session_01U256CtHZBuXRJeecsuc1c1)_