### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+Closes #
+
+## Scope
+
+- [ ] API (OpenRestoApi)
+- [ ] Frontend (openresto-frontend)
+- [ ] Database migration
+- [ ] Docs / infra
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] `OpenRestoApi.Tests` pass locally
+- [ ] Frontend tests/build pass locally
+- [ ] CI passes (build, migration-check)
+- [ ] Manually verified the change end-to-end
+
+## Migrations
+
+- [ ] This PR includes a database migration
+- [ ] Migration was tested locally (up and, if applicable, down)
+
+## Checklist
+
+- [ ] No secrets, connection strings, or credentials committed
+- [ ] Docs updated if API contracts or setup changed


### PR DESCRIPTION
Adds `.github/pull_request_template.md` covering API/frontend/migration scope and the migration-check CI so PRs start with a consistent structure.