### PR TITLE
chore(deps): bump GitHub Actions to latest majors and safe npm patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         working-directory: openresto-frontend
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload Frontend Coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-coverage
           path: openresto-frontend/coverage/
@@ -68,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
 
@@ -106,14 +106,14 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: "TestResults/*.trx"
 
       - name: Upload Backend Coverage Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: backend-coverage
           path: "CoverageReport/"
@@ -129,7 +129,7 @@ jobs:
 
       - name: Add Coverage to PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           path: code-coverage-results.md
 
@@ -150,7 +150,7 @@ jobs:
     needs: [frontend, backend]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Patch backend env file for CI
         run: |
@@ -218,7 +218,7 @@ jobs:
           [ "$STATUS" = "200" ] || exit 1
 
       - name: OWASP ZAP API Scan
-        uses: zaproxy/action-api-scan@v0.9.0
+        uses: zaproxy/action-api-scan@v0.10.0
         with:
           target: http://localhost:5062/openapi/v1.json
           rules_file_name: .zap-rules.tsv
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload ZAP Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap-report
           path: |
@@ -273,7 +273,7 @@ jobs:
       COMPOSE_FILE: docker-compose.yml:docker-compose.e2e.yml
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Patch backend env file for CI
         run: |
@@ -316,7 +316,7 @@ jobs:
           exit 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -339,7 +339,7 @@ jobs:
 
       - name: Upload Playwright Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: openresto-frontend/playwright-report/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses"
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -27,11 +27,11 @@ jobs:
       ASPNETCORE_ENVIRONMENT: Development
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     name: Build backend (multi-arch)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -26,7 +26,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/karanshukla/openresto-backend
           tags: |
@@ -35,7 +35,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./OpenRestoApi
           file: ./OpenRestoApi/Dockerfile
@@ -50,11 +50,11 @@ jobs:
     name: Build frontend (multi-arch)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/karanshukla/openresto-frontend
           tags: |
@@ -71,7 +71,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./openresto-frontend
           file: ./openresto-frontend/Dockerfile
@@ -87,11 +87,11 @@ jobs:
     name: Build nginx (multi-arch)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/karanshukla/openresto-nginx
           tags: |
@@ -108,7 +108,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./nginx
           file: ./nginx/Dockerfile
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-backend, build-frontend, build-nginx]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Extract release notes for this version
         run: |

--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -24,10 +24,10 @@
         "expo-symbols": "~56.0.6",
         "expo-system-ui": "~56.0.5",
         "expo-web-browser": "~56.0.5",
-        "react": "19.2.3",
-        "react-dom": "19.2.3",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "react-native": "0.85.3",
-        "react-native-gesture-handler": "~3.0.0",
+        "react-native-gesture-handler": "~3.1.0",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "~5.8.0",
         "react-native-web": "~0.21.2",
@@ -7083,6 +7083,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11133,9 +11134,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11173,15 +11174,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-fast-compare": {
@@ -11300,9 +11301,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-3.0.2.tgz",
-      "integrity": "sha512-XBTgmvr2jh/xrMwlHTV2Z1x6IFUl3zfLxyaCAnvj3GSXK5YlY3ZmiIs57hniPmh3I7RtjPFxtGdRr0i+PzyBrg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-3.1.0.tgz",
+      "integrity": "sha512-+kWVyZ6vLdtyFa1/aOc/sZncLAVPUKxhji/ttbiLI7hOaSU44bLjhI7p+Ns+pMl2r3RqPXssl5qHReYet9G77g==",
       "license": "MIT",
       "dependencies": {
         "@types/react-test-renderer": "^19.1.0",
@@ -11560,17 +11561,17 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
-      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.8.tgz",
+      "integrity": "sha512-GHKPaDRaNYU24PHTLG8Bx8VMY9t+qNfxQbt/Yjp7aMWBkKU6766SR0n6TnYu7P5I1MfEuAMUadqiyDHyI4Yy9Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.8",
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.8"
       }
     },
     "node_modules/redent": {

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -36,10 +36,10 @@
     "expo-symbols": "~56.0.6",
     "expo-system-ui": "~56.0.5",
     "expo-web-browser": "~56.0.5",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "react-native": "0.85.3",
-    "react-native-gesture-handler": "~3.0.0",
+    "react-native-gesture-handler": "~3.1.0",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.8.0",
     "react-native-web": "~0.21.2",
@@ -94,7 +94,7 @@
     ]
   },
   "overrides": {
-    "react-test-renderer": "19.2.3",
+    "react-test-renderer": "19.2.8",
     "uuid": ">=14.0.0",
     "shell-quote": ">=1.8.4",
     "js-yaml": ">=4.2.0"


### PR DESCRIPTION
## Summary

Scheduled dependency audit across the repo (npm frontend, .NET backend NuGet, GitHub Actions). No CVEs were found affecting any currently pinned dependency version — `npm audit` is clean, and the backend's `net10.0`/EF Core/ASP.NET Core packages are already pinned to `10.0.10`, which is the patched release for the recent 2026 .NET runtime advisories (CVE-2026-50648, CVE-2026-45591, CVE-2026-33116). This PR applies the updates that were safe to make without a large refactor; larger breaking-change upgrades are called out below for a separate, deliberate migration.

## Related issue

Closes #

## Scope

- [x] Frontend (openresto-frontend)
- [x] Docs / infra (CI workflows)

## Changes

- **GitHub Actions**, bumped to latest stable majors:
  - `actions/checkout` v4 → v7 (v7 blocks "pwn request" patterns by default for `pull_request_target`/`workflow_run` triggers — this repo uses neither, so it's a no-op behavior-wise, just picks up the hardening)
  - `actions/setup-node` v4 → v7, `actions/setup-dotnet` v4 → v6, `actions/upload-artifact` v4 → v7
  - `docker/setup-buildx-action` v3 → v4, `docker/login-action` v3 → v4, `docker/metadata-action` v5 → v6, `docker/build-push-action` v6 → v7
  - `marocchino/sticky-pull-request-comment` v2 → v3
  - `zaproxy/action-api-scan` v0.9.0 → v0.10.0
  - `appleboy/ssh-action` v1.2.0 → v1.2.5
- **Frontend** (`openresto-frontend/package.json`):
  - `react` / `react-dom` 19.2.3 → 19.2.8 (patch releases; satisfies `react-native@0.85.3`'s `^19.2.3` peer dep)
  - `react-native-gesture-handler` ~3.0.0 → ~3.1.0
  - matching `react-test-renderer` override bump (19.2.3 → 19.2.8) so `@testing-library/react-native`'s peer-version check keeps passing

### Left out of scope

No CVEs apply to these, but they're major/breaking version jumps that need coordinated, hands-on testing rather than an automated bump:

- Expo SDK 56 → 57 (all `expo-*` packages move together)
- `react-native` 0.85 → 0.86
- `react-native-reanimated` / `react-native-worklets` (paired with the RN bump)
- `jest` 29 → 30 and `jest-expo` 56 → 57
- `@testing-library/react-native` 13 → 14
- `typescript` 5.9 → 7.0 (the TS team skipped 6.x for the native/Go compiler rewrite)

Backend NuGet packages (`OpenRestoApi.csproj`, `OpenRestoApi.Tests.csproj`) were all confirmed at latest stable or already pinned to the security-patched release — no changes needed there this round. (Note: this sandbox doesn't have the .NET SDK installed, so backend package bumps couldn't be build-verified here even if any had been needed.)

## Testing

- [ ] `OpenRestoApi.Tests` pass locally — not applicable, no backend changes
- [x] Frontend tests/build pass locally — `npx jest` (147 suites / 1902 tests), `npm run check` (prettier + oxlint), `npx tsc --noEmit` all pass
- [ ] CI passes (build, migration-check) — pending
- [x] Manually verified the change end-to-end — workflow YAML re-parses cleanly after the Actions version edits; `npm ls` confirms the react/react-dom/react-test-renderer trio dedupes cleanly at 19.2.8

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed — not applicable, no API contract changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwKdjwToD4uf1buivBasXZ)_