### PR TITLE
feat: support uploading a menu PDF in addition to linking one

### DIFF
--- a/OpenRestoApi.Tests/Controllers/MediaControllerUnitTests.cs
+++ b/OpenRestoApi.Tests/Controllers/MediaControllerUnitTests.cs
@@ -126,4 +126,63 @@ public class MediaControllerUnitTests
 
         Assert.IsType<NoContentResult>(result);
     }
+
+    [Fact]
+    public async Task UploadMenu_ReturnsBadRequest_ForDisallowedContentType()
+    {
+        IActionResult result = await _controller.UploadMenu(1, CreateFile("image/png", 100));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UploadMenu_ReturnsBadRequest_WhenOverSizeLimit()
+    {
+        IActionResult result = await _controller.UploadMenu(1, CreateFile("application/pdf", 11 * 1024 * 1024));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UploadMenu_ReturnsNotFound_WhenServiceReturnsNull()
+    {
+        _mockService.Setup(s => s.UploadMenuAsync(1, It.IsAny<Stream>()))
+            .ReturnsAsync((string?)null);
+
+        IActionResult result = await _controller.UploadMenu(1, CreateFile("application/pdf", 100));
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UploadMenu_ReturnsOkWithUrl_OnSuccess()
+    {
+        _mockService.Setup(s => s.UploadMenuAsync(1, It.IsAny<Stream>()))
+            .ReturnsAsync("/media/menu-1.pdf?v=1");
+
+        IActionResult result = await _controller.UploadMenu(1, CreateFile("application/pdf", 100));
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("/media/menu-1.pdf?v=1", ok.Value!.GetType().GetProperty("url")!.GetValue(ok.Value));
+    }
+
+    [Fact]
+    public async Task DeleteMenu_ReturnsNotFound_WhenServiceReturnsFalse()
+    {
+        _mockService.Setup(s => s.DeleteMenuAsync(1)).ReturnsAsync(false);
+
+        IActionResult result = await _controller.DeleteMenu(1);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteMenu_ReturnsNoContent_WhenServiceReturnsTrue()
+    {
+        _mockService.Setup(s => s.DeleteMenuAsync(1)).ReturnsAsync(true);
+
+        IActionResult result = await _controller.DeleteMenu(1);
+
+        Assert.IsType<NoContentResult>(result);
+    }
 }

--- a/OpenRestoApi.Tests/Services/MediaServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/MediaServiceTests.cs
@@ -269,4 +269,133 @@ public class MediaServiceTests : IDisposable
         BrandSettings brand = await db.Set<BrandSettings>().SingleAsync();
         Assert.Null(brand.HeaderImageUrl);
     }
+
+    [Fact]
+    public async Task UploadMenuAsync_ReturnsNull_WhenRestaurantNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UploadMenuAsync_ReturnsNull_WhenRestaurantNotFound));
+        MediaService svc = CreateService(db);
+        using var stream = new MemoryStream([1]);
+
+        string? url = await svc.UploadMenuAsync(999, stream);
+
+        Assert.Null(url);
+    }
+
+    [Fact]
+    public async Task UploadMenuAsync_WritesFileAndUpdatesRestaurant()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UploadMenuAsync_WritesFileAndUpdatesRestaurant));
+        var restaurant = new Restaurant { Name = "R", Address = "A", Timezone = "UTC" };
+        db.Restaurants.Add(restaurant);
+        await db.SaveChangesAsync();
+        MediaService svc = CreateService(db);
+        using var stream = new MemoryStream([1, 2]);
+
+        string? url = await svc.UploadMenuAsync(restaurant.Id, stream);
+
+        Assert.NotNull(url);
+        Assert.StartsWith($"/media/menu-{restaurant.Id}.pdf?v=", url);
+        Assert.True(File.Exists(Path.Combine(MediaDir, $"menu-{restaurant.Id}.pdf")));
+        Restaurant reloaded = await db.Restaurants.SingleAsync(r => r.Id == restaurant.Id);
+        Assert.Equal(url, reloaded.MenuUrl);
+    }
+
+    [Fact]
+    public async Task UploadMenuAsync_OverwritesPreviousUploadAndExternalLink()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UploadMenuAsync_OverwritesPreviousUploadAndExternalLink));
+        var restaurant = new Restaurant
+        {
+            Name = "R",
+            Address = "A",
+            Timezone = "UTC",
+            MenuUrl = "https://example.com/external-menu.pdf",
+        };
+        db.Restaurants.Add(restaurant);
+        await db.SaveChangesAsync();
+        MediaService svc = CreateService(db);
+
+        using var first = new MemoryStream([1]);
+        await svc.UploadMenuAsync(restaurant.Id, first);
+        Assert.True(File.Exists(Path.Combine(MediaDir, $"menu-{restaurant.Id}.pdf")));
+
+        // A second upload replaces the first file on disk and the MenuUrl column.
+        using var second = new MemoryStream([2]);
+        string? url = await svc.UploadMenuAsync(restaurant.Id, second);
+
+        Assert.NotNull(url);
+        Assert.True(File.Exists(Path.Combine(MediaDir, $"menu-{restaurant.Id}.pdf")));
+        Restaurant reloaded = await db.Restaurants.SingleAsync(r => r.Id == restaurant.Id);
+        Assert.Equal(url, reloaded.MenuUrl);
+    }
+
+    [Fact]
+    public async Task DeleteMenuAsync_ReturnsFalse_WhenRestaurantNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(DeleteMenuAsync_ReturnsFalse_WhenRestaurantNotFound));
+        MediaService svc = CreateService(db);
+
+        bool result = await svc.DeleteMenuAsync(999);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task DeleteMenuAsync_ReturnsTrue_WhenMenuUrlAlreadyNull()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(DeleteMenuAsync_ReturnsTrue_WhenMenuUrlAlreadyNull));
+        var restaurant = new Restaurant { Name = "R", Address = "A", Timezone = "UTC", MenuUrl = null };
+        db.Restaurants.Add(restaurant);
+        await db.SaveChangesAsync();
+        MediaService svc = CreateService(db);
+
+        bool result = await svc.DeleteMenuAsync(restaurant.Id);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task DeleteMenuAsync_ClearsReferenceAndDeletesFile()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(DeleteMenuAsync_ClearsReferenceAndDeletesFile));
+        var restaurant = new Restaurant { Name = "R", Address = "A", Timezone = "UTC" };
+        db.Restaurants.Add(restaurant);
+        await db.SaveChangesAsync();
+        MediaService svc = CreateService(db);
+        using (var stream = new MemoryStream([1]))
+            await svc.UploadMenuAsync(restaurant.Id, stream);
+        Assert.True(File.Exists(Path.Combine(MediaDir, $"menu-{restaurant.Id}.pdf")));
+
+        bool result = await svc.DeleteMenuAsync(restaurant.Id);
+
+        Assert.True(result);
+        Restaurant reloaded = await db.Restaurants.SingleAsync(r => r.Id == restaurant.Id);
+        Assert.Null(reloaded.MenuUrl);
+        Assert.False(File.Exists(Path.Combine(MediaDir, $"menu-{restaurant.Id}.pdf")));
+    }
+
+    [Fact]
+    public async Task DeleteMenuAsync_ClearsExternalLinkWithoutTouchingDisk()
+    {
+        // An external link isn't backed by a file under _mediaDir; DeleteMenuAsync must
+        // still clear the column (no-op disk delete) and not throw.
+        using AppDbContext db = TestDbFactory.Create(nameof(DeleteMenuAsync_ClearsExternalLinkWithoutTouchingDisk));
+        var restaurant = new Restaurant
+        {
+            Name = "R",
+            Address = "A",
+            Timezone = "UTC",
+            MenuUrl = "https://example.com/external-menu.pdf",
+        };
+        db.Restaurants.Add(restaurant);
+        await db.SaveChangesAsync();
+        MediaService svc = CreateService(db);
+
+        bool result = await svc.DeleteMenuAsync(restaurant.Id);
+
+        Assert.True(result);
+        Restaurant reloaded = await db.Restaurants.SingleAsync(r => r.Id == restaurant.Id);
+        Assert.Null(reloaded.MenuUrl);
+    }
 }

--- a/OpenRestoApi/Controllers/MediaController.cs
+++ b/OpenRestoApi/Controllers/MediaController.cs
@@ -16,6 +16,8 @@ public class MediaController(MediaService mediaService) : ControllerBase
     private static readonly string[] _allowedTypes = ["image/jpeg", "image/png", "image/webp"];
     private const long _maxHeroBytes = 5 * 1024 * 1024;
     private const long _maxLocationBytes = 2 * 1024 * 1024;
+    private const long _maxMenuBytes = 10 * 1024 * 1024;
+    private const string _menuContentType = "application/pdf";
 
     [HttpPost("hero")]
     [RequestSizeLimit(5 * 1024 * 1024 + 8192)]
@@ -59,6 +61,30 @@ public class MediaController(MediaService mediaService) : ControllerBase
     public async Task<IActionResult> DeleteLocation(int id)
     {
         bool found = await _mediaService.DeleteLocationAsync(id);
+        if (!found) return NotFound();
+        return NoContent();
+    }
+
+    [HttpPost("menu/{id:int}")]
+    [RequestSizeLimit(10 * 1024 * 1024 + 8192)]
+    public async Task<IActionResult> UploadMenu(int id, IFormFile file)
+    {
+        if (file.ContentType != _menuContentType)
+            return BadRequest(new { message = "Only PDF menu files are accepted." });
+
+        if (file.Length > _maxMenuBytes)
+            return BadRequest(new { message = "Menu file must be under 10 MB." });
+
+        await using Stream stream = file.OpenReadStream();
+        string? url = await _mediaService.UploadMenuAsync(id, stream);
+        if (url == null) return NotFound();
+        return Ok(new { url });
+    }
+
+    [HttpDelete("menu/{id:int}")]
+    public async Task<IActionResult> DeleteMenu(int id)
+    {
+        bool found = await _mediaService.DeleteMenuAsync(id);
         if (!found) return NotFound();
         return NoContent();
     }

--- a/OpenRestoApi/Core/Application/Services/MediaService.cs
+++ b/OpenRestoApi/Core/Application/Services/MediaService.cs
@@ -93,6 +93,46 @@ public class MediaService(
         return true;
     }
 
+    public virtual async Task<string?> UploadMenuAsync(int id, Stream fileStream)
+    {
+        Restaurant? restaurant = await _restaurantRepository.FindByIdAsync(id);
+        if (restaurant == null) return null;
+
+        EnsureMediaDir();
+        // Only the instance-served menu file occupies the menu-<id>.* slot, so any
+        // previous upload (regardless of extension) is cleared before writing the
+        // new one. External links live in the same MenuUrl column; if the previous
+        // value was a link rather than a served file, TryDeleteFile below is a no-op
+        // (the path won't resolve under _mediaDir) and the link is simply replaced.
+        foreach (string old in Directory.GetFiles(_mediaDir, $"menu-{id}.*"))
+            System.IO.File.Delete(old);
+
+        string filename = $"menu-{id}.pdf";
+        await using (FileStream dest = System.IO.File.Create(Path.Combine(_mediaDir, filename)))
+            await fileStream.CopyToAsync(dest);
+
+        string url = $"/media/{filename}?v={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+        restaurant.MenuUrl = url;
+        await _restaurantRepository.SaveChangesAsync();
+        return url;
+    }
+
+    public virtual async Task<bool> DeleteMenuAsync(int id)
+    {
+        Restaurant? restaurant = await _restaurantRepository.FindByIdAsync(id);
+        if (restaurant == null) return false;
+        if (restaurant.MenuUrl != null)
+        {
+            // Clear the persisted reference first so a missing/invalid physical file
+            // never blocks removal. Best-effort deletion of the file on disk.
+            string url = restaurant.MenuUrl;
+            restaurant.MenuUrl = null;
+            await _restaurantRepository.SaveChangesAsync();
+            TryDeleteFile(url);
+        }
+        return true;
+    }
+
     private void EnsureMediaDir() => Directory.CreateDirectory(_mediaDir);
 
     /// <summary>

--- a/nginx-vps/default.conf.template
+++ b/nginx-vps/default.conf.template
@@ -47,7 +47,8 @@ server {
     proxy_cache_bypass $http_upgrade;
     proxy_redirect off;
 
-    client_max_body_size 10M;
+    # Large enough for a 10 MB PDF menu upload plus multipart framing
+    client_max_body_size 12M;
 
     # Block dotfiles
     location ~ /\.(?!well-known).* {

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,8 +24,8 @@ http {
     server {
         listen 80;
         
-        # Max body size
-        client_max_body_size 10M;
+        # Max body size — large enough for a 10 MB PDF menu upload plus multipart framing
+        client_max_body_size 12M;
 
         # Shared security headers logic (simplified for standalone file)
         set $proxy_target "ReverseProxy";

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -32,7 +32,8 @@ server {
     proxy_read_timeout    120s;
     proxy_buffering       off;
 
-    client_max_body_size 10M;
+    # Large enough for a 10 MB PDF menu upload plus multipart framing
+    client_max_body_size 12M;
 
     # Block dotfiles
     location ~ /\.(?!well-known).* {

--- a/openresto-frontend/api/restaurants.ts
+++ b/openresto-frontend/api/restaurants.ts
@@ -272,3 +272,32 @@ export async function deleteLocationImage(restaurantId: number): Promise<boolean
     return false;
   }
 }
+
+export async function uploadMenuFile(restaurantId: number, file: File): Promise<string | null> {
+  try {
+    const form = new FormData();
+    form.append("file", file);
+    const res = await fetch(buildUrl(`/media/menu/${restaurantId}`), {
+      method: "POST",
+      credentials: "include",
+      body: form,
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteMenuFile(restaurantId: number): Promise<boolean> {
+  try {
+    const res = await fetch(buildUrl(`/media/menu/${restaurantId}`), {
+      method: "DELETE",
+      credentials: "include",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -3,10 +3,17 @@ import { View, Pressable } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
 import { useAppTheme } from "@/hooks/use-app-theme";
-import { DayHoursDto, RestaurantDto, updateRestaurant } from "@/api/restaurants";
+import {
+  DayHoursDto,
+  RestaurantDto,
+  deleteMenuFile,
+  updateRestaurant,
+  uploadMenuFile,
+} from "@/api/restaurants";
 import { getHoursForDay, hasCustomHours, parseOpenDays } from "@/utils/openingHours";
 import { parseWalkInDays } from "@/utils/walkIn";
 import { Ionicons } from "@expo/vector-icons";
+import { theme } from "@/theme/theme";
 import { isOvernight } from "./sectionHelpers";
 import { OpeningHoursSection } from "./OpeningHoursSection";
 import { WalkInPolicySection } from "./WalkInPolicySection";
@@ -78,6 +85,16 @@ const SLOT_INTERVAL_OPTIONS = [15, 30, 60];
 // Max spare-seats options for MaxTableOversizeSeats. null = "Off" (unrestricted); the cap
 // rejects a table when (table.seats - partySize) exceeds the selected value.
 const OVERSIZE_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8] as const;
+
+// Mirrors the backend MediaController._maxMenuBytes cap. A file picker pre-check keeps the
+// UX instantaneous for oversize uploads instead of waiting on the server's 400 response.
+const MAX_MENU_BYTES = 10 * 1024 * 1024;
+
+// A MenuUrl pointing at this instance's own /media/menu-<id>.pdf path means it's a file
+// the admin uploaded through OpenResto (vs. an external link they pasted). Used to decide
+// which affordance to show: "Remove uploaded file" for served files, or the link input only.
+const isServedMenuFile = (url: string | null | undefined): boolean =>
+  !!url && /^\/media\/menu-\d+\.pdf(\?|$)/.test(url);
 
 function formatDurationLabel(minutes: number): string {
   const hours = Math.floor(minutes / 60);
@@ -152,6 +169,8 @@ export function RestaurantInfoForm({
   );
   const [tags, setTags] = useState<string[]>(restaurant.tags ?? []);
   const [tagInput, setTagInput] = useState("");
+  const [menuUploading, setMenuUploading] = useState(false);
+  const [menuMsg, setMenuMsg] = useState<{ text: string; ok: boolean } | null>(null);
   const [saving, setSaving] = useState(false);
 
   const addTag = (raw: string) => {
@@ -201,6 +220,48 @@ export function RestaurantInfoForm({
     restaurant.closeTime ?? "22:00"
   );
   const hoursDirty = JSON.stringify(openHoursPayload) !== JSON.stringify(initialOpenHours);
+
+  const menuUrlIsServedFile = isServedMenuFile(restaurant.menuUrl);
+
+  const handlePickMenu = () => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "application/pdf";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      if (file.size > MAX_MENU_BYTES) {
+        setMenuMsg({ text: "Menu file must be under 10 MB.", ok: false });
+        return;
+      }
+      setMenuUploading(true);
+      setMenuMsg(null);
+      const url = await uploadMenuFile(restaurant.id, file);
+      setMenuUploading(false);
+      if (url) {
+        // A served file supersedes any typed link; clear it locally so the link input
+        // doesn't read as stale text next to the newly-uploaded file indicator.
+        setMenuUrl("");
+        onSaved({ menuUrl: url });
+        setMenuMsg({ text: "Menu uploaded.", ok: true });
+      } else {
+        setMenuMsg({ text: "Failed to upload menu.", ok: false });
+      }
+    };
+    input.click();
+  };
+
+  const handleDeleteMenu = async () => {
+    setMenuUploading(true);
+    const ok = await deleteMenuFile(restaurant.id);
+    setMenuUploading(false);
+    if (ok) {
+      onSaved({ menuUrl: null });
+      setMenuMsg({ text: "Menu removed.", ok: true });
+    } else {
+      setMenuMsg({ text: "Failed to remove menu.", ok: false });
+    }
+  };
 
   const dirty =
     name !== restaurant.name ||
@@ -342,20 +403,84 @@ export function RestaurantInfoForm({
         </View>
 
         <View style={{ gap: 6 }}>
-          <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>
-            Menu link (optional)
-          </ThemedText>
-          <Input
-            value={menuUrl}
-            onChangeText={setMenuUrl}
-            placeholder="https://your-menu-url.com/menu.pdf"
-            autoCapitalize="none"
-            autoCorrect={false}
-            keyboardType="url"
-          />
+          <View style={{ flexDirection: "row", alignItems: "baseline", gap: 8 }}>
+            <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>Menu</ThemedText>
+            <ThemedText
+              style={{
+                fontSize: 10,
+                fontWeight: "600",
+                textTransform: "uppercase" as const,
+                letterSpacing: 1,
+                color: mutedColor,
+              }}
+            >
+              optional
+            </ThemedText>
+          </View>
+          {menuUrlIsServedFile ? (
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 10,
+                paddingVertical: 12,
+                paddingHorizontal: 14,
+                borderWidth: 1,
+                borderColor,
+                borderRadius: 10,
+                backgroundColor: surface2,
+              }}
+            >
+              <Ionicons name="document-text-outline" size={18} color={primaryColor} />
+              <ThemedText style={{ fontSize: 13, flex: 1 }} numberOfLines={1}>
+                Uploaded menu PDF
+              </ThemedText>
+              <Pressable
+                style={[sharedStyles.secBtn, { borderColor, opacity: menuUploading ? 0.5 : 1 }]}
+                onPress={handleDeleteMenu}
+                disabled={menuUploading}
+              >
+                <ThemedText style={[sharedStyles.secBtnText, { color: theme.colors.error }]}>
+                  {menuUploading ? "Removing…" : "Remove file"}
+                </ThemedText>
+              </Pressable>
+            </View>
+          ) : (
+            <Input
+              value={menuUrl}
+              onChangeText={setMenuUrl}
+              placeholder="https://your-menu-url.com/menu.pdf"
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+            />
+          )}
+          <View style={{ flexDirection: "row", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            {!menuUrlIsServedFile && (
+              <Pressable
+                style={[sharedStyles.secBtn, { borderColor, opacity: menuUploading ? 0.5 : 1 }]}
+                onPress={handlePickMenu}
+                disabled={menuUploading}
+              >
+                <ThemedText style={[sharedStyles.secBtnText, { color: primaryColor }]}>
+                  {menuUploading ? "Uploading…" : "Upload PDF"}
+                </ThemedText>
+              </Pressable>
+            )}
+            {menuMsg && (
+              <ThemedText
+                style={{
+                  fontSize: 12,
+                  color: menuMsg.ok ? theme.colors.success : theme.colors.error,
+                }}
+              >
+                {menuMsg.text}
+              </ThemedText>
+            )}
+          </View>
           <ThemedText style={{ fontSize: 11, color: mutedColor }}>
-            Link to your menu — a PDF, a page on your site, wherever it lives. Shown as a &quot;View
-            menu&quot; button on the location page.
+            Upload a PDF (max 10 MB) or paste a link to your menu. Shown as a &quot;View menu&quot;
+            button on the location page.
           </ThemedText>
         </View>
 
@@ -388,6 +513,10 @@ export function RestaurantInfoForm({
                 </option>
               ))}
             </select>
+            <ThemedText style={{ fontSize: 11, color: mutedColor }}>
+              If this value differs from the customer's device timezone, a note will appear on the
+              booking page.
+            </ThemedText>
           </View>
           <View style={{ flex: 1, minWidth: 220, gap: 6 }}>
             <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>

--- a/openresto-frontend/tests/api/restaurants.test.ts
+++ b/openresto-frontend/tests/api/restaurants.test.ts
@@ -12,6 +12,8 @@ import {
   deleteTable,
   uploadLocationImage,
   deleteLocationImage,
+  uploadMenuFile,
+  deleteMenuFile,
 } from "@/api/restaurants";
 
 // Restaurants API now uses credentials: "include" for cookie-based auth
@@ -342,5 +344,70 @@ describe("deleteLocationImage", () => {
   it("returns false on network error", async () => {
     mockFetch.mockRejectedValueOnce(new Error("offline"));
     expect(await deleteLocationImage(1)).toBe(false);
+  });
+});
+
+// ---------- uploadMenuFile ----------
+
+describe("uploadMenuFile", () => {
+  it("posts form data and returns url on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ url: "/media/menu-1.pdf?v=1" }),
+    });
+
+    const file = new File(["content"], "menu.pdf", { type: "application/pdf" });
+    const result = await uploadMenuFile(1, file);
+
+    expect(result).toBe("/media/menu-1.pdf?v=1");
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/media/menu/1");
+    expect(opts.method).toBe("POST");
+    expect(opts.credentials).toBe("include");
+    expect(opts.body).toBeInstanceOf(FormData);
+  });
+
+  it("returns null when response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    const file = new File(["x"], "menu.pdf", { type: "application/pdf" });
+    expect(await uploadMenuFile(1, file)).toBeNull();
+  });
+
+  it("returns null when url missing from response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    const file = new File(["x"], "menu.pdf", { type: "application/pdf" });
+    expect(await uploadMenuFile(1, file)).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    const file = new File(["x"], "menu.pdf", { type: "application/pdf" });
+    expect(await uploadMenuFile(1, file)).toBeNull();
+  });
+});
+
+// ---------- deleteMenuFile ----------
+
+describe("deleteMenuFile", () => {
+  it("sends DELETE to menu media endpoint and returns true on success", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const result = await deleteMenuFile(1);
+
+    expect(result).toBe(true);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/media/menu/1");
+    expect(opts.method).toBe("DELETE");
+    expect(opts.credentials).toBe("include");
+  });
+
+  it("returns false on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    expect(await deleteMenuFile(1)).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    expect(await deleteMenuFile(1)).toBe(false);
   });
 });

--- a/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
@@ -1,5 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
 import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react-native";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react-native";
 import { RestaurantInfoForm } from "@/components/admin/settings/RestaurantInfoForm";
 import * as restaurantsApi from "@/api/restaurants";
 import { useColorScheme } from "@/hooks/use-color-scheme";
@@ -10,6 +13,8 @@ jest.mock("@expo/vector-icons", () => ({
 
 jest.mock("@/api/restaurants", () => ({
   updateRestaurant: jest.fn(),
+  uploadMenuFile: jest.fn(),
+  deleteMenuFile: jest.fn(),
 }));
 
 jest.mock("@/context/BrandContext", () => {
@@ -807,5 +812,198 @@ describe("RestaurantInfoForm", () => {
     fireEvent.press(screen.getByText("Discard"));
     expect(screen.getByDisplayValue("Saved blurb")).toBeTruthy();
     expect(screen.getByText("All changes saved")).toBeTruthy();
+  });
+
+  // ── Menu file upload (#246) ──────────────────────────────────────────────
+  // Admins can either paste an external link OR upload a PDF — both reuse
+  // Restaurant.MenuUrl. A served file is recognized by its /media/menu-<id>.pdf
+  // shape, which swaps the link input for a "Remove file" affordance.
+
+  it("shows the Upload PDF button and the link input when no menu is set", () => {
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    expect(screen.getByText("Upload PDF")).toBeTruthy();
+    expect(screen.getByPlaceholderText("https://your-menu-url.com/menu.pdf")).toBeTruthy();
+  });
+
+  it("pre-fills the link input when the restaurant has an external menu URL", () => {
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, menuUrl: "https://example.com/menu.pdf" }}
+        onSaved={onSaved}
+      />
+    );
+    expect(screen.getByDisplayValue("https://example.com/menu.pdf")).toBeTruthy();
+  });
+
+  it("shows Remove file instead of the link input when a PDF is uploaded", () => {
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, menuUrl: "/media/menu-1.pdf?v=123" }}
+        onSaved={onSaved}
+      />
+    );
+    expect(screen.getByText("Uploaded menu PDF")).toBeTruthy();
+    expect(screen.getByText("Remove file")).toBeTruthy();
+    expect(screen.queryByPlaceholderText("https://your-menu-url.com/menu.pdf")).toBeNull();
+    expect(screen.queryByText("Upload PDF")).toBeNull();
+  });
+
+  it("calls uploadMenuFile and onSaved when a PDF is selected", async () => {
+    (restaurantsApi.uploadMenuFile as jest.Mock).mockResolvedValue("/media/menu-1.pdf?v=1");
+    const mockInput = {
+      type: "",
+      accept: "",
+      onchange: null as ((e: Event) => void) | null,
+      click: jest.fn(),
+      files: [new File(["pdf-bytes"], "menu.pdf", { type: "application/pdf" })],
+    };
+    jest.spyOn(document, "createElement").mockReturnValueOnce(mockInput as unknown as HTMLElement);
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    act(() => {
+      fireEvent.press(screen.getByText("Upload PDF"));
+    });
+    await act(async () => {
+      mockInput.onchange?.({} as Event);
+    });
+    expect(restaurantsApi.uploadMenuFile).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ type: "application/pdf" })
+    );
+    expect(onSaved).toHaveBeenCalledWith({ menuUrl: "/media/menu-1.pdf?v=1" });
+  });
+
+  it("shows Menu uploaded message after successful upload", async () => {
+    (restaurantsApi.uploadMenuFile as jest.Mock).mockResolvedValue("/media/menu-1.pdf?v=1");
+    const mockInput = {
+      type: "",
+      accept: "",
+      onchange: null as ((e: Event) => void) | null,
+      click: jest.fn(),
+      files: [new File(["pdf-bytes"], "menu.pdf", { type: "application/pdf" })],
+    };
+    jest.spyOn(document, "createElement").mockReturnValueOnce(mockInput as unknown as HTMLElement);
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    act(() => {
+      fireEvent.press(screen.getByText("Upload PDF"));
+    });
+    await act(async () => {
+      mockInput.onchange?.({} as Event);
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Menu uploaded.")).toBeTruthy();
+    });
+  });
+
+  it("shows an error message when upload fails", async () => {
+    (restaurantsApi.uploadMenuFile as jest.Mock).mockResolvedValue(null);
+    const mockInput = {
+      type: "",
+      accept: "",
+      onchange: null as ((e: Event) => void) | null,
+      click: jest.fn(),
+      files: [new File(["pdf-bytes"], "menu.pdf", { type: "application/pdf" })],
+    };
+    jest.spyOn(document, "createElement").mockReturnValueOnce(mockInput as unknown as HTMLElement);
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    act(() => {
+      fireEvent.press(screen.getByText("Upload PDF"));
+    });
+    await act(async () => {
+      mockInput.onchange?.({} as Event);
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Failed to upload menu.")).toBeTruthy();
+    });
+  });
+
+  it("shows a size error when the selected file exceeds 10 MB", async () => {
+    const largeFile = new File(["x".repeat(11 * 1024 * 1024)], "big.pdf", {
+      type: "application/pdf",
+    });
+    const mockInput = {
+      type: "",
+      accept: "",
+      onchange: null as ((e: Event) => void) | null,
+      click: jest.fn(),
+      files: [largeFile],
+    };
+    jest.spyOn(document, "createElement").mockReturnValueOnce(mockInput as unknown as HTMLElement);
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    act(() => {
+      fireEvent.press(screen.getByText("Upload PDF"));
+    });
+    await act(async () => {
+      mockInput.onchange?.({} as Event);
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Menu file must be under 10 MB.")).toBeTruthy();
+    });
+    expect(restaurantsApi.uploadMenuFile).not.toHaveBeenCalled();
+  });
+
+  it("calls deleteMenuFile and onSaved with null menuUrl when Remove file is pressed", async () => {
+    (restaurantsApi.deleteMenuFile as jest.Mock).mockResolvedValue(true);
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, menuUrl: "/media/menu-1.pdf?v=123" }}
+        onSaved={onSaved}
+      />
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByText("Remove file"));
+    });
+    expect(restaurantsApi.deleteMenuFile).toHaveBeenCalledWith(1);
+    expect(onSaved).toHaveBeenCalledWith({ menuUrl: null });
+  });
+
+  it("shows Menu removed message after successful delete", async () => {
+    (restaurantsApi.deleteMenuFile as jest.Mock).mockResolvedValue(true);
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, menuUrl: "/media/menu-1.pdf?v=123" }}
+        onSaved={onSaved}
+      />
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByText("Remove file"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Menu removed.")).toBeTruthy();
+    });
+  });
+
+  it("shows an error when delete fails", async () => {
+    (restaurantsApi.deleteMenuFile as jest.Mock).mockResolvedValue(false);
+    render(
+      <RestaurantInfoForm
+        restaurant={{ ...mockRestaurant, menuUrl: "/media/menu-1.pdf?v=123" }}
+        onSaved={onSaved}
+      />
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByText("Remove file"));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Failed to remove menu.")).toBeTruthy();
+    });
+  });
+
+  it("does nothing when no file is selected in the picker", async () => {
+    const mockInput = {
+      type: "",
+      accept: "",
+      onchange: null as ((e: Event) => void) | null,
+      click: jest.fn(),
+      files: [],
+    };
+    jest.spyOn(document, "createElement").mockReturnValueOnce(mockInput as unknown as HTMLElement);
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    act(() => {
+      fireEvent.press(screen.getByText("Upload PDF"));
+    });
+    await act(async () => {
+      mockInput.onchange?.({} as Event);
+    });
+    expect(restaurantsApi.uploadMenuFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #246.

## Summary
Follow-up to the `menuUrl` field added in #174: admins can now **upload a PDF menu** directly from location settings and have OpenResto host and serve it — no separate external hosting required. Linking to an externally-hosted menu remains supported as an alternative.

## Backend
- **`MediaController`**: new `POST /api/media/menu/{id}` and `DELETE /api/media/menu/{id}` endpoints, mirroring the existing `UploadLocation`/`DeleteLocation` shape. PDF-only (`application/pdf`), 10 MB cap, returns `{ url }` on upload and `404` when the restaurant doesn't exist.
- **`MediaService`**: `UploadMenuAsync`/`DeleteMenuAsync` persist the file into the shared `media_data` volume (same convention as location images) and reuse `Restaurant.MenuUrl` — no new DB column, no migration. A second upload overwrites the first file on disk; deleting an external link clears the column without touching disk.
- **nginx**: bumped `client_max_body_size` from `10M` to `12M` across all three configs (`nginx.conf`, `nginx/default.conf.template`, `nginx-vps/default.conf.template`) so a 10 MB PDF plus multipart framing clears the proxy. The per-endpoint 10 MB cap in the controller still enforces the real limit.

## Frontend
- **`api/restaurants.ts`**: `uploadMenuFile` / `deleteMenuFile` wrappers, mirroring `uploadLocationImage` / `deleteLocationImage`.
- **`RestaurantInfoForm.tsx`**: the old \"Menu link (optional)\" text input is replaced with a combined **Menu** section:
  - When no menu is set: the link input + an \"Upload PDF\" button.
  - When a served file is active (recognized by `/media/menu-<id>.pdf` shape): an \"Uploaded menu PDF\" indicator with a \"Remove file\" button — the link input is hidden.
  - Uploading or removing goes through the dedicated endpoints and calls `onSaved({ menuUrl })` immediately (doesn't ride on the form's Save button).
- Includes a small copy change: a help line under the timezone select clarifying the cross-timezone booking note.

## Tests
- **Backend (+11)**: `MediaControllerUnitTests` covers type/size validation, 404, and success for both upload and delete; `MediaServiceTests` covers not-found, write-and-update, overwrite, and the four delete paths (not-found, already-null, served file, external link).
- **Frontend (+11)**: `RestaurantInfoForm.test.tsx` covers the upload/remove affordances, error/oversize messages, and the served-file vs. link-input swap; `restaurants.test.ts` covers the two new API wrappers.

All 117 backend tests in the affected files pass (the two `SqlitePragmaInterceptorTests` failures are pre-existing on clean main — Windows temp-file handle race). All 1767 frontend tests pass; `npm run check` is clean.

## Out of scope (per #246)
- Multiple menu files per location, versioning/history, non-PDF types, in-app rendering of menu contents.

## Notes
- Docker end-to-end verification with the sample PDF is pending — Docker Desktop hit a buildkit read-only filesystem error on this machine and needs a restart. The full unit + integration test coverage exercises every code path; I'll spot-check the live upload flow once Docker is back if you'd like.