### PR TITLE
feat(booking): show restaurant blurb on booking page (#184)

### DIFF
--- a/openresto-frontend/app/(user)/book/[restaurantId].tsx
+++ b/openresto-frontend/app/(user)/book/[restaurantId].tsx
@@ -14,6 +14,7 @@ import { convertLocalToUtc } from "@/utils/date";
 import BookingSkeleton from "@/components/booking/BookingSkeleton";
 import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 import WalkInNotice from "@/components/booking/WalkInNotice";
+import { LinkedText } from "@/components/common/LinkedText";
 import Footer from "@/components/layout/Footer";
 
 export default function BookScreen() {
@@ -138,6 +139,10 @@ export default function BookScreen() {
             at {restaurant.name}
           </ThemedText>
 
+          {restaurant.description ? (
+            <LinkedText text={restaurant.description} style={styles.description} />
+          ) : null}
+
           {restaurant.walkInOnly ? (
             <WalkInNotice scope="location" />
           ) : (
@@ -180,6 +185,12 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 16,
+    marginBottom: 24,
+  },
+  description: {
+    fontSize: 15,
+    lineHeight: 22,
+    marginTop: -12,
     marginBottom: 24,
   },
   imageBanner: {


### PR DESCRIPTION
## Summary

Issue #184 added the backend support for a restaurant "blurb" and it is already fully wired in the frontend (typed as `RestaurantDto.description`, fetched via `fetchRestaurantById`, editable in admin settings, and rendered on the restaurant **detail** page via `LinkedText`). However it was **not** shown on the **booking page** — which is what @MattSharp reported.

As noted in #184, the larger "locations" refactor in the frontend is still in flight, so as an interim step this just surfaces the blurb on the booking page (where the data is already in scope).

## Related issue

Closes #184

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `app/(user)/book/[restaurantId].tsx`: import the existing `LinkedText` component and render `restaurant.description` between the "at {name}" subtitle and the form/walk-in notice. Conditionally rendered, so restaurants without a blurb are unaffected.
- Added a matching `description` style (15px / 22 line-height) consistent with the detail page, with a negative top margin so it nests under the subtitle while preserving the existing 24px gap to the form.

Reuses the same `LinkedText` renderer the detail page uses, so `[label](url)` links behave consistently.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally — `tsc --noEmit`, `oxlint`, and `prettier --check` all clean on the changed file
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed