### PR TITLE
Add 'Any section' auto-assign to booking flow

### DIFF
--- a/OpenRestoApi.Tests/Controllers/BookingsControllerUnitTests.cs
+++ b/OpenRestoApi.Tests/Controllers/BookingsControllerUnitTests.cs
@@ -18,7 +18,10 @@ public class BookingsControllerUnitTests
 
     public BookingsControllerUnitTests()
     {
-        _mockBookingService = new Mock<BookingService>(null!, null!, null!, null!, null!, null!, null!, null!);
+        // BookingService has 7 required ctor params (the last being TableAutoAssigner, added
+        // for "Any section" auto-assign) + 2 optional. Moq needs a value per param to create
+        // the proxy; null! skips real initialization since these tests mock the methods directly.
+        _mockBookingService = new Mock<BookingService>(null!, null!, null!, null!, null!, null!, null!, null!, null!);
 
         var mockProvider = new Mock<IDataProtectionProvider>();
         mockProvider.Setup(p => p.CreateProtector(It.IsAny<string>())).Returns(new Mock<IDataProtector>().Object);

--- a/OpenRestoApi.Tests/Controllers/HoldsControllerUnitTests.cs
+++ b/OpenRestoApi.Tests/Controllers/HoldsControllerUnitTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using OpenRestoApi.Controllers;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Tests.Controllers;
@@ -17,15 +18,42 @@ public class HoldsControllerUnitTests
     {
         _mockHoldService = new Mock<IHoldService>();
         _mockPolicy = new Mock<IHoldPolicyService>();
-        _controller = new HoldsController(_mockHoldService.Object, _mockPolicy.Object);
+        // TableAutoAssigner is sealed, so we instantiate it directly. The explicit-table path
+        // under test never invokes it; the auto-assign tests below substitute via the policy mock.
+        TableAutoAssigner autoAssigner = new(new Mock<IBookingRepository>().Object);
+        _controller = new HoldsController(_mockHoldService.Object, _mockPolicy.Object, autoAssigner);
     }
+
+    private static PlaceHoldRequest ExplicitRequest(DateTime date) => new()
+    {
+        RestaurantId = 1,
+        TableId = 1,
+        SectionId = 1,
+        Date = date
+    };
 
     [Fact]
     public async Task PlaceHold_ReturnsBadRequest_WhenModelStateInvalid()
     {
         _controller.ModelState.AddModelError("Error", "Message");
-        var result = await _controller.PlaceHold(new PlaceHoldRequest());
+        var result = await _controller.PlaceHold(ExplicitRequest(DateTime.UtcNow.AddDays(1)));
         Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PlaceHold_ReturnsBadRequest_WhenOnlyOneOfTableOrSectionProvided()
+    {
+        var result = await _controller.PlaceHold(new PlaceHoldRequest
+        {
+            RestaurantId = 1,
+            TableId = 1,
+            // SectionId omitted
+            Date = DateTime.UtcNow.AddDays(1)
+        });
+
+        BadRequestObjectResult bad = Assert.IsType<BadRequestObjectResult>(result);
+        MessageResponse msg = Assert.IsType<MessageResponse>(bad.Value);
+        Assert.Contains("Specify both TableId and SectionId", msg.Message);
     }
 
     [Fact]
@@ -34,7 +62,7 @@ public class HoldsControllerUnitTests
         _mockPolicy.Setup(p => p.ValidateAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>()))
             .ReturnsAsync(HoldPolicyResult.NotFound());
 
-        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = DateTime.UtcNow.AddDays(1) });
+        var result = await _controller.PlaceHold(ExplicitRequest(DateTime.UtcNow.AddDays(1)));
 
         NotFoundObjectResult notFound = Assert.IsType<NotFoundObjectResult>(result);
         MessageResponse msg = Assert.IsType<MessageResponse>(notFound.Value);
@@ -47,7 +75,7 @@ public class HoldsControllerUnitTests
         _mockPolicy.Setup(p => p.ValidateAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>()))
             .ReturnsAsync(HoldPolicyResult.Rejected("no."));
 
-        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = DateTime.UtcNow.AddDays(1) });
+        var result = await _controller.PlaceHold(ExplicitRequest(DateTime.UtcNow.AddDays(1)));
 
         BadRequestObjectResult bad = Assert.IsType<BadRequestObjectResult>(result);
         MessageResponse msg = Assert.IsType<MessageResponse>(bad.Value);
@@ -60,7 +88,7 @@ public class HoldsControllerUnitTests
         _mockPolicy.Setup(p => p.ValidateAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>()))
             .ReturnsAsync(HoldPolicyResult.Booked("taken."));
 
-        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = DateTime.UtcNow.AddDays(1) });
+        var result = await _controller.PlaceHold(ExplicitRequest(DateTime.UtcNow.AddDays(1)));
 
         ConflictObjectResult conflict = Assert.IsType<ConflictObjectResult>(result);
         MessageResponse msg = Assert.IsType<MessageResponse>(conflict.Value);
@@ -81,7 +109,7 @@ public class HoldsControllerUnitTests
         _mockHoldService.Setup(s => s.PlaceHold(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>()))
             .Returns((HoldResult?)null);
 
-        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = date });
+        var result = await _controller.PlaceHold(ExplicitRequest(date));
 
         Assert.IsType<ConflictObjectResult>(result);
     }
@@ -99,7 +127,7 @@ public class HoldsControllerUnitTests
         _mockHoldService.Setup(s => s.PlaceHold(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), normalizedDate, It.IsAny<string?>(), 75))
             .Returns(new HoldResult("hold-1", DateTime.UtcNow.AddMinutes(5)));
 
-        var result = await _controller.PlaceHold(new PlaceHoldRequest { Date = rawDate });
+        var result = await _controller.PlaceHold(ExplicitRequest(rawDate));
 
         OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
         HoldResponse response = Assert.IsType<HoldResponse>(ok.Value);

--- a/OpenRestoApi.Tests/Holds/HoldServiceTests.cs
+++ b/OpenRestoApi.Tests/Holds/HoldServiceTests.cs
@@ -310,4 +310,113 @@ public class HoldServiceTests
 
         Assert.Equal(_clock.UtcNow + HoldService.HoldDuration, result.ExpiresAt);
     }
+
+    // ── PlaceAutoHold ────────────────────────────────────────────────────────
+
+    private static readonly TableCandidate[] _twoCandidates =
+    [
+        new(10, 1, 2),  // smallest first
+        new(11, 1, 4)
+    ];
+
+    [Fact]
+    public void PlaceAutoHold_PicksFirstFreeCandidate()
+    {
+        AutoAssignResult? result = _svc.PlaceAutoHold(_restaurantId, _twoCandidates, _bookingDate);
+
+        Assert.NotNull(result);
+        Assert.Equal(10, result!.TableId);
+        Assert.Equal(1, result.SectionId);
+        Assert.NotEmpty(result.HoldId);
+        Assert.Equal(_baseTime.Add(HoldService.HoldDuration), result.ExpiresAt);
+    }
+
+    [Fact]
+    public void PlaceAutoHold_FallsThroughToNextCandidate_WhenFirstIsHeld()
+    {
+        // Hold the first candidate via the single-table path (simulating another user).
+        _svc.PlaceHold(_restaurantId, tableId: 10, sectionId: 1, _bookingDate);
+
+        AutoAssignResult? result = _svc.PlaceAutoHold(_restaurantId, _twoCandidates, _bookingDate);
+
+        Assert.NotNull(result);
+        Assert.Equal(11, result!.TableId); // fell through to the 4-seater
+        Assert.Equal(1, result.SectionId);
+    }
+
+    [Fact]
+    public void PlaceAutoHold_ReturnsNull_WhenAllCandidatesHeld()
+    {
+        _svc.PlaceHold(_restaurantId, tableId: 10, sectionId: 1, _bookingDate);
+        _svc.PlaceHold(_restaurantId, tableId: 11, sectionId: 1, _bookingDate);
+
+        AutoAssignResult? result = _svc.PlaceAutoHold(_restaurantId, _twoCandidates, _bookingDate);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void PlaceAutoHold_ReturnsNull_ForEmptyCandidateList()
+    {
+        AutoAssignResult? result = _svc.PlaceAutoHold(_restaurantId, Array.Empty<TableCandidate>(), _bookingDate);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void PlaceAutoHold_AtomicallyExcludesCallerCurrentHold_OnSameTable()
+    {
+        // Caller already holds T10; re-requesting auto-assign with currentHoldId must allow
+        // re-acquiring the same candidate (mirrors PlaceHold's atomic-replace semantics).
+        AutoAssignResult first = _svc.PlaceAutoHold(_restaurantId, _twoCandidates, _bookingDate)!;
+
+        AutoAssignResult? second = _svc.PlaceAutoHold(
+            _restaurantId, _twoCandidates, _bookingDate, currentHoldId: first.HoldId);
+
+        Assert.NotNull(second);
+        Assert.NotEqual(first.HoldId, second!.HoldId);
+        Assert.Null(_svc.GetHold(first.HoldId)); // previous hold released
+    }
+
+    [Fact]
+    public void PlaceAutoHold_PersistedEntry_HasChosenTableAndSection()
+    {
+        AutoAssignResult result = _svc.PlaceAutoHold(_restaurantId, _twoCandidates, _bookingDate)!;
+
+        HoldEntry? entry = _svc.GetHold(result.HoldId);
+
+        Assert.NotNull(entry);
+        Assert.Equal(result.TableId, entry!.TableId);
+        Assert.Equal(result.SectionId, entry.SectionId);
+        Assert.Equal(_restaurantId, entry.RestaurantId);
+    }
+
+    [Fact]
+    public async Task PlaceAutoHold_NeverDoubleBooksSameTable_WhenContended()
+    {
+        // Stress the lock: 20 concurrent auto-assign requests competing for 3 candidate tables.
+        // Exactly 3 should win (one per table); the rest get null.
+        var candidates = new TableCandidate[]
+        {
+            new(100, 1, 2),
+            new(101, 1, 2),
+            new(102, 1, 2)
+        };
+        int successes = 0;
+        var winners = new System.Collections.Concurrent.ConcurrentBag<int>();
+
+        var tasks = Enumerable.Range(0, 20).Select(_ => Task.Run(() =>
+        {
+            AutoAssignResult? r = _svc.PlaceAutoHold(_restaurantId, candidates, _bookingDate);
+            if (r is not null)
+            {
+                System.Threading.Interlocked.Increment(ref successes);
+                winners.Add(r.TableId);
+            }
+        })).ToArray();
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(3, successes);                         // one winner per table
+        Assert.Equal(3, winners.Distinct().Count());        // no two winners share a table
+    }
 }

--- a/OpenRestoApi.Tests/Integration/BookingsControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/BookingsControllerTests.cs
@@ -418,4 +418,111 @@ public class BookingsControllerTests(TestWebAppFactory factory) : IClassFixture<
         Assert.NotEmpty(body!);
         Assert.Contains(body!, e => e.Email == "recent@test.com");
     }
+
+    // ── Auto-assign ("Any section") ───────────────────────────────────────────
+
+    private (int restaurantId, int t2Id, int t2SectionId) GetPastaPlaceIds()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        Restaurant pasta = db.Restaurants.First(r => r.Name == "Pasta Place");
+        Table t2 = db.Tables.First(t => t.Name == "T2");
+        return (pasta.Id, t2.Id, t2.SectionId);
+    }
+
+    [Fact]
+    public async Task CreateBooking_AutoAssign_PersistsResolvedTable()
+    {
+        HttpClient client = _factory.CreateClient();
+        (int restaurantId, int t2Id, int t2SectionId) = GetPastaPlaceIds();
+        string date = DateTime.UtcNow.AddDays(90).ToString("yyyy-MM-ddT12:00:00");
+
+        // No tableId/sectionId/holdId → server must auto-assign. For 2 seats the smallest
+        // fitting free table across Pasta Place is T2 (2 seats).
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/bookings", new
+        {
+            restaurantId,
+            date,
+            customerEmail = "auto@test.com",
+            seats = 2
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.False(string.IsNullOrEmpty(body.GetProperty("bookingRef").GetString()));
+        Assert.Equal(t2Id, body.GetProperty("tableId").GetInt32());
+        Assert.Equal(t2SectionId, body.GetProperty("sectionId").GetInt32());
+    }
+
+    [Fact]
+    public async Task CreateBooking_AutoAssign_ConsumesAutoHold()
+    {
+        HttpClient client = _factory.CreateClient();
+        (int restaurantId, int t2Id, _) = GetPastaPlaceIds();
+        string date = DateTime.UtcNow.AddDays(91).ToString("yyyy-MM-ddT12:00:00");
+
+        // Place an auto-assigned hold first.
+        HttpResponseMessage holdResp = await client.PostAsJsonAsync("/api/holds", new
+        {
+            restaurantId,
+            seats = 2,
+            date
+        });
+        Assert.Equal(HttpStatusCode.OK, holdResp.StatusCode);
+        JsonElement holdBody = await holdResp.Content.ReadFromJsonAsync<JsonElement>();
+        string? holdId = holdBody.GetProperty("holdId").GetString();
+        Assert.Equal(t2Id, holdBody.GetProperty("tableId").GetInt32()); // auto-resolved to T2
+
+        // Consume that hold with an auto-assign booking.
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/bookings", new
+        {
+            restaurantId,
+            date,
+            customerEmail = "auto2@test.com",
+            seats = 2,
+            holdId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(t2Id, body.GetProperty("tableId").GetInt32());
+    }
+
+    [Fact]
+    public async Task CreateBooking_AutoAssign_NeverDoubleBooksSameTable_WhenContended()
+    {
+        // Concurrency AC: two near-simultaneous "any table" submissions for the same slot
+        // must never both land on the same table. Pasta Place has exactly one 2-seat table
+        // (T2) and two 4-seat tables (T1, P1). For a 4-seat request, exactly two of three
+        // concurrent submissions should succeed (one per 4-seat table); the third should
+        // conflict. No table should be double-booked.
+        HttpClient client = _factory.CreateClient();
+        (int restaurantId, _, _) = GetPastaPlaceIds();
+        string date = DateTime.UtcNow.AddDays(92).ToString("yyyy-MM-ddT12:00:00");
+
+        var tasks = Enumerable.Range(0, 3).Select(i => Task.Run(async () =>
+        {
+            HttpClient c = _factory.CreateClient();
+            HttpResponseMessage r = await c.PostAsJsonAsync("/api/bookings", new
+            {
+                restaurantId,
+                date,
+                customerEmail = $"race{i}@test.com",
+                seats = 4
+            });
+            JsonElement body = await r.Content.ReadFromJsonAsync<JsonElement>();
+            return new { status = r.StatusCode, body };
+        })).ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        int created = results.Count(r => r.status == HttpStatusCode.Created);
+        Assert.Equal(2, created); // T1 and P1 each take one winner
+
+        // Collect the tableIds of the winners; they must be distinct.
+        var winnerTables = results
+            .Where(r => r.status == HttpStatusCode.Created)
+            .Select(r => r.body.GetProperty("tableId").GetInt32())
+            .ToList();
+        Assert.Equal(winnerTables.Count, winnerTables.Distinct().Count());
+    }
 }

--- a/OpenRestoApi.Tests/Integration/HoldsControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/HoldsControllerTests.cs
@@ -178,4 +178,89 @@ public class HoldsControllerTests(TestWebAppFactory factory) : IClassFixture<Tes
         HttpResponseMessage response = await client.PostAsJsonAsync("/api/holds", new { restaurantId = "invalid" });
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
+
+    // ── Auto-assign ("Any section") ───────────────────────────────────────────
+
+    private (int restaurantId, int t1Id, int t2Id, int p1Id, int t1SectionId, int p1SectionId) GetPastaPlaceTableIds()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        Restaurant pasta = db.Restaurants.First(r => r.Name == "Pasta Place");
+        Table t1 = db.Tables.First(t => t.Name == "T1");
+        Table t2 = db.Tables.First(t => t.Name == "T2");
+        Table p1 = db.Tables.First(t => t.Name == "P1");
+        return (pasta.Id, t1.Id, t2.Id, p1.Id, t1.SectionId, p1.SectionId);
+    }
+
+    [Fact]
+    public async Task PlaceHold_AutoAssign_ReturnsHoldWithResolvedTable()
+    {
+        HttpClient client = _factory.CreateClient();
+        (int restaurantId, int t1Id, int t2Id, int p1Id, _, _) = GetPastaPlaceTableIds();
+        // 2 seats → smallest fitting free table is T2 (2 seats).
+        var date = DateTime.UtcNow.AddDays(120).ToString("yyyy-MM-ddT12:00:00");
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/holds", new
+        {
+            restaurantId,
+            seats = 2,
+            date
+            // tableId/sectionId omitted → auto-assign
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.False(string.IsNullOrEmpty(body.GetProperty("holdId").GetString()));
+        Assert.Equal(t2Id, body.GetProperty("tableId").GetInt32()); // resolved to T2
+    }
+
+    [Fact]
+    public async Task PlaceHold_AutoAssign_Returns400_WhenSeatsMissing()
+    {
+        HttpClient client = _factory.CreateClient();
+        int restaurantId = GetPastaPlaceTableIds().restaurantId;
+        var date = DateTime.UtcNow.AddDays(121).ToString("yyyy-MM-ddT12:00:00");
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/holds", new
+        {
+            restaurantId,
+            date
+            // no seats, no tableId/sectionId
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PlaceHold_AutoAssign_Returns409_WhenAllEligibleTablesHeld()
+    {
+        HttpClient client = _factory.CreateClient();
+        (int restaurantId, int t1Id, int t2Id, int p1Id, int t1SectionId, int p1SectionId) = GetPastaPlaceTableIds();
+        string date = DateTime.UtcNow.AddDays(122).ToString("yyyy-MM-ddT12:00:00");
+
+        // Hold all 2-seat-fitting tables (T1, T2, P1 all fit 2 seats) via explicit holds.
+        // T1 and T2 share the Indoor section; P1 is in Patio.
+        foreach ((int tid, int sid) in new[] { (t1Id, t1SectionId), (t2Id, t1SectionId), (p1Id, p1SectionId) })
+        {
+            HttpResponseMessage holdResp = await client.PostAsJsonAsync("/api/holds", new
+            {
+                restaurantId,
+                tableId = tid,
+                sectionId = sid,
+                date
+            });
+            Assert.Equal(HttpStatusCode.OK, holdResp.StatusCode);
+        }
+
+        // Now an auto-assign for 2 seats should find no free candidate.
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/holds", new
+        {
+            restaurantId,
+            seats = 2,
+            date
+        });
+
+        Assert.True(response.StatusCode == HttpStatusCode.Conflict,
+            $"Expected Conflict but got {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+    }
 }

--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -18,7 +18,11 @@ public class BookingServiceTests
         IHoldService? holdService = null,
         IBookingConfirmationService? confirmationService = null)
     {
-        holdService ??= new Mock<IHoldService>().Object;
+        // Auto-assign tests need a real in-memory HoldService so PlaceAutoHold actually places
+        // holds (a loose Mock<IHoldService> returns null from PlaceAutoHold, which the service
+        // interprets as "all candidates held"). Tests that don't exercise auto-assign can pass
+        // their own mock.
+        holdService ??= new OpenRestoApi.Infrastructure.Holds.HoldService(new UtcClock());
         return new BookingService(
             new BookingRepository(db),
             new TableRepository(db),
@@ -26,7 +30,40 @@ public class BookingServiceTests
             new RestaurantRepository(db),
             holdService,
             new BookingMapper(),
+            new TableAutoAssigner(new BookingRepository(db)),
             confirmationService);
+    }
+
+    private sealed class UtcClock : ISystemClock
+    {
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Seeds a restaurant with two sections and a spread of table sizes, for auto-assign
+    /// tests that need to assert "smallest fitting free table across sections".
+    ///
+    /// Section 1 "Main":  T1 (2 seats), T2 (4 seats), T3 (6 seats)
+    /// Section 2 "Patio": P1 (2 seats), P2 (4 seats)
+    /// </summary>
+    private static void SeedMultiTableRestaurant(AppDbContext db)
+    {
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "Auto-Assign Bistro",
+            OpenTime = "00:00",
+            CloseTime = "23:59",
+            Timezone = "UTC"
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Sections.Add(new Section { Id = 2, Name = "Patio", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 2, SectionId = 1 });
+        db.Tables.Add(new Table { Id = 2, Name = "T2", Seats = 4, SectionId = 1 });
+        db.Tables.Add(new Table { Id = 3, Name = "T3", Seats = 6, SectionId = 1 });
+        db.Tables.Add(new Table { Id = 4, Name = "P1", Seats = 2, SectionId = 2 });
+        db.Tables.Add(new Table { Id = 5, Name = "P2", Seats = 4, SectionId = 2 });
+        db.SaveChanges();
     }
 
     // ── CreateBookingAsync ────────────────────────────────────────────────────
@@ -809,5 +846,213 @@ public class BookingServiceTests
         });
 
         Assert.NotEmpty(result.BookingRef!);
+    }
+
+    // ── CreateBookingAsync — auto-assign ("Any section") ──────────────────────
+    //
+    // When TableId/SectionId are both null, the service picks the smallest fitting free
+    // table across all sections, atomically places a hold, and persists the booking against
+    // the resolved table. These tests cover each branch of that path.
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_PicksSmallestFittingFreeTable()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_PicksSmallestFittingFreeTable));
+        SeedMultiTableRestaurant(db);
+        BookingService svc = CreateService(db);
+
+        // 3 seats — fits T2(4)/T3(6)/P2(4) but not T1(2)/P1(2). Smallest fitting is T2.
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 3,
+            Date = DateTime.UtcNow.AddDays(7)
+        });
+
+        Assert.Equal(2, result.TableId); // T2 — smallest fitting free
+        Assert.Equal(1, result.SectionId);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_TiebreaksByTableId()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_TiebreaksByTableId));
+        SeedMultiTableRestaurant(db);
+        BookingService svc = CreateService(db);
+
+        // 2 seats — both T1(2) and P1(2) fit. Tie-break by TableId: T1 (id 1) < P1 (id 4).
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = DateTime.UtcNow.AddDays(8)
+        });
+
+        Assert.Equal(1, result.TableId);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_FallsThroughToNextTable_WhenFirstTaken()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_FallsThroughToNextTable_WhenFirstTaken));
+        SeedMultiTableRestaurant(db);
+        // Pre-book T1 (the smallest 2-seater) for the target date.
+        DateTime date = DateTime.UtcNow.AddDays(9);
+        db.Bookings.Add(new Booking
+        {
+            RestaurantId = 1, TableId = 1, SectionId = 1, Date = date,
+            BookingRef = "PREBOOK", EndTime = date.AddMinutes(60)
+        });
+        db.SaveChanges();
+        BookingService svc = CreateService(db);
+
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = date
+        });
+
+        // T1 is taken; next smallest 2-seater is P1 (id 4).
+        Assert.Equal(4, result.TableId);
+        Assert.Equal(2, result.SectionId);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_CrossesSections_WhenSectionFull()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_CrossesSections_WhenSectionFull));
+        SeedMultiTableRestaurant(db);
+        DateTime date = DateTime.UtcNow.AddDays(10);
+        // Fill every Main-section table that fits 2 seats.
+        foreach (int tid in new[] { 1, 2, 3 })
+        {
+            db.Bookings.Add(new Booking
+            {
+                RestaurantId = 1, TableId = tid, SectionId = 1, Date = date,
+                BookingRef = $"PRE{tid}", EndTime = date.AddMinutes(60)
+            });
+        }
+        db.SaveChanges();
+        BookingService svc = CreateService(db);
+
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = date
+        });
+
+        // All Main tables booked → auto-assign should land in Patio (section 2).
+        Assert.Equal(2, result.SectionId);
+        Assert.Equal(4, result.TableId); // P1, smallest Patio 2-seater
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_Throws_WhenNoEligibleTable()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_Throws_WhenNoEligibleTable));
+        SeedMultiTableRestaurant(db);
+        BookingService svc = CreateService(db);
+
+        // 100 seats — no table fits.
+        ConflictException ex = await Assert.ThrowsAsync<ConflictException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 100,
+            Date = DateTime.UtcNow.AddDays(11)
+        }));
+
+        Assert.Contains("No tables are available", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]   // TableId null, SectionId set
+    [InlineData(1, null)]   // TableId set, SectionId null
+    public async Task CreateBookingAsync_AutoAssign_Throws_WhenExactlyOneIdNull(int? tableId, int? sectionId)
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_Throws_WhenExactlyOneIdNull) + $"_{tableId}_{sectionId}");
+        SeedMultiTableRestaurant(db);
+        BookingService svc = CreateService(db);
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            TableId = tableId,
+            SectionId = sectionId,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = DateTime.UtcNow.AddDays(12)
+        }));
+
+        Assert.Contains("Specify both TableId and SectionId", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_AdoptsTableFromValidHold()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_AdoptsTableFromValidHold));
+        SeedMultiTableRestaurant(db);
+        DateTime date = DateTime.UtcNow.AddDays(13);
+
+        // Simulate a pre-existing auto-assigned hold on T2 via a mocked IHoldService.
+        // The service's ResolveAutoAssignAsync should adopt the held table/section without
+        // running the candidate search.
+        var holdMock = new Mock<IHoldService>();
+        holdMock
+            .Setup(h => h.GetHold("hold-T2"))
+            .Returns(new HoldEntry("hold-T2", TableId: 2, SectionId: 1, RestaurantId: 1, Date: date, ExpiresAt: DateTime.UtcNow.AddMinutes(5)));
+        holdMock.Setup(h => h.IsTableHeld(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>())).Returns(false);
+        holdMock.Setup(h => h.ReleaseHold(It.IsAny<string>()));
+        BookingService svc = new BookingService(
+            new BookingRepository(db),
+            new TableRepository(db),
+            new SectionRepository(db),
+            new RestaurantRepository(db),
+            holdMock.Object,
+            new BookingMapper(),
+            new TableAutoAssigner(new BookingRepository(db)));
+
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 4,
+            Date = date,
+            HoldId = "hold-T2"
+        });
+
+        Assert.Equal(2, result.TableId); // adopted from the hold
+        Assert.Equal(1, result.SectionId);
+        // The candidate path must not have been invoked.
+        holdMock.Verify(h => h.PlaceAutoHold(It.IsAny<int>(), It.IsAny<IReadOnlyList<TableCandidate>>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_PersistsResolvedTableOnBookingRow()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_PersistsResolvedTableOnBookingRow));
+        SeedMultiTableRestaurant(db);
+        BookingService svc = CreateService(db);
+        DateTime date = DateTime.UtcNow.AddDays(14);
+
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "persist@example.com",
+            Seats = 2,
+            Date = date
+        });
+
+        // Reload from DB to confirm the resolved table/section were persisted.
+        Booking? persisted = await db.Bookings.FirstOrDefaultAsync(b => b.BookingRef == result.BookingRef);
+        Assert.NotNull(persisted);
+        Assert.Equal(result.TableId, persisted!.TableId);
+        Assert.Equal(result.SectionId, persisted.SectionId);
     }
 }

--- a/OpenRestoApi.Tests/Services/HoldPolicyServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/HoldPolicyServiceTests.cs
@@ -297,4 +297,102 @@ public class HoldPolicyServiceTests
         mockBookingRepo.Verify(
             b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), 90), Times.Once);
     }
+
+    // ── ValidateAnyTableAsync ────────────────────────────────────────────────
+    //
+    // Mirrors ValidateAsync's restaurant-level policy gates but skips the per-table booking
+    // check (the candidate builder handles that). The tests below confirm the restaurant-level
+    // gates still fire and that a confirmed booking does NOT block auto-assign upfront.
+
+    [Fact]
+    public async Task ValidateAnyTableAsync_ReturnsNotFound_WhenRestaurantMissing()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(ValidateAnyTableAsync_ReturnsNotFound_WhenRestaurantMissing));
+        HoldPolicyService svc = NewService(db);
+
+        HoldPolicyResult result = await svc.ValidateAnyTableAsync(999, DateTime.UtcNow.AddDays(1));
+
+        Assert.Equal(HoldPolicyStatus.NotFound, result.Status);
+    }
+
+    [Fact]
+    public async Task ValidateAnyTableAsync_ReturnsRejected_WhenPastDate()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(ValidateAnyTableAsync_ReturnsRejected_WhenPastDate));
+        SeedRestaurant(db);
+        HoldPolicyService svc = NewService(db);
+
+        HoldPolicyResult result = await svc.ValidateAnyTableAsync(1, DateTime.UtcNow.AddHours(-1));
+
+        Assert.Equal(HoldPolicyStatus.Rejected, result.Status);
+        Assert.Contains("past", result.FailureMessage);
+    }
+
+    [Fact]
+    public async Task ValidateAnyTableAsync_ReturnsRejected_WhenPaused()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(ValidateAnyTableAsync_ReturnsRejected_WhenPaused));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1, Name = "T", OpenTime = "00:00", CloseTime = "23:59", Timezone = "UTC",
+            BookingsPausedUntil = DateTime.UtcNow.AddDays(1)
+        });
+        db.SaveChanges();
+        HoldPolicyService svc = NewService(db);
+
+        HoldPolicyResult result = await svc.ValidateAnyTableAsync(1, DateTime.UtcNow.AddDays(2));
+
+        Assert.Equal(HoldPolicyStatus.Rejected, result.Status);
+        Assert.Contains("paused", result.FailureMessage);
+    }
+
+    [Fact]
+    public async Task ValidateAnyTableAsync_ReturnsEligible_AndSkipsPerTableBookingCheck()
+    {
+        // Key difference vs ValidateAsync: a confirmed booking on a specific table does NOT
+        // block the auto-assign policy gate. The candidate builder will simply exclude that
+        // table from the pool; another free table can still win.
+        using AppDbContext db = TestDbFactory.Create(nameof(ValidateAnyTableAsync_ReturnsEligible_AndSkipsPerTableBookingCheck));
+        SeedRestaurant(db);
+        var date = DateTime.UtcNow.Date.AddDays(1).AddHours(12);
+        db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, TableId = 1, SectionId = 1, Date = date, BookingRef = "B1"
+        });
+        db.SaveChanges();
+
+        // Use a mock booking repo to assert the per-table check is NOT called for auto-assign.
+        var mockBookingRepo = new Mock<IBookingRepository>();
+        mockBookingRepo
+            .Setup(b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ReturnsAsync(true); // would block if called
+        var svc = new HoldPolicyService(new RestaurantRepository(db), mockBookingRepo.Object);
+
+        HoldPolicyResult result = await svc.ValidateAnyTableAsync(1, date);
+
+        Assert.Equal(HoldPolicyStatus.Eligible, result.Status);
+        Assert.NotNull(result.Restaurant);
+        mockBookingRepo.Verify(
+            b => b.IsTableBookedOnDateAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ValidateAnyTableAsync_ReturnsRejected_WhenClosed()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(ValidateAnyTableAsync_ReturnsRejected_WhenClosed));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1, Name = "T", OpenTime = "17:00", CloseTime = "22:00", Timezone = "UTC"
+        });
+        db.SaveChanges();
+        HoldPolicyService svc = NewService(db);
+
+        // 10:00 UTC is before opening — should be rejected.
+        var closedTime = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
+        HoldPolicyResult result = await svc.ValidateAnyTableAsync(1, closedTime);
+
+        Assert.Equal(HoldPolicyStatus.Rejected, result.Status);
+        Assert.Contains("closed", result.FailureMessage);
+    }
 }

--- a/OpenRestoApi/Controllers/HoldsController.cs
+++ b/OpenRestoApi/Controllers/HoldsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Services;
 
 namespace OpenRestoApi.Controllers;
 
@@ -10,14 +11,18 @@ namespace OpenRestoApi.Controllers;
 [EnableRateLimiting("public")]
 public class HoldsController(
     IHoldService holdService,
-    IHoldPolicyService holdPolicyService) : ControllerBase
+    IHoldPolicyService holdPolicyService,
+    TableAutoAssigner autoAssigner) : ControllerBase
 {
     private readonly IHoldService _holdService = holdService;
     private readonly IHoldPolicyService _holdPolicyService = holdPolicyService;
+    private readonly TableAutoAssigner _autoAssigner = autoAssigner;
 
     /// <summary>
     /// Places a temporary hold on a table for a given date.
     /// Returns 409 Conflict if the table is already held by someone else.
+    /// When <see cref="PlaceHoldRequest.TableId"/>/<see cref="PlaceHoldRequest.SectionId"/>
+    /// are omitted, the server auto-assigns the best available table across all sections.
     /// </summary>
     [HttpPost]
     public async Task<IActionResult> PlaceHold([FromBody] PlaceHoldRequest request)
@@ -27,15 +32,27 @@ public class HoldsController(
             return BadRequest(ModelState);
         }
 
-        HoldPolicyResult policy = await _holdPolicyService.ValidateAsync(
-            request.RestaurantId, request.TableId, request.Date);
+        bool autoAssign = request.TableId is null && request.SectionId is null;
+        if (request.TableId is null ^ request.SectionId is null)
+        {
+            return BadRequest(new MessageResponse
+            {
+                Message = "Specify both TableId and SectionId, or omit both for auto-assign."
+            });
+        }
+
+        HoldPolicyResult policy = autoAssign
+            ? await _holdPolicyService.ValidateAnyTableAsync(request.RestaurantId, request.Date)
+            : await _holdPolicyService.ValidateAsync(request.RestaurantId, request.TableId!.Value, request.Date);
 
         return policy.Status switch
         {
             HoldPolicyStatus.NotFound => NotFound(new MessageResponse { Message = "Restaurant not found." }),
             HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage! }),
             HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage! }),
-            _ => PlaceEligibleHold(request, policy)
+            _ => autoAssign
+                ? await PlaceAutoAssignedHold(request, policy)
+                : PlaceEligibleHold(request, policy)
         };
     }
 
@@ -43,8 +60,8 @@ public class HoldsController(
     {
         HoldResult? result = _holdService.PlaceHold(
             request.RestaurantId,
-            request.TableId,
-            request.SectionId,
+            request.TableId!.Value,
+            request.SectionId!.Value,
             policy.BookingDate,
             request.CurrentHoldId,
             policy.Restaurant!.DefaultBookingDurationMinutes);
@@ -58,6 +75,51 @@ public class HoldsController(
         {
             HoldId = result.HoldId,
             ExpiresAt = result.ExpiresAt
+        });
+    }
+
+    private async Task<IActionResult> PlaceAutoAssignedHold(PlaceHoldRequest request, HoldPolicyResult policy)
+    {
+        if (request.Seats <= 0)
+        {
+            return BadRequest(new MessageResponse
+            {
+                Message = "Seats is required for auto-assign so the server can pick a table that fits your party."
+            });
+        }
+
+        IReadOnlyList<TableCandidate> candidates = await _autoAssigner.BuildCandidatesAsync(
+            policy.Restaurant!, request.Seats, policy.BookingDate);
+
+        if (candidates.Count == 0)
+        {
+            return Conflict(new MessageResponse
+            {
+                Message = "No tables are available for the requested time and party size."
+            });
+        }
+
+        AutoAssignResult? result = _holdService.PlaceAutoHold(
+            request.RestaurantId,
+            candidates,
+            policy.BookingDate,
+            request.CurrentHoldId,
+            policy.Restaurant!.DefaultBookingDurationMinutes);
+
+        if (result == null)
+        {
+            return Conflict(new MessageResponse
+            {
+                Message = "All suitable tables are currently being held by other users. Please try again shortly."
+            });
+        }
+
+        return Ok(new HoldResponse
+        {
+            HoldId = result.HoldId,
+            ExpiresAt = result.ExpiresAt,
+            TableId = result.TableId,
+            SectionId = result.SectionId
         });
     }
 

--- a/OpenRestoApi/Core/Application/DTOs/HoldDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/HoldDto.cs
@@ -3,10 +3,28 @@ namespace OpenRestoApi.Core.Application.DTOs;
 public class PlaceHoldRequest
 {
     public int RestaurantId { get; set; }
-    public int TableId { get; set; }
-    public int SectionId { get; set; }
+
+    /// <summary>
+    /// Specific table to hold. When null (and <see cref="SectionId"/> is also null), the
+    /// server auto-assigns the best available table across all sections ("Any section" flow).
+    /// </summary>
+    public int? TableId { get; set; }
+
+    /// <summary>
+    /// Specific section of <see cref="TableId"/>. When null (and <see cref="TableId"/> is
+    /// also null), the server auto-assigns. Must be provided whenever <see cref="TableId"/> is.
+    /// </summary>
+    public int? SectionId { get; set; }
+
+    /// <summary>
+    /// Party size. Required for auto-assign (so the server can pick a table with enough seats);
+    /// ignored for explicit-table holds (the capacity check happens at booking time).
+    /// </summary>
+    public int Seats { get; set; }
+
     /// <summary>Full ISO 8601 datetime of the intended booking.</summary>
     public DateTime Date { get; set; }
+
     /// <summary>If the caller already holds this ID, the backend atomically replaces it.</summary>
     public string? CurrentHoldId { get; set; }
 }
@@ -15,6 +33,18 @@ public class HoldResponse
 {
     public string HoldId { get; set; } = string.Empty;
     public DateTime ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Resolved table for auto-assigned holds ("Any section"). Null for explicit-table holds
+    /// where the caller already knows the table.
+    /// </summary>
+    public int? TableId { get; set; }
+
+    /// <summary>
+    /// Resolved section for auto-assigned holds ("Any section"). Null for explicit-table holds.
+    /// </summary>
+    public int? SectionId { get; set; }
+
     /// <summary>Seconds until the hold expires, for countdown display.</summary>
     public int SecondsRemaining => Math.Max(0, (int)(ExpiresAt - DateTime.UtcNow).TotalSeconds);
 }

--- a/OpenRestoApi/Core/Application/Interfaces/IHoldPolicyService.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IHoldPolicyService.cs
@@ -49,4 +49,14 @@ public interface IHoldPolicyService
     /// confirmed booking overlaps the table. Never throws for expected policy violations.
     /// </summary>
     Task<HoldPolicyResult> ValidateAsync(int restaurantId, int tableId, DateTime requestedDate);
+
+    /// <summary>
+    /// Validates an "Any section" / auto-assign hold request. Runs the same restaurant-level
+    /// policy checks as <see cref="ValidateAsync"/> (restaurant exists, timezone-normalize,
+    /// past-date, pause, walk-in, operating hours) but skips the per-table booking check —
+    /// the caller computes the candidate pool separately and the hold placement happens
+    /// atomically inside <c>HoldService</c>. Returns <see cref="HoldPolicyStatus.Eligible"/>
+    /// with the resolved restaurant + UTC booking date.
+    /// </summary>
+    Task<HoldPolicyResult> ValidateAnyTableAsync(int restaurantId, DateTime requestedDate);
 }

--- a/OpenRestoApi/Core/Application/Interfaces/IHoldService.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IHoldService.cs
@@ -11,6 +11,19 @@ public record HoldEntry(
 
 public record HoldResult(string HoldId, DateTime ExpiresAt);
 
+/// <summary>
+/// A restaurant-wide candidate table for auto-assignment ("Any section").
+/// Callers pre-sort candidates by <see cref="Seats"/> ascending (then by <see cref="TableId"/>
+/// for determinism) before passing them in, so the smallest fitting table wins.
+/// </summary>
+public record TableCandidate(int TableId, int SectionId, int Seats);
+
+/// <summary>
+/// Outcome of an auto-assign hold: the placed hold plus the table/section the server
+/// resolved, so the caller can persist or display the chosen table.
+/// </summary>
+public record AutoAssignResult(string HoldId, DateTime ExpiresAt, int TableId, int SectionId);
+
 public interface IHoldService
 {
     HoldResult? PlaceHold(int restaurantId, int tableId, int sectionId, DateTime bookingDate, string? currentHoldId = null, int durationMinutes = 60);
@@ -18,4 +31,19 @@ public interface IHoldService
     bool IsTableHeld(int tableId, DateTime bookingDate, string? excludeHoldId = null, int durationMinutes = 60);
     HoldEntry? GetHold(string holdId);
     int GetActiveHoldsCount();
+
+    /// <summary>
+    /// Auto-assign variant of <see cref="PlaceHold"/> for "Any section" requests. Iterates
+    /// <paramref name="candidates"/> (already sorted by the caller: Seats ascending, then
+    /// TableId) and places a hold on the first one that is not held by someone else, all
+    /// inside the existing placement lock so the pick + hold are atomic. Returns
+    /// <c>null</c> if every candidate is taken. The caller's <paramref name="currentHoldId"/>
+    /// is excluded from the held-check and atomically replaced, matching <see cref="PlaceHold"/>.
+    /// </summary>
+    AutoAssignResult? PlaceAutoHold(
+        int restaurantId,
+        IReadOnlyList<TableCandidate> candidates,
+        DateTime bookingDate,
+        string? currentHoldId = null,
+        int durationMinutes = 60);
 }

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -14,6 +14,7 @@ public class BookingService(
     IRestaurantRepository restaurantRepository,
     IHoldService holdService,
     BookingMapper mapper,
+    TableAutoAssigner autoAssigner,
     IBookingConfirmationService? confirmationService = null,
     INotificationQueue? notificationQueue = null)
 {
@@ -23,6 +24,7 @@ public class BookingService(
     private readonly IRestaurantRepository _restaurantRepository = restaurantRepository;
     private readonly IHoldService _holdService = holdService;
     private readonly BookingMapper _mapper = mapper;
+    private readonly TableAutoAssigner _autoAssigner = autoAssigner;
     private readonly IBookingConfirmationService? _confirmationService = confirmationService;
     private readonly INotificationQueue? _notificationQueue = notificationQueue;
 
@@ -66,11 +68,25 @@ public class BookingService(
         }
 
         if (bookingDto.TableId is null || bookingDto.SectionId is null)
-            throw new ValidationException("TableId and SectionId are required.");
+        {
+            // Exactly one of the two is null — that's ambiguous; reject. Both null means
+            // "Any section" auto-assign, which we resolve below before the rest of the
+            // method (which assumes concrete ids).
+            if (bookingDto.TableId is null ^ bookingDto.SectionId is null)
+            {
+                throw new ValidationException("Specify both TableId and SectionId, or neither for auto-assign.");
+            }
+
+            await ResolveAutoAssignAsync(bookingDto, restaurant, bookingDate);
+        }
+
+        // After auto-assign resolution (or an explicit selection) both ids are guaranteed set.
+        int tableId = bookingDto.TableId!.Value;
+        int sectionId = bookingDto.SectionId!.Value;
 
         // 1. Check DB for an existing confirmed booking on the same table+date
         bool alreadyBooked = await _bookingRepository.IsTableBookedOnDateAsync(
-            bookingDto.TableId.Value, bookingDate, restaurant.DefaultBookingDurationMinutes);
+            tableId, bookingDate, restaurant.DefaultBookingDurationMinutes);
 
         if (alreadyBooked)
         {
@@ -79,7 +95,7 @@ public class BookingService(
 
         // 2. Check for an active hold by someone else
         bool heldByOther = _holdService.IsTableHeld(
-            bookingDto.TableId.Value, bookingDate, excludeHoldId: bookingDto.HoldId,
+            tableId, bookingDate, excludeHoldId: bookingDto.HoldId,
             durationMinutes: restaurant.DefaultBookingDurationMinutes);
 
         if (heldByOther)
@@ -88,7 +104,7 @@ public class BookingService(
         }
 
         // 3. Check for seat capacity
-        Table? table = await _tableRepository.GetByIdAsync(bookingDto.TableId.Value);
+        Table? table = await _tableRepository.GetByIdAsync(tableId);
         if (table != null && bookingDto.Seats > table.Seats)
         {
             throw new ConflictException($"This table only has {table.Seats} seats, but {bookingDto.Seats} guests were requested.");
@@ -100,7 +116,7 @@ public class BookingService(
         booking.BookingRef = BookingRefGenerator.Generate();
         booking.EndTime = bookingDate.AddMinutes(restaurant.DefaultBookingDurationMinutes);
         booking.Table = table!;
-        booking.Section = (await _sectionRepository.GetByIdAsync(bookingDto.SectionId.Value))!;
+        booking.Section = (await _sectionRepository.GetByIdAsync(sectionId))!;
         booking.Restaurant = restaurant;
 
         Booking newBooking = await _bookingRepository.AddAsync(booking);
@@ -127,6 +143,67 @@ public class BookingService(
         }
 
         return _mapper.ToDto(newBooking);
+    }
+
+    /// <summary>
+    /// Resolves a "Any section" auto-assign booking request: populates
+    /// <paramref name="bookingDto"/>.TableId/SectionId (and HoldId when a fresh hold is placed)
+    /// so the caller's downstream checks and persistence work unchanged. If a valid
+    /// <see cref="BookingDto.HoldId"/> was provided, the held table/section are adopted
+    /// directly; otherwise the candidate pool is built and a new hold is placed atomically
+    /// via <see cref="IHoldService.PlaceAutoHold"/>. Throws <see cref="ConflictException"/>
+    /// when no candidate is free.
+    /// </summary>
+    private async Task ResolveAutoAssignAsync(BookingDto bookingDto, Restaurant restaurant, DateTime bookingDate)
+    {
+        // 1. If the caller already holds an auto-assigned table, adopt it. This avoids a
+        //    second race: the hold was placed atomically, so the held table is "ours" until
+        //    the booking lands or the hold expires.
+        if (!string.IsNullOrEmpty(bookingDto.HoldId))
+        {
+            HoldEntry? held = _holdService.GetHold(bookingDto.HoldId);
+            if (held is not null && held.RestaurantId == restaurant.Id)
+            {
+                // The hold is on a specific table — verify it still fits and isn't double-booked
+                // in the DB (the hold only guards against other in-memory holds). If something
+                // changed under us, fall through to the candidate search.
+                bool booked = await _bookingRepository.IsTableBookedOnDateAsync(
+                    held.TableId, bookingDate, restaurant.DefaultBookingDurationMinutes);
+                if (!booked)
+                {
+                    bookingDto.TableId = held.TableId;
+                    bookingDto.SectionId = held.SectionId;
+                    return;
+                }
+            }
+        }
+
+        // 2. No usable hold — build candidates and place a fresh hold atomically. The new
+        //    hold id is stashed on the DTO so the existing "release hold after persist" step
+        //    at the end of CreateBookingAsync cleans it up.
+        IReadOnlyList<TableCandidate> candidates = await _autoAssigner.BuildCandidatesAsync(
+            restaurant, bookingDto.Seats, bookingDate);
+
+        if (candidates.Count == 0)
+        {
+            throw new ConflictException("No tables are available for the requested time and party size.");
+        }
+
+        AutoAssignResult? assigned = _holdService.PlaceAutoHold(
+            restaurant.Id,
+            candidates,
+            bookingDate,
+            currentHoldId: bookingDto.HoldId,
+            restaurant.DefaultBookingDurationMinutes);
+
+        if (assigned is null)
+        {
+            throw new ConflictException("All suitable tables are currently being held by other users. Please try again shortly.");
+        }
+
+        bookingDto.TableId = assigned.TableId;
+        bookingDto.SectionId = assigned.SectionId;
+        bookingDto.HoldId = assigned.HoldId; // ensure the release-at-end step tears it down
     }
 
     public virtual async Task<BookingDto?> GetBookingByIdAsync(int id)

--- a/OpenRestoApi/Core/Application/Services/HoldPolicyService.cs
+++ b/OpenRestoApi/Core/Application/Services/HoldPolicyService.cs
@@ -20,6 +20,42 @@ public sealed class HoldPolicyService(
 
     public async Task<HoldPolicyResult> ValidateAsync(int restaurantId, int tableId, DateTime requestedDate)
     {
+        HoldPolicyResult restaurantPolicy = await ValidateRestaurantPolicyAsync(restaurantId, requestedDate);
+        if (restaurantPolicy.Status != HoldPolicyStatus.Eligible)
+        {
+            return restaurantPolicy;
+        }
+
+        // Existing confirmed booking on the same table.
+        DateTime bookingDate = restaurantPolicy.BookingDate;
+        Restaurant restaurant = restaurantPolicy.Restaurant!;
+        bool alreadyBooked = await _bookingRepository.IsTableBookedOnDateAsync(
+            tableId, bookingDate, restaurant.DefaultBookingDurationMinutes);
+        if (alreadyBooked)
+        {
+            return HoldPolicyResult.Booked("This table is already booked for that time.");
+        }
+
+        return restaurantPolicy;
+    }
+
+    public async Task<HoldPolicyResult> ValidateAnyTableAsync(int restaurantId, DateTime requestedDate)
+    {
+        // Same restaurant-level policy gates as ValidateAsync, but no per-table booking
+        // check — the caller will compute the candidate pool and HoldService.PlaceAutoHold
+        // will atomically pick the first free table under its lock.
+        return await ValidateRestaurantPolicyAsync(restaurantId, requestedDate);
+    }
+
+    /// <summary>
+    /// Shared restaurant-level policy checks (1–6 of the original ValidateAsync): fetch +
+    /// timezone-normalize + past-date + pause + walk-in + operating hours. Returns
+    /// <see cref="HoldPolicyStatus.Eligible"/> with the resolved restaurant and UTC booking
+    /// date, or the appropriate rejection status. The per-table booking check is left to
+    /// the callers because auto-assign needs to evaluate it per-candidate, not upfront.
+    /// </summary>
+    private async Task<HoldPolicyResult> ValidateRestaurantPolicyAsync(int restaurantId, DateTime requestedDate)
+    {
         // 1. Fetch restaurant first to get its timezone.
         Restaurant? restaurant = await _restaurantRepository.GetByIdAsync(restaurantId);
         if (restaurant == null)
@@ -54,14 +90,6 @@ public sealed class HoldPolicyService(
         if (!restaurant.IsOpenAt(bookingDate))
         {
             return HoldPolicyResult.Rejected("The restaurant is closed at the requested time.");
-        }
-
-        // 7. Existing confirmed booking on the same table.
-        bool alreadyBooked = await _bookingRepository.IsTableBookedOnDateAsync(
-            tableId, bookingDate, restaurant.DefaultBookingDurationMinutes);
-        if (alreadyBooked)
-        {
-            return HoldPolicyResult.Booked("This table is already booked for that time.");
         }
 
         return HoldPolicyResult.Eligible(restaurant, bookingDate);

--- a/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
+++ b/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
@@ -1,0 +1,68 @@
+using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Core.Application.Services;
+
+/// <summary>
+/// Computes the ordered candidate-table list for "Any section" auto-assignment, shared by
+/// the holds controller (hold placement) and <see cref="BookingService"/> (booking creation).
+/// The actual atomic pick happens inside <see cref="IHoldService.PlaceAutoHold"/>'s lock —
+/// this class only builds the pre-sorted pool (smallest fitting free table first).
+/// </summary>
+public sealed class TableAutoAssigner(IBookingRepository bookingRepository)
+{
+    private readonly IBookingRepository _bookingRepository = bookingRepository;
+
+    /// <summary>
+    /// Returns the restaurant's tables that (a) have at least <paramref name="seats"/> seats and
+    /// (b) have no overlapping confirmed booking at <paramref name="bookingDateUtc"/>, ordered
+    /// ascending by <see cref="Table.Seats"/> then <see cref="Table.Id"/> for a deterministic
+    /// "smallest fitting free table" pick. Empty when nothing fits.
+    /// </summary>
+    public async Task<IReadOnlyList<TableCandidate>> BuildCandidatesAsync(
+        Restaurant restaurant,
+        int seats,
+        DateTime bookingDateUtc)
+    {
+        if (restaurant.Sections is null || restaurant.Sections.Count == 0 || seats <= 0)
+        {
+            return Array.Empty<TableCandidate>();
+        }
+
+        // Capacity filter first — same predicate as AvailabilityService.GetAvailabilityAsync's
+        // restaurant-wide eligible-table set, so the auto-assign pool matches what the
+        // availability feed advertises per slot.
+        var eligible = restaurant.Sections
+            .Where(s => s.Tables != null)
+            .SelectMany(s => s.Tables!.Where(t => t != null).Select(t => (table: t!, sectionId: s.Id)))
+            .Where(x => x.table.Seats >= seats)
+            .ToList();
+
+        if (eligible.Count == 0)
+        {
+            return Array.Empty<TableCandidate>();
+        }
+
+        int durationMinutes = restaurant.DefaultBookingDurationMinutes;
+
+        // Drop tables with an existing confirmed booking overlapping this slot. Done serially
+        // because IsTableBookedOnDateAsync is per-table; the candidate count is small (one
+        // restaurant's tables) and this runs once per auto-assign request before the lock.
+        var free = new List<TableCandidate>(eligible.Count);
+        foreach ((Table table, int sectionId) in eligible)
+        {
+            bool booked = await _bookingRepository.IsTableBookedOnDateAsync(
+                table.Id, bookingDateUtc, durationMinutes);
+            if (!booked)
+            {
+                free.Add(new TableCandidate(table.Id, sectionId, table.Seats));
+            }
+        }
+
+        // Smallest fitting free table first; tie-break by id for deterministic ordering.
+        return free
+            .OrderBy(c => c.Seats)
+            .ThenBy(c => c.TableId)
+            .ToList();
+    }
+}

--- a/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
+++ b/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
@@ -158,6 +158,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISystemClock, SystemClock>();
         services.AddSingleton<IHoldService, HoldService>();
         services.AddScoped<IHoldPolicyService, HoldPolicyService>();
+        services.AddScoped<TableAutoAssigner>();
 
         services.AddScoped<IBookingRepository, BookingRepository>();
         services.AddScoped<IBookingFilterRepository, BookingFilterRepository>();

--- a/OpenRestoApi/Infrastructure/Holds/HoldService.cs
+++ b/OpenRestoApi/Infrastructure/Holds/HoldService.cs
@@ -12,6 +12,7 @@ namespace OpenRestoApi.Infrastructure.Holds;
 /// </summary>
 [OnlyAccessibleBy("OpenRestoApi.Extensions.ServiceCollectionExtensions")]
 [OnlyAccessibleBy("OpenRestoApi.Tests.Holds.HoldServiceTests")]
+[OnlyAccessibleBy("OpenRestoApi.Tests.Services.BookingServiceTests")]
 [ExternalAccessAllowed]
 internal class HoldService(ISystemClock clock) : IHoldService
 {
@@ -48,6 +49,47 @@ internal class HoldService(ISystemClock clock) : IHoldService
             _holds[holdId] = entry;
 
             return new HoldResult(holdId, expiresAt);
+        }
+    }
+
+    public AutoAssignResult? PlaceAutoHold(
+        int restaurantId,
+        IReadOnlyList<TableCandidate> candidates,
+        DateTime bookingDate,
+        string? currentHoldId = null,
+        int durationMinutes = 60)
+    {
+        // The candidate scan + the place must happen under the same lock so two concurrent
+        // "any" submissions can't both observe the same table as free and grab it (TOCTOU).
+        // IsTableHeld reads _holds, and PlaceHold writes to it — both under _placeLock today,
+        // so reusing that lock here keeps the auto-assign pick race-free by construction.
+        lock (_placeLock)
+        {
+            Cleanup();
+
+            foreach (TableCandidate candidate in candidates)
+            {
+                if (IsTableHeld(candidate.TableId, bookingDate, excludeHoldId: currentHoldId, durationMinutes: durationMinutes))
+                {
+                    continue;
+                }
+
+                // Atomically release the caller's previous hold before placing the new one
+                if (currentHoldId != null)
+                {
+                    _holds.TryRemove(currentHoldId, out _);
+                }
+
+                string holdId = Guid.NewGuid().ToString("N");
+                DateTime expiresAt = _clock.UtcNow.Add(HoldDuration);
+                var entry = new HoldEntry(holdId, candidate.TableId, candidate.SectionId, restaurantId, bookingDate, expiresAt);
+
+                _holds[holdId] = entry;
+
+                return new AutoAssignResult(holdId, expiresAt, candidate.TableId, candidate.SectionId);
+            }
+
+            return null;
         }
     }
 

--- a/openresto-frontend/api/bookings.ts
+++ b/openresto-frontend/api/bookings.ts
@@ -21,8 +21,10 @@ export interface BookingDto {
 
 export interface BookingCreationDto {
   restaurantId: number;
-  tableId: number;
-  sectionId: number;
+  /** Omit (or null) for "Any section" auto-assign — the server picks the best table. */
+  tableId: number | null;
+  /** Omit (or null) for "Any section" auto-assign. */
+  sectionId: number | null;
   customerEmail: string;
   customerName: string;
   seats: number;

--- a/openresto-frontend/api/holds.ts
+++ b/openresto-frontend/api/holds.ts
@@ -2,8 +2,12 @@ import { post, del } from "./client";
 
 export interface HoldRequest {
   restaurantId: number;
-  tableId: number;
-  sectionId: number;
+  /** Omit (or null) for "Any section" auto-assign — the server picks the best table. */
+  tableId: number | null;
+  /** Omit (or null) for "Any section" auto-assign. */
+  sectionId: number | null;
+  /** Required for auto-assign so the server can pick a table that fits the party. */
+  seats?: number;
   date: string; // ISO 8601
   currentHoldId?: string;
 }
@@ -12,6 +16,10 @@ export interface HoldResponse {
   holdId: string;
   expiresAt: string; // ISO 8601
   secondsRemaining: number;
+  /** Resolved table id for auto-assigned holds; null for explicit-table holds. */
+  tableId?: number | null;
+  /** Resolved section id for auto-assigned holds; null for explicit-table holds. */
+  sectionId?: number | null;
 }
 
 /** Successful hold. */

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -25,8 +25,10 @@ export interface BookingFormData {
   customerEmail: string;
   customerName: string;
   seats: number;
-  tableId: number;
-  sectionId: number;
+  /** null when "Any section" is selected (server auto-assigns the table). */
+  tableId: number | null;
+  /** null when "Any section" is selected. */
+  sectionId: number | null;
   date: string;
   time: string;
   holdId: string | null;
@@ -93,10 +95,16 @@ export default function BookingForm({
   const [specialRequests, setSpecialRequests] = useState("");
   const [seats, setSeats] = useState(initialSeats ?? 2);
   const [submitting, setSubmitting] = useState(false);
-  const [sectionId, setSectionId] = useState<number>(() => restaurant.sections[0]?.id ?? 0);
+  const [sectionId, setSectionId] = useState<number>(0); // 0 = "Any section" (server auto-assigns)
 
   const allTables = restaurant.sections.flatMap((s) => s.tables);
-  const sectionOptions = restaurant.sections.map((s) => ({ label: s.name, value: s.id }));
+  // "Any section" is the default option (value 0); concrete sections follow. When selected,
+  // the form hides the table dropdown and lets the server pick the best available table.
+  const sectionOptions = [
+    { label: "Any section", value: 0 },
+    ...restaurant.sections.map((s) => ({ label: s.name, value: s.id })),
+  ];
+  const isAutoAssign = sectionId === 0;
   const tablesInSection = restaurant.sections.find((s) => s.id === sectionId)?.tables ?? allTables;
 
   const timezone = restaurant.timezone || "UTC";
@@ -137,15 +145,24 @@ export default function BookingForm({
     return eligible[0]?.id ?? pool[0]?.id;
   }
 
-  const { holdStatus, holdMessage, secondsLeft, holdId, setHoldStatus, releaseCurrentHold } =
-    useTableHold({
-      restaurantId: restaurant.id,
-      sections: restaurant.sections,
-      tableId,
-      date,
-      time,
-      email: customerEmail,
-    });
+  const {
+    holdStatus,
+    holdMessage,
+    secondsLeft,
+    holdId,
+    resolvedTableId,
+    setHoldStatus,
+    releaseCurrentHold,
+  } = useTableHold({
+    restaurantId: restaurant.id,
+    sections: restaurant.sections,
+    tableId,
+    date,
+    time,
+    email: customerEmail,
+    autoAssign: isAutoAssign,
+    seats,
+  });
 
   // Fetch availability when date/seats change
   useEffect(() => {
@@ -183,8 +200,13 @@ export default function BookingForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [date, seats, restaurant.id]);
 
-  // When availability or time changes, ensure we have a valid table selected
+  // When availability or time changes, ensure we have a valid table selected.
+  // Skipped in auto-assign mode — the server picks the table, so we don't pre-select one here.
   useEffect(() => {
+    if (isAutoAssign) {
+      if (tableId !== undefined) setTableId(undefined);
+      return;
+    }
     const candidates = restaurant.sections.find((s) => s.id === sectionId)?.tables ?? allTables;
     if (availableTableIds.length > 0) {
       if (!tableId || !availableTableIds.includes(tableId)) {
@@ -195,11 +217,17 @@ export default function BookingForm({
       setTableId(bestTableFor(seats, undefined, candidates));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [availableTableIds, seats]);
+  }, [availableTableIds, seats, isAutoAssign]);
 
-  // When section changes, release hold and pick best table in new section
+  // When section changes, release hold and pick best table in new section (or clear the
+  // table selection when switching into "Any section" auto-assign mode).
   useEffect(() => {
     releaseCurrentHold();
+    if (isAutoAssign) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setTableId(undefined);
+      return;
+    }
     const candidates = restaurant.sections.find((s) => s.id === sectionId)?.tables ?? allTables;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setTableId(
@@ -253,7 +281,7 @@ export default function BookingForm({
     selectedDayHours.close <= selectedDayHours.open ? "23:45" : selectedDayHours.close;
 
   const isValid =
-    !!tableId &&
+    (isAutoAssign || !!tableId) && // table dropdown hidden for "Any section" — auto-hold still gates
     !!date &&
     !!time &&
     customerName.trim().length > 0 &&
@@ -279,8 +307,10 @@ export default function BookingForm({
         customerEmail,
         customerName,
         seats,
-        tableId,
-        sectionId,
+        // For "Any section", defer table selection to the server (null ids trigger auto-assign
+        // on the booking create path; the server will adopt the held table from the hold id).
+        tableId: isAutoAssign ? null : (tableId ?? null),
+        sectionId: isAutoAssign ? null : sectionId,
         date,
         time,
         holdId,
@@ -377,7 +407,12 @@ export default function BookingForm({
       <View style={isWeb ? styles.fieldRow : undefined}>
         <View style={[styles.field, isWeb && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Table</ThemedText>
-          {eligibleTables.length === 0 ? (
+          {isAutoAssign ? (
+            <ThemedText style={[styles.autoAssignHint, { color: colors.muted }]}>
+              We'll seat you at the best available table
+              {resolvedTableId ? "" : " across all sections"}.
+            </ThemedText>
+          ) : eligibleTables.length === 0 ? (
             <ThemedText style={[styles.noTables, { color: colors.error }]}>
               No tables available for {seats} guests.
             </ThemedText>
@@ -425,7 +460,7 @@ export default function BookingForm({
             <HoldStatusBanner
               holdStatus={holdStatus}
               secondsLeft={secondsLeft}
-              hasSelection={!!tableId && !!date && !!time}
+              hasSelection={(isAutoAssign || !!tableId) && !!date && !!time}
               holdMessage={holdMessage}
               onRefresh={onRefresh}
             />
@@ -462,7 +497,7 @@ export default function BookingForm({
         )}
       </Button>
 
-      {!submitting && holdStatus !== "held" && tableId && date && time && (
+      {!submitting && holdStatus !== "held" && (isAutoAssign || tableId) && date && time && (
         <ThemedText style={styles.hint}>A table hold is required before confirming.</ThemedText>
       )}
     </View>
@@ -500,6 +535,10 @@ const styles = StyleSheet.create({
   noTables: {
     color: "#e53e3e",
     fontSize: 13,
+  },
+  autoAssignHint: {
+    fontSize: 13,
+    fontStyle: "italic",
   },
   closedDayNotice: {
     fontSize: 13,

--- a/openresto-frontend/components/booking/useTableHold.ts
+++ b/openresto-frontend/components/booking/useTableHold.ts
@@ -14,6 +14,10 @@ export interface UseTableHoldParams {
   date: string;
   time: string;
   email: string;
+  /** When true, fire holds without a specific table ("Any section") and let the server pick. */
+  autoAssign?: boolean;
+  /** Required when autoAssign is true — sent so the server can pick a fitting table. */
+  seats?: number;
 }
 
 export interface UseTableHoldResult {
@@ -22,6 +26,10 @@ export interface UseTableHoldResult {
   holdMessage: string | null;
   secondsLeft: number;
   holdId: string | null;
+  /** Table id the server resolved for an auto-assigned hold (null for explicit holds). */
+  resolvedTableId: number | null;
+  /** Section id the server resolved for an auto-assigned hold (null for explicit holds). */
+  resolvedSectionId: number | null;
   setHoldStatus: (status: HoldStatus) => void;
   releaseCurrentHold: () => void;
 }
@@ -33,12 +41,16 @@ export function useTableHold({
   date,
   time,
   email,
+  autoAssign = false,
+  seats,
 }: UseTableHoldParams): UseTableHoldResult {
   const [hold, setHold] = useState<HoldResponse | null>(null);
   const [holdStatus, setHoldStatus] = useState<HoldStatus>("idle");
   const [holdMessage, setHoldMessage] = useState<string | null>(null);
   const [secondsLeft, setSecondsLeft] = useState(0);
   const [holdId, setHoldId] = useState<string | null>(null);
+  const [resolvedTableId, setResolvedTableId] = useState<number | null>(null);
+  const [resolvedSectionId, setResolvedSectionId] = useState<number | null>(null);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentHoldId = useRef<string | null>(null);
@@ -79,12 +91,16 @@ export function useTableHold({
     setHold(null);
     setHoldStatus("idle");
     setHoldMessage(null);
+    setResolvedTableId(null);
+    setResolvedSectionId(null);
     clearCountdown();
   }
 
   // Debounced hold trigger
   useEffect(() => {
-    if (!tableId || !date || !time || !isValidEmail(email)) {
+    // Auto-assign mode fires without a tableId; explicit mode still requires one.
+    const hasTableForHold = autoAssign || (!!tableId && tableId > 0);
+    if (!hasTableForHold || !date || !time || !isValidEmail(email)) {
       if (debounceTimer.current) {
         clearTimeout(debounceTimer.current);
       }
@@ -94,7 +110,7 @@ export function useTableHold({
       return;
     }
 
-    const paramsKey = `${restaurantId}-${tableId}-${date}-${time}`;
+    const paramsKey = `${restaurantId}-${autoAssign ? "auto" : tableId}-${date}-${time}-${seats ?? ""}`;
     if (hold && holdStatus === "held" && lastAppliedParams.current === paramsKey) {
       return;
     }
@@ -108,14 +124,19 @@ export function useTableHold({
       const previousHoldId = currentHoldId.current;
       lastAppliedParams.current = paramsKey;
 
-      const sectionId = sections.find((s) => s.tables.some((t) => t.id === tableId))?.id ?? 0;
+      // For auto-assign, send null table/section + seats so the server picks the best table.
+      // For explicit selection, resolve the section from the tableId as before.
+      const sectionId = autoAssign
+        ? null
+        : (sections.find((s) => s.tables.some((t) => t.id === tableId))?.id ?? 0);
       // Send naive ISO string (no 'Z' or offset) so backend can interpret as restaurant-local
       const naiveIsoDate = `${date}T${time}:00`;
 
       const result = await createHold({
         restaurantId,
-        tableId,
+        tableId: autoAssign ? null : tableId!,
         sectionId,
+        seats: autoAssign ? seats : undefined,
         date: naiveIsoDate,
         currentHoldId: previousHoldId ?? undefined,
       });
@@ -126,6 +147,10 @@ export function useTableHold({
         setHoldId(result.hold.holdId);
         setHold(result.hold);
         setHoldMessage(null);
+        // For auto-assigned holds, capture the server-resolved table/section so the form
+        // can submit them with the booking (the booking create then "adopts" the held table).
+        setResolvedTableId(result.hold.tableId ?? null);
+        setResolvedSectionId(result.hold.sectionId ?? null);
         setHoldStatus("held");
         startCountdown(result.hold.expiresAt);
       } else {
@@ -135,6 +160,8 @@ export function useTableHold({
         currentHoldId.current = null;
         setHoldId(null);
         setHold(null);
+        setResolvedTableId(null);
+        setResolvedSectionId(null);
         clearCountdown();
         setHoldMessage(result.message);
         setHoldStatus("unavailable");
@@ -147,7 +174,7 @@ export function useTableHold({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tableId, date, time, email]);
+  }, [tableId, date, time, email, autoAssign, seats]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -168,6 +195,8 @@ export function useTableHold({
     holdMessage,
     secondsLeft,
     holdId,
+    resolvedTableId,
+    resolvedSectionId,
     setHoldStatus,
     releaseCurrentHold,
   };

--- a/openresto-frontend/components/restaurant/LocationListItem.tsx
+++ b/openresto-frontend/components/restaurant/LocationListItem.tsx
@@ -188,6 +188,13 @@ export default function LocationListItem({
   const handleSubmit = async (data: BookingFormData) => {
     setSubmitError(null);
     const dateTime = convertLocalToUtc(data.date, data.time, restaurant.timezone || "UTC");
+    // For "Any section" (null tableId/sectionId), the server auto-assigns the best table.
+    // For explicit selection, fall back to the table's owning section if sectionId wasn't set.
+    const resolvedSectionId =
+      data.sectionId ??
+      (data.tableId !== null
+        ? (restaurant.sections.find((s) => s.tables.some((t) => t.id === data.tableId))?.id ?? null)
+        : null);
     const bookingData = {
       customerEmail: data.customerEmail,
       customerName: data.customerName,
@@ -195,10 +202,7 @@ export default function LocationListItem({
       tableId: data.tableId,
       holdId: data.holdId,
       restaurantId: restaurant.id,
-      sectionId:
-        data.sectionId ||
-        restaurant.sections.find((s) => s.tables.some((t) => t.id === data.tableId))?.id ||
-        0,
+      sectionId: resolvedSectionId,
       date: dateTime,
       specialRequests: data.specialRequests || null,
     };

--- a/openresto-frontend/tests/api/holds.test.ts
+++ b/openresto-frontend/tests/api/holds.test.ts
@@ -86,6 +86,34 @@ describe("createHold", () => {
     const result = await createHold(request);
     expect(result.ok).toBe(false);
   });
+
+  it("posts auto-assign hold (null table/section + seats) and returns resolved table", async () => {
+    // "Any section" request: null tableId/sectionId + seats, so the server picks the table.
+    const autoRequest = {
+      restaurantId: 1,
+      tableId: null,
+      sectionId: null,
+      seats: 2,
+      date: "2026-06-15T19:00:00Z",
+    };
+    const holdResp = {
+      holdId: "auto-1",
+      expiresAt: "2026-06-15T19:05:00Z",
+      secondsRemaining: 300,
+      tableId: 42, // server-resolved
+      sectionId: 7,
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => holdResp,
+    });
+
+    const result = await createHold(autoRequest);
+    expect(result).toEqual({ ok: true, hold: holdResp });
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(JSON.parse(opts.body)).toEqual(autoRequest);
+  });
 });
 
 describe("releaseHold", () => {

--- a/openresto-frontend/tests/components/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/BookingForm.test.tsx
@@ -57,6 +57,8 @@ describe("BookingForm", () => {
       holdStatus: "held",
       secondsLeft: 60,
       holdId: "h-123",
+      resolvedTableId: null,
+      resolvedSectionId: null,
       setHoldStatus: mockSetHoldStatus,
       releaseCurrentHold: mockReleaseCurrentHold,
     });
@@ -64,6 +66,17 @@ describe("BookingForm", () => {
     delete (window as any).confirm;
     (window as any).confirm = jest.fn(() => true);
   });
+
+  /**
+   * The form defaults to "Any section" (table dropdown hidden). Tests that exercise the
+   * explicit-table path call this to switch into the "Main" section first.
+   */
+  function selectMainSection() {
+    // The section Select's trigger shows the selected option label. Open the modal, then
+    // pick "Main".
+    fireEvent.press(screen.getByText("Any section"));
+    fireEvent.press(screen.getByText("Main"));
+  }
 
   it("renders correctly and handles submission", async () => {
     const onSubmit = jest.fn();
@@ -88,6 +101,9 @@ describe("BookingForm", () => {
   it("shows warning when seats exceed table capacity", async () => {
     const onSubmit = jest.fn();
     renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={onSubmit} />);
+
+    // Switch out of "Any section" so the explicit table dropdown is visible.
+    selectMainSection();
 
     // Select 4 guests (Table T1 has 2, T2 has 4).
     // The component defaults to best fitting table.
@@ -117,6 +133,9 @@ describe("BookingForm", () => {
     (window as any).confirm = jest.fn(() => false);
     const onSubmit = jest.fn();
     renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={onSubmit} />);
+
+    // Switch out of "Any section" so the explicit table dropdown is visible.
+    selectMainSection();
 
     // Bumping guests to 5 (above every table's capacity) re-runs
     // auto-selection, which falls back to the first table (T1, 2 seats),
@@ -168,6 +187,9 @@ describe("BookingForm", () => {
     };
     renderWithProviders(<BookingForm restaurant={restaurant} onSubmit={jest.fn()} />);
 
+    // Switch out of "Any section" so the explicit table dropdown is visible.
+    selectMainSection();
+
     // T1 (2 seats) is auto-selected by default; open the table Select to
     // reveal the full option list, including the unnamed table's fallback label.
     fireEvent.press(screen.getByText("T1 (2 seats)"));
@@ -177,6 +199,9 @@ describe("BookingForm", () => {
 
   it("renders 'No tables available' when guests exceed all tables", () => {
     renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={jest.fn()} />);
+
+    // Switch out of "Any section" so the explicit table dropdown is visible.
+    selectMainSection();
 
     fireEvent.press(screen.getByText("2 seats"));
     fireEvent.press(screen.getByText("10 seats")); // mockRestaurant max is 4
@@ -211,6 +236,9 @@ describe("BookingForm", () => {
     renderWithProviders(
       <BookingForm restaurant={mockRestaurant} onSubmit={jest.fn()} initialTime="09:00" />
     );
+
+    // Switch out of "Any section" so the explicit table dropdown is visible.
+    selectMainSection();
 
     await waitFor(() => {
       // Only T2 (id 101) should be shown; T1 (id 100) should be filtered out

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -40,6 +40,8 @@ jest.mock("@/components/booking/useTableHold", () => ({
     holdStatus: mockHoldStatus,
     secondsLeft: 0,
     holdId: null,
+    resolvedTableId: null,
+    resolvedSectionId: null,
     setHoldStatus: mockSetHoldStatus,
     releaseCurrentHold: mockReleaseCurrentHold,
   }),
@@ -239,8 +241,12 @@ const mockRestaurantWideOpen = {
 beforeEach(() => {
   jest.clearAllMocks();
   mockHoldStatus = "idle";
+  // Both tables (T1=100 in Main, T2=200 in Patio) are available so switching sections
+  // in either direction still surfaces a table dropdown.
   mockFetchAvailability.mockResolvedValue({
-    slots: [{ time: "19:00", isAvailable: true, availableTableIds: [100], category: "Dinner" }],
+    slots: [
+      { time: "19:00", isAvailable: true, availableTableIds: [100, 200], category: "Dinner" },
+    ],
   });
   // jest.clearAllMocks() clears call history but not a mockReturnValue set by
   // an earlier test — restore the module's default "now" here so tests don't
@@ -340,9 +346,11 @@ describe("BookingForm", () => {
     });
   });
 
-  it("renders 'No tables available' and omits the timezone hint for a restaurant with no sections and no timezone", () => {
+  it("renders the 'Any section' auto-assign hint and omits the timezone hint for a restaurant with no sections and no timezone", () => {
+    // With no sections to switch to, the form stays in "Any section" mode and shows the
+    // auto-assign hint instead of the legacy "No tables available" explicit-table message.
     render(<BookingForm restaurant={mockRestaurantEmptySections} onSubmit={jest.fn()} />);
-    expect(screen.getByText("No tables available for 2 guests.")).toBeTruthy();
+    expect(screen.getByText(/We'll seat you at the best available table/)).toBeTruthy();
     expect(screen.queryByText(/All times are in/)).toBeNull();
   });
 
@@ -442,24 +450,76 @@ describe("BookingForm", () => {
   it("resets hold status to idle when the table is changed while held", async () => {
     mockHoldStatus = "held";
     render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    // The form defaults to "Any section" (table dropdown hidden); switch to a concrete
+    // section to expose the table dropdown.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select"));
+    });
     await waitFor(() => expect(screen.getByTestId("table-select")).toBeTruthy());
-    fireEvent.press(screen.getByTestId("table-select"));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("table-select"));
+    });
     expect(mockSetHoldStatus).toHaveBeenCalledWith("idle");
   });
 
   it("resets hold status to idle when the table is changed while expired", async () => {
     mockHoldStatus = "expired";
     render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select"));
+    });
     await waitFor(() => expect(screen.getByTestId("table-select")).toBeTruthy());
-    fireEvent.press(screen.getByTestId("table-select"));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("table-select"));
+    });
     expect(mockSetHoldStatus).toHaveBeenCalledWith("idle");
   });
 
   it("does not reset hold status when the table is changed while idle", async () => {
     mockHoldStatus = "idle";
     render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select"));
+    });
     await waitFor(() => expect(screen.getByTestId("table-select")).toBeTruthy());
-    fireEvent.press(screen.getByTestId("table-select"));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("table-select"));
+    });
     expect(mockSetHoldStatus).not.toHaveBeenCalled();
+  });
+
+  // ── "Any section" auto-assign ──────────────────────────────────────────────
+
+  it("defaults to 'Any section' and shows the auto-assign hint instead of the table dropdown", () => {
+    render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    // The auto-assign hint replaces the table dropdown.
+    expect(screen.getByText(/We'll seat you at the best available table/)).toBeTruthy();
+    expect(screen.queryByTestId("table-select")).toBeNull();
+  });
+
+  it("reveals the table dropdown when a concrete section is selected", async () => {
+    render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    expect(screen.queryByTestId("table-select")).toBeNull();
+    // section-select mock fires onSelect(20) -> Patio section.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select"));
+    });
+    await waitFor(() => expect(screen.getByTestId("table-select")).toBeTruthy());
+    // Switching out of "Any section" hides the auto-assign hint.
+    expect(screen.queryByText(/We'll seat you at the best available table/)).toBeNull();
+  });
+
+  it("submits with null tableId/sectionId when 'Any section' is active", async () => {
+    mockHoldStatus = "held";
+    const onSubmit = jest.fn();
+    render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={onSubmit} />);
+    fireEvent.changeText(screen.getByPlaceholderText("Your full name"), "Auto User");
+    fireEvent.changeText(screen.getByPlaceholderText("your@email.com"), "auto@test.com");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Confirm Booking"));
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ tableId: null, sectionId: null })
+    );
   });
 });

--- a/openresto-frontend/tests/hooks/useTableHold.test.ts
+++ b/openresto-frontend/tests/hooks/useTableHold.test.ts
@@ -272,4 +272,68 @@ describe("useTableHold", () => {
     expect(result.current.holdStatus).toBe("unavailable");
     expect(result.current.hold).toBeNull();
   });
+
+  // ── Auto-assign ("Any section") mode ───────────────────────────────────────
+
+  it("auto-assign mode fires hold without a tableId and adopts the server-resolved table", async () => {
+    mockCreateHold.mockResolvedValueOnce({
+      ok: true,
+      hold: {
+        holdId: "auto-hold-1",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+        tableId: 42, // server-resolved
+        sectionId: 7,
+      },
+    });
+
+    // autoAssign + seats; tableId left undefined.
+    const params: UseTableHoldParams = {
+      ...defaultParams,
+      autoAssign: true,
+      seats: 2,
+    };
+    const { result } = renderHook(() => useTableHold(params));
+
+    expect(result.current.holdStatus).toBe("pending");
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    // Must send null table/section + seats so the server picks the table.
+    expect(mockCreateHold).toHaveBeenCalledWith(
+      expect.objectContaining({
+        restaurantId: 1,
+        tableId: null,
+        sectionId: null,
+        seats: 2,
+      })
+    );
+    expect(result.current.holdStatus).toBe("held");
+    expect(result.current.resolvedTableId).toBe(42);
+    expect(result.current.resolvedSectionId).toBe(7);
+  });
+
+  it("auto-assign mode surfaces unavailable when server rejects", async () => {
+    mockCreateHold.mockResolvedValueOnce({
+      ok: false,
+      message: "No tables are available for the requested time and party size.",
+    });
+
+    const params: UseTableHoldParams = {
+      ...defaultParams,
+      autoAssign: true,
+      seats: 99,
+    };
+    const { result } = renderHook(() => useTableHold(params));
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.holdStatus).toBe("unavailable");
+    expect(result.current.resolvedTableId).toBeNull();
+    expect(result.current.resolvedSectionId).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #243.

## Summary

Decouples the customer's section/table choice from the booking: when the customer picks **"Any section"** (now the default), the server picks the best available table across all sections at submit time. This eliminates the race where two concurrent "any" submissions could grab the same nominally-free table, and removes the friction of forcing every customer to choose a specific section/table.

Per the issue's explicit requirement: *"The server, not the client, performs the final table assignment at submit time."* The auto-assign pick happens **inside `HoldService`'s existing `lock (_placeLock)`** so the candidate scan + hold placement are atomic.

## Changes

**Backend**
- `IHoldService.PlaceAutoHold` — iterates pre-sorted candidates inside the existing placement lock; first free table wins (TOCTOU-safe by construction).
- `IHoldPolicyService.ValidateAnyTableAsync` — runs restaurant-level policy gates (pause/walk-in/open-hours/past-date) without the per-table booking check; the candidate builder handles that.
- `TableAutoAssigner` (new) — shared helper that builds the ordered candidate pool (smallest fitting free table first, tie-broken by `TableId`), reusing the same capacity + booking-overlap predicates as `AvailabilityService`.
- `HoldsController` + `BookingService.CreateBookingAsync` — branch on null `TableId`/`SectionId` to auto-assign. `BookingService` adopts the held table when a `HoldId` is provided, otherwise places a fresh auto-hold atomically.
- `PlaceHoldRequest.TableId`/`SectionId` widened to `int?`; `HoldResponse` gains `TableId`/`SectionId` for the server-resolved table. No schema migration — `Booking.TableId`/`SectionId` are already `int?`.

**Frontend**
- `BookingForm` defaults to "Any section" (`value: 0`); the table dropdown is hidden and replaced with a muted *"We'll seat you at the best available table"* hint. Selecting a concrete section reveals the table dropdown as before.
- `useTableHold` gains `autoAssign` + `seats` params; fires holds with `null` table/section and adopts the server-resolved table from the response.
- `api/holds.ts` + `api/bookings.ts` + `BookingFormData` widen ids to `number | null`.

## Acceptance criteria

- [x] Section selector defaults to and offers an "Any section" option — `BookingForm.tsx` default `sectionId = 0`, "Any section" prepended to options.
- [x] With "Any section" selected, the customer isn't required to pick a specific table — table dropdown hidden, `isValid` drops the `!!tableId` requirement when `isAutoAssign`.
- [x] `POST /api/holds` accepts a request with no `TableId`/`SectionId` and returns a hold for a server-chosen eligible table — `HoldsControllerTests.PlaceHold_AutoAssign_ReturnsHoldWithResolvedTable`.
- [x] `POST /api/bookings` accepts a booking with no `TableId`/`SectionId` (or consumes the auto-assigned hold) and persists the resolved table/section — `BookingsControllerTests.CreateBooking_AutoAssign_PersistsResolvedTable` + `CreateBooking_AutoAssign_ConsumesAutoHold`.
- [x] Two near-simultaneous "any table" submissions for the same slot never both succeed for the same table — `HoldServiceTests.PlaceAutoHold_NeverDoubleBooksSameTable_WhenContended` (20-way stress) + `BookingsControllerTests.CreateBooking_AutoAssign_NeverDoubleBooksSameTable_WhenContended` (3-way HTTP).
- [x] Existing explicit section/table selection continues to work unchanged — all pre-existing booking/hold tests stay green; explicit selection path preserved.

## Test coverage

- **Backend unit:** `BookingServiceTests` (9 new auto-assign tests), `HoldServiceTests` (7 new incl. 20-way concurrency), `HoldPolicyServiceTests` (5 new `ValidateAnyTableAsync` tests).
- **Backend integration:** `HoldsControllerTests` (3 new), `BookingsControllerTests` (3 new incl. 3-way concurrency over HTTP).
- **Frontend:** `BookingForm.test.tsx` (both files — 5 new auto-assign tests + updated existing tests to select a section first), `useTableHold.test.ts` (2 new), `holds.test.ts` (1 new).

Full suite: backend 1142/1144 pass (2 pre-existing `SqlitePragmaInterceptorTests` Windows file-locking failures unrelated to this change, confirmed on clean main); frontend 1876/1876 pass.

## Out of scope (per issue)
- Admin walk-in bookings (`AdminService.CreateBookingAsync`) — unchanged.
- Multi-instance/Redis-backed holds — documented single-instance; out of scope.

## Notes
- No schema migration, no `scripts/` changes, no docker stack changes (verified — no env vars/ports/volumes/healthchecks reference table selection).