### PR TITLE
fix(web): size #root against viewport instead of body to remove sticky-footer gap

### DIFF
--- a/openresto-frontend/app/+html.tsx
+++ b/openresto-frontend/app/+html.tsx
@@ -34,14 +34,17 @@ export default function Root({ children }: PropsWithChildren) {
           }}
         />
         <ScrollViewStyleReset />
-        {/* ScrollViewStyleReset sizes #root off body's (percentage) height, so third-party
-            wrappers that pad body (e.g. a proxy-injected banner) can inflate it past the
-            viewport and push the sticky footer down (issue #226). Cap #root at the real
-            viewport height so the flex chain stays correct regardless of body's own size. */}
+        {/* ScrollViewStyleReset sizes #root from body's height (`html,body,#root{height:100%}`),
+            so any padding a third-party layer adds to body — e.g. a reverse-proxy demo banner
+            reserving space with `body{padding-bottom}` — leaks into the sticky-footer flex chain
+            and leaves a blank gap below the footer (issue #226). Size #root against the viewport
+            instead so the layout is independent of body's box. No-op for normal deploys where
+            body has no extra padding (100dvh == 100%); `vh` is the fallback for browsers without
+            `dvh`. The dvh line is intentionally last so it wins the cascade over the reset above. */}
         <style
-          id="root-viewport-height-cap"
+          id="root-viewport-height"
           dangerouslySetInnerHTML={{
-            __html: `#root { max-height: 100vh; max-height: 100dvh; }`,
+            __html: `#root { height: 100vh; height: 100dvh; }`,
           }}
         />
       </head>


### PR DESCRIPTION
## Summary

Follow-up to #227, whose fix turned out to be inert. This replaces it with the real, non-brittle fix.

**Why #227 didn't work:** it capped `#root` with `max-height: 100vh`. But with `box-sizing: border-box` (set globally in `global.css`) plus `body { padding-bottom }`, `#root`'s `height: 100%` already resolves to `viewport − padding`, which is *less* than `100vh` — so the cap never triggered. It was a no-op.

**Actual root cause:** `expo-router`'s `ScrollViewStyleReset` sizes the whole app off `body`'s height (`html, body, #root { height: 100% }`). Any padding a third-party layer adds to `body` — e.g. the demo site's reverse-proxy banner reserving space with `body { padding-bottom }` — leaks into the sticky-footer flex chain rooted at `#root`. The footer then anchors at `viewport − padding`, leaving blank footer background below it (the "oversized footer" gap in #226). Reproduced locally at a tablet-height viewport: a 200px body reservation produces a ~179px blank gap and also clips the last card on long pages.

**Fix:** size `#root` against the viewport (`height: 100dvh`, with `100vh` fallback) instead of inheriting from `body`. The app's full-height frame is now independent of `body`'s box, so nothing an external wrapper does to `body` can leak into the layout. This is your issue's suggested option 2, applied in-app.

- **No-op for normal deploys** — where `body` has no extra padding, `100dvh == 100%`, so behavior is unchanged.
- **Centralized** — fixes every page sharing the sticky-footer pattern (`index`, `lookup`, `restaurant/[id]`, `book/[restaurantId]`, `booking-confirmation`) via one rule; no per-page churn.
- The banner's own space reservation is intentionally left to the external nginx layer (the banner is demo-only and its height isn't known to the shipped app).

## Test plan

Verified against a production static export (`expo export -p web`) driven with Chromium/Playwright, API mocked for realistic content:

- [x] **No regression** — no banner, no body padding: footer sticks to the bottom as before (`#root` = full viewport).
- [x] **Gap removed** — 200px `body` padding + fixed banner at tablet height: `#root` stays at full viewport (ignores the padding), footer sits at the bottom, the ~179px gap is gone.
- [x] **Scrolling intact** — long page (12 cards) at a short viewport: internal `ScrollView` still reaches the last card.
- [x] `npm run check` (prettier + oxlint) passes with no new findings.

Refs #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U256CtHZBuXRJeecsuc1c1

---
_Generated by [Claude Code](https://claude.ai/code/session_01U256CtHZBuXRJeecsuc1c1)_