### PR TITLE
follow-up: seed new fields + standardize admin label fonts

### DIFF
--- a/openresto-frontend/components/admin/settings/BrandSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/BrandSettingsCard.tsx
@@ -314,9 +314,7 @@ export function BrandSettingsCard({
               Homepage Header Image (max {MAX_HERO_MB} MB)
             </ThemedText>
             <View style={{ gap: 6 }}>
-              <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-                Image fit
-              </ThemedText>
+              <ThemedText style={styles.fieldLabel}>Image fit</ThemedText>
               <select
                 data-testid="header-image-fit-select"
                 value={headerImageFit}

--- a/openresto-frontend/components/admin/settings/HighlightsCard.tsx
+++ b/openresto-frontend/components/admin/settings/HighlightsCard.tsx
@@ -347,7 +347,7 @@ function HighlightEditForm({
     >
       {/* Icon picker */}
       <View style={{ gap: 6 }}>
-        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>Icon</ThemedText>
+        <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Icon</ThemedText>
         <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
           {ICON_OPTIONS.map((icon) => (
             <Pressable
@@ -376,9 +376,7 @@ function HighlightEditForm({
 
       {/* Title */}
       <View style={{ gap: 4 }}>
-        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-          Title
-        </ThemedText>
+        <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Title</ThemedText>
         <Input
           value={state.title}
           onChangeText={(v) => onChange({ ...state, title: v })}
@@ -388,9 +386,7 @@ function HighlightEditForm({
 
       {/* Body */}
       <View style={{ gap: 4 }}>
-        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-          Description
-        </ThemedText>
+        <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Description</ThemedText>
         <Input
           value={state.body}
           onChangeText={(v) => onChange({ ...state, body: v })}
@@ -403,9 +399,7 @@ function HighlightEditForm({
 
       {/* Link (optional) */}
       <View style={{ gap: 4 }}>
-        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-          Link (optional)
-        </ThemedText>
+        <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Link (optional)</ThemedText>
         <Input
           value={state.link}
           onChangeText={(v) => onChange({ ...state, link: v })}

--- a/openresto-frontend/components/admin/settings/LocationTagsSection.tsx
+++ b/openresto-frontend/components/admin/settings/LocationTagsSection.tsx
@@ -2,6 +2,7 @@ import { View, Pressable } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
+import { styles } from "./settings.styles";
 
 export interface LocationTagsSectionProps {
   tags: string[];
@@ -35,9 +36,7 @@ export function LocationTagsSection({
 }: LocationTagsSectionProps) {
   return (
     <View style={{ gap: 6 }}>
-      <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-        Location tags
-      </ThemedText>
+      <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Location tags</ThemedText>
       {tags.length > 0 && (
         <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6, marginBottom: 4 }}>
           {tags.map((tag) => (

--- a/openresto-frontend/components/admin/settings/OpeningHoursSection.tsx
+++ b/openresto-frontend/components/admin/settings/OpeningHoursSection.tsx
@@ -3,6 +3,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/themed-text";
 import TimePicker from "@/components/common/TimePicker";
 import { DAY_LABELS, DAY_SHORT, modeButton } from "./sectionHelpers";
+import { styles } from "./settings.styles";
 
 type WeekHours = Record<number, { open: string; close: string }>;
 
@@ -115,9 +116,7 @@ export function OpeningHoursSection({
         <>
           <View style={{ flexDirection: "row", gap: 14 }}>
             <View style={{ flex: 1, gap: 6 }}>
-              <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-                Opens
-              </ThemedText>
+              <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Opens</ThemedText>
               <TimePicker
                 selectedTime={openTime}
                 onSelect={onSetOpenTime}
@@ -126,9 +125,7 @@ export function OpeningHoursSection({
               />
             </View>
             <View style={{ flex: 1, gap: 6 }}>
-              <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-                Closes
-              </ThemedText>
+              <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Closes</ThemedText>
               <TimePicker
                 selectedTime={closeTime}
                 onSelect={onSetCloseTime}
@@ -139,9 +136,7 @@ export function OpeningHoursSection({
           </View>
 
           <View style={{ gap: 6 }}>
-            <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-              Open days
-            </ThemedText>
+            <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Open days</ThemedText>
             <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
               {DAY_LABELS.map((label, i) => {
                 const day = i + 1;

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -11,6 +11,7 @@ import { isOvernight } from "./sectionHelpers";
 import { OpeningHoursSection } from "./OpeningHoursSection";
 import { WalkInPolicySection } from "./WalkInPolicySection";
 import { LocationTagsSection } from "./LocationTagsSection";
+import { styles as sharedStyles } from "./settings.styles";
 
 const TIMEZONES = [
   "UTC",
@@ -284,21 +285,19 @@ export function RestaurantInfoForm({
       {/* Form */}
       <View style={{ gap: 14 }}>
         <View style={{ gap: 6 }}>
-          <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+          <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>
             Restaurant name
           </ThemedText>
           <Input value={name} onChangeText={setName} placeholder="Restaurant name" />
         </View>
 
         <View style={{ gap: 6 }}>
-          <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-            Address
-          </ThemedText>
+          <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>Address</ThemedText>
           <Input value={address} onChangeText={setAddress} placeholder="e.g. 123 Main St" />
         </View>
 
         <View style={{ gap: 6 }}>
-          <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+          <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>
             Description (optional)
           </ThemedText>
           <Input
@@ -316,7 +315,7 @@ export function RestaurantInfoForm({
 
         <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 14 }}>
           <View style={{ flex: 1, minWidth: 220, gap: 6 }}>
-            <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+            <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>
               Timezone
             </ThemedText>
             <select
@@ -345,7 +344,7 @@ export function RestaurantInfoForm({
             </select>
           </View>
           <View style={{ flex: 1, minWidth: 220, gap: 6 }}>
-            <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+            <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>
               Default Booking duration
             </ThemedText>
             <select

--- a/openresto-frontend/components/admin/settings/SocialLinkEditForm.tsx
+++ b/openresto-frontend/components/admin/settings/SocialLinkEditForm.tsx
@@ -4,6 +4,7 @@ import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
 import { Ionicons } from "@expo/vector-icons";
 import { ThemeColors } from "@/theme/theme";
+import { styles } from "./settings.styles";
 
 /**
  * The icon-picker + label/url inputs + save/cancel actions used when creating or editing a
@@ -89,7 +90,7 @@ export function SocialLinkEditForm({
     >
       {/* Icon picker */}
       <View style={{ gap: 6 }}>
-        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>Icon</ThemedText>
+        <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Icon</ThemedText>
         <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
           {ICON_OPTIONS.map((icon) => (
             <Pressable
@@ -118,9 +119,7 @@ export function SocialLinkEditForm({
 
       {/* Label */}
       <View style={{ gap: 4 }}>
-        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
-          Label
-        </ThemedText>
+        <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>Label</ThemedText>
         <Input
           value={state.label}
           onChangeText={(v) => onChange({ ...state, label: v })}
@@ -130,7 +129,7 @@ export function SocialLinkEditForm({
 
       {/* URL */}
       <View style={{ gap: 4 }}>
-        <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>URL</ThemedText>
+        <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>URL</ThemedText>
         <Input
           value={state.url}
           onChangeText={(v) => onChange({ ...state, url: v })}

--- a/openresto-frontend/components/admin/settings/WalkInPolicySection.tsx
+++ b/openresto-frontend/components/admin/settings/WalkInPolicySection.tsx
@@ -2,6 +2,7 @@ import { View, Pressable } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/themed-text";
 import { DAY_LABELS, DAY_SHORT, modeButton } from "./sectionHelpers";
+import { styles } from "./settings.styles";
 
 export interface WalkInPolicySectionProps {
   walkInOnly: boolean;
@@ -107,7 +108,7 @@ export function WalkInPolicySection({
         </View>
       ) : (
         <View style={{ gap: 6 }}>
-          <ThemedText style={{ fontSize: 12, color: mutedColor, fontWeight: "500" }}>
+          <ThemedText style={[styles.fieldLabel, { color: mutedColor }]}>
             Walk-in only days
           </ThemedText>
           <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>

--- a/openresto-frontend/components/admin/settings/settings.styles.ts
+++ b/openresto-frontend/components/admin/settings/settings.styles.ts
@@ -167,7 +167,9 @@ export const styles = StyleSheet.create({
   flex2: { flex: 2 },
   infoForm: { gap: theme.spacing.md },
   field: { gap: theme.spacing.xs },
-  fieldLabel: { ...theme.typography.label },
+  // Shared form-field label style used across every settings card. Inline copies in
+  // RestaurantInfoForm / HighlightsCard should migrate to this token (see #231).
+  fieldLabel: { fontSize: 12, fontWeight: "500" as const },
   hoursRow: { flexDirection: "row", gap: theme.spacing.md, marginTop: theme.spacing.xs },
   hoursField: { flex: 1, gap: theme.spacing.xs },
   dayRow: {

--- a/scripts/config-snapshot.sql
+++ b/scripts/config-snapshot.sql
@@ -29,6 +29,7 @@ WHERE
   );
 
 -- Brand
+-- HeaderImageFit left NULL → defaults to Cover (today's behaviour).
 INSERT INTO
   BrandSettings (
     Id,
@@ -38,7 +39,10 @@ INSERT INTO
     HeaderImageUrl,
     FaviconIcon,
     WebsiteUrl,
-    CopyrightText
+    CopyrightText,
+    Subtitle,
+    HighlightsHeading,
+    HighlightsSubheading
   )
 VALUES
   (
@@ -49,7 +53,10 @@ VALUES
     '/media/hero.jpg?v=1780749336371',
     'pizza',
     'https://openres.to',
-    NULL
+    NULL,
+    'Philadelphia''s home of milk steak and jelly beans.',
+    'What we''re known for',
+    'Curated by Frank Reynolds'
   );
 
 -- Social Links (footer)
@@ -68,6 +75,7 @@ VALUES
 -- DefaultBookingDurationMinutes defaults to 60 (NOT NULL, added by migration).
 -- OpenHoursJson is NULL so OpenTime/CloseTime apply to every day.
 -- WalkInOnly is 0 and WalkInDays is NULL so online bookings stay enabled.
+-- Description supports [label](url) inline links — see app/(user)/restaurant/[id].tsx.
 INSERT INTO
   Restaurants (
     Id,
@@ -84,7 +92,8 @@ INSERT INTO
     DefaultBookingDurationMinutes,
     OpenHoursJson,
     WalkInOnly,
-    WalkInDays
+    WalkInDays,
+    Description
   )
 VALUES
   (
@@ -102,7 +111,8 @@ VALUES
     60,
     NULL,
     0,
-    NULL
+    NULL,
+    'Philadelphia''s worst bar, now taking bookings. See our [menu](https://paddyspub.example/menu) — cash only.'
   );
 
 INSERT INTO
@@ -121,7 +131,8 @@ INSERT INTO
     DefaultBookingDurationMinutes,
     OpenHoursJson,
     WalkInOnly,
-    WalkInDays
+    WalkInDays,
+    Description
   )
 VALUES
   (
@@ -139,7 +150,8 @@ VALUES
     60,
     NULL,
     0,
-    NULL
+    NULL,
+    'The Alley Behind the Alley. Walk-ins welcome, online bookings for the brave.'
   );
 
 INSERT INTO
@@ -158,7 +170,8 @@ INSERT INTO
     DefaultBookingDurationMinutes,
     OpenHoursJson,
     WalkInOnly,
-    WalkInDays
+    WalkInDays,
+    Description
   )
 VALUES
   (
@@ -176,7 +189,8 @@ VALUES
     60,
     NULL,
     0,
-    NULL
+    NULL,
+    'Open 24 hours because we lost the keys to the lock. [Reviews](https://paddyspub.example/reviews).'
   );
 
 -- Sections
@@ -246,49 +260,53 @@ INSERT INTO
 VALUES
   (8, 'Table 1', 4, 5);
 
--- Highlights
+-- Highlights (Link=NULL → static card; set a Link to make the whole card clickable)
 INSERT INTO
-  Highlights (Id, Title, Body, IconKey, SortOrder)
+  Highlights (Id, Title, Body, IconKey, SortOrder, Link)
 VALUES
   (
     1,
     'Dayman Live Every Friday',
     'Fighter of the Nightman. No cover charge. Cash only. Residency secured after a lengthy legal dispute.',
     'star-outline',
-    0
+    0,
+    'https://paddyspub.example/dayman'
   );
 
 INSERT INTO
-  Highlights (Id, Title, Body, IconKey, SortOrder)
+  Highlights (Id, Title, Body, IconKey, SortOrder, Link)
 VALUES
   (
     2,
     'Frank''s Famous Rum Ham',
     'A Reynolds family tradition since 1981. Seasonal availability. Do not ask about the ingredients. Do not ask where Frank has been.',
     'pizza-outline',
-    1
+    1,
+    NULL
   );
 
 INSERT INTO
-  Highlights (Id, Title, Body, IconKey, SortOrder)
+  Highlights (Id, Title, Body, IconKey, SortOrder, Link)
 VALUES
   (
     3,
     'Chardee MacDennis',
     'The Game of Games. Teams of 2. Bring your own wine glass to smash. Management not responsible for emotional damage.',
     'gift-outline',
-    2
+    2,
+    NULL
   );
 
 INSERT INTO
-  Highlights (Id, Title, Body, IconKey, SortOrder)
+  Highlights (Id, Title, Body, IconKey, SortOrder, Link)
 VALUES
   (
     4,
     'Milk Steak - Our Signature Dish',
     'Boiled over hard, served with a side of your finest jelly beans. Charlie''s personal recipe. Our most polarising menu item. Loved by ghouls.',
     'nutrition-outline',
-    3
+    3,
+    'https://paddyspub.example/menu'
   );
 
 PRAGMA foreign_keys = ON;

--- a/scripts/seed-local.sh
+++ b/scripts/seed-local.sh
@@ -166,12 +166,14 @@ exec 3>"$SQL_FILE"
   echo "DELETE FROM sqlite_sequence WHERE name IN ('Bookings','Highlights','SocialLinks','Tables','Sections','Restaurants','BrandSettings','EmailSettings','AdminCredentials','AdminNotifications','EmailFailures');"
 
   # Brand (EmailSettings intentionally left empty — no SMTP creds in source control)
-  echo "INSERT INTO BrandSettings(AppName,PrimaryColor,AccentColor,FaviconIcon,HeaderImageUrl,WebsiteUrl,CopyrightText) VALUES('Paddy''s Pub','#059669',NULL,'pizza','/media/hero.jpg','https://openres.to',NULL);"
+  # HeaderImageFit left NULL → defaults to Cover (today's behaviour).
+  echo "INSERT INTO BrandSettings(AppName,PrimaryColor,AccentColor,FaviconIcon,HeaderImageUrl,WebsiteUrl,CopyrightText,Subtitle,HighlightsHeading,HighlightsSubheading) VALUES('Paddy''s Pub','#059669',NULL,'pizza','/media/hero.jpg','https://openres.to',NULL,'Philadelphia''s home of milk steak and jelly beans.','What we''re known for','Curated by Frank Reynolds');"
 
   # Restaurants (WalkInOnly=0 / WalkInDays=NULL keeps online bookings enabled everywhere)
-  echo "INSERT INTO Restaurants(Id,Name,Address,OpenTime,CloseTime,OpenDays,Timezone,BookingsPausedUntil,Tags,ImageUrl,IsArchived,WalkInOnly,WalkInDays) VALUES(1,'Paddy''s Pub','346 W Girard Ave, Philadelphia, PA','09:00','23:45','1,2,3,4,5,6','America/Toronto',NULL,'mac and cheese,fight milk','/media/location-1.jpg',0,0,NULL);"
-  echo "INSERT INTO Restaurants(Id,Name,Address,OpenTime,CloseTime,OpenDays,Timezone,BookingsPausedUntil,Tags,ImageUrl,IsArchived,WalkInOnly,WalkInDays) VALUES(2,'Paddy''s Pub Toronto','The Alley Behind the Alley, Toronto, ON','09:00','23:45','3,4,5,6','America/Toronto',NULL,'charlie work,mantis toboggan','/media/location-2.webp',0,0,NULL);"
-  echo "INSERT INTO Restaurants(Id,Name,Address,OpenTime,CloseTime,OpenDays,Timezone,BookingsPausedUntil,Tags,ImageUrl,IsArchived,WalkInOnly,WalkInDays) VALUES(3,'Paddy''s Pub (Vancouver)','Multiple Areas, please don''t ask','00:00','23:00','1,2,3,4,5,6,7','America/Los_Angeles',NULL,'wolf cola,dennis system','/media/location-3.jpg',0,0,NULL);"
+  # Description supports [label](url) inline links — see app/(user)/restaurant/[id].tsx.
+  echo "INSERT INTO Restaurants(Id,Name,Address,OpenTime,CloseTime,OpenDays,Timezone,BookingsPausedUntil,Tags,ImageUrl,IsArchived,WalkInOnly,WalkInDays,Description) VALUES(1,'Paddy''s Pub','346 W Girard Ave, Philadelphia, PA','09:00','23:45','1,2,3,4,5,6','America/Toronto',NULL,'mac and cheese,fight milk','/media/location-1.jpg',0,0,NULL,'Philadelphia''s worst bar, now taking bookings. See our [menu](https://paddyspub.example/menu) — cash only.');"
+  echo "INSERT INTO Restaurants(Id,Name,Address,OpenTime,CloseTime,OpenDays,Timezone,BookingsPausedUntil,Tags,ImageUrl,IsArchived,WalkInOnly,WalkInDays,Description) VALUES(2,'Paddy''s Pub Toronto','The Alley Behind the Alley, Toronto, ON','09:00','23:45','3,4,5,6','America/Toronto',NULL,'charlie work,mantis toboggan','/media/location-2.webp',0,0,NULL,'The Alley Behind the Alley. Walk-ins welcome, online bookings for the brave.');"
+  echo "INSERT INTO Restaurants(Id,Name,Address,OpenTime,CloseTime,OpenDays,Timezone,BookingsPausedUntil,Tags,ImageUrl,IsArchived,WalkInOnly,WalkInDays,Description) VALUES(3,'Paddy''s Pub (Vancouver)','Multiple Areas, please don''t ask','00:00','23:00','1,2,3,4,5,6,7','America/Los_Angeles',NULL,'wolf cola,dennis system','/media/location-3.jpg',0,0,NULL,'Open 24 hours because we lost the keys to the lock. [Reviews](https://paddyspub.example/reviews).');"
 
   # Sections (SortOrder is explicit per-restaurant display order, not insertion order)
   echo "INSERT INTO Sections(Id,Name,RestaurantId,SortOrder) VALUES(1,'Indoor',1,0);"
@@ -190,11 +192,11 @@ exec 3>"$SQL_FILE"
   echo "INSERT INTO Tables(Id,Name,Seats,SectionId) VALUES(7,'B3',1,3);"
   echo "INSERT INTO Tables(Id,Name,Seats,SectionId) VALUES(8,'Table 1',4,5);"
 
-  # Highlights
-  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder) VALUES(1,'Dayman Live Every Friday','Fighter of the Nightman. No cover charge. Cash only. Residency secured after a lengthy legal dispute.','star-outline',0);"
-  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder) VALUES(2,'Frank''s Famous Rum Ham','A Reynolds family tradition since 1981. Seasonal availability. Do not ask about the ingredients. Do not ask where Frank has been.','pizza-outline',1);"
-  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder) VALUES(3,'Chardee MacDennis','The Game of Games. Teams of 2. Bring your own wine glass to smash. Management not responsible for emotional damage.','gift-outline',2);"
-  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder) VALUES(4,'Milk Steak - Our Signature Dish','Boiled over hard, served with a side of your finest jelly beans. Charlie''s personal recipe. Our most polarising menu item. Loved by ghouls.','nutrition-outline',3);"
+  # Highlights (Link=NULL → static card; set a Link to make the whole card clickable)
+  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder,Link) VALUES(1,'Dayman Live Every Friday','Fighter of the Nightman. No cover charge. Cash only. Residency secured after a lengthy legal dispute.','star-outline',0,'https://paddyspub.example/dayman');"
+  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder,Link) VALUES(2,'Frank''s Famous Rum Ham','A Reynolds family tradition since 1981. Seasonal availability. Do not ask about the ingredients. Do not ask where Frank has been.','pizza-outline',1,NULL);"
+  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder,Link) VALUES(3,'Chardee MacDennis','The Game of Games. Teams of 2. Bring your own wine glass to smash. Management not responsible for emotional damage.','gift-outline',2,NULL);"
+  echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder,Link) VALUES(4,'Milk Steak - Our Signature Dish','Boiled over hard, served with a side of your finest jelly beans. Charlie''s personal recipe. Our most polarising menu item. Loved by ghouls.','nutrition-outline',3,'https://paddyspub.example/menu');"
 
   # Social Links (footer)
   echo "INSERT INTO SocialLinks(Id,Label,Url,IconKey,SortOrder) VALUES(1,'Instagram','https://instagram.com/paddyspub','logo-instagram',0);"


### PR DESCRIPTION
Follow-up to #231 (merged) with two things that landed on the feature branch *after* it merged, so they never made it into `main`.

## 1. Seed the new home-page customization fields (`scripts/`)

`seed-local.sh` and `config-snapshot.sql` (kept in deliberate parity) now populate the fields added by `AddHomePageCustomization` with sample Paddy's Pub data so the features are visible on a fresh seed:

- **BrandSettings**: `Subtitle`, `HighlightsHeading`, `HighlightsSubheading` (`HeaderImageFit` left NULL → defaults to Cover)
- **Restaurants**: `Description` with `[label](url)` inline links on all 3 locations
- **Highlights**: `Link` set on 2 of 4 (others stay static) to exercise both clickable and non-clickable card paths

Existing inserts named every column explicitly, so nothing broke when the nullable columns were added — this is purely so the demo dataset shows the new functionality. `purge-bookings.sh` and `reset-admin.sh` need no changes (they don't do column-level config inserts).

## 2. Standardize admin settings field labels to 12/500 (`components/admin/settings/`)

Field labels across the admin dashboard had drifted into two conventions:
- shared `fieldLabel` token = **fontSize 13 / weight 600** (Brand, Email, Footer, Security cards)
- inline copies = **fontSize 12 / weight 500** (RestaurantInfoForm, HighlightsCard + sub-sections)

The mixed sizes made the dashboard feel inconsistent and the 13/600 labels read as too large next to their neighbors. Standardized on the smaller 12/500:
- `settings.styles.ts`: `fieldLabel` token now resolves to fontSize 12, fontWeight 500.
- Migrated every inline label in RestaurantInfoForm, HighlightsCard, LocationTagsSection, OpeningHoursSection, WalkInPolicySection, and SocialLinkEditForm to the shared token, preserving their muted color via array-merge.

## Verification
- `npx tsc --noEmit`: clean
- `npm run check` (prettier + oxlint): exit 0
- 1849 frontend tests pass (unchanged — these are purely presentational swaps)