### PR TITLE
feat: home-page customization (#183, #184, #185, #187)

### DIFF
--- a/OpenRestoApi.Tests/Services/BrandServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BrandServiceTests.cs
@@ -171,6 +171,120 @@ public class BrandServiceTests
         Assert.Null(result.WebsiteUrl);
     }
 
+    // ── Subtitle (#183) ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveAsync_Throws_WhenSubtitleTooLong()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Throws_WhenSubtitleTooLong));
+        var svc = CreateService(db);
+        await Assert.ThrowsAsync<ValidationException>(
+            () => svc.SaveAsync(null, null, null, subtitle: new string('a', 161)));
+    }
+
+    [Fact]
+    public async Task SaveAsync_Persists_Subtitle_Trimmed()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Persists_Subtitle_Trimmed));
+        var svc = CreateService(db);
+        await svc.SaveAsync(null, null, null, subtitle: "  A cozy neighborhood spot  ");
+        BrandSettings result = await svc.GetAsync();
+        Assert.Equal("A cozy neighborhood spot", result.Subtitle);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Clears_Subtitle_WhenBlankPassed()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Clears_Subtitle_WhenBlankPassed));
+        var svc = CreateService(db);
+        await svc.SaveAsync(null, null, null, subtitle: "A tagline");
+        await svc.SaveAsync(null, null, null, subtitle: "   ");
+        BrandSettings result = await svc.GetAsync();
+        Assert.Null(result.Subtitle);
+    }
+
+    // ── Highlights heading / subheading (#185) ────────────────────────────────
+
+    [Fact]
+    public async Task SaveAsync_Persists_HighlightsHeading_AndSubheading()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Persists_HighlightsHeading_AndSubheading));
+        var svc = CreateService(db);
+        await svc.SaveAsync(
+            null, null, null,
+            highlightsHeading: "What we love",
+            highlightsSubheading: "Picked fresh weekly");
+        BrandSettings result = await svc.GetAsync();
+        Assert.Equal("What we love", result.HighlightsHeading);
+        Assert.Equal("Picked fresh weekly", result.HighlightsSubheading);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Throws_WhenHighlightsHeadingTooLong()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Throws_WhenHighlightsHeadingTooLong));
+        var svc = CreateService(db);
+        await Assert.ThrowsAsync<ValidationException>(
+            () => svc.SaveAsync(null, null, null, highlightsHeading: new string('a', 61)));
+    }
+
+    // ── Header image fit (#187) ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Cover")]
+    [InlineData("Contain")]
+    [InlineData("cover")]   // case-insensitive, normalized to canonical casing
+    [InlineData("CONTAIN")]
+    public async Task SaveAsync_Persists_HeaderImageFit_WhenAllowed(string fit)
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Persists_HeaderImageFit_WhenAllowed) + fit);
+        var svc = CreateService(db);
+        await svc.SaveAsync(null, null, null, headerImageFit: fit);
+        BrandSettings result = await svc.GetAsync();
+        Assert.NotNull(result.HeaderImageFit);
+        // Canonical casing (first-letter-capitalized form from the allow-list)
+        Assert.Equal(System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(fit.ToLower()),
+            result.HeaderImageFit);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Throws_WhenHeaderImageFitInvalid()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Throws_WhenHeaderImageFitInvalid));
+        var svc = CreateService(db);
+        await Assert.ThrowsAsync<ValidationException>(
+            () => svc.SaveAsync(null, null, null, headerImageFit: "fill"));
+    }
+
+    [Fact]
+    public async Task SaveAsync_Clears_HeaderImageFit_WhenBlankPassed()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Clears_HeaderImageFit_WhenBlankPassed));
+        var svc = CreateService(db);
+        await svc.SaveAsync(null, null, null, headerImageFit: "Contain");
+        await svc.SaveAsync(null, null, null, headerImageFit: "   ");
+        BrandSettings result = await svc.GetAsync();
+        Assert.Null(result.HeaderImageFit);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Preserves_HeaderImageFit_WhenNullPassed()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(SaveAsync_Preserves_HeaderImageFit_WhenNullPassed));
+        var svc = CreateService(db);
+        await svc.SaveAsync(null, null, null, headerImageFit: "Contain");
+        await svc.SaveAsync(null, null, null, headerImageFit: null);
+        BrandSettings result = await svc.GetAsync();
+        Assert.Equal("Contain", result.HeaderImageFit);
+    }
+
+    [Fact]
+    public void AllowedHeaderImageFits_ContainsCoverAndContain()
+    {
+        Assert.Contains("Cover", BrandService.AllowedHeaderImageFits);
+        Assert.Contains("Contain", BrandService.AllowedHeaderImageFits);
+    }
+
     [Fact]
     public void GetWebsiteUrl_ReturnsBrandWebsiteUrl_WhenSet()
     {

--- a/OpenRestoApi.Tests/Services/HighlightServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/HighlightServiceTests.cs
@@ -75,6 +75,44 @@ public class HighlightServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_PersistsLink_Trimmed_AndReturnsDto()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_PersistsLink_Trimmed_AndReturnsDto));
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = "Test",
+            Body = "body",
+            IconKey = "star",
+            SortOrder = 0,
+            Link = "  https://example.com/menu  "
+        };
+
+        HighlightDto result = await svc.CreateAsync(req);
+
+        Assert.Equal("https://example.com/menu", result.Link);
+    }
+
+    [Fact]
+    public async Task CreateAsync_NormalizesBlankLink_ToNull()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_NormalizesBlankLink_ToNull));
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = "Test",
+            Body = "body",
+            IconKey = "star",
+            SortOrder = 0,
+            Link = "   "
+        };
+
+        HighlightDto result = await svc.CreateAsync(req);
+
+        Assert.Null(result.Link);
+    }
+
+    [Fact]
     public async Task UpdateAsync_ReturnsUpdatedDto_WhenFound()
     {
         using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_ReturnsUpdatedDto_WhenFound));
@@ -83,7 +121,14 @@ public class HighlightServiceTests
         int id = db.Highlights.First().Id;
 
         var svc = new HighlightService(new HighlightRepository(db));
-        var req = new UpdateHighlightRequest { Title = "New", Body = "new body", IconKey = "flame", SortOrder = 5 };
+        var req = new UpdateHighlightRequest
+        {
+            Title = "New",
+            Body = "new body",
+            IconKey = "flame",
+            SortOrder = 5,
+            Link = "https://example.com"
+        };
 
         HighlightDto? result = await svc.UpdateAsync(id, req);
 
@@ -92,6 +137,57 @@ public class HighlightServiceTests
         Assert.Equal("new body", result.Body);
         Assert.Equal("flame", result.IconKey);
         Assert.Equal(5, result.SortOrder);
+        Assert.Equal("https://example.com", result.Link);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ClearsLink_WhenBlankProvided()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_ClearsLink_WhenBlankProvided));
+        db.Highlights.Add(new RestaurantHighlight
+        {
+            Title = "H",
+            Body = "b",
+            SortOrder = 0,
+            Link = "https://example.com"
+        });
+        await db.SaveChangesAsync();
+        int id = db.Highlights.First().Id;
+
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new UpdateHighlightRequest
+        {
+            Title = "H",
+            Body = "b",
+            IconKey = "star-outline",
+            SortOrder = 0,
+            Link = "   "
+        };
+
+        HighlightDto? result = await svc.UpdateAsync(id, req);
+
+        Assert.NotNull(result);
+        Assert.Null(result.Link);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_MapsLink()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAllAsync_MapsLink));
+        db.Highlights.Add(new RestaurantHighlight
+        {
+            Title = "T",
+            Body = "B",
+            SortOrder = 0,
+            Link = "https://example.com"
+        });
+        await db.SaveChangesAsync();
+
+        var svc = new HighlightService(new HighlightRepository(db));
+        List<HighlightDto> result = await svc.GetAllAsync();
+
+        HighlightDto dto = Assert.Single(result);
+        Assert.Equal("https://example.com", dto.Link);
     }
 
     [Fact]

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -118,6 +118,79 @@ public class RestaurantManagementServiceTests
         Assert.Equal("GMT", result.Timezone);
     }
 
+    // ── Description blurb (#184) ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_Persists_Description_Trimmed()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_Persists_Description_Trimmed));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            Description = "  A cozy spot with [menu](https://example.com) links.  "
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("A cozy spot with [menu](https://example.com) links.", result.Description);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Clears_Description_WhenBlank()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_Clears_Description_WhenBlank));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC", Description = "Old blurb" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            Description = "   "
+        });
+
+        Assert.NotNull(result);
+        Assert.Null(result.Description);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Keeps_Description_WhenNull()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_Keeps_Description_WhenNull));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC", Description = "Persisted blurb" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        // No Description on the request → PATCH leaves it untouched.
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest { Name = "R2" });
+
+        Assert.NotNull(result);
+        Assert.Equal("Persisted blurb", result.Description);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Returns_Description()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetByIdAsync_Returns_Description));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "R",
+            Timezone = "UTC",
+            Description = "Our little place"
+        });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.GetByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal("Our little place", result.Description);
+    }
+
     // ── Per-day opening hours (#175) ─────────────────────────────────────────
 
     [Fact]

--- a/OpenRestoApi/Controllers/BrandController.cs
+++ b/OpenRestoApi/Controllers/BrandController.cs
@@ -28,6 +28,10 @@ public class BrandController(BrandService brandService) : ControllerBase
             WebsiteUrl = _brand.GetWebsiteUrl(brand),
             FaviconIcon = brand.FaviconIcon,
             CopyrightText = brand.CopyrightText,
+            Subtitle = brand.Subtitle,
+            HighlightsHeading = brand.HighlightsHeading,
+            HighlightsSubheading = brand.HighlightsSubheading,
+            HeaderImageFit = brand.HeaderImageFit,
         });
     }
 
@@ -97,7 +101,11 @@ public class BrandController(BrandService brandService) : ControllerBase
             req.AccentColor,
             req.FaviconIcon,
             req.WebsiteUrl,
-            req.CopyrightText);
+            req.CopyrightText,
+            req.Subtitle,
+            req.HighlightsHeading,
+            req.HighlightsSubheading,
+            req.HeaderImageFit);
         return Ok(new { message = "Brand settings saved." });
     }
 }
@@ -113,6 +121,18 @@ public class BrandRequest
 
     [StringLength(200, ErrorMessage = "Copyright text cannot exceed 200 characters.")]
     public string? CopyrightText { get; set; }
+
+    [StringLength(160, ErrorMessage = "Subtitle cannot exceed 160 characters.")]
+    public string? Subtitle { get; set; }
+
+    [StringLength(60, ErrorMessage = "Highlights heading cannot exceed 60 characters.")]
+    public string? HighlightsHeading { get; set; }
+
+    [StringLength(60, ErrorMessage = "Highlights subheading cannot exceed 60 characters.")]
+    public string? HighlightsSubheading { get; set; }
+
+    /// <summary>"Cover" (default) or "Contain". Null means leave the stored value unchanged.</summary>
+    public string? HeaderImageFit { get; set; }
 }
 
 public class BrandResponse
@@ -124,4 +144,8 @@ public class BrandResponse
     public string? WebsiteUrl { get; set; }
     public string? FaviconIcon { get; set; }
     public string? CopyrightText { get; set; }
+    public string? Subtitle { get; set; }
+    public string? HighlightsHeading { get; set; }
+    public string? HighlightsSubheading { get; set; }
+    public string? HeaderImageFit { get; set; }
 }

--- a/OpenRestoApi/Core/Application/DTOs/HighlightDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/HighlightDto.cs
@@ -7,6 +7,7 @@ public class HighlightDto
     public string Body { get; set; } = null!;
     public string IconKey { get; set; } = "star-outline";
     public int SortOrder { get; set; }
+    public string? Link { get; set; }
 }
 
 public class CreateHighlightRequest
@@ -15,6 +16,7 @@ public class CreateHighlightRequest
     public string Body { get; set; } = null!;
     public string IconKey { get; set; } = "star-outline";
     public int SortOrder { get; set; }
+    public string? Link { get; set; }
 }
 
 public class UpdateHighlightRequest
@@ -23,4 +25,5 @@ public class UpdateHighlightRequest
     public string Body { get; set; } = null!;
     public string IconKey { get; set; } = "star-outline";
     public int SortOrder { get; set; }
+    public string? Link { get; set; }
 }

--- a/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
@@ -11,6 +11,12 @@ public class UpdateRestaurantRequest
     public string? OpenDays { get; set; }
 
     /// <summary>
+    /// Optional freeform blurb shown on the public location detail page. Supports basic
+    /// markdown-style inline links. Empty string clears the field; null leaves it untouched.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
     /// Per-day opening hours (ISO day 1=Monday … 7=Sunday). When provided, takes
     /// precedence over OpenTime/CloseTime; identical hours for all 7 days collapse
     /// back into the uniform OpenTime/CloseTime pair.
@@ -109,6 +115,10 @@ public class RestaurantDto
     public string Timezone { get; set; } = "UTC";
     public string[] Tags { get; set; } = [];
     public string? ImageUrl { get; set; }
+
+    /// <summary>Optional blurb shown on the public location detail page (null when none).</summary>
+    public string? Description { get; set; }
+
     public bool IsArchived { get; set; }
 
     /// <summary>When true the whole location is walk-in only — the booking flow is disabled.</summary>

--- a/OpenRestoApi/Core/Application/Services/BrandService.cs
+++ b/OpenRestoApi/Core/Application/Services/BrandService.cs
@@ -10,6 +10,10 @@ public class BrandService(IBrandSettingsRepository brandRepository, IConfigurati
     private readonly IBrandSettingsRepository _brandRepository = brandRepository;
     private readonly IConfiguration _configuration = configuration;
 
+    /// <summary>Permitted values for <see cref="BrandSettings.HeaderImageFit"/> (case-insensitive).</summary>
+    public static readonly HashSet<string> AllowedHeaderImageFits =
+        new(StringComparer.OrdinalIgnoreCase) { "Cover", "Contain" };
+
     private static bool IsValidHexColor(string color)
     {
         return Regex.IsMatch(color, @"^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$");
@@ -58,7 +62,11 @@ public class BrandService(IBrandSettingsRepository brandRepository, IConfigurati
         string? accentColor,
         string? faviconIcon = null,
         string? websiteUrl = null,
-        string? copyrightText = null)
+        string? copyrightText = null,
+        string? subtitle = null,
+        string? highlightsHeading = null,
+        string? highlightsSubheading = null,
+        string? headerImageFit = null)
     {
         if (appName != null && appName.Length > 32)
         {
@@ -85,6 +93,31 @@ public class BrandService(IBrandSettingsRepository brandRepository, IConfigurati
             throw new ValidationException("Copyright text cannot exceed 200 characters.");
         }
 
+        if (subtitle != null && subtitle.Length > 160)
+        {
+            throw new ValidationException("Subtitle cannot exceed 160 characters.");
+        }
+
+        if (highlightsHeading != null && highlightsHeading.Length > 60)
+        {
+            throw new ValidationException("Highlights heading cannot exceed 60 characters.");
+        }
+
+        if (highlightsSubheading != null && highlightsSubheading.Length > 60)
+        {
+            throw new ValidationException("Highlights subheading cannot exceed 60 characters.");
+        }
+
+        // Empty string clears the fit (falls back to the default "Cover"); a non-empty value
+        // must be one of the allowed modes. Null leaves the stored value untouched.
+        if (headerImageFit != null
+            && !string.IsNullOrWhiteSpace(headerImageFit)
+            && !AllowedHeaderImageFits.Contains(headerImageFit))
+        {
+            throw new ValidationException(
+                $"HeaderImageFit must be one of: {string.Join(", ", AllowedHeaderImageFits.Order())}.");
+        }
+
         BrandSettings? brand = await _brandRepository.GetAsync();
         bool isNew = false;
         if (brand == null)
@@ -107,6 +140,32 @@ public class BrandService(IBrandSettingsRepository brandRepository, IConfigurati
         if (copyrightText != null)
         {
             brand.CopyrightText = string.IsNullOrWhiteSpace(copyrightText) ? null : copyrightText.Trim();
+        }
+        if (subtitle != null)
+        {
+            brand.Subtitle = string.IsNullOrWhiteSpace(subtitle) ? null : subtitle.Trim();
+        }
+        if (highlightsHeading != null)
+        {
+            brand.HighlightsHeading = string.IsNullOrWhiteSpace(highlightsHeading) ? null : highlightsHeading.Trim();
+        }
+        if (highlightsSubheading != null)
+        {
+            brand.HighlightsSubheading = string.IsNullOrWhiteSpace(highlightsSubheading) ? null : highlightsSubheading.Trim();
+        }
+        // HeaderImageFit: blank/whitespace clears to null (→ default Cover). Normalize casing
+        // of the allowed value (e.g. "contain" → "Contain") so persisted data is canonical.
+        if (headerImageFit != null)
+        {
+            if (string.IsNullOrWhiteSpace(headerImageFit))
+            {
+                brand.HeaderImageFit = null;
+            }
+            else
+            {
+                brand.HeaderImageFit = AllowedHeaderImageFits.First(f =>
+                    f.Equals(headerImageFit, StringComparison.OrdinalIgnoreCase));
+            }
         }
 
         if (isNew)

--- a/OpenRestoApi/Core/Application/Services/HighlightService.cs
+++ b/OpenRestoApi/Core/Application/Services/HighlightService.cs
@@ -22,6 +22,7 @@ public class HighlightService(IHighlightRepository highlightRepository)
             Body = req.Body,
             IconKey = req.IconKey,
             SortOrder = req.SortOrder,
+            Link = NormalizeLink(req.Link),
         };
         await _highlightRepository.AddAsync(entity);
         return ToDto(entity);
@@ -38,6 +39,7 @@ public class HighlightService(IHighlightRepository highlightRepository)
         entity.Body = req.Body;
         entity.IconKey = req.IconKey;
         entity.SortOrder = req.SortOrder;
+        entity.Link = NormalizeLink(req.Link);
         await _highlightRepository.SaveChangesAsync();
         return ToDto(entity);
     }
@@ -61,5 +63,19 @@ public class HighlightService(IHighlightRepository highlightRepository)
         Body = h.Body,
         IconKey = h.IconKey,
         SortOrder = h.SortOrder,
+        Link = h.Link,
     };
+
+    /// <summary>
+    /// Trims the link URL and treats blank/whitespace as null so empty inputs are stored
+    /// consistently (matching the whitespace-to-null convention used for brand text fields).
+    /// </summary>
+    private static string? NormalizeLink(string? link)
+    {
+        if (string.IsNullOrWhiteSpace(link))
+        {
+            return null;
+        }
+        return link.Trim();
+    }
 }

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -62,6 +62,10 @@ public class RestaurantManagementService(
 
         r.Name = req.Name;
         r.Address = req.Address;
+        if (req.Description != null)
+        {
+            r.Description = string.IsNullOrWhiteSpace(req.Description) ? null : req.Description.Trim();
+        }
         if (req.OpenTime != null)
         {
             r.OpenTime = req.OpenTime;
@@ -129,6 +133,7 @@ public class RestaurantManagementService(
                 ? []
                 : r.Tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
             ImageUrl = r.ImageUrl,
+            Description = r.Description,
             WalkInOnly = r.WalkInOnly,
             WalkInDays = r.WalkInDays ?? "",
             DefaultBookingDurationMinutes = r.DefaultBookingDurationMinutes,
@@ -259,6 +264,7 @@ public class RestaurantManagementService(
             ? []
             : r.Tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
         ImageUrl = r.ImageUrl,
+        Description = r.Description,
         IsArchived = r.IsArchived,
         WalkInOnly = r.WalkInOnly,
         WalkInDays = r.WalkInDays ?? "",

--- a/OpenRestoApi/Core/Domain/BrandSettings.cs
+++ b/OpenRestoApi/Core/Domain/BrandSettings.cs
@@ -20,4 +20,32 @@ public class BrandSettings
 
     [StringLength(200)]
     public string? CopyrightText { get; set; }
+
+    /// <summary>
+    /// Short tagline shown under <see cref="AppName"/> on the home page, in place of the
+    /// hard-coded default subheading. Null falls back to the default copy.
+    /// </summary>
+    [StringLength(160)]
+    public string? Subtitle { get; set; }
+
+    /// <summary>
+    /// Optional heading text above the home page highlights section
+    /// (defaults to "Restaurant highlights" when null).
+    /// </summary>
+    [StringLength(60)]
+    public string? HighlightsHeading { get; set; }
+
+    /// <summary>
+    /// Optional subheading text above the home page highlights section
+    /// (defaults to "Curated by the owner" when null).
+    /// </summary>
+    [StringLength(60)]
+    public string? HighlightsSubheading { get; set; }
+
+    /// <summary>
+    /// How the home page hero image is fit into its frame. Null/"Cover" (the default)
+    /// keeps today's behaviour; "Contain" shows the whole image. See <see cref="HeaderImageFit"/>.
+    /// </summary>
+    [StringLength(10)]
+    public string? HeaderImageFit { get; set; }
 }

--- a/OpenRestoApi/Core/Domain/Restaurant.cs
+++ b/OpenRestoApi/Core/Domain/Restaurant.cs
@@ -43,6 +43,13 @@ public class Restaurant
 
     public string? ImageUrl { get; set; }
 
+    /// <summary>
+    /// Optional freeform blurb shown on the public location detail page. Supports basic
+    /// markdown-style inline links (e.g. "See our [menu](https://example.com/menu)").
+    /// Null/empty hides the blurb entirely.
+    /// </summary>
+    public string? Description { get; set; }
+
     public bool IsArchived { get; set; }
 
     /// <summary>

--- a/OpenRestoApi/Core/Domain/RestaurantHighlight.cs
+++ b/OpenRestoApi/Core/Domain/RestaurantHighlight.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace OpenRestoApi.Core.Domain;
 
 public class RestaurantHighlight
@@ -7,4 +9,11 @@ public class RestaurantHighlight
     public string Body { get; set; } = null!;
     public string IconKey { get; set; } = "star-outline";
     public int SortOrder { get; set; }
+
+    /// <summary>
+    /// Optional URL the highlight links to from the home page. Null/empty renders the
+    /// highlight as a plain (non-clickable) card, exactly as it did before this field existed.
+    /// </summary>
+    [StringLength(500)]
+    public string? Link { get; set; }
 }

--- a/OpenRestoApi/Migrations/20260714155638_AddHomePageCustomization.Designer.cs
+++ b/OpenRestoApi/Migrations/20260714155638_AddHomePageCustomization.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpenRestoApi.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using OpenRestoApi.Infrastructure.Persistence;
 namespace OpenRestoApi.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714155638_AddHomePageCustomization")]
+    partial class AddHomePageCustomization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.9");

--- a/OpenRestoApi/Migrations/20260714155638_AddHomePageCustomization.cs
+++ b/OpenRestoApi/Migrations/20260714155638_AddHomePageCustomization.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OpenRestoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHomePageCustomization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Restaurants",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Link",
+                table: "Highlights",
+                type: "TEXT",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HeaderImageFit",
+                table: "BrandSettings",
+                type: "TEXT",
+                maxLength: 10,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HighlightsHeading",
+                table: "BrandSettings",
+                type: "TEXT",
+                maxLength: 60,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HighlightsSubheading",
+                table: "BrandSettings",
+                type: "TEXT",
+                maxLength: 60,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Subtitle",
+                table: "BrandSettings",
+                type: "TEXT",
+                maxLength: 160,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Restaurants");
+
+            migrationBuilder.DropColumn(
+                name: "Link",
+                table: "Highlights");
+
+            migrationBuilder.DropColumn(
+                name: "HeaderImageFit",
+                table: "BrandSettings");
+
+            migrationBuilder.DropColumn(
+                name: "HighlightsHeading",
+                table: "BrandSettings");
+
+            migrationBuilder.DropColumn(
+                name: "HighlightsSubheading",
+                table: "BrandSettings");
+
+            migrationBuilder.DropColumn(
+                name: "Subtitle",
+                table: "BrandSettings");
+        }
+    }
+}

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -494,6 +494,10 @@ export interface BrandSettingsDto {
   faviconIcon?: string;
   websiteUrl?: string;
   copyrightText?: string;
+  subtitle?: string;
+  highlightsHeading?: string;
+  highlightsSubheading?: string;
+  headerImageFit?: string;
 }
 
 export async function saveBrandSettings(
@@ -548,6 +552,7 @@ export interface AdminHighlightDto {
   body: string;
   iconKey: string;
   sortOrder: number;
+  link?: string | null;
 }
 
 export interface CreateHighlightRequest {
@@ -555,6 +560,7 @@ export interface CreateHighlightRequest {
   body: string;
   iconKey: string;
   sortOrder: number;
+  link?: string | null;
 }
 
 export interface UpdateHighlightRequest {
@@ -562,6 +568,7 @@ export interface UpdateHighlightRequest {
   body: string;
   iconKey: string;
   sortOrder: number;
+  link?: string | null;
 }
 
 export async function adminGetHighlights(): Promise<AdminHighlightDto[]> {

--- a/openresto-frontend/api/restaurants.ts
+++ b/openresto-frontend/api/restaurants.ts
@@ -32,6 +32,8 @@ export interface RestaurantDto {
   timezone: string;
   tags?: string[];
   imageUrl?: string | null;
+  /** Optional blurb shown on the location detail page (supports [label](url) links). */
+  description?: string | null;
   isArchived?: boolean;
   /** When true the whole location is walk-in only — the booking flow is disabled. */
   walkInOnly?: boolean;
@@ -86,6 +88,7 @@ export interface HighlightDto {
   body: string;
   iconKey: string;
   sortOrder: number;
+  link?: string | null;
 }
 
 export async function fetchHighlights(): Promise<HighlightDto[]> {
@@ -132,6 +135,7 @@ export async function updateRestaurant(
     defaultBookingDurationMinutes?: number;
     walkInOnly?: boolean;
     walkInDays?: string;
+    description?: string | null;
   }
 ): Promise<RestaurantDto | null> {
   try {

--- a/openresto-frontend/app/(user)/index.tsx
+++ b/openresto-frontend/app/(user)/index.tsx
@@ -4,7 +4,9 @@ import { fetchRestaurants, fetchHighlights, RestaurantDto, HighlightDto } from "
 import { useEffect, useState, useRef, useCallback, type ComponentProps } from "react";
 import {
   ActivityIndicator,
+  Linking,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   useWindowDimensions,
@@ -65,6 +67,19 @@ export default function HomeScreen() {
   const accentB = parseInt(accentHex.slice(4, 6), 16);
   const accentSoft = `rgba(${accentR},${accentG},${accentB},0.18)`;
 
+  // Home-page copy falls back to the pre-customization defaults when unset.
+  const DEFAULT_SUBTITLE =
+    "Scroll down to pick a location below, choose a time, enter your email address, and you're booked!";
+  const heroSubtitle = brand.subtitle?.trim() || DEFAULT_SUBTITLE;
+  const highlightsHeading = brand.highlightsHeading?.trim() || "Restaurant highlights";
+  const highlightsSubheading = brand.highlightsSubheading?.trim() || "Curated by the owner";
+
+  // "Contain" shows the whole image (avoids aggressive cropping on mobile); anything else
+  // (null unset, or "Cover") keeps today's cover behaviour — no visual regression.
+  const heroContain = brand.headerImageFit?.toLowerCase() === "contain";
+  const heroObjectFit = heroContain ? "contain" : "cover";
+  const heroObjectPosition = heroContain ? "center top" : "center";
+
   const numColumns = width < 600 ? 1 : width < 1000 ? 2 : 3;
   const numHighlightCols = width < 600 ? 1 : width < 900 ? 2 : 4;
 
@@ -111,8 +126,8 @@ export default function HomeScreen() {
                     bottom: 0,
                     width: "100%",
                     height: "100%",
-                    objectFit: "cover",
-                    objectPosition: "center",
+                    objectFit: heroObjectFit,
+                    objectPosition: heroObjectPosition,
                     pointerEvents: "none",
                   }}
                 />
@@ -146,8 +161,7 @@ export default function HomeScreen() {
                   {brand.appName}
                 </ThemedText>
                 <ThemedText style={[styles.heroSub, { color: mutedColor }]}>
-                  Scroll down to pick a location below, choose a time, enter your email address, and
-                  you're booked!
+                  {heroSubtitle}
                 </ThemedText>
               </View>
             </View>
@@ -164,7 +178,7 @@ export default function HomeScreen() {
                       hasHero && ({ textShadow: heroTextShadow } as object),
                     ]}
                   >
-                    Restaurant highlights
+                    {highlightsHeading}
                   </ThemedText>
                   <ThemedText
                     style={[
@@ -173,7 +187,7 @@ export default function HomeScreen() {
                       hasHero && ({ textShadow: heroTextShadow } as object),
                     ]}
                   >
-                    Curated by the owner
+                    {highlightsSubheading}
                   </ThemedText>
                 </View>
                 <View
@@ -182,41 +196,68 @@ export default function HomeScreen() {
                     numHighlightCols > 1 && { flexDirection: "row", flexWrap: "wrap" },
                   ]}
                 >
-                  {highlights.map((h) => (
-                    <View
-                      key={h.id}
-                      style={[
-                        styles.highlightCard,
-                        { backgroundColor: surface, borderColor: border },
-                        numHighlightCols > 1 && {
-                          width:
-                            numHighlightCols === 2
-                              ? ("calc(50% - 6px)" as unknown as number)
-                              : ("calc(25% - 9px)" as unknown as number),
-                          minWidth: 200,
-                        },
-                      ]}
-                    >
-                      <View style={styles.highlightHeader}>
-                        <View
-                          style={[
-                            styles.highlightIconBox,
-                            { backgroundColor: `rgba(${accentR},${accentG},${accentB},0.18)` },
-                          ]}
-                        >
-                          <Ionicons
-                            name={h.iconKey as ComponentProps<typeof Ionicons>["name"]}
-                            size={16}
-                            color={primaryColor}
-                          />
+                  {highlights.map((h) => {
+                    const cardStyle = [
+                      styles.highlightCard,
+                      { backgroundColor: surface, borderColor: border },
+                      numHighlightCols > 1 && {
+                        width:
+                          numHighlightCols === 2
+                            ? ("calc(50% - 6px)" as unknown as number)
+                            : ("calc(25% - 9px)" as unknown as number),
+                        minWidth: 200,
+                      },
+                      // A linked card reads as interactive: lift it slightly.
+                      h.link && { cursor: "pointer" as const },
+                    ];
+                    const cardContent = (
+                      <>
+                        <View style={styles.highlightHeader}>
+                          <View
+                            style={[
+                              styles.highlightIconBox,
+                              {
+                                backgroundColor: `rgba(${accentR},${accentG},${accentB},0.18)`,
+                              },
+                            ]}
+                          >
+                            <Ionicons
+                              name={h.iconKey as ComponentProps<typeof Ionicons>["name"]}
+                              size={16}
+                              color={primaryColor}
+                            />
+                          </View>
+                          <ThemedText style={styles.highlightTitle}>{h.title}</ThemedText>
+                          {h.link ? (
+                            <Ionicons
+                              name="open-outline"
+                              size={13}
+                              color={mutedColor}
+                              style={{ marginLeft: "auto" }}
+                            />
+                          ) : null}
                         </View>
-                        <ThemedText style={styles.highlightTitle}>{h.title}</ThemedText>
+                        <ThemedText style={[styles.highlightBody, { color: mutedColor }]}>
+                          {h.body}
+                        </ThemedText>
+                      </>
+                    );
+                    return h.link ? (
+                      <Pressable
+                        key={h.id}
+                        accessibilityRole="link"
+                        accessibilityHint={h.link}
+                        onPress={() => Linking.openURL(h.link!)}
+                        style={cardStyle}
+                      >
+                        {cardContent}
+                      </Pressable>
+                    ) : (
+                      <View key={h.id} style={cardStyle}>
+                        {cardContent}
                       </View>
-                      <ThemedText style={[styles.highlightBody, { color: mutedColor }]}>
-                        {h.body}
-                      </ThemedText>
-                    </View>
-                  ))}
+                    );
+                  })}
                 </View>
               </View>
             )}

--- a/openresto-frontend/components/admin/settings/BrandSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/BrandSettingsCard.tsx
@@ -25,11 +25,17 @@ export function BrandSettingsCard({
   cardBg: string;
 }) {
   const brand = useBrand();
-  const { primaryColor } = useAppTheme();
+  const { primaryColor, colors } = useAppTheme();
   const [appName, setAppName] = useState(brand.appName);
   const [brandPrimaryColor, setBrandPrimaryColor] = useState(brand.primaryColor);
   const [faviconIcon, setFaviconIcon] = useState<string | undefined>(brand.faviconIcon);
   const [websiteUrl, setWebsiteUrl] = useState(brand.websiteUrl ?? "");
+  const [subtitle, setSubtitle] = useState(brand.subtitle ?? "");
+  const [highlightsHeading, setHighlightsHeading] = useState(brand.highlightsHeading ?? "");
+  const [highlightsSubheading, setHighlightsSubheading] = useState(
+    brand.highlightsSubheading ?? ""
+  );
+  const [headerImageFit, setHeaderImageFit] = useState(brand.headerImageFit ?? "Cover");
   const [heroPreview, setHeroPreview] = useState<string | null>(brand.headerImageUrl ?? null);
   const [heroUploading, setHeroUploading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -41,6 +47,10 @@ export function BrandSettingsCard({
     brandPrimaryColor !== brand.primaryColor ||
     faviconIcon !== brand.faviconIcon ||
     websiteUrl.trim() !== (brand.websiteUrl ?? "") ||
+    subtitle.trim() !== (brand.subtitle ?? "") ||
+    highlightsHeading.trim() !== (brand.highlightsHeading ?? "") ||
+    highlightsSubheading.trim() !== (brand.highlightsSubheading ?? "") ||
+    headerImageFit !== (brand.headerImageFit ?? "Cover") ||
     heroPreview !== (brand.headerImageUrl ?? null);
 
   useEffect(() => {
@@ -49,6 +59,10 @@ export function BrandSettingsCard({
     setBrandPrimaryColor(brand.primaryColor);
     setFaviconIcon(brand.faviconIcon);
     setWebsiteUrl(brand.websiteUrl ?? "");
+    setSubtitle(brand.subtitle ?? "");
+    setHighlightsHeading(brand.highlightsHeading ?? "");
+    setHighlightsSubheading(brand.highlightsSubheading ?? "");
+    setHeaderImageFit(brand.headerImageFit ?? "Cover");
     setHeroPreview(brand.headerImageUrl ?? null);
   }, [brand]);
 
@@ -94,6 +108,10 @@ export function BrandSettingsCard({
       primaryColor: brandPrimaryColor,
       faviconIcon,
       websiteUrl: websiteUrl.trim() || undefined,
+      subtitle: subtitle.trim() || "",
+      highlightsHeading: highlightsHeading.trim() || "",
+      highlightsSubheading: highlightsSubheading.trim() || "",
+      headerImageFit,
     });
     setSaving(false);
     if (result) {
@@ -157,6 +175,35 @@ export function BrandSettingsCard({
               placeholder="Open Resto"
               maxLength={32}
             />
+          </View>
+
+          <View style={styles.field}>
+            <View
+              style={{
+                flexDirection: "row",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
+              <ThemedText style={styles.fieldLabel}>Home Page Subtitle</ThemedText>
+              <ThemedText
+                style={{
+                  fontSize: 11,
+                  color: subtitle.length > 160 ? theme.colors.error : mutedColor,
+                }}
+              >
+                {subtitle.length}/160
+              </ThemedText>
+            </View>
+            <Input
+              value={subtitle}
+              onChangeText={setSubtitle}
+              placeholder="Scroll down to pick a location below…"
+              maxLength={160}
+            />
+            <ThemedText style={{ fontSize: 11, color: mutedColor, marginTop: 4 }}>
+              Tagline shown under the app name. Leave blank for the default text.
+            </ThemedText>
           </View>
 
           <View style={styles.field}>
@@ -240,10 +287,63 @@ export function BrandSettingsCard({
           </View>
 
           <View style={styles.field}>
+            <ThemedText style={styles.fieldLabel}>Highlights Heading</ThemedText>
+            <Input
+              value={highlightsHeading}
+              onChangeText={setHighlightsHeading}
+              placeholder="Restaurant highlights"
+              maxLength={60}
+            />
+            <ThemedText style={{ fontSize: 11, color: mutedColor, marginTop: 4 }}>
+              Heading above the highlights section. Leave blank for the default.
+            </ThemedText>
+          </View>
+
+          <View style={styles.field}>
+            <ThemedText style={styles.fieldLabel}>Highlights Subheading</ThemedText>
+            <Input
+              value={highlightsSubheading}
+              onChangeText={setHighlightsSubheading}
+              placeholder="Curated by the owner"
+              maxLength={60}
+            />
+          </View>
+
+          <View style={styles.field}>
             <ThemedText style={styles.fieldLabel}>
               Homepage Header Image (max {MAX_HERO_MB} MB)
             </ThemedText>
-            <View style={{ gap: 8 }}>
+            <View style={{ gap: 6 }}>
+              <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+                Image fit
+              </ThemedText>
+              <select
+                data-testid="header-image-fit-select"
+                value={headerImageFit}
+                onChange={/* istanbul ignore next */ (e) => setHeaderImageFit(e.target.value)}
+                style={{
+                  width: "100%",
+                  height: 44,
+                  borderWidth: 1,
+                  borderStyle: "solid" as const,
+                  borderColor: colors.border,
+                  borderRadius: 8,
+                  paddingLeft: 12,
+                  paddingRight: 12,
+                  fontSize: 14,
+                  backgroundColor: colors.input,
+                  color: colors.text,
+                  cursor: "pointer",
+                }}
+              >
+                <option value="Cover">Cover (fill, may crop)</option>
+                <option value="Contain">Contain (show whole image)</option>
+              </select>
+              <ThemedText style={{ fontSize: 11, color: mutedColor }}>
+                &quot;Contain&quot; avoids cropping on mobile; &quot;Cover&quot; fills the frame.
+              </ThemedText>
+            </View>
+            <View style={{ gap: 8, marginTop: 8 }}>
               {heroPreview ? (
                 <View
                   style={{

--- a/openresto-frontend/components/admin/settings/HighlightsCard.tsx
+++ b/openresto-frontend/components/admin/settings/HighlightsCard.tsx
@@ -56,10 +56,11 @@ interface EditState {
   body: string;
   iconKey: IconKey;
   sortOrder: number;
+  link: string;
 }
 
 function emptyEdit(sortOrder = 0): EditState {
-  return { title: "", body: "", iconKey: "star-outline", sortOrder };
+  return { title: "", body: "", iconKey: "star-outline", sortOrder, link: "" };
 }
 
 export function HighlightsCard({
@@ -95,6 +96,7 @@ export function HighlightsCard({
       body: h.body,
       iconKey: h.iconKey as IconKey,
       sortOrder: h.sortOrder,
+      link: h.link ?? "",
     });
   };
 
@@ -117,6 +119,7 @@ export function HighlightsCard({
         body: editState.body.trim(),
         iconKey: editState.iconKey,
         sortOrder: editState.sortOrder,
+        link: editState.link.trim() || null,
       });
       if (created) setHighlights((prev) => [...prev, created]);
     } else if (editingId != null) {
@@ -125,6 +128,7 @@ export function HighlightsCard({
         body: editState.body.trim(),
         iconKey: editState.iconKey,
         sortOrder: editState.sortOrder,
+        link: editState.link.trim() || null,
       });
       if (updated) {
         setHighlights((prev) => prev.map((h) => (h.id === editingId ? updated : h)));
@@ -253,6 +257,24 @@ export function HighlightsCard({
                         <ThemedText style={{ fontSize: 12, color: mutedColor, marginTop: 2 }}>
                           {h.body}
                         </ThemedText>
+                        {h.link ? (
+                          <View
+                            style={{
+                              flexDirection: "row",
+                              alignItems: "center",
+                              gap: 3,
+                              marginTop: 3,
+                            }}
+                          >
+                            <Ionicons name="link-outline" size={11} color={primaryColor} />
+                            <ThemedText
+                              style={{ fontSize: 11, color: primaryColor }}
+                              numberOfLines={1}
+                            >
+                              {h.link}
+                            </ThemedText>
+                          </View>
+                        ) : null}
                       </View>
                       <View style={{ flexDirection: "row", gap: 6 }}>
                         <Pressable onPress={() => startEdit(h)} style={{ padding: 6 }}>
@@ -377,6 +399,23 @@ function HighlightEditForm({
           numberOfLines={3}
           style={{ height: 76, paddingTop: 10, paddingBottom: 10 }}
         />
+      </View>
+
+      {/* Link (optional) */}
+      <View style={{ gap: 4 }}>
+        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+          Link (optional)
+        </ThemedText>
+        <Input
+          value={state.link}
+          onChangeText={(v) => onChange({ ...state, link: v })}
+          placeholder="https://example.com/menu"
+          autoCapitalize="none"
+          keyboardType="url"
+        />
+        <ThemedText style={{ fontSize: 11, color: mutedColor }}>
+          Makes the whole card clickable. Leave blank for a static highlight.
+        </ThemedText>
       </View>
 
       {/* Actions */}

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -119,6 +119,7 @@ export function RestaurantInfoForm({
 
   const [name, setName] = useState(restaurant.name);
   const [address, setAddress] = useState(restaurant.address ?? "");
+  const [description, setDescription] = useState(restaurant.description ?? "");
   const [openTime, setOpenTime] = useState(restaurant.openTime ?? "09:00");
   const [closeTime, setCloseTime] = useState(restaurant.closeTime ?? "22:00");
   const [customHours, setCustomHours] = useState(() => hasCustomHours(restaurant));
@@ -187,6 +188,7 @@ export function RestaurantInfoForm({
   const dirty =
     name !== restaurant.name ||
     address !== (restaurant.address ?? "") ||
+    description !== (restaurant.description ?? "") ||
     hoursDirty ||
     openDays.join(",") !== parseOpenDays(restaurant.openDays).join(",") ||
     walkInOnly !== !!restaurant.walkInOnly ||
@@ -198,6 +200,7 @@ export function RestaurantInfoForm({
   const discard = () => {
     setName(restaurant.name);
     setAddress(restaurant.address ?? "");
+    setDescription(restaurant.description ?? "");
     setOpenTime(restaurant.openTime ?? "09:00");
     setCloseTime(restaurant.closeTime ?? "22:00");
     setCustomHours(hasCustomHours(restaurant));
@@ -220,6 +223,7 @@ export function RestaurantInfoForm({
     const result = await updateRestaurant(restaurant.id, {
       name: name.trim(),
       address: address.trim() || null,
+      description: description.trim() || null,
       openTime: customHours ? undefined : openTime,
       closeTime: customHours ? undefined : closeTime,
       openHours: openHoursPayload,
@@ -235,6 +239,7 @@ export function RestaurantInfoForm({
       onSaved({
         name: result.name,
         address: result.address,
+        description: result.description,
         openTime: result.openTime,
         closeTime: result.closeTime,
         openHours: result.openHours,
@@ -290,6 +295,23 @@ export function RestaurantInfoForm({
             Address
           </ThemedText>
           <Input value={address} onChangeText={setAddress} placeholder="e.g. 123 Main St" />
+        </View>
+
+        <View style={{ gap: 6 }}>
+          <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+            Description (optional)
+          </ThemedText>
+          <Input
+            value={description}
+            onChangeText={setDescription}
+            placeholder="Short blurb shown on the location page. Supports links like [menu](https://example.com)."
+            multiline
+            numberOfLines={4}
+            style={{ height: 96, paddingTop: 10, paddingBottom: 10 }}
+          />
+          <ThemedText style={{ fontSize: 11, color: mutedColor }}>
+            Shown on the public location page. Use [label](https://url) for links.
+          </ThemedText>
         </View>
 
         <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 14 }}>

--- a/openresto-frontend/components/common/LinkedText.tsx
+++ b/openresto-frontend/components/common/LinkedText.tsx
@@ -1,0 +1,94 @@
+import { type ReactNode } from "react";
+import { Pressable, Linking, type TextStyle, type ViewStyle } from "react-native";
+import { ThemedText } from "@/components/themed-text";
+import { useAppTheme } from "@/hooks/use-app-theme";
+
+/**
+ * A single parsed segment: either a run of plain text or a matched inline link
+ * `[label](url)`. Unmatched brackets are emitted as plain text (never silently dropped).
+ */
+export interface TextSegment {
+  text: string;
+  url?: string;
+}
+
+// Matches inline markdown-style links: [label](url). The label forbids ']' so a stray
+// '[' without a matching '](...' falls through as plain text. The URL forbids whitespace.
+const LINK_PATTERN = /\[([^\]]+)\]\(([^)\s]+)\)/g;
+
+/**
+ * Parse a string into an ordered list of plain-text and link segments.
+ *
+ * Exported for unit testing. Examples:
+ *   "hello"                          → [{ text: "hello" }]
+ *   "see [menu](https://e.com)"      → [{ text: "see " }, { text: "menu", url: "https://e.com" }]
+ *   "a [broken]( link"               → [{ text: "a [broken]( link" }]  (unmatched → plain)
+ *   "[x](u1) and [y](u2)"            → [{ text: "x", url: "u1" }, { text: " and " }, { text: "y", url: "u2" }]
+ */
+export function parseLinkedText(input: string): TextSegment[] {
+  const segments: TextSegment[] = [];
+  let lastIndex = 0;
+
+  // LINK_PATTERN is stateful with the `g` flag, so create a fresh copy per call to avoid
+  // shared lastIndex across invocations.
+  const pattern = new RegExp(LINK_PATTERN);
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(input)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ text: input.slice(lastIndex, match.index) });
+    }
+    segments.push({ text: match[1], url: match[2] });
+    lastIndex = pattern.lastIndex;
+  }
+
+  if (lastIndex < input.length) {
+    segments.push({ text: input.slice(lastIndex) });
+  }
+
+  // An input with no matches still yields a single plain-text segment.
+  return segments.length > 0 ? segments : [{ text: input }];
+}
+
+/**
+ * Renders text that may contain markdown-style inline links (`[label](url)`).
+ * Plain-text runs use `ThemedText`; each link becomes an accessible `Pressable` that
+ * opens the URL via `Linking.openURL`. No external markdown dependency.
+ */
+export function LinkedText({
+  text,
+  style,
+  linkStyle,
+}: {
+  text: string;
+  style?: TextStyle;
+  linkStyle?: ViewStyle;
+}) {
+  const { primaryColor } = useAppTheme();
+  const segments = parseLinkedText(text);
+
+  const nodes: ReactNode[] = segments.map((seg, i) => {
+    if (seg.url) {
+      return (
+        <Pressable
+          key={`link-${i}`}
+          accessibilityRole="link"
+          accessibilityHint={seg.url}
+          onPress={() => Linking.openURL(seg.url!)}
+          style={linkStyle}
+        >
+          <ThemedText style={[style, { color: primaryColor, textDecorationLine: "underline" }]}>
+            {seg.text}
+          </ThemedText>
+        </Pressable>
+      );
+    }
+    return (
+      <ThemedText key={`text-${i}`} style={style}>
+        {seg.text}
+      </ThemedText>
+    );
+  });
+
+  return <>{nodes}</>;
+}

--- a/openresto-frontend/components/restaurant/RestaurantDetails.tsx
+++ b/openresto-frontend/components/restaurant/RestaurantDetails.tsx
@@ -1,5 +1,6 @@
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
+import { LinkedText } from "@/components/common/LinkedText";
 import { RestaurantDto } from "@/api/restaurants";
 import { StyleSheet, View } from "react-native";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -24,6 +25,10 @@ export default function RestaurantDetails({ restaurant }: { restaurant: Restaura
             {restaurant.address}
           </ThemedText>
         </View>
+      ) : null}
+
+      {restaurant.description ? (
+        <LinkedText text={restaurant.description} style={styles.description} />
       ) : null}
 
       <View style={[styles.divider, { backgroundColor: borderColor }]} />
@@ -71,6 +76,10 @@ const styles = StyleSheet.create({
   },
   address: {
     fontSize: 15,
+  },
+  description: {
+    fontSize: 15,
+    lineHeight: 22,
   },
   divider: {
     height: 1,

--- a/openresto-frontend/context/BrandContext.tsx
+++ b/openresto-frontend/context/BrandContext.tsx
@@ -28,6 +28,10 @@ export function BrandProvider({ children }: { children: React.ReactNode }) {
             faviconIcon: data.faviconIcon || undefined,
             websiteUrl: data.websiteUrl || undefined,
             copyrightText: data.copyrightText || undefined,
+            subtitle: data.subtitle || undefined,
+            highlightsHeading: data.highlightsHeading || undefined,
+            highlightsSubheading: data.highlightsSubheading || undefined,
+            headerImageFit: data.headerImageFit || undefined,
           });
         }
       })

--- a/openresto-frontend/tests/app/(user)/index.test.tsx
+++ b/openresto-frontend/tests/app/(user)/index.test.tsx
@@ -156,6 +156,82 @@ describe("HomeScreen", () => {
     expect(screen.getByText("Curated by the owner")).toBeTruthy();
   });
 
+  it("renders the default hero subtitle when brand.subtitle is unset", async () => {
+    renderWithProviders(<HomeScreen />);
+    await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
+    expect(
+      screen.getByText(
+        "Scroll down to pick a location below, choose a time, enter your email address, and you're booked!"
+      )
+    ).toBeTruthy();
+  });
+
+  it("renders a custom brand subtitle when set", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          appName: "Custom Brand",
+          primaryColor: "#0a7ea4",
+          subtitle: "Book the best table in town.",
+        }),
+    });
+    renderWithProviders(<HomeScreen />);
+    await waitFor(() => expect(screen.getAllByText("Custom Brand").length).toBeGreaterThan(0));
+    expect(screen.getByText("Book the best table in town.")).toBeTruthy();
+    expect(screen.queryByText(/Scroll down to pick a location/)).toBeNull();
+  });
+
+  it("renders custom highlights heading/subheading from brand settings", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          appName: "Open Resto",
+          primaryColor: "#0a7ea4",
+          highlightsHeading: "Why visit us",
+          highlightsSubheading: "Hand-picked favourites",
+        }),
+    });
+    renderWithProviders(<HomeScreen />);
+    await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
+    expect(screen.getByText("Why visit us")).toBeTruthy();
+    expect(screen.getByText("Hand-picked favourites")).toBeTruthy();
+    expect(screen.queryByText("Restaurant highlights")).toBeNull();
+    expect(screen.queryByText("Curated by the owner")).toBeNull();
+  });
+
+  it("opens the url when a linked highlight card is pressed", async () => {
+    const { Linking } = require("react-native");
+    const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined as never);
+    (fetchHighlights as jest.Mock).mockResolvedValue([
+      {
+        id: 10,
+        title: "Full menu",
+        body: "See what's cooking.",
+        iconKey: "restaurant-outline",
+        sortOrder: 0,
+        link: "https://example.com/menu",
+      },
+    ]);
+    renderWithProviders(<HomeScreen />);
+    await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
+
+    // The linked card carries the url as its accessibilityHint.
+    const link = screen.getByA11yHint("https://example.com/menu");
+    fireEvent.press(link);
+    expect(openURLSpy).toHaveBeenCalledWith("https://example.com/menu");
+    openURLSpy.mockRestore();
+  });
+
+  it("renders a non-linked highlight as a plain card (no link role)", async () => {
+    renderWithProviders(<HomeScreen />);
+    await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
+    // The default mock highlight has no link → no link hint present.
+    expect(screen.queryByA11yHint("https://example.com/menu")).toBeNull();
+    expect(screen.getByText("Wood-fired kitchen")).toBeTruthy();
+  });
+
   it("renders empty highlights gracefully (section heading hidden too)", async () => {
     (fetchHighlights as jest.Mock).mockResolvedValue([]);
     renderWithProviders(<HomeScreen />);

--- a/openresto-frontend/tests/app/(user)/restaurant.test.tsx
+++ b/openresto-frontend/tests/app/(user)/restaurant.test.tsx
@@ -66,6 +66,35 @@ describe("RestaurantScreen", () => {
     });
   });
 
+  it("renders the location description with a parsed inline link when set", async () => {
+    const { fetchRestaurantById } = require("@/api/restaurants");
+    const { Linking } = require("react-native");
+    const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined as never);
+    fetchRestaurantById.mockResolvedValueOnce({
+      ...mockRestaurant,
+      description: "Family-run since 1998. See our [menu](https://example.com/menu).",
+    });
+    renderWithProviders(<RestaurantScreen />);
+    await waitFor(() => {
+      expect(screen.getByText("Sushi Spot")).toBeTruthy();
+    });
+    // Plain-text run rendered.
+    expect(screen.getByText(/Family-run since 1998/)).toBeTruthy();
+    // Link label rendered and tappable.
+    expect(screen.getByText("menu")).toBeTruthy();
+    fireEvent.press(screen.getByA11yHint("https://example.com/menu"));
+    expect(openURLSpy).toHaveBeenCalledWith("https://example.com/menu");
+    openURLSpy.mockRestore();
+  });
+
+  it("does not render a description block when the field is unset", async () => {
+    renderWithProviders(<RestaurantScreen />);
+    await waitFor(() => {
+      expect(screen.getByText("Sushi Spot")).toBeTruthy();
+    });
+    expect(screen.queryByText(/Family-run/)).toBeNull();
+  });
+
   it("replaces the Book a Table button with a walk-in notice for walk-in only locations", async () => {
     const { fetchRestaurantById } = require("@/api/restaurants");
     fetchRestaurantById.mockResolvedValueOnce({ ...mockRestaurant, walkInOnly: true });

--- a/openresto-frontend/tests/components/admin/settings/BrandSettingsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/BrandSettingsCard.test.tsx
@@ -23,6 +23,10 @@ let mockBrandData: {
   headerImageUrl: string | null;
   faviconIcon?: string;
   websiteUrl?: string;
+  subtitle?: string;
+  highlightsHeading?: string;
+  highlightsSubheading?: string;
+  headerImageFit?: string;
 } = {
   primaryColor: "#0a7ea4",
   appName: "Open Resto",
@@ -112,10 +116,12 @@ describe("BrandSettingsCard", () => {
     await act(async () => {
       fireEvent.press(screen.getByText("Save"));
     });
-    expect(adminApi.saveBrandSettings).toHaveBeenCalledWith({
-      appName: "My Resto",
-      primaryColor: "#0a7ea4",
-    });
+    expect(adminApi.saveBrandSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appName: "My Resto",
+        primaryColor: "#0a7ea4",
+      })
+    );
     await waitFor(() => {
       expect(screen.getByText("Saved successfully.")).toBeTruthy();
     });
@@ -400,5 +406,104 @@ describe("BrandSettingsCard", () => {
       rerender(<BrandSettingsCard {...baseProps} />);
     });
     expect(screen.getByDisplayValue("https://v2.example.com")).toBeTruthy();
+  });
+
+  // ── New home-page customization fields (#183, #185, #187) ──────────────────
+
+  it("renders the Home Page Subtitle field and char counter", () => {
+    render(<BrandSettingsCard {...baseProps} />);
+    expect(screen.getByText("Home Page Subtitle")).toBeTruthy();
+    expect(screen.getByText("0/160")).toBeTruthy();
+  });
+
+  it("pre-fills subtitle from brand context and updates it", () => {
+    mockBrandData = {
+      primaryColor: "#0a7ea4",
+      appName: "Open Resto",
+      headerImageUrl: null,
+      subtitle: "Welcome to our table",
+    };
+    render(<BrandSettingsCard {...baseProps} />);
+    expect(screen.getByDisplayValue("Welcome to our table")).toBeTruthy();
+  });
+
+  it("passes subtitle to saveBrandSettings when set", async () => {
+    (adminApi.saveBrandSettings as jest.Mock).mockResolvedValue({ message: "Saved." });
+    render(<BrandSettingsCard {...baseProps} />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Scroll down to pick a location below…"),
+      "Best pizza in town"
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    expect(adminApi.saveBrandSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ subtitle: "Best pizza in town" })
+    );
+  });
+
+  it("renders Highlights Heading and Subheading fields", () => {
+    render(<BrandSettingsCard {...baseProps} />);
+    expect(screen.getByText("Highlights Heading")).toBeTruthy();
+    expect(screen.getByText("Highlights Subheading")).toBeTruthy();
+  });
+
+  it("pre-fills highlights heading/subheading from brand context", () => {
+    mockBrandData = {
+      primaryColor: "#0a7ea4",
+      appName: "Open Resto",
+      headerImageUrl: null,
+      highlightsHeading: "What we love",
+      highlightsSubheading: "Hand-picked",
+    };
+    render(<BrandSettingsCard {...baseProps} />);
+    expect(screen.getByDisplayValue("What we love")).toBeTruthy();
+    expect(screen.getByDisplayValue("Hand-picked")).toBeTruthy();
+  });
+
+  it("passes highlights heading/subheading to saveBrandSettings", async () => {
+    (adminApi.saveBrandSettings as jest.Mock).mockResolvedValue({ message: "Saved." });
+    render(<BrandSettingsCard {...baseProps} />);
+    fireEvent.changeText(screen.getByPlaceholderText("Restaurant highlights"), "Why visit us");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    expect(adminApi.saveBrandSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ highlightsHeading: "Why visit us" })
+    );
+  });
+
+  it("renders the Header image fit select defaulting to Cover", () => {
+    render(<BrandSettingsCard {...baseProps} />);
+    // Raw web <select> forwards `data-testid` not `testID` (same as the booking-duration
+    // select in RestaurantInfoForm), so query via UNSAFE_getByProps.
+    const select = screen.UNSAFE_getByProps({ "data-testid": "header-image-fit-select" });
+    expect(select.props.value).toBe("Cover");
+  });
+
+  it("pre-fills headerImageFit from brand context", () => {
+    mockBrandData = {
+      primaryColor: "#0a7ea4",
+      appName: "Open Resto",
+      headerImageUrl: null,
+      headerImageFit: "Contain",
+    };
+    render(<BrandSettingsCard {...baseProps} />);
+    const select = screen.UNSAFE_getByProps({ "data-testid": "header-image-fit-select" });
+    expect(select.props.value).toBe("Contain");
+  });
+
+  it("passes headerImageFit to saveBrandSettings", async () => {
+    (adminApi.saveBrandSettings as jest.Mock).mockResolvedValue({ message: "Saved." });
+    render(<BrandSettingsCard {...baseProps} />);
+    // Change the fit select to Contain.
+    const select = screen.UNSAFE_getByProps({ "data-testid": "header-image-fit-select" });
+    fireEvent(select, "change", { target: { value: "Contain" } });
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    expect(adminApi.saveBrandSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ headerImageFit: "Contain" })
+    );
   });
 });

--- a/openresto-frontend/tests/components/admin/settings/HighlightsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/HighlightsCard.test.tsx
@@ -271,4 +271,82 @@ describe("HighlightsCard", () => {
     fireEvent.press(accessible[accessible.length - 1]);
     expect(screen.getByPlaceholderText("e.g. Wood-fired kitchen")).toBeTruthy();
   });
+
+  // ── Link field (#185) ───────────────────────────────────────────────────
+
+  it("renders the Link input in the new highlight form", async () => {
+    render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Add"));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("https://example.com/menu")).toBeTruthy()
+    );
+  });
+
+  it("passes link to adminCreateHighlight when set", async () => {
+    const created = {
+      id: 5,
+      title: "Menu",
+      body: "",
+      iconKey: "star-outline",
+      sortOrder: 0,
+      link: "https://example.com/menu",
+    };
+    (adminApi.adminCreateHighlight as jest.Mock).mockResolvedValue(created);
+    render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Add"));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("e.g. Wood-fired kitchen")).toBeTruthy()
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("e.g. Wood-fired kitchen"), "Menu");
+    fireEvent.changeText(
+      screen.getByPlaceholderText("https://example.com/menu"),
+      "https://example.com/menu"
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    expect(adminApi.adminCreateHighlight).toHaveBeenCalledWith(
+      expect.objectContaining({ link: "https://example.com/menu" })
+    );
+  });
+
+  it("passes null link when the link field is left blank", async () => {
+    const created = {
+      id: 5,
+      title: "Plain",
+      body: "",
+      iconKey: "star-outline",
+      sortOrder: 0,
+      link: null,
+    };
+    (adminApi.adminCreateHighlight as jest.Mock).mockResolvedValue(created);
+    render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Add"));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("e.g. Wood-fired kitchen")).toBeTruthy()
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("e.g. Wood-fired kitchen"), "Plain");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    expect(adminApi.adminCreateHighlight).toHaveBeenCalledWith(
+      expect.objectContaining({ link: null })
+    );
+  });
+
+  it("pre-fills the link field when editing a highlight that has one", async () => {
+    (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue([
+      { ...mockHighlights[0], link: "https://example.com/book" },
+    ]);
+    render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Great Food")).toBeTruthy());
+    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
+    fireEvent.press(accessible[4]);
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("https://example.com/book")).toBeTruthy();
+    });
+  });
 });

--- a/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
@@ -565,4 +565,85 @@ describe("RestaurantInfoForm", () => {
     });
     expect(screen.getByText("Save changes")).toBeTruthy();
   });
+
+  // ── Description blurb (#184) ──────────────────────────────────────────────
+
+  it("renders the description field (empty when unset)", () => {
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    expect(
+      screen.getByPlaceholderText(
+        "Short blurb shown on the location page. Supports links like [menu](https://example.com)."
+      )
+    ).toBeTruthy();
+  });
+
+  it("pre-fills the description field from the restaurant", () => {
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, description: "A cozy spot." }}
+        onSaved={onSaved}
+      />
+    );
+    expect(screen.getByDisplayValue("A cozy spot.")).toBeTruthy();
+  });
+
+  it("marks the form dirty and saves the description when edited", async () => {
+    (restaurantsApi.updateRestaurant as jest.Mock).mockResolvedValue({
+      ...mockRestaurant,
+      description: "Our little place",
+    });
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText(
+        "Short blurb shown on the location page. Supports links like [menu](https://example.com)."
+      ),
+      "Our little place"
+    );
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save changes"));
+    });
+    expect(restaurantsApi.updateRestaurant).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ description: "Our little place" })
+    );
+    expect(onSaved).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Our little place" })
+    );
+  });
+
+  it("saves description as null when cleared to blank", async () => {
+    (restaurantsApi.updateRestaurant as jest.Mock).mockResolvedValue({
+      ...mockRestaurant,
+      description: null,
+    });
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, description: "Existing blurb" }}
+        onSaved={onSaved}
+      />
+    );
+    fireEvent.changeText(screen.getByDisplayValue("Existing blurb"), "   ");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save changes"));
+    });
+    expect(restaurantsApi.updateRestaurant).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ description: null })
+    );
+  });
+
+  it("discard restores the original description", () => {
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, description: "Saved blurb" }}
+        onSaved={onSaved}
+      />
+    );
+    fireEvent.changeText(screen.getByDisplayValue("Saved blurb"), "Typed something");
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    fireEvent.press(screen.getByText("Discard"));
+    expect(screen.getByDisplayValue("Saved blurb")).toBeTruthy();
+    expect(screen.getByText("All changes saved")).toBeTruthy();
+  });
 });

--- a/openresto-frontend/tests/components/common/LinkedText.test.tsx
+++ b/openresto-frontend/tests/components/common/LinkedText.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { screen, fireEvent } from "@testing-library/react-native";
+import { parseLinkedText, LinkedText } from "@/components/common/LinkedText";
+import { renderWithProviders } from "@/tests/helpers/renderWithProviders";
+
+jest.mock("expo-router", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() })),
+  usePathname: jest.fn(() => "/"),
+}));
+
+describe("parseLinkedText", () => {
+  it("returns a single plain-text segment for text without links", () => {
+    expect(parseLinkedText("Hello world")).toEqual([{ text: "Hello world" }]);
+  });
+
+  it("parses a single inline link", () => {
+    expect(parseLinkedText("see [menu](https://e.com)")).toEqual([
+      { text: "see " },
+      { text: "menu", url: "https://e.com" },
+    ]);
+  });
+
+  it("parses multiple inline links", () => {
+    expect(parseLinkedText("[x](u1) and [y](u2)")).toEqual([
+      { text: "x", url: "u1" },
+      { text: " and " },
+      { text: "y", url: "u2" },
+    ]);
+  });
+
+  it("passes unmatched brackets through as plain text", () => {
+    expect(parseLinkedText("a [broken]( link")).toEqual([{ text: "a [broken]( link" }]);
+    expect(parseLinkedText("just [a bracket")).toEqual([{ text: "just [a bracket" }]);
+  });
+
+  it("handles an empty string", () => {
+    expect(parseLinkedText("")).toEqual([{ text: "" }]);
+  });
+
+  it("does not carry lastIndex state across calls (fresh regex per call)", () => {
+    // Calling twice must produce identical results — a stateful g-flag regex would drift.
+    expect(parseLinkedText("[a](b)")).toEqual([{ text: "a", url: "b" }]);
+    expect(parseLinkedText("[a](b)")).toEqual([{ text: "a", url: "b" }]);
+  });
+});
+
+describe("LinkedText component", () => {
+  it("renders plain text with no link affordance", () => {
+    renderWithProviders(<LinkedText text="Just plain copy." />);
+    expect(screen.getByText("Just plain copy.")).toBeTruthy();
+    expect(screen.queryByLabelText("http://anything")).toBeNull();
+  });
+
+  it("renders a tappable link for matched [label](url)", () => {
+    const { Linking } = require("react-native");
+    const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined as never);
+
+    renderWithProviders(<LinkedText text="See our [menu](https://example.com/menu)." />);
+
+    expect(screen.getByText("menu")).toBeTruthy();
+    // The Pressable carries the url as its accessibilityHint.
+    const link = screen.getByA11yHint("https://example.com/menu");
+    fireEvent.press(link);
+    expect(openURLSpy).toHaveBeenCalledWith("https://example.com/menu");
+    openURLSpy.mockRestore();
+  });
+
+  it("renders multiple links and text runs together", () => {
+    renderWithProviders(<LinkedText text="[menu](https://e.com/m) and [book](https://e.com/b)" />);
+    expect(screen.getByText("menu")).toBeTruthy();
+    expect(screen.getByText("book")).toBeTruthy();
+    expect(screen.getByText(" and ")).toBeTruthy();
+  });
+});

--- a/openresto-frontend/types/index.ts
+++ b/openresto-frontend/types/index.ts
@@ -12,4 +12,12 @@ export interface Brand {
   faviconIcon?: string;
   websiteUrl?: string;
   copyrightText?: string;
+  /** Tagline shown under the app name on the home page hero. */
+  subtitle?: string;
+  /** Heading above the highlights section (falls back to "Restaurant highlights"). */
+  highlightsHeading?: string;
+  /** Subheading above the highlights section (falls back to "Curated by the owner"). */
+  highlightsSubheading?: string;
+  /** How the hero image is fit: "Cover" (default) or "Contain". */
+  headerImageFit?: string;
 }


### PR DESCRIPTION
## Summary

Four home-page customization issues in one PR, all following the repo's existing **nullable field → migration → DTO → service → admin UI → render** pattern. Closes #183, #184, #185, #187.

| Issue | Field | Where |
|---|---|---|
| **#183** | `BrandSettings.Subtitle` | tagline under the app name on the home page hero (replaces hard-coded subheading) |
| **#184** | `Restaurant.Description` | freeform blurb on the location detail page with `[label](url)` inline links |
| **#185** | `RestaurantHighlight.Link` + `BrandSettings.HighlightsHeading` / `HighlightsSubheading` | clickable highlight cards + configurable section titles |
| **#187** | `BrandSettings.HeaderImageFit` (`Cover`/`Contain`) | hero image scaling, with attention to mobile |

All fields default to today's behaviour when unset — **zero visual regression for existing installs**.

## Decisions (confirmed with maintainer)
- **#184 link format**: markdown-style inline links `[label](url)`, parsed by a new dependency-free `LinkedText` component (no rich-text editor anywhere in the admin UI today).
- **#187 scope**: Cover/Contain toggle only — no focal-point picker (materially more UI work, not grounded in existing code).

## Backend
- **Single migration** `AddHomePageCustomization` adds 6 nullable columns across `BrandSettings`, `Restaurants`, and `Highlights`. Generated via `dotnet ef migrations add` (snapshot regenerated; migration-safety CI invariant preserved).
- Entities, DTOs, services, and `BrandController` extended with PATCH semantics (null = skip, blank = clear) matching the existing `copyrightText`/`websiteUrl` pattern.
- `HeaderImageFit` validated against an allow-list (`Cover`/`Contain`, case-insensitive, normalized to canonical casing on save).
- xUnit tests added to `BrandServiceTests`, `HighlightServiceTests`, `RestaurantManagementServiceTests`.

## Frontend
- `Brand`, `RestaurantDto`, `HighlightDto` types + `BrandContext` fetch mapping + `api/admin.ts` + `api/restaurants.ts` extended.
- **BrandSettingsCard**: subtitle (with char counter), highlights heading, highlights subheading, and a native `<select>` for image fit (styled to match the existing timezone/duration selects).
- **HighlightsCard**: new optional `Link` input per highlight (URL keyboardType); linked highlights show a link affordance in the display row.
- **RestaurantInfoForm**: description textarea with `[label](url)` hint.
- **Home page**: subtitle/heading/subheading fall back to current defaults; linked highlight cards render as accessible `Pressable` (open-outline glyph, `Linking.openURL`); hero `<img>` `objectFit`/`objectPosition` driven by the fit setting.
- **New `LinkedText`** component renders plain-text runs + tappable inline links; used by `RestaurantDetails`.
- Jest tests added/updated across every touched component, plus a dedicated `LinkedText.test.tsx` (parser + component).

## Test results
- **Backend**: 1076 passed (2 pre-existing flaky SQLite pragma file-lock failures on Windows — unrelated to these changes, fail in isolation on `main` too).
- **Frontend**: 1849 passed across 143 suites.
- `npx tsc --noEmit`: clean.
- `npm run check` (prettier + oxlint, what CI runs): exit 0.