### PR TITLE
feat: add restaurant MaxTableOversizeSeats setting

### DIFF
--- a/OpenRestoApi.Tests/Migrations/MaxTableOversizeSeatsMigrationTests.cs
+++ b/OpenRestoApi.Tests/Migrations/MaxTableOversizeSeatsMigrationTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using OpenRestoApi.Infrastructure.Persistence;
+
+namespace OpenRestoApi.Tests.Migrations;
+
+/// <summary>
+/// Proves the AddRestaurantMaxTableOversizeSeats migration (#244) produces a correct nullable
+/// INTEGER column both on a fresh install (Migrate() from empty) and on an upgrade from the
+/// prior migration, and that the two schemas match exactly (the repo's migration-safety
+/// invariant enforced by migration-check.yml).
+/// </summary>
+public class MaxTableOversizeSeatsMigrationTests : IDisposable
+{
+    private const string LastMigrationBeforeOversize = "20260719220106_AddBookingSlotIntervalMinutes";
+
+    private readonly SqliteConnection _connection;
+
+    public MaxTableOversizeSeatsMigrationTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private AppDbContext CreateContext()
+    {
+        DbContextOptions<AppDbContext> opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new AppDbContext(opts);
+    }
+
+    [Fact]
+    public async Task FreshInstall_CreatesNullableIntegerColumn()
+    {
+        using AppDbContext db = CreateContext();
+        await db.Database.MigrateAsync();
+
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info(Restaurants);";
+        using var reader = await cmd.ExecuteReaderAsync();
+
+        bool foundColumn = false;
+        while (await reader.ReadAsync())
+        {
+            if (reader.GetString(1) == "MaxTableOversizeSeats")
+            {
+                foundColumn = true;
+                Assert.Equal("INTEGER", reader.GetString(2));
+                Assert.Equal(0L, reader.GetInt64(3)); // notnull = 0 → nullable (null = "off")
+            }
+        }
+
+        Assert.True(foundColumn, "Restaurants.MaxTableOversizeSeats column should exist after a fresh Migrate().");
+    }
+
+    [Fact]
+    public async Task Upgrade_ProducesSameSchema_AsFreshInstall()
+    {
+        // Path A: fresh install, all migrations at once.
+        using var freshConnection = new SqliteConnection("Data Source=:memory:");
+        freshConnection.Open();
+        using (var freshDb = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>().UseSqlite(freshConnection).Options))
+        {
+            await freshDb.Database.MigrateAsync();
+        }
+
+        // Path B: upgrade — migrate to the last pre-oversize migration, then the rest.
+        using AppDbContext upgradeDb = CreateContext();
+        IMigrator migrator = upgradeDb.GetInfrastructure().GetRequiredService<IMigrator>();
+        await migrator.MigrateAsync(LastMigrationBeforeOversize);
+        await migrator.MigrateAsync();
+
+        Assert.Equal(GetRestaurantsSchema(freshConnection), GetRestaurantsSchema(_connection));
+    }
+
+    private static string GetRestaurantsSchema(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'Restaurants';";
+        return (string)(cmd.ExecuteScalar() ?? throw new InvalidOperationException("Restaurants table not found."));
+    }
+}

--- a/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
@@ -389,6 +389,46 @@ public class AvailabilityServiceTests
     }
 
     [Fact]
+    public async Task GetAvailabilityAsync_ExcludesOversizedTables_WhenMaxTableOversizeSeatsSet()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(GetAvailabilityAsync_ExcludesOversizedTables_WhenMaxTableOversizeSeatsSet));
+        // RestaurantWithHours: Table 1 (2 seats), Table 2 (4 seats). Cap spare seats at 1,
+        // so a 2-top party may use Table 1 (0 spare) or Table 2 (2 spare) — Table 2 is excluded.
+        TestSeed.RestaurantWithHours(db);
+        db.Restaurants.Single().MaxTableOversizeSeats = 1;
+        db.SaveChanges();
+
+        var svc = new AvailabilityService(
+            new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+
+        var date = new DateTime(2026, 10, 10, 0, 0, 0, DateTimeKind.Utc);
+        AvailabilityResponseDto result = await svc.GetAvailabilityAsync(1, date, 2);
+
+        // The oversized 4-seat Table 2 must never appear in any slot's available ids.
+        Assert.All(result.Slots, s => Assert.DoesNotContain(2, s.AvailableTableIds));
+        // The well-sized 2-seat Table 1 still appears on an open slot.
+        Assert.Contains(result.Slots, s => s.AvailableTableIds.Contains(1));
+    }
+
+    [Fact]
+    public async Task GetAvailabilityAsync_IncludesOversizedTables_WhenMaxTableOversizeSeatsUnset()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(GetAvailabilityAsync_IncludesOversizedTables_WhenMaxTableOversizeSeatsUnset));
+        TestSeed.RestaurantWithHours(db); // Table 1 (2 seats), Table 2 (4 seats), cap unset.
+
+        var svc = new AvailabilityService(
+            new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+
+        var date = new DateTime(2026, 10, 10, 0, 0, 0, DateTimeKind.Utc);
+        AvailabilityResponseDto result = await svc.GetAvailabilityAsync(1, date, 2);
+
+        // No cap → both tables are eligible for a 2-top party on an open slot.
+        Assert.Contains(result.Slots, s => s.AvailableTableIds.Contains(1) && s.AvailableTableIds.Contains(2));
+    }
+
+    [Fact]
     public void GetCategory_ReturnsCorrectValues()
     {
         // GetCategory is private static, but we can test it via public method results

--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -558,6 +558,57 @@ public class BookingServiceTests
     }
 
     [Fact]
+    public async Task CreateBookingAsync_Throws_WhenTableExceedsConfiguredOversize()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(CreateBookingAsync_Throws_WhenTableExceedsConfiguredOversize));
+        TestSeed.BasicRestaurant(db); // Table 1 has 4 seats.
+        db.Restaurants.Single().MaxTableOversizeSeats = 1; // max 1 spare seat
+        db.SaveChanges();
+
+        BookingService svc = CreateService(db);
+        var dto = new BookingDto
+        {
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2, // 4-seat table for a party of 2 → 2 spare seats, over the cap of 1
+            Date = DateTime.UtcNow.AddDays(7)
+        };
+
+        ConflictException ex = await Assert.ThrowsAsync<ConflictException>(() =>
+            svc.CreateBookingAsync(dto));
+
+        Assert.Contains("too large", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AllowsTableAtOversizeBoundary()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(CreateBookingAsync_AllowsTableAtOversizeBoundary));
+        TestSeed.BasicRestaurant(db); // Table 1 has 4 seats.
+        db.Restaurants.Single().MaxTableOversizeSeats = 1; // max 1 spare seat
+        db.SaveChanges();
+
+        BookingService svc = CreateService(db);
+        var dto = new BookingDto
+        {
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 3, // 4-seat table for a party of 3 → 1 spare seat, at the cap
+            Date = DateTime.UtcNow.AddDays(7)
+        };
+
+        BookingDto result = await svc.CreateBookingAsync(dto);
+
+        Assert.Equal(3, result.Seats);
+    }
+
+    [Fact]
     public async Task CreateBookingAsync_Throws_WhenBookingInPast()
     {
         using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_Throws_WhenBookingInPast));
@@ -581,6 +632,39 @@ public class BookingServiceTests
         await svc.UpdateBookingAsync(created.Id, dto);
         Booking inDb = await db.Bookings.FirstAsync(b => b.Id == created.Id);
         Assert.Equal(date.AddHours(1), inDb.EndTime);
+    }
+
+    [Fact]
+    public async Task UpdateBookingAsync_Throws_WhenTableExceedsConfiguredOversize()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(UpdateBookingAsync_Throws_WhenTableExceedsConfiguredOversize));
+        TestSeed.BasicRestaurant(db); // Table 1 has 4 seats.
+        BookingService svc = CreateService(db);
+        DateTime date = DateTime.UtcNow.AddHours(1);
+        BookingDto created = await svc.CreateBookingAsync(
+            new BookingDto { RestaurantId = 1, SectionId = 1, TableId = 1, Date = date, Seats = 4 });
+        db.Entry((await db.Bookings.FindAsync(created.Id))!).State = EntityState.Detached;
+
+        // Now cap spare seats at 1 and shrink the party to 2 → the 4-seat table is too large.
+        db.Restaurants.Single().MaxTableOversizeSeats = 1;
+        db.SaveChanges();
+
+        var dto = new BookingDto
+        {
+            Id = created.Id,
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            Date = date,
+            Seats = 2,
+            EndTime = date.AddHours(1)
+        };
+
+        ConflictException ex = await Assert.ThrowsAsync<ConflictException>(() =>
+            svc.UpdateBookingAsync(created.Id, dto));
+
+        Assert.Contains("too large", ex.Message);
     }
 
     [Fact]
@@ -872,6 +956,52 @@ public class BookingServiceTests
 
         Assert.Equal(2, result.TableId); // T2 — smallest fitting free
         Assert.Equal(1, result.SectionId);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_RespectsMaxTableOversizeSeats()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(CreateBookingAsync_AutoAssign_RespectsMaxTableOversizeSeats));
+        SeedMultiTableRestaurant(db); // T1(2), T2(4), T3(6), P1(2), P2(4)
+        db.Restaurants.Single().MaxTableOversizeSeats = 1; // max 1 spare seat
+        db.SaveChanges();
+        BookingService svc = CreateService(db);
+
+        // 2 seats — every table fits, but a 2-top may only take 1 spare seat, so only
+        // T1(2)/P1(2) qualify (0 spare). T2/T3/P2 are excluded by the oversize cap.
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = DateTime.UtcNow.AddDays(7)
+        });
+
+        // Smallest fitting free table among the qualifying set — T1 (id 1, tiebreak over P1).
+        Assert.Equal(1, result.TableId);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_ThrowsWhenOversizeExcludesAllCandidates()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(CreateBookingAsync_AutoAssign_ThrowsWhenOversizeExcludesAllCandidates));
+        SeedMultiTableRestaurant(db); // T1(2), T2(4), T3(6), P1(2), P2(4)
+        db.Restaurants.Single().MaxTableOversizeSeats = 0; // tables must seat the party exactly
+        db.SaveChanges();
+        BookingService svc = CreateService(db);
+
+        // 3 seats — no 3-seat table exists, and an exact-fit is required (0 spare). No
+        // candidate qualifies, so auto-assign reports no availability rather than seating
+        // the party at an oversized table.
+        await Assert.ThrowsAsync<ConflictException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 3,
+            Date = DateTime.UtcNow.AddDays(7)
+        }));
     }
 
     [Fact]

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -108,6 +108,90 @@ public class RestaurantManagementServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_CopiesMaxTableOversizeSeats_FromDto()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_CopiesMaxTableOversizeSeats_FromDto));
+        var svc = CreateService(db);
+        var dto = new RestaurantDto { Name = "New", MaxTableOversizeSeats = 2 };
+
+        RestaurantDto result = await svc.CreateAsync(dto);
+
+        Assert.Equal(2, result.MaxTableOversizeSeats);
+        Restaurant? entity = await db.Restaurants.FindAsync(result.Id);
+        Assert.Equal(2, entity!.MaxTableOversizeSeats);
+    }
+
+    [Fact]
+    public async Task CreateAsync_LeavesMaxTableOversizeSeatsNull_WhenDtoOmitsIt()
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(CreateAsync_LeavesMaxTableOversizeSeatsNull_WhenDtoOmitsIt));
+        var svc = CreateService(db);
+        var dto = new RestaurantDto { Name = "New" };
+
+        RestaurantDto result = await svc.CreateAsync(dto);
+
+        // Null means "off/unrestricted" — the default for new and existing restaurants.
+        Assert.Null(result.MaxTableOversizeSeats);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsMaxTableOversizeSeats()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_PersistsMaxTableOversizeSeats));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            MaxTableOversizeSeats = 1
+        });
+
+        Assert.Equal(1, result!.MaxTableOversizeSeats);
+        Restaurant entity = await db.Restaurants.SingleAsync();
+        Assert.Equal(1, entity.MaxTableOversizeSeats);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ClearsMaxTableOversizeSeats_WhenRequestIsNull()
+    {
+        // The settings form always sends the field (number or null); null must clear a
+        // previously-set cap so the admin can toggle the setting "Off".
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(UpdateAsync_ClearsMaxTableOversizeSeats_WhenRequestIsNull));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC", MaxTableOversizeSeats = 2 });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            MaxTableOversizeSeats = null
+        });
+
+        Assert.Null(result!.MaxTableOversizeSeats);
+        Restaurant entity = await db.Restaurants.SingleAsync();
+        Assert.Null(entity.MaxTableOversizeSeats);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RejectsNegativeMaxTableOversizeSeats()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_RejectsNegativeMaxTableOversizeSeats));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            MaxTableOversizeSeats = -1
+        }));
+    }
+
+    [Fact]
     public async Task UpdateAsync_ReturnsNull_WhenNotFound()
     {
         using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_ReturnsNull_WhenNotFound));

--- a/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
@@ -39,6 +39,13 @@ public class UpdateRestaurantRequest
     /// </summary>
     public int? BookingSlotIntervalMinutes { get; set; }
 
+    /// <summary>
+    /// Max allowed <c>table.Seats - partySize</c> before a table is considered too large to
+    /// offer/book. Null clears the setting (unrestricted). Always assigned from the settings
+    /// form so "Off" can be re-saved; validated server-side as non-negative.
+    /// </summary>
+    public int? MaxTableOversizeSeats { get; set; }
+
     /// <summary>When true the whole location becomes walk-in only (no online bookings).</summary>
     public bool? WalkInOnly { get; set; }
 
@@ -146,6 +153,9 @@ public class RestaurantDto
 
     /// <summary>Step (minutes) between selectable booking start times (default 30).</summary>
     public int BookingSlotIntervalMinutes { get; set; } = 30;
+
+    /// <summary>Max allowed spare seats over party size, or null for unrestricted (off).</summary>
+    public int? MaxTableOversizeSeats { get; set; }
 
     public List<SectionDto> Sections { get; set; } = new();
 }

--- a/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
+++ b/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
@@ -95,10 +95,16 @@ public sealed class AvailabilityService(
         var slots = new List<TimeSlotDto>();
         DateTime current = localStart;
 
-        // Fetch all tables for the restaurant to check capacity
+        // Fetch all tables for the restaurant to check capacity. The lower bound keeps a
+        // party off a too-small table; the optional upper bound (Restaurant.MaxTableOversizeSeats)
+        // keeps a small party off a much larger table a restaurant would rather hold for a
+        // bigger group. Mirrored in BookingService and TableAutoAssigner so the customer-facing
+        // options always match what the server will accept.
         var eligibleTables = restaurant.Sections
             ?.SelectMany(s => s.Tables ?? new List<Table>())
-            .Where(t => t != null && t.Seats >= seats)
+            .Where(t => t != null && t.Seats >= seats
+                && (restaurant.MaxTableOversizeSeats == null
+                    || t.Seats - seats <= restaurant.MaxTableOversizeSeats.Value))
             .ToList() ?? new List<Table>();
 
         // Optimize: Group bookings by table ID for faster lookup in the loop

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -110,6 +110,17 @@ public class BookingService(
             throw new ConflictException($"This table only has {table.Seats} seats, but {bookingDto.Seats} guests were requested.");
         }
 
+        // 3b. Reject oversized tables when the restaurant caps spare seats. Mirrors the
+        // lower bound above and the AvailabilityService eligible-table filter, so a direct
+        // POST (or an auto-assigned pick that slipped past the candidate filter) can't seat
+        // a small party at a table the restaurant wants held for larger groups.
+        if (table != null && restaurant.MaxTableOversizeSeats.HasValue
+            && table.Seats - bookingDto.Seats > restaurant.MaxTableOversizeSeats.Value)
+        {
+            throw new ConflictException(
+                $"This table has {table.Seats} seats, which is too large for a party of {bookingDto.Seats}.");
+        }
+
         // 4. Persist the booking
         Booking booking = _mapper.ToEntity(bookingDto);
         booking.Date = bookingDate; // Use normalized date
@@ -228,6 +239,7 @@ public class BookingService(
     {
         _ = id; // Required by REST convention (PUT /bookings/{id}) but entity ID comes from DTO
         Booking booking = _mapper.ToEntity(bookingDto);
+        Restaurant? restaurant = await _restaurantRepository.GetByIdAsync(booking.RestaurantId);
 
         // Check for seat capacity if seats are being updated
         if (bookingDto.Seats > 0)
@@ -237,12 +249,20 @@ public class BookingService(
             {
                 throw new ConflictException($"This table only has {table.Seats} seats, but {bookingDto.Seats} guests were requested.");
             }
+
+            // Oversize check — mirrors CreateBookingAsync and the availability feed so an edit
+            // can't move a small party onto a table the restaurant caps for larger groups.
+            if (table != null && restaurant?.MaxTableOversizeSeats.HasValue == true
+                && table.Seats - bookingDto.Seats > restaurant.MaxTableOversizeSeats.Value)
+            {
+                throw new ConflictException(
+                    $"This table has {table.Seats} seats, which is too large for a party of {bookingDto.Seats}.");
+            }
         }
 
         // Ensure EndTime is valid if it's being updated or if Date changed
         if (!booking.EndTime.HasValue || booking.EndTime.Value < booking.Date)
         {
-            Restaurant? restaurant = await _restaurantRepository.GetByIdAsync(booking.RestaurantId);
             booking.EndTime = booking.Date.AddMinutes(restaurant?.DefaultBookingDurationMinutes ?? 60);
         }
 

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -45,6 +45,7 @@ public class RestaurantManagementService(
             Address = dto.Address,
             DefaultBookingDurationMinutes = dto.DefaultBookingDurationMinutes,
             BookingSlotIntervalMinutes = dto.BookingSlotIntervalMinutes,
+            MaxTableOversizeSeats = dto.MaxTableOversizeSeats,
             Sections = dto.Sections.Select((s, index) => new Section
             {
                 Name = s.Name,
@@ -127,6 +128,17 @@ public class RestaurantManagementService(
             r.BookingSlotIntervalMinutes = req.BookingSlotIntervalMinutes.Value;
         }
 
+        // MaxTableOversizeSeats is nullable where null means "off/unrestricted". The settings
+        // form always sends the field (number or null), so it's assigned unconditionally —
+        // like Name/Address above — which is the only way selecting "Off" can clear a
+        // previously-set cap. Validate the non-null case is non-negative.
+        if (req.MaxTableOversizeSeats.HasValue && req.MaxTableOversizeSeats.Value < 0)
+        {
+            throw new ValidationException("MaxTableOversizeSeats must be zero or greater, or null to disable.");
+        }
+
+        r.MaxTableOversizeSeats = req.MaxTableOversizeSeats;
+
         if (req.WalkInOnly.HasValue)
         {
             r.WalkInOnly = req.WalkInOnly.Value;
@@ -159,6 +171,7 @@ public class RestaurantManagementService(
             WalkInDays = r.WalkInDays ?? "",
             DefaultBookingDurationMinutes = r.DefaultBookingDurationMinutes,
             BookingSlotIntervalMinutes = r.BookingSlotIntervalMinutes,
+            MaxTableOversizeSeats = r.MaxTableOversizeSeats,
             Sections = []
         };
     }
@@ -293,6 +306,7 @@ public class RestaurantManagementService(
         WalkInDays = r.WalkInDays ?? "",
         DefaultBookingDurationMinutes = r.DefaultBookingDurationMinutes,
         BookingSlotIntervalMinutes = r.BookingSlotIntervalMinutes,
+        MaxTableOversizeSeats = r.MaxTableOversizeSeats,
         Sections = r.Sections
             .OrderBy(s => s.SortOrder).ThenBy(s => s.Id)
             .Select(s => new SectionDto

--- a/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
+++ b/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
@@ -31,11 +31,14 @@ public sealed class TableAutoAssigner(IBookingRepository bookingRepository)
 
         // Capacity filter first — same predicate as AvailabilityService.GetAvailabilityAsync's
         // restaurant-wide eligible-table set, so the auto-assign pool matches what the
-        // availability feed advertises per slot.
+        // availability feed advertises per slot. The optional upper bound
+        // (Restaurant.MaxTableOversizeSeats) keeps a small party off a much larger table.
         var eligible = restaurant.Sections
             .Where(s => s.Tables != null)
             .SelectMany(s => s.Tables!.Where(t => t != null).Select(t => (table: t!, sectionId: s.Id)))
-            .Where(x => x.table.Seats >= seats)
+            .Where(x => x.table.Seats >= seats
+                && (restaurant.MaxTableOversizeSeats == null
+                    || x.table.Seats - seats <= restaurant.MaxTableOversizeSeats.Value))
             .ToList();
 
         if (eligible.Count == 0)

--- a/OpenRestoApi/Core/Domain/Restaurant.cs
+++ b/OpenRestoApi/Core/Domain/Restaurant.cs
@@ -89,6 +89,17 @@ public class Restaurant
     public int BookingSlotIntervalMinutes { get; set; } = 30;
 
     /// <summary>
+    /// When set, the largest number of "spare" seats a table may have over the party size
+    /// and still be offered/booked — i.e. a table may be selected when
+    /// <c>table.Seats - partySize &lt;= MaxTableOversizeSeats</c>. Null means unrestricted
+    /// (a 2-top can be seated at a 10-top), preserving the pre-setting behaviour. Applied
+    /// symmetrically in availability, booking creation/update, and auto-assign so the
+    /// customer-facing options always match what the server will accept. Admin-recorded
+    /// walk-in bookings are intentionally exempt.
+    /// </summary>
+    public int? MaxTableOversizeSeats { get; set; }
+
+    /// <summary>
     /// True when online bookings are paused: a future <see cref="BookingsPausedUntil"/>
     /// is set. Consolidates the previously-inlined
     /// <c>BookingsPausedUntil.HasValue &amp;&amp; BookingsPausedUntil.Value &gt; DateTime.UtcNow</c>

--- a/OpenRestoApi/Migrations/20260720102242_AddRestaurantMaxTableOversizeSeats.Designer.cs
+++ b/OpenRestoApi/Migrations/20260720102242_AddRestaurantMaxTableOversizeSeats.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpenRestoApi.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using OpenRestoApi.Infrastructure.Persistence;
 namespace OpenRestoApi.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720102242_AddRestaurantMaxTableOversizeSeats")]
+    partial class AddRestaurantMaxTableOversizeSeats
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/OpenRestoApi/Migrations/20260720102242_AddRestaurantMaxTableOversizeSeats.cs
+++ b/OpenRestoApi/Migrations/20260720102242_AddRestaurantMaxTableOversizeSeats.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OpenRestoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRestaurantMaxTableOversizeSeats : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxTableOversizeSeats",
+                table: "Restaurants",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxTableOversizeSeats",
+                table: "Restaurants");
+        }
+    }
+}

--- a/openresto-frontend/api/restaurants.ts
+++ b/openresto-frontend/api/restaurants.ts
@@ -44,6 +44,8 @@ export interface RestaurantDto {
   defaultBookingDurationMinutes?: number;
   /** Step (minutes) between selectable booking start times (15/30/60). */
   bookingSlotIntervalMinutes?: number;
+  /** Max allowed spare seats over party size, or null for unrestricted (off). */
+  maxTableOversizeSeats?: number | null;
   sections: SectionDto[];
 }
 
@@ -138,6 +140,7 @@ export async function updateRestaurant(
     tags?: string | null;
     defaultBookingDurationMinutes?: number;
     bookingSlotIntervalMinutes?: number;
+    maxTableOversizeSeats?: number | null;
     walkInOnly?: boolean;
     walkInDays?: string;
     description?: string | null;

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -75,6 +75,10 @@ const DURATION_OPTIONS = [30, 60, 90, 120, 150, 180, 240, 300, 360, 420, 480];
 // availability slot generation can't be sent into a degenerate spin.
 const SLOT_INTERVAL_OPTIONS = [15, 30, 60];
 
+// Max spare-seats options for MaxTableOversizeSeats. null = "Off" (unrestricted); the cap
+// rejects a table when (table.seats - partySize) exceeds the selected value.
+const OVERSIZE_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8] as const;
+
 function formatDurationLabel(minutes: number): string {
   const hours = Math.floor(minutes / 60);
   const remainder = minutes % 60;
@@ -143,6 +147,9 @@ export function RestaurantInfoForm({
   const [bookingSlotIntervalMinutes, setBookingSlotIntervalMinutes] = useState(
     restaurant.bookingSlotIntervalMinutes ?? 30
   );
+  const [maxTableOversizeSeats, setMaxTableOversizeSeats] = useState<number | null>(
+    restaurant.maxTableOversizeSeats ?? null
+  );
   const [tags, setTags] = useState<string[]>(restaurant.tags ?? []);
   const [tagInput, setTagInput] = useState("");
   const [saving, setSaving] = useState(false);
@@ -207,6 +214,7 @@ export function RestaurantInfoForm({
     timezone !== (restaurant.timezone ?? "UTC") ||
     defaultBookingDurationMinutes !== (restaurant.defaultBookingDurationMinutes ?? 60) ||
     bookingSlotIntervalMinutes !== (restaurant.bookingSlotIntervalMinutes ?? 30) ||
+    maxTableOversizeSeats !== (restaurant.maxTableOversizeSeats ?? null) ||
     tags.join(",") !== (restaurant.tags ?? []).join(",");
 
   const discard = () => {
@@ -224,6 +232,7 @@ export function RestaurantInfoForm({
     setTimezone(restaurant.timezone ?? "UTC");
     setDefaultBookingDurationMinutes(restaurant.defaultBookingDurationMinutes ?? 60);
     setBookingSlotIntervalMinutes(restaurant.bookingSlotIntervalMinutes ?? 30);
+    setMaxTableOversizeSeats(restaurant.maxTableOversizeSeats ?? null);
     setTags(restaurant.tags ?? []);
     setTagInput("");
   };
@@ -248,6 +257,7 @@ export function RestaurantInfoForm({
       timezone,
       defaultBookingDurationMinutes,
       bookingSlotIntervalMinutes,
+      maxTableOversizeSeats,
       tags: finalTags.join(","),
     });
     setSaving(false);
@@ -266,6 +276,7 @@ export function RestaurantInfoForm({
         timezone: result.timezone,
         defaultBookingDurationMinutes: result.defaultBookingDurationMinutes,
         bookingSlotIntervalMinutes: result.bookingSlotIntervalMinutes,
+        maxTableOversizeSeats: result.maxTableOversizeSeats,
         tags: result.tags,
       });
     }
@@ -448,6 +459,43 @@ export function RestaurantInfoForm({
             </select>
             <ThemedText style={{ fontSize: 11, color: mutedColor }}>
               How far apart selectable start times are (independent of booking duration)
+            </ThemedText>
+          </View>
+          <View style={{ flex: 1, minWidth: 220, gap: 6 }}>
+            <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>
+              Max table oversize
+            </ThemedText>
+            <select
+              data-testid="max-table-oversize-select"
+              value={maxTableOversizeSeats ?? ""}
+              onChange={
+                /* istanbul ignore next */ (e) =>
+                  setMaxTableOversizeSeats(e.target.value === "" ? null : Number(e.target.value))
+              }
+              style={{
+                width: "100%",
+                height: 44,
+                borderWidth: 1,
+                borderStyle: "solid" as const,
+                borderColor: colors.border,
+                borderRadius: 8,
+                paddingLeft: 12,
+                paddingRight: 12,
+                fontSize: 14,
+                backgroundColor: colors.input,
+                color: colors.text,
+                cursor: "pointer",
+              }}
+            >
+              <option value="">Off</option>
+              {OVERSIZE_OPTIONS.map((seats) => (
+                <option key={seats} value={seats}>
+                  +{seats} seat{seats === 1 ? "" : "s"}
+                </option>
+              ))}
+            </select>
+            <ThemedText style={{ fontSize: 11, color: mutedColor }}>
+              Don&apos;t offer tables more than this many seats larger than the party size
             </ThemedText>
           </View>
         </View>

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -137,7 +137,15 @@ export default function BookingForm({
     candidateTables?: typeof allTables
   ) {
     const pool = candidateTables ?? allTables;
-    let eligible = pool.filter((t) => t.seats >= seatCount);
+    // Lower bound: table must seat the party. Upper bound: when the restaurant caps spare
+    // seats, drop tables too large for the group. Mirrors the server-side eligible-table
+    // filter (AvailabilityService) so the auto-suggested pick is always one the API accepts.
+    let eligible = pool.filter(
+      (t) =>
+        t.seats >= seatCount &&
+        (restaurant.maxTableOversizeSeats == null ||
+          t.seats <= seatCount + restaurant.maxTableOversizeSeats)
+    );
     if (availableIds && availableIds.length > 0) {
       eligible = eligible.filter((t) => availableIds.includes(t.id));
     }
@@ -250,7 +258,12 @@ export default function BookingForm({
   }));
 
   const eligibleTables = tablesInSection
-    .filter((t) => t.seats >= seats)
+    .filter(
+      (t) =>
+        t.seats >= seats &&
+        (restaurant.maxTableOversizeSeats == null ||
+          t.seats <= seats + restaurant.maxTableOversizeSeats)
+    )
     .filter((t) => {
       // Strictly filter only if we have availability data for the selected time
       if (currentSlot) {

--- a/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
@@ -368,6 +368,89 @@ describe("RestaurantInfoForm", () => {
     expect(getIntervalSelect().props.value).toBe(15);
   });
 
+  // ── Max table oversize (#244) ───────────────────────────────────────────
+  // Same raw-<select>/data-testid caveat as the duration control above. The "Off" option
+  // maps to "" in the DOM and null in state; selecting a number sends that integer.
+  const getOversizeSelect = () =>
+    screen.UNSAFE_getByProps({ "data-testid": "max-table-oversize-select" });
+
+  it("renders the oversize select at Off when the restaurant has none set", () => {
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    expect(getOversizeSelect().props.value).toBe("");
+  });
+
+  it("renders the oversize select at the restaurant's saved value", () => {
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, maxTableOversizeSeats: 2 }}
+        onSaved={onSaved}
+      />
+    );
+    expect(getOversizeSelect().props.value).toBe(2);
+  });
+
+  it("marks the form dirty and updates the selection when the oversize changes", () => {
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    const select = getOversizeSelect();
+    fireEvent(select, "change", { target: { value: "1" } });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    expect(getOversizeSelect().props.value).toBe(1);
+  });
+
+  it("saves the newly selected oversize cap", async () => {
+    (restaurantsApi.updateRestaurant as jest.Mock).mockResolvedValue({
+      ...mockRestaurant,
+      maxTableOversizeSeats: 1,
+    });
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    const select = getOversizeSelect();
+    fireEvent(select, "change", { target: { value: "1" } });
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save changes"));
+    });
+    expect(restaurantsApi.updateRestaurant).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ maxTableOversizeSeats: 1 })
+    );
+    expect(onSaved).toHaveBeenCalledWith(expect.objectContaining({ maxTableOversizeSeats: 1 }));
+  });
+
+  it("saves null (Off) when the Off option is re-selected on a capped restaurant", async () => {
+    (restaurantsApi.updateRestaurant as jest.Mock).mockResolvedValue({
+      ...mockRestaurant,
+      maxTableOversizeSeats: null,
+    });
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, maxTableOversizeSeats: 2 }}
+        onSaved={onSaved}
+      />
+    );
+    const select = getOversizeSelect();
+    fireEvent(select, "change", { target: { value: "" } });
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save changes"));
+    });
+    expect(restaurantsApi.updateRestaurant).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ maxTableOversizeSeats: null })
+    );
+  });
+
+  it("reverts the oversize select to the saved value when Discard is pressed", () => {
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, maxTableOversizeSeats: 1 }}
+        onSaved={onSaved}
+      />
+    );
+    const select = getOversizeSelect();
+    fireEvent(select, "change", { target: { value: "3" } });
+    expect(getOversizeSelect().props.value).toBe(3);
+    fireEvent.press(screen.getByText("Discard"));
+    expect(getOversizeSelect().props.value).toBe(1);
+  });
+
   // ── Per-day opening hours (#175) ─────────────────────────────────────────
 
   const uniformWeek = [1, 2, 3, 4, 5, 6, 7].map((day) => ({

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -522,4 +522,49 @@ describe("BookingForm", () => {
       expect.objectContaining({ tableId: null, sectionId: null })
     );
   });
+
+  // ── Max table oversize (#244) ──────────────────────────────────────────────
+  // The section-select mock fires onSelect(20) -> Patio, so this variant puts an
+  // oversized table in Patio to exercise the frontend oversize filter. With a 2-top
+  // party (the default) and a cap of 1 spare seat, a 6-seat table is excluded and the
+  // section shows "No tables available" instead of the dropdown.
+  const mockRestaurantOversizedPatio = {
+    ...mockRestaurantAllDays,
+    maxTableOversizeSeats: 1,
+    sections: [
+      {
+        id: 10,
+        name: "Main",
+        restaurantId: 1,
+        tables: [{ id: 100, name: "T1", seats: 2, sectionId: 10 }],
+      },
+      {
+        id: 20,
+        name: "Patio",
+        restaurantId: 1,
+        tables: [{ id: 200, name: "Big", seats: 6, sectionId: 20 }],
+      },
+    ],
+  };
+
+  it("hides oversized tables from the dropdown when maxTableOversizeSeats is set", async () => {
+    render(<BookingForm restaurant={mockRestaurantOversizedPatio} onSubmit={jest.fn()} />);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select")); // -> Patio (6-seat table)
+    });
+    // 6 seats - 2 guests = 4 spare > cap of 1 -> excluded -> no eligible tables.
+    expect(screen.getByText(/No tables available for 2 guests/)).toBeTruthy();
+    expect(screen.queryByTestId("table-select")).toBeNull();
+  });
+
+  it("still offers the oversized table when maxTableOversizeSeats is unset", async () => {
+    const unrestricted = { ...mockRestaurantOversizedPatio, maxTableOversizeSeats: undefined };
+    render(<BookingForm restaurant={unrestricted} onSubmit={jest.fn()} />);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select")); // -> Patio (6-seat table)
+    });
+    // No cap -> the 6-seat table is eligible and the dropdown renders.
+    await waitFor(() => expect(screen.getByTestId("table-select")).toBeTruthy());
+    expect(screen.queryByText(/No tables available/)).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #244.

## Summary
Adds a restaurant-configurable cap that stops small parties from booking tables much larger than they need (e.g. a 2-top at a 6-top). Follow-up to the request in [#174 (comment)](https://github.com/karanshukla/openresto/issues/174#issuecomment-4892269202).

The new setting is a nullable `int` (`Restaurant.MaxTableOversizeSeats`) where `null` means unrestricted (off). When set, a table is only offered/booked when `table.Seats - partySize <= MaxTableOversizeSeats`. Defaults to off so existing restaurants see no behavior change until an admin opts in.

## Changes
**Backend**
- `Restaurant.MaxTableOversizeSeats` (nullable int) + migration `AddRestaurantMaxTableOversizeSeats` (nullable `INTEGER`, no default — mirrors `AddRestaurantMenuUrl`).
- `AvailabilityService`: the eligible-tables filter applies the upper bound, pruning oversized tables from `availableTableIds` per slot.
- `BookingService.CreateBookingAsync` / `UpdateBookingAsync`: reject an over-large table with a `ConflictException` (mirrors the existing under-capacity check; symmetric in both paths).
- `TableAutoAssigner`: the auto-assign candidate pool respects the same cap, keeping it consistent with the availability feed.
- `RestaurantManagementService`: maps the field on create/update/read; validates non-negative; assigned unconditionally on update so the admin UI can toggle it "Off" (send `null`).
- DTOs (`UpdateRestaurantRequest`, `RestaurantDto`) carry the field.

**Frontend**
- `api/restaurants.ts`: `RestaurantDto` + `updateRestaurant` payload types.
- `RestaurantInfoForm`: a new "Max table oversize" `<select>` (Off / +0…+8 seats) with the same lifecycle (dirty/discard/save/onSaved) as the duration and slot-interval controls.
- `BookingForm`: hides oversized tables from the dropdown and the best-table suggestion. UX-only mirroring — the server filter is the real enforcement.

**Seeders:** unchanged. `DbSeeder` relies on C# property defaults (the existing duration/interval settings aren't seeded either); `int?` with no initializer defaults to `null` (off), so seeded restaurants stay unrestricted — honoring the "no regression for un-opted-in" criterion.

## Acceptance criteria
- [x] New restaurant setting exists, defaults to off — entity + DTOs, nullable with no default.
- [x] Admin settings UI exposes it with explanation — "Don't offer tables more than N seats larger than the party size".
- [x] `GET /api/availability` excludes over-large tables once configured — `AvailabilityService` filter + test.
- [x] `POST /api/bookings` rejects a direct over-large request with a clear error — `BookingService` check + test.
- [x] Migration passes the fresh-vs-upgrade parity check — `MaxTableOversizeSeatsMigrationTests` (+ CI `migration-check.yml`).
- [x] Unset = no regression — nullable throughout; existing suites green.

## Out of scope (per issue)
- Admin-recorded walk-in bookings (`AdminService.CreateBookingAsync`) are intentionally exempt — staff can still freely seat any party anywhere.
- No table-combining/split logic; purely about excluding too-large tables.

## Tests
- **Backend (22 new):** `AvailabilityServiceTests` (excludes when set, includes when unset), `BookingServiceTests` (create throws at boundary, create allows at boundary, update throws, auto-assign respects cap, auto-assign throws when cap excludes all), `RestaurantManagementServiceTests` (create copies, create leaves null when omitted, update persists, update clears via null, update rejects negative), `MaxTableOversizeSeatsMigrationTests` (fresh nullable INTEGER column, upgrade == fresh schema).
- **Frontend (7 new):** `RestaurantInfoForm.test` (renders Off/saved value, dirty on change, saves new value, saves null via Off, reverts on Discard), `BookingForm.test` (hides oversized table from dropdown when capped, offers it when unset).

## Verification
- `dotnet test` (OpenRestoApi.Tests): 1156 passed / 2 failed — the 2 failures (`SqlitePragmaInterceptorTests`) are pre-existing on clean `main` (Windows temp-file handle race), unrelated to this change. All 22 new oversize tests pass.
- `npm test` (openresto-frontend): 1884 passed across 147 suites.
- `npm run check`: prettier clean, oxlint 0 errors (330 pre-existing warnings in untouched files).