### PR TITLE
feat(admin): sortable bookings list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ docs/*
 
 #Claude
 .claude/investigations
+
+# ZCode local session data
+.zcode/

--- a/openresto-frontend/app/(admin)/bookings/index.tsx
+++ b/openresto-frontend/app/(admin)/bookings/index.tsx
@@ -11,7 +11,7 @@ import { getHoursForDay } from "@/utils/openingHours";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import AlertModal from "@/components/common/AlertModal";
 import { NewBookingModal } from "@/components/admin/bookings/NewBookingModal";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePersistedState } from "@/hooks/use-persisted-state";
 import { useBookingsGrid } from "@/hooks/use-bookings-grid";
 import {
@@ -32,6 +32,13 @@ import { BookingDetailPopup } from "@/components/admin/bookings/BookingDetailPop
 import { BookingsWideTable } from "@/components/admin/bookings/BookingsWideTable";
 import { BookingsCardList } from "@/components/admin/bookings/BookingsCardList";
 import { BookingLookupBar } from "@/components/admin/bookings/BookingLookupBar";
+import {
+  defaultSortFor,
+  nextSort,
+  sortBookings,
+  type SortKey,
+  type SortState,
+} from "@/components/admin/bookings/sorting";
 import { styles } from "@/components/admin/bookings/bookings.styles";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useErrorHandler } from "@/hooks/useErrorHandler";
@@ -52,6 +59,13 @@ export default function AdminBookingsScreen() {
   const [statusFilter, setStatusFilter] = usePersistedState<BookingStatusFilter>(
     "bookings:statusFilter",
     "active"
+  );
+  // Sort preference persists across sessions but resets to the contextual
+  // default whenever the status filter changes (see effect below) — so the
+  // "past" tab still defaults to most-recent-first, etc.
+  const [sort, setSort] = usePersistedState<SortState>(
+    "bookings:sort",
+    defaultSortFor(statusFilter)
   );
 
   const [selectedBookingId, setSelectedBookingId] = useState<number | null>(null);
@@ -173,6 +187,20 @@ export default function AdminBookingsScreen() {
     if (viewMode === "timetable") loadGrid(id, gridDate);
   };
 
+  // When the user switches status filter, reset the sort to that tab's
+  // contextual default (e.g. past = most-recent-first). We deliberately do NOT
+  // fire on the initial mount — a sort preference persisted from a previous
+  // session should survive reload. `prevStatusFilter` starts undefined, so the
+  // first (mount) run is skipped; subsequent real changes trigger the reset.
+  const prevStatusFilter = useRef<BookingStatusFilter | undefined>(undefined);
+  useEffect(() => {
+    const prev = prevStatusFilter.current;
+    prevStatusFilter.current = statusFilter;
+    if (prev === undefined || prev === statusFilter) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSort(defaultSortFor(statusFilter));
+  }, [statusFilter, setSort]);
+
   const switchToTimetable = () => {
     setViewMode("timetable");
     if (selectedRestaurantId) loadGrid(selectedRestaurantId, gridDate);
@@ -186,11 +214,9 @@ export default function AdminBookingsScreen() {
     }
   };
 
-  // Past tab: most-recent first. All other views: soonest first.
-  const sorted = [...bookings].sort((a, b) => {
-    const diff = new Date(a.date).getTime() - new Date(b.date).getTime();
-    return statusFilter === "past" ? -diff : diff;
-  });
+  const sorted = sortBookings(bookings, sort);
+
+  const handleSortChange = (key: SortKey) => setSort((prev) => nextSort(prev, key));
 
   // Only wired via useKeyboardShortcuts below when sorted.length > 0, so
   // sorted is guaranteed non-empty whenever this actually runs.
@@ -544,6 +570,8 @@ export default function AdminBookingsScreen() {
           focusedRowId={focusedRowId}
           onOpenBooking={(id) => openBooking(id)}
           onCancelBooking={(b) => setCancelTarget(b)}
+          sort={sort}
+          onSortChange={handleSortChange}
           borderColor={borderColor}
           cardBg={cardBg}
           mutedColor={mutedColor}
@@ -556,6 +584,8 @@ export default function AdminBookingsScreen() {
           bookings={sorted}
           focusedRowId={focusedRowId}
           onOpenBooking={(id) => openBooking(id)}
+          sort={sort}
+          onSortChange={handleSortChange}
           borderColor={borderColor}
           cardBg={cardBg}
           mutedColor={mutedColor}

--- a/openresto-frontend/components/admin/bookings/BookingsCardList.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsCardList.tsx
@@ -7,11 +7,16 @@ import { StatusBadge } from "@/components/admin/bookings/StatusBadge";
 import { styles } from "@/components/admin/bookings/bookings.styles";
 import { focusedRowHighlight, rowA11yProps } from "@/components/admin/bookings/bookingRowProps";
 import { initials } from "@/utils/formatters";
+import { BookingsSortControl } from "@/components/admin/bookings/BookingsSortControl";
+import type { SortKey, SortState } from "@/components/admin/bookings/sorting";
 
 export interface BookingsCardListProps {
   bookings: BookingDetailDto[];
   focusedRowId: number | null;
   onOpenBooking: (id: number) => void;
+  /** Active sort (drives the control indicator). */
+  sort: SortState;
+  onSortChange: (key: SortKey) => void;
   /** Theme values passed from the orchestrating screen (presentational). */
   borderColor: string;
   cardBg: string;
@@ -22,12 +27,16 @@ export interface BookingsCardListProps {
 
 /**
  * Narrow (mobile) bookings list — one card per booking. Extracted from the
- * bookings screen for decomposition; presentational, owns no state.
+ * bookings screen for decomposition; presentational, owns no state. A
+ * `BookingsSortControl` row above the cards provides the sort affordance that
+ * the wide table gets via clickable column headers.
  */
 export function BookingsCardList({
   bookings,
   focusedRowId,
   onOpenBooking,
+  sort,
+  onSortChange,
   borderColor,
   cardBg,
   mutedColor,
@@ -35,79 +44,89 @@ export function BookingsCardList({
   primaryColor,
 }: BookingsCardListProps) {
   return (
-    <View style={styles.cardList}>
-      {bookings.map((b) => (
-        <Pressable
-          key={b.id}
-          {...rowA11yProps(b.id, focusedRowId)}
-          style={[
-            styles.listCard,
-            { backgroundColor: cardBg, borderColor },
-            focusedRowHighlight(b.id, focusedRowId, primaryColor),
-          ]}
-          onPress={() => onOpenBooking(b.id)}
-        >
-          <View style={styles.listCardRow}>
-            <View
-              style={{
-                width: 40,
-                height: 40,
-                borderRadius: 20,
-                backgroundColor: `${primaryColor}18`,
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <ThemedText style={{ fontSize: 13, fontWeight: "700", color: primaryColor }}>
-                {initials(b.customerName ?? b.customerEmail)}
-              </ThemedText>
-            </View>
-            <View style={styles.listCardInfo}>
-              <ThemedText style={styles.tdGuest} numberOfLines={1}>
-                {b.customerName ?? b.customerEmail}
-              </ThemedText>
-              {b.customerName ? (
-                <ThemedText style={[styles.tdNotes, { color: mutedColor }]} numberOfLines={1}>
-                  {b.customerEmail}
-                </ThemedText>
-              ) : null}
-              <ThemedText style={[styles.tdTime, { fontSize: 13 }]}>
-                {new Date(b.date).toLocaleString(undefined, {
-                  weekday: "short",
-                  month: "short",
-                  day: "numeric",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </ThemedText>
-              <View style={styles.partyPill}>
-                <Ionicons name="people-outline" size={12} color={mutedColor} />
-                <ThemedText style={[styles.tdDate, { color: mutedColor }]}>
-                  {b.seats} guests · {b.tableName}
+    <View style={styles.cardListWrap}>
+      <BookingsSortControl
+        sort={sort}
+        onSortChange={onSortChange}
+        borderColor={borderColor}
+        cardBg={cardBg}
+        mutedColor={mutedColor}
+        primaryColor={primaryColor}
+      />
+      <View style={styles.cardList}>
+        {bookings.map((b) => (
+          <Pressable
+            key={b.id}
+            {...rowA11yProps(b.id, focusedRowId)}
+            style={[
+              styles.listCard,
+              { backgroundColor: cardBg, borderColor },
+              focusedRowHighlight(b.id, focusedRowId, primaryColor),
+            ]}
+            onPress={() => onOpenBooking(b.id)}
+          >
+            <View style={styles.listCardRow}>
+              <View
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 20,
+                  backgroundColor: `${primaryColor}18`,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <ThemedText style={{ fontSize: 13, fontWeight: "700", color: primaryColor }}>
+                  {initials(b.customerName ?? b.customerEmail)}
                 </ThemedText>
               </View>
-            </View>
-            <View style={styles.listCardRight}>
-              {b.isCancelled ? (
-                <View
-                  style={[
-                    styles.badge,
-                    {
-                      backgroundColor: theme.status.cancelled.bg[isDark ? "dark" : "light"],
-                    },
-                  ]}
-                >
-                  <ThemedText style={[styles.badgeText, { color: theme.status.cancelled.text }]}>
-                    Cancelled
+              <View style={styles.listCardInfo}>
+                <ThemedText style={styles.tdGuest} numberOfLines={1}>
+                  {b.customerName ?? b.customerEmail}
+                </ThemedText>
+                {b.customerName ? (
+                  <ThemedText style={[styles.tdNotes, { color: mutedColor }]} numberOfLines={1}>
+                    {b.customerEmail}
+                  </ThemedText>
+                ) : null}
+                <ThemedText style={[styles.tdTime, { fontSize: 13 }]}>
+                  {new Date(b.date).toLocaleString(undefined, {
+                    weekday: "short",
+                    month: "short",
+                    day: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </ThemedText>
+                <View style={styles.partyPill}>
+                  <Ionicons name="people-outline" size={12} color={mutedColor} />
+                  <ThemedText style={[styles.tdDate, { color: mutedColor }]}>
+                    {b.seats} guests · {b.tableName}
                   </ThemedText>
                 </View>
-              ) : (
-                <StatusBadge date={b.date} isDark={isDark} />
-              )}
+              </View>
+              <View style={styles.listCardRight}>
+                {b.isCancelled ? (
+                  <View
+                    style={[
+                      styles.badge,
+                      {
+                        backgroundColor: theme.status.cancelled.bg[isDark ? "dark" : "light"],
+                      },
+                    ]}
+                  >
+                    <ThemedText style={[styles.badgeText, { color: theme.status.cancelled.text }]}>
+                      Cancelled
+                    </ThemedText>
+                  </View>
+                ) : (
+                  <StatusBadge date={b.date} isDark={isDark} />
+                )}
+              </View>
             </View>
-          </View>
-        </Pressable>
-      ))}
+          </Pressable>
+        ))}
+      </View>
     </View>
   );
 }

--- a/openresto-frontend/components/admin/bookings/BookingsSortControl.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsSortControl.tsx
@@ -1,0 +1,89 @@
+import { Pressable, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/themed-text";
+import { styles } from "@/components/admin/bookings/bookings.styles";
+import type { SortKey, SortState } from "@/components/admin/bookings/sorting";
+
+export interface BookingsSortControlProps {
+  sort: SortState;
+  onSortChange: (key: SortKey) => void;
+  /** Theme values passed from the orchestrating screen (presentational). */
+  borderColor: string;
+  cardBg: string;
+  mutedColor: string;
+  primaryColor: string;
+}
+
+const COLUMNS: { key: SortKey; label: string }[] = [
+  { key: "date", label: "Time" },
+  { key: "guest", label: "Guest" },
+  { key: "seats", label: "Party" },
+  { key: "table", label: "Table" },
+  { key: "status", label: "Status" },
+];
+
+/**
+ * Sort affordance for the mobile card list — column headers don't apply to a
+ * card layout, so this offers the same sort axes as the wide table via a row of
+ * chips, each with a direction toggle (tap the active chip to flip asc/desc).
+ * Presentational; the screen owns the sort state.
+ */
+export function BookingsSortControl({
+  sort,
+  onSortChange,
+  borderColor,
+  cardBg,
+  mutedColor,
+  primaryColor,
+}: BookingsSortControlProps) {
+  return (
+    <View style={[styles.sortControl, { borderColor, backgroundColor: cardBg }]}>
+      <ThemedText style={[styles.sortControlLabel, { color: mutedColor }]}>Sort</ThemedText>
+      <View style={styles.sortControlChips}>
+        {COLUMNS.map(({ key, label }) => {
+          const isActive = sort.key === key;
+          const dirLabel = isActive
+            ? sort.dir === "asc"
+              ? "ascending"
+              : "descending"
+            : "not sorted";
+          return (
+            <Pressable
+              key={key}
+              testID={`sort-chip-${key}`}
+              accessibilityRole="button"
+              accessibilityLabel={`Sort by ${label}, ${dirLabel}`}
+              style={[
+                styles.sortChip,
+                { borderColor: isActive ? primaryColor : borderColor },
+                isActive && { backgroundColor: primaryColor },
+              ]}
+              onPress={() => onSortChange(key)}
+            >
+              <ThemedText
+                style={[
+                  styles.sortChipText,
+                  { color: isActive ? "#fff" : mutedColor },
+                  isActive && styles.sortChipTextActive,
+                ]}
+              >
+                {label}
+              </ThemedText>
+              <Ionicons
+                name={
+                  !isActive
+                    ? "swap-vertical-outline"
+                    : sort.dir === "asc"
+                      ? "chevron-up-outline"
+                      : "chevron-down-outline"
+                }
+                size={11}
+                color={isActive ? "#fff" : mutedColor}
+              />
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/openresto-frontend/components/admin/bookings/BookingsWideTable.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsWideTable.tsx
@@ -1,4 +1,4 @@
-import { Pressable, View } from "react-native";
+import { Pressable, View, type ViewStyle } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/themed-text";
 import { BookingDetailDto } from "@/api/admin";
@@ -7,12 +7,16 @@ import { initials } from "@/utils/formatters";
 import { isPast, StatusBadge } from "@/components/admin/bookings/StatusBadge";
 import { styles } from "@/components/admin/bookings/bookings.styles";
 import { focusedRowHighlight, rowA11yProps } from "@/components/admin/bookings/bookingRowProps";
+import type { SortKey, SortState } from "@/components/admin/bookings/sorting";
 
 export interface BookingsWideTableProps {
   bookings: BookingDetailDto[];
   focusedRowId: number | null;
   onOpenBooking: (id: number) => void;
   onCancelBooking: (booking: BookingDetailDto) => void;
+  /** Active sort (drives header indicator). */
+  sort: SortState;
+  onSortChange: (key: SortKey) => void;
   /** Theme values passed from the orchestrating screen (presentational). */
   borderColor: string;
   cardBg: string;
@@ -24,35 +28,72 @@ export interface BookingsWideTableProps {
 /**
  * Wide (desktop/tablet) bookings list — a bordered table with one row per
  * booking. Extracted from the bookings screen for decomposition; presentational,
- * owns no state (the screen drives focus + open/cancel callbacks).
+ * owns no state (the screen drives focus + open/cancel callbacks + sort).
+ *
+ * TIME / GUEST / PARTY / TABLE headers are pressable and drive sort state;
+ * STATUS reflects booking state and isn't a sort axis.
  */
 export function BookingsWideTable({
   bookings,
   focusedRowId,
   onOpenBooking,
   onCancelBooking,
+  sort,
+  onSortChange,
   borderColor,
   cardBg,
   mutedColor,
   isDark,
   primaryColor,
 }: BookingsWideTableProps) {
+  const headerBg = isDark ? "#28292b" : "#f8f8f9";
+  // Subtle alternating row tint for scannability. Translucent so the focused-
+  // row highlight (`primaryColor` tint) still reads on top of it.
+  const zebraBg = isDark ? "rgba(255,255,255,0.022)" : "rgba(0,0,0,0.018)";
+
+  const renderSortHeader = (key: SortKey, label: string, columnStyle: ViewStyle) => {
+    const isActive = sort.key === key;
+    const dirLabel = isActive ? (sort.dir === "asc" ? "ascending" : "descending") : "not sorted";
+    const icon = !isActive
+      ? "swap-vertical-outline"
+      : sort.dir === "asc"
+        ? "chevron-up-outline"
+        : "chevron-down-outline";
+    return (
+      <Pressable
+        testID={`sort-header-${key}`}
+        accessibilityRole="button"
+        accessibilityLabel={`Sort by ${label}, ${dirLabel}`}
+        style={[styles.thSortBtn, columnStyle]}
+        onPress={() => onSortChange(key)}
+      >
+        <ThemedText
+          style={[
+            styles.thCell,
+            { color: isActive ? primaryColor : mutedColor },
+            isActive && styles.thCellActive,
+          ]}
+        >
+          {label}
+        </ThemedText>
+        <Ionicons name={icon} size={11} color={isActive ? primaryColor : mutedColor} />
+      </Pressable>
+    );
+  };
+
   return (
     <View style={[styles.tableCard, { backgroundColor: cardBg, borderColor }]}>
-      <View style={[styles.tableHeader, { backgroundColor: isDark ? "#28292b" : "#f8f8f9" }]}>
-        <ThemedText style={[styles.thCell, styles.colTime, { color: mutedColor }]}>TIME</ThemedText>
-        <ThemedText style={[styles.thCell, styles.colGuest, { color: mutedColor }]}>
-          GUEST
-        </ThemedText>
-        <ThemedText style={[styles.thCell, styles.colParty, { color: mutedColor }]}>
-          PARTY
-        </ThemedText>
-        <ThemedText style={[styles.thCell, styles.colTable, { color: mutedColor }]}>
-          TABLE
-        </ThemedText>
-        <ThemedText style={[styles.thCell, styles.colStatus, { color: mutedColor }]}>
-          STATUS
-        </ThemedText>
+      <View
+        style={[
+          styles.tableHeader,
+          { backgroundColor: headerBg, borderBottomWidth: 1, borderBottomColor: borderColor },
+        ]}
+      >
+        {renderSortHeader("date", "TIME", styles.colTime)}
+        {renderSortHeader("guest", "GUEST", styles.colGuest)}
+        {renderSortHeader("seats", "PARTY", styles.colParty)}
+        {renderSortHeader("table", "TABLE", styles.colTable)}
+        {renderSortHeader("status", "STATUS", styles.colStatus)}
         <View style={styles.colAction} />
       </View>
 
@@ -64,6 +105,10 @@ export function BookingsWideTable({
             styles.tableRow,
             i > 0 && { borderTopWidth: 1, borderTopColor: borderColor },
             { cursor: "pointer" } as const,
+            // Even rows get the faint zebra tint unless they're focused.
+            i % 2 === 1 && !focusedRowHighlight(b.id, focusedRowId, primaryColor)
+              ? { backgroundColor: zebraBg }
+              : null,
             focusedRowHighlight(b.id, focusedRowId, primaryColor),
           ]}
           onPress={() => onOpenBooking(b.id)}

--- a/openresto-frontend/components/admin/bookings/StatusBadge.tsx
+++ b/openresto-frontend/components/admin/bookings/StatusBadge.tsx
@@ -2,6 +2,7 @@ import { View } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { theme } from "@/theme/theme";
 import { styles } from "./bookings.styles";
+import { BookingDetailDto } from "@/api/admin";
 
 export type BadgeVariant = "arrived" | "seated" | "upcoming" | "scheduled" | "completed";
 
@@ -26,6 +27,25 @@ export function getStatus(date: string): { label: string; variant: BadgeVariant 
   if (diffMins < 5) return { label: "Arrived", variant: "arrived" };
   if (diffMins < 60) return { label: "Upcoming", variant: "upcoming" };
   return { label: "Scheduled", variant: "scheduled" };
+}
+
+// Lifecycle rank for status-based sorting (issue #208). Higher rank surfaces
+// earlier in the default (ascending) sort, so the most attention-worthy rows
+// land at the top: in-progress first, then upcoming/future, then historical,
+// with cancelled last. Reuses getStatus so the time thresholds stay defined
+// in exactly one place (see the keep-in-sync note on isPast above).
+const STATUS_RANK: Record<BadgeVariant, number> = {
+  arrived: 5, // in-progress: sitting down now
+  seated: 4, // in-progress: recently seated
+  upcoming: 3, // imminent (next hour)
+  scheduled: 2, // future
+  completed: 1, // historical
+};
+
+/** Numeric status rank for sorting; cancelled bookings sort last (rank 0). */
+export function statusRankFor(b: BookingDetailDto): number {
+  if (b.isCancelled) return 0;
+  return STATUS_RANK[getStatus(b.date).variant];
 }
 
 const BADGE_STYLES: Record<

--- a/openresto-frontend/components/admin/bookings/bookings.styles.ts
+++ b/openresto-frontend/components/admin/bookings/bookings.styles.ts
@@ -103,6 +103,40 @@ export const styles = StyleSheet.create({
     paddingVertical: theme.spacing.md,
   },
   thCell: { ...theme.typography.labelSmall, letterSpacing: 0.8 },
+  thCellActive: { color: undefined },
+  thSortBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingVertical: 2,
+    paddingHorizontal: 2,
+    marginVertical: -2,
+    marginHorizontal: -2,
+    borderRadius: theme.borderRadius.sm,
+  },
+  sortControl: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.sm,
+    flexWrap: "wrap",
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+  },
+  sortControlLabel: { ...theme.typography.caption, fontWeight: "600" as const },
+  sortControlChips: { flexDirection: "row", alignItems: "center", gap: 6, flexWrap: "wrap" },
+  sortChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: theme.borderRadius.full,
+    borderWidth: 1,
+  },
+  sortChipText: { ...theme.typography.caption, fontWeight: "600" as const },
+  sortChipTextActive: { color: "#fff" },
   tableRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -132,6 +166,7 @@ export const styles = StyleSheet.create({
   rowActionBtn: { padding: 6, borderRadius: theme.borderRadius.md },
 
   // Card list (mobile)
+  cardListWrap: { gap: theme.spacing.md },
   cardList: { gap: theme.spacing.md },
   listCard: {
     borderRadius: theme.borderRadius.xl,

--- a/openresto-frontend/components/admin/bookings/sorting.ts
+++ b/openresto-frontend/components/admin/bookings/sorting.ts
@@ -1,0 +1,85 @@
+import { BookingDetailDto, BookingStatusFilter } from "@/api/admin";
+import { statusRankFor } from "@/components/admin/bookings/StatusBadge";
+
+/**
+ * User-controlled sorting for the admin bookings list (issue #208).
+ *
+ * The list previously had a single hardcoded rule: sort by date, ascending for
+ * the "past" tab and descending otherwise. These helpers expose the sort as
+ * user state (column + direction) while preserving that rule as the per-filter
+ * default, so the keyboard-navigation index math in `index.tsx` (which depends
+ * on the rendered order of `sorted`) keeps working unchanged.
+ */
+
+/** Columns a booking list can be sorted by. */
+export type SortKey = "date" | "guest" | "seats" | "table" | "status";
+
+export type SortDir = "asc" | "desc";
+
+export interface SortState {
+  key: SortKey;
+  dir: SortDir;
+}
+
+/**
+ * Contextual default for a status filter. Matches the pre-sort behavior:
+ * soonest-first (asc) for everything except "past", which is most-recent-first
+ * (desc). `cancelled` follows the "past" convention — both are historical views
+ * where the most recent event is the interesting one.
+ */
+export function defaultSortFor(statusFilter: BookingStatusFilter): SortState {
+  const historical = statusFilter === "past" || statusFilter === "cancelled";
+  return { key: "date", dir: historical ? "desc" : "asc" };
+}
+
+/**
+ * Click-toggle rule for a column header:
+ * - same column → flip direction
+ * - different column → switch to it, using its natural default direction
+ *   (date/seats/status descending = newest/largest/most-urgent first;
+ *   guest/table ascending = A→Z)
+ */
+export function nextSort(current: SortState, key: SortKey): SortState {
+  if (current.key === key) {
+    return { key, dir: current.dir === "asc" ? "desc" : "asc" };
+  }
+  const defaultDir: SortDir =
+    key === "date" || key === "seats" || key === "status" ? "desc" : "asc";
+  return { key, dir: defaultDir };
+}
+
+function guestLabel(b: BookingDetailDto): string {
+  return (b.customerName ?? b.customerEmail ?? "").toLowerCase();
+}
+
+/** Raw comparator for two bookings by key/direction. */
+export function compareBookings(
+  a: BookingDetailDto,
+  b: BookingDetailDto,
+  state: SortState
+): number {
+  let diff: number;
+  switch (state.key) {
+    case "date":
+      diff = new Date(a.date).getTime() - new Date(b.date).getTime();
+      break;
+    case "guest":
+      diff = guestLabel(a).localeCompare(guestLabel(b));
+      break;
+    case "seats":
+      diff = a.seats - b.seats;
+      break;
+    case "table":
+      diff = (a.tableName ?? "").localeCompare(b.tableName ?? "");
+      break;
+    case "status":
+      diff = statusRankFor(a) - statusRankFor(b);
+      break;
+  }
+  return state.dir === "asc" ? diff : -diff;
+}
+
+/** Returns a new, sorted copy of the list (does not mutate the input). */
+export function sortBookings(bookings: BookingDetailDto[], state: SortState): BookingDetailDto[] {
+  return [...bookings].sort((a, b) => compareBookings(a, b, state));
+}

--- a/openresto-frontend/e2e/keyboard-shortcuts.spec.ts
+++ b/openresto-frontend/e2e/keyboard-shortcuts.spec.ts
@@ -232,7 +232,12 @@ test.describe("Admin keyboard shortcuts", () => {
       // first makes it reliable. Not our shortcut hook's bug (it's how any
       // focused HTML button responds to Enter), but real if a user clicks
       // the toggle then immediately uses j/k/Enter.
-      await page.getByText("TIME", { exact: true }).click();
+      //
+      // Blur via the DOM directly rather than clicking another element: the
+      // table column headers (TIME/GUEST/...) are now sortable <button>s, so
+      // clicking one would both steal focus and flip the sort out from under
+      // the "j clamps onto the last row" assumption below.
+      await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
 
       // "j" advances the selection one row at a time and clamps at the last
       // row rather than wrapping (app/(admin)/bookings/index.tsx's

--- a/openresto-frontend/tests/components/StatusBadge.test.tsx
+++ b/openresto-frontend/tests/components/StatusBadge.test.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
-import { StatusBadge, getStatus, isPast } from "@/components/admin/bookings/StatusBadge";
+import {
+  StatusBadge,
+  getStatus,
+  isPast,
+  statusRankFor,
+} from "@/components/admin/bookings/StatusBadge";
 
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
@@ -52,6 +57,28 @@ describe("getStatus", () => {
   it("returns 'Scheduled' for bookings more than 60 minutes in the future", () => {
     const date = new Date(Date.now() + 120 * 60 * 1000).toISOString();
     expect(getStatus(date)).toEqual({ label: "Scheduled", variant: "scheduled" });
+  });
+});
+
+describe("statusRankFor", () => {
+  const mk = (date: string, isCancelled = false) =>
+    ({ id: 1, restaurantId: 1, date, isCancelled }) as any;
+
+  it("ranks cancelled bookings lowest (0)", () => {
+    const now = Date.now();
+    expect(statusRankFor(mk(new Date(now + 120 * 60000).toISOString(), true))).toBe(0);
+  });
+
+  it("ranks in-progress (arrived) above upcoming/scheduled/completed", () => {
+    const now = Date.now();
+    const min = 60 * 1000;
+    const arrived = mk(new Date(now - 2 * min).toISOString());
+    const upcoming = mk(new Date(now + 30 * min).toISOString());
+    const scheduled = mk(new Date(now + 120 * min).toISOString());
+    const completed = mk(new Date(now - 100 * min).toISOString());
+    expect(statusRankFor(arrived)).toBeGreaterThan(statusRankFor(upcoming));
+    expect(statusRankFor(upcoming)).toBeGreaterThan(statusRankFor(scheduled));
+    expect(statusRankFor(scheduled)).toBeGreaterThan(statusRankFor(completed));
   });
 });
 

--- a/openresto-frontend/tests/components/admin/bookings/BookingsCardList.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingsCardList.test.tsx
@@ -32,12 +32,16 @@ const booking: BookingDetailDto = {
 } as BookingDetailDto;
 
 describe("BookingsCardList", () => {
+  const sort = { key: "date" as const, dir: "asc" as const };
+
   it("renders the customer name, email, party + table info", () => {
     render(
       <BookingsCardList
         bookings={[booking]}
         focusedRowId={null}
         onOpenBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
@@ -53,6 +57,8 @@ describe("BookingsCardList", () => {
         bookings={[{ ...booking, isCancelled: true }]}
         focusedRowId={null}
         onOpenBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
@@ -66,10 +72,26 @@ describe("BookingsCardList", () => {
         bookings={[booking]}
         focusedRowId={null}
         onOpenBooking={onOpen}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
     fireEvent.press(screen.getByTestId("booking-row-2"));
     expect(onOpen).toHaveBeenCalledWith(2);
+  });
+
+  it("renders the sort control above the cards", () => {
+    render(
+      <BookingsCardList
+        bookings={[booking]}
+        focusedRowId={null}
+        onOpenBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
+        {...theme}
+      />
+    );
+    expect(screen.getByLabelText(/Sort by Guest/)).toBeTruthy();
   });
 });

--- a/openresto-frontend/tests/components/admin/bookings/BookingsSortControl.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingsSortControl.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { BookingsSortControl } from "@/components/admin/bookings/BookingsSortControl";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+const theme = {
+  borderColor: "#ddd",
+  cardBg: "#fff",
+  mutedColor: "#888",
+  primaryColor: "#0a7ea4",
+};
+
+describe("BookingsSortControl", () => {
+  it("renders a chip per sort column", () => {
+    render(
+      <BookingsSortControl sort={{ key: "date", dir: "asc" }} onSortChange={() => {}} {...theme} />
+    );
+    expect(screen.getByText("Time")).toBeTruthy();
+    expect(screen.getByText("Guest")).toBeTruthy();
+    expect(screen.getByText("Party")).toBeTruthy();
+    expect(screen.getByText("Table")).toBeTruthy();
+    expect(screen.getByText("Status")).toBeTruthy();
+  });
+
+  it("marks the active column as sorted with its direction in the label", () => {
+    render(
+      <BookingsSortControl
+        sort={{ key: "guest", dir: "desc" }}
+        onSortChange={() => {}}
+        {...theme}
+      />
+    );
+    expect(screen.getByLabelText("Sort by Guest, descending")).toBeTruthy();
+    // Inactive chips are labeled "not sorted"
+    expect(screen.getByLabelText("Sort by Time, not sorted")).toBeTruthy();
+  });
+
+  it("calls onSortChange with the column key when a chip is pressed", () => {
+    const onSort = jest.fn();
+    render(
+      <BookingsSortControl sort={{ key: "date", dir: "asc" }} onSortChange={onSort} {...theme} />
+    );
+    fireEvent.press(screen.getByTestId("sort-chip-seats"));
+    expect(onSort).toHaveBeenCalledWith("seats");
+  });
+});

--- a/openresto-frontend/tests/components/admin/bookings/BookingsWideTable.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingsWideTable.test.tsx
@@ -31,6 +31,8 @@ const activeBooking: BookingDetailDto = {
   bookingRef: "ABC123",
 } as BookingDetailDto;
 
+const sort = { key: "date" as const, dir: "asc" as const };
+
 describe("BookingsWideTable", () => {
   it("renders one row per booking with the customer name + initials", () => {
     render(
@@ -39,6 +41,8 @@ describe("BookingsWideTable", () => {
         focusedRowId={null}
         onOpenBooking={() => {}}
         onCancelBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
@@ -55,6 +59,8 @@ describe("BookingsWideTable", () => {
         focusedRowId={null}
         onOpenBooking={() => {}}
         onCancelBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
@@ -69,6 +75,8 @@ describe("BookingsWideTable", () => {
         focusedRowId={null}
         onOpenBooking={() => {}}
         onCancelBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
@@ -84,6 +92,8 @@ describe("BookingsWideTable", () => {
         focusedRowId={null}
         onOpenBooking={onOpen}
         onCancelBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
@@ -99,10 +109,65 @@ describe("BookingsWideTable", () => {
         focusedRowId={null}
         onOpenBooking={() => {}}
         onCancelBooking={onCancel}
+        sort={sort}
+        onSortChange={() => {}}
         {...theme}
       />
     );
     fireEvent.press(screen.getByLabelText("Cancel booking"));
     expect(onCancel).toHaveBeenCalledWith(activeBooking);
+  });
+
+  it("renders sortable TIME/GUEST/PARTY/TABLE headers (STATUS is not sortable)", () => {
+    render(
+      <BookingsWideTable
+        bookings={[activeBooking]}
+        focusedRowId={null}
+        onOpenBooking={() => {}}
+        onCancelBooking={() => {}}
+        sort={sort}
+        onSortChange={() => {}}
+        {...theme}
+      />
+    );
+    expect(screen.getByLabelText(/Sort by TIME/)).toBeTruthy();
+    expect(screen.getByLabelText(/Sort by GUEST/)).toBeTruthy();
+    expect(screen.getByLabelText(/Sort by PARTY/)).toBeTruthy();
+    expect(screen.getByLabelText(/Sort by TABLE/)).toBeTruthy();
+    expect(screen.getByLabelText(/Sort by STATUS/)).toBeTruthy();
+  });
+
+  it("marks the active column header with its sort direction in the label", () => {
+    render(
+      <BookingsWideTable
+        bookings={[activeBooking]}
+        focusedRowId={null}
+        onOpenBooking={() => {}}
+        onCancelBooking={() => {}}
+        sort={{ key: "guest", dir: "desc" }}
+        onSortChange={() => {}}
+        {...theme}
+      />
+    );
+    expect(screen.getByLabelText("Sort by GUEST, descending")).toBeTruthy();
+    // An inactive header is labeled "not sorted".
+    expect(screen.getByLabelText("Sort by TIME, not sorted")).toBeTruthy();
+  });
+
+  it("calls onSortChange with the column key when a header is pressed", () => {
+    const onSort = jest.fn();
+    render(
+      <BookingsWideTable
+        bookings={[activeBooking]}
+        focusedRowId={null}
+        onOpenBooking={() => {}}
+        onCancelBooking={() => {}}
+        sort={sort}
+        onSortChange={onSort}
+        {...theme}
+      />
+    );
+    fireEvent.press(screen.getByTestId("sort-header-table"));
+    expect(onSort).toHaveBeenCalledWith("table");
   });
 });

--- a/openresto-frontend/tests/components/admin/bookings/sorting.test.ts
+++ b/openresto-frontend/tests/components/admin/bookings/sorting.test.ts
@@ -1,0 +1,150 @@
+import {
+  compareBookings,
+  defaultSortFor,
+  nextSort,
+  sortBookings,
+} from "@/components/admin/bookings/sorting";
+import { BookingDetailDto, BookingStatusFilter } from "@/api/admin";
+
+const mk = (over: Partial<BookingDetailDto>): BookingDetailDto =>
+  ({
+    id: 1,
+    restaurantId: 1,
+    restaurantName: "R",
+    sectionId: null,
+    sectionName: "S",
+    tableId: null,
+    tableName: "T1",
+    date: "2026-01-01T12:00:00Z",
+    customerEmail: "a@x.com",
+    seats: 2,
+    ...over,
+  }) as BookingDetailDto;
+
+const A = mk({
+  id: 1,
+  customerName: "Alice",
+  date: "2026-03-01T10:00:00Z",
+  seats: 4,
+  tableName: "T3",
+});
+const B = mk({
+  id: 2,
+  customerName: "Bob",
+  date: "2026-02-01T10:00:00Z",
+  seats: 2,
+  tableName: "T1",
+});
+const C = mk({
+  id: 3,
+  customerName: "Carol",
+  date: "2026-01-01T10:00:00Z",
+  seats: 6,
+  tableName: "T2",
+});
+
+describe("defaultSortFor", () => {
+  it("defaults active/all to date ascending (soonest first)", () => {
+    expect(defaultSortFor("active")).toEqual({ key: "date", dir: "asc" });
+    expect(defaultSortFor("all")).toEqual({ key: "date", dir: "asc" });
+  });
+
+  it("defaults past/cancelled to date descending (most-recent first)", () => {
+    const filters: BookingStatusFilter[] = ["past", "cancelled"];
+    filters.forEach((f) => expect(defaultSortFor(f)).toEqual({ key: "date", dir: "desc" }));
+  });
+});
+
+describe("nextSort", () => {
+  it("flips direction when the same column is pressed", () => {
+    expect(nextSort({ key: "date", dir: "asc" }, "date")).toEqual({ key: "date", dir: "desc" });
+    expect(nextSort({ key: "date", dir: "desc" }, "date")).toEqual({ key: "date", dir: "asc" });
+  });
+
+  it("switches to a new column with its natural default direction", () => {
+    // date/seats/status default to desc (newest/largest/most-urgent first)
+    expect(nextSort({ key: "guest", dir: "asc" }, "date")).toEqual({ key: "date", dir: "desc" });
+    expect(nextSort({ key: "date", dir: "asc" }, "seats")).toEqual({ key: "seats", dir: "desc" });
+    expect(nextSort({ key: "date", dir: "asc" }, "status")).toEqual({ key: "status", dir: "desc" });
+    // guest/table default to asc (A→Z)
+    expect(nextSort({ key: "date", dir: "desc" }, "guest")).toEqual({ key: "guest", dir: "asc" });
+    expect(nextSort({ key: "date", dir: "desc" }, "table")).toEqual({ key: "table", dir: "asc" });
+  });
+});
+
+describe("compareBookings", () => {
+  it("sorts by date ascending and descending", () => {
+    expect(compareBookings(A, B, { key: "date", dir: "asc" })).toBeGreaterThan(0); // A is later
+    expect(compareBookings(A, B, { key: "date", dir: "desc" })).toBeLessThan(0);
+  });
+
+  it("sorts by guest alphabetically (case-insensitive), falling back to email", () => {
+    expect(compareBookings(A, B, { key: "guest", dir: "asc" })).toBeLessThan(0); // Alice < Bob
+    const noName1 = mk({ id: 9, customerName: undefined, customerEmail: "zoe@x.com" });
+    const noName2 = mk({ id: 10, customerName: undefined, customerEmail: "amy@x.com" });
+    expect(compareBookings(noName1, noName2, { key: "guest", dir: "asc" })).toBeGreaterThan(0);
+  });
+
+  it("sorts by seats numerically", () => {
+    expect(compareBookings(A, B, { key: "seats", dir: "asc" })).toBeGreaterThan(0); // 4 > 2
+    expect(compareBookings(A, B, { key: "seats", dir: "desc" })).toBeLessThan(0);
+  });
+
+  it("sorts by table name alphabetically", () => {
+    expect(compareBookings(A, B, { key: "table", dir: "asc" })).toBeGreaterThan(0); // T3 > T1
+    expect(compareBookings(A, B, { key: "table", dir: "desc" })).toBeLessThan(0);
+  });
+
+  it("sorts by status lifecycle rank (cancelled last; arrived > scheduled > completed asc)", () => {
+    // Build bookings that land in distinct status variants relative to now.
+    const now = Date.now();
+    const min = 60 * 1000;
+    const arrived = mk({ id: 11, date: new Date(now - 2 * min).toISOString() }); // arrived
+    const scheduled = mk({ id: 12, date: new Date(now + 120 * min).toISOString() }); // scheduled
+    const completed = mk({ id: 13, date: new Date(now - 100 * min).toISOString() }); // completed
+    const cancelled = mk({
+      id: 14,
+      date: new Date(now + 120 * min).toISOString(),
+      isCancelled: true,
+    });
+
+    // Ascending rank: completed(low) < scheduled < arrived ; cancelled is lowest.
+    expect(compareBookings(completed, arrived, { key: "status", dir: "asc" })).toBeLessThan(0);
+    expect(compareBookings(arrived, scheduled, { key: "status", dir: "asc" })).toBeGreaterThan(0);
+    expect(compareBookings(scheduled, completed, { key: "status", dir: "asc" })).toBeGreaterThan(0);
+    // Cancelled ranks below everything (asc => comes last).
+    expect(compareBookings(cancelled, completed, { key: "status", dir: "asc" })).toBeLessThan(0);
+  });
+});
+
+describe("sortBookings", () => {
+  it("returns a new sorted copy and does not mutate the input", () => {
+    const input = [A, B, C];
+    const out = sortBookings(input, { key: "date", dir: "asc" });
+    expect(out.map((b) => b.id)).toEqual([C.id, B.id, A.id]);
+    // input order untouched
+    expect(input.map((b) => b.id)).toEqual([A.id, B.id, C.id]);
+    // new array reference
+    expect(out).not.toBe(input);
+  });
+
+  it("sorts seats descending (largest party first)", () => {
+    const out = sortBookings([A, B, C], { key: "seats", dir: "desc" });
+    expect(out.map((b) => b.id)).toEqual([C.id, A.id, B.id]);
+  });
+
+  it("sorts by status descending (most attention-worthy first, cancelled last)", () => {
+    const now = Date.now();
+    const min = 60 * 1000;
+    const scheduled = mk({ id: 12, date: new Date(now + 120 * min).toISOString() });
+    const arrived = mk({ id: 11, date: new Date(now - 2 * min).toISOString() });
+    const cancelled = mk({
+      id: 14,
+      date: new Date(now + 120 * min).toISOString(),
+      isCancelled: true,
+    });
+    // desc => highest rank first: arrived > scheduled > ... > cancelled
+    const out = sortBookings([scheduled, cancelled, arrived], { key: "status", dir: "desc" });
+    expect(out.map((b) => b.id)).toEqual([arrived.id, scheduled.id, cancelled.id]);
+  });
+});


### PR DESCRIPTION
Closes #208.

## Summary

Adds real, user-controlled sorting to the admin bookings list, replacing the single hardcoded date sort. Both views gain a sort affordance, and the chosen column + direction persist across sessions.

The issue was filed underspecified (screenshot-only, no description), but the codebase gap and title ("for clarity with sorting") pointed clearly at sortability. Per discussion, scope is **sorting + tasteful visual polish**, and **STATUS is included** as a sortable column.

## What changed

**Sort logic — `components/admin/bookings/sorting.ts` (new, pure & unit-tested)**
- `SortKey` (`date | guest | seats | table | status`), `SortDir`, `SortState`
- `compareBookings` / `sortBookings` (returns a new copy, never mutates)
- `nextSort` — header toggle rule (same column flips direction; new column picks its natural default)
- `defaultSortFor(statusFilter)` — encodes the *old* hardcoded rule as the per-tab default, so nothing changes for users who never touch the sort

**Screen — `app/(admin)/bookings/index.tsx`**
- Persisted sort state (`usePersistedState("bookings:sort", …)`)
- Generic comparator replaces the fixed date sort
- Ref-guarded effect resets to the contextual default on a **real** status-filter change (not on mount — a persisted preference survives reload)
- The `j`/`k`/`Enter`/`e` keyboard nav is unchanged; it operates on the rendered `sorted` array regardless of which column drove it

**Wide table — `BookingsWideTable.tsx`**
- TIME / GUEST / PARTY / TABLE / **STATUS** are now pressable headers with a direction chevron (active column tinted in the primary color)
- Subtle zebra striping for scannability (translucent so the focused-row tint still reads on top)

**Mobile — `BookingsSortControl.tsx` (new) + `BookingsCardList.tsx`**
- Cards have no column headers, so a chip row above the list offers the same five sort axes; tapping the active chip flips direction

**Status sort — `StatusBadge.tsx`**
- New `statusRankFor(booking)` helper gives status a lifecycle rank: `arrived > seated > upcoming > scheduled > completed`, with **cancelled last**. Reuses `getStatus` so the time thresholds stay defined in exactly one place (the file already warns against duplicating them). Sorting descending surfaces the most attention-worthy rows first.

## Status sort order (ascending → descending)

| Rank | Variant |
|---|---|
| 5 | arrived |
| 4 | seated |
| 3 | upcoming |
| 2 | scheduled |
| 1 | completed |
| 0 | cancelled |

## Out of scope (per issue)
- Existing status-filter row — already works as a filter, untouched
- `timetable` view mode

## Verification
- `tsc --noEmit`: clean
- `npm run check` (prettier + oxlint): 0 errors
- `npm test`: **1812 pass** (142 suites) — including new `sorting.test.ts`, `BookingsSortControl.test.tsx`, and updated `BookingsWideTable`/`BookingsCardList`/`StatusBadge` suites

## Notes for review
- The sort-reset-on-tab-change was the subtlest piece — first pass reset on every effect run (which would clobber a persisted preference on reload); refactored to skip the mount run via a `useRef` sentinel.
- STATUS sort reuses `getStatus` thresholds rather than re-deriving them, so it stays correct if those buckets ever change.