### PR TITLE
fix(locations): consistent expand chevron, scroll-to-form on Book/details, show blurb+menu when collapsed

### DIFF
--- a/openresto-frontend/components/restaurant/LocationListItem.tsx
+++ b/openresto-frontend/components/restaurant/LocationListItem.tsx
@@ -153,6 +153,20 @@ export default function LocationListItem({
     });
   };
 
+  // The "Book / details" CTA has booking intent, so on expand it scrolls the
+  // form itself into view (like a slot press) rather than just the header —
+  // unlike the generic header-click expand, which keeps the card top in view.
+  const handleViewDetailsPress = () => {
+    setExpanded((prev) => {
+      const next = !prev;
+      if (next) {
+        if (onScrollToForm) onScrollToForm(restaurant.id);
+        else if (onExpand) onExpand(restaurant.id);
+      }
+      return next;
+    });
+  };
+
   const handleSlotPress = (time: string) => {
     // Expanding with a prefilled time seeds BookingForm's initialTime via key
     // remount — the time is captured in the router query on the parent screen,
@@ -315,6 +329,11 @@ export default function LocationListItem({
           </View>
         </View>
 
+        {/* Blurb — visible in the collapsed card, not just when expanded */}
+        {restaurant.description ? (
+          <LinkedText text={restaurant.description} style={styles.description} />
+        ) : null}
+
         {tags.length > 0 && (
           <View style={styles.tags}>
             {tags.map((t) => (
@@ -327,6 +346,38 @@ export default function LocationListItem({
             ))}
           </View>
         )}
+
+        {/* Menu link — visible in the collapsed card, not just when expanded.
+            Nested inside the header's expand Pressable, so stop propagation to
+            open the menu instead of also toggling the accordion. */}
+        {restaurant.menuUrl ? (
+          <Pressable
+            style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
+              styles.menuLink,
+              {
+                backgroundColor: hovered || pressed ? accentSoft : surface2,
+                borderColor: hovered || pressed ? accentBorder : borderColor,
+              },
+            ]}
+            onPress={(e) => {
+              e?.stopPropagation?.();
+              Linking.openURL(restaurant.menuUrl!);
+            }}
+            accessibilityRole="link"
+            accessibilityLabel="View menu"
+          >
+            <Ionicons name="document-text-outline" size={16} color={primaryColor} />
+            <ThemedText style={[styles.menuLinkText, { color: primaryColor }]}>
+              View menu
+            </ThemedText>
+            <Ionicons
+              name="open-outline"
+              size={13}
+              color={mutedColor}
+              style={{ marginLeft: "auto" }}
+            />
+          </Pressable>
+        ) : null}
 
         {/* Hours + slot quick-pick */}
         <View style={styles.slotsArea}>
@@ -398,16 +449,22 @@ export default function LocationListItem({
               </>
             )}
           </View>
-          <View style={[styles.viewBtn, { backgroundColor: surface2 }]}>
+          <Pressable
+            onPress={(e) => {
+              e?.stopPropagation?.();
+              handleViewDetailsPress();
+            }}
+            style={[styles.viewBtn, { backgroundColor: surface2 }]}
+          >
             <ThemedText style={[styles.viewBtnText, { color: primaryColor }]}>
               {expanded ? "Hide details" : "Book / details"}
             </ThemedText>
             <Ionicons
-              name={expanded ? "chevron-up" : "arrow-forward"}
+              name={expanded ? "chevron-up" : "chevron-down"}
               size={13}
               color={primaryColor}
             />
-          </View>
+          </Pressable>
         </View>
       </Pressable>
 
@@ -459,38 +516,6 @@ export default function LocationListItem({
               </Pressable>
             </View>
           )}
-
-          {/* Blurb */}
-          {restaurant.description ? (
-            <LinkedText text={restaurant.description} style={styles.description} />
-          ) : null}
-
-          {/* Menu link */}
-          {restaurant.menuUrl ? (
-            <Pressable
-              style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
-                styles.menuLink,
-                {
-                  backgroundColor: hovered || pressed ? accentSoft : surface2,
-                  borderColor: hovered || pressed ? accentBorder : borderColor,
-                },
-              ]}
-              onPress={() => Linking.openURL(restaurant.menuUrl!)}
-              accessibilityRole="link"
-              accessibilityLabel="View menu"
-            >
-              <Ionicons name="document-text-outline" size={16} color={primaryColor} />
-              <ThemedText style={[styles.menuLinkText, { color: primaryColor }]}>
-                View menu
-              </ThemedText>
-              <Ionicons
-                name="open-outline"
-                size={13}
-                color={mutedColor}
-                style={{ marginLeft: "auto" }}
-              />
-            </Pressable>
-          ) : null}
 
           {/* Full weekly hours */}
           <View style={styles.subSection}>


### PR DESCRIPTION
## Summary

Three small UX fixes to the Locations list card (`LocationListItem.tsx`) from the recent navigation redesign (#205/#211):

- The "Book / details" CTA used a rightward arrow while the image banner used a chevron for the same expand/collapse concept — swapped it to a downward chevron (flipping to up on expand) for consistency.
- Clicking "Book / details" toggled the card open but only re-anchored the card *header* to the top of the viewport, which was a no-op once the header was already visible — leaving the newly revealed booking form off-screen below the fold. It now scrolls the booking form itself into view on expand, the same way a slot-time press already does.
- The description blurb and "View menu" link were only rendered once a location was expanded. They're now shown in the collapsed card as well, so a visitor can read the blurb and reach the menu without expanding first.

## Related issue

Follow-up polish to #205 / #211 (no tracking issue).

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `chevron-down`/`chevron-up` instead of `arrow-forward`/`chevron-up` on the "Book / details" pill.
- New `handleViewDetailsPress` handler: on expand, scrolls the booking form into view (via `onScrollToForm`) rather than the generic header-scroll (`onExpand`) used by clicks elsewhere in the card.
- Moved the description (`LinkedText`) and "View menu" `Pressable` blocks from the expanded-only accordion body up into the always-visible collapsed header.
- Converted the "Book / details" footer and "View menu" link to their own `Pressable`s (they're nested inside the header's expand-on-click `Pressable`), each calling `e?.stopPropagation?.()` so pressing them doesn't also toggle the outer expand — the `?.` guards are necessary because `fireEvent.press` in RNTL (and native press events generally) don't always populate a `stopPropagation` method on the event.

## Testing

- [x] `OpenRestoApi.Tests` pass locally (not touched, no backend changes)
- [x] Frontend tests/build pass locally — `npm test` (1864/1864 passed), `npm run check` (prettier + oxlint, exit 0), `tsc --noEmit` clean
- [x] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — ran the app locally (`dotnet watch` + `expo start --web`), confirmed via DOM/scroll-position inspection that clicking "Book / details" now scrolls the booking form to the top of the viewport (vs. a ~80px no-op scroll before), confirmed "View menu" no longer double-toggles the accordion, and confirmed the general header click (name/image) still uses the original lighter header-scroll — no regression there.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed (not applicable — no API/contract change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)