### PR TITLE
fix(pre-commit): scope frontend linter to staged files

### DIFF
--- a/scripts/pre-commit.js
+++ b/scripts/pre-commit.js
@@ -74,9 +74,17 @@ const frontendFiles = stagedFiles.filter(
   (f) => f.startsWith("openresto-frontend/") && /\.(js|jsx|ts|tsx)$/.test(f),
 );
 if (frontendFiles.length > 0) {
-  console.log("Running Frontend Linter (Full Project)...");
+  console.log("Running Frontend Linter (staged files)...");
+  // Scope oxlint to the staged files only. Previously this ran `oxlint --fix`
+  // across the whole project, which rewrote (and sometimes mangled) files the
+  // developer never staged — the changes leaked into the working tree because
+  // the re-add step below only re-stages originally-staged files. oxlint runs
+  // with cwd=openresto-frontend, so strip that prefix from each path.
+  const relFiles = frontendFiles.map(
+    (f) => `"${f.slice("openresto-frontend/".length)}"`,
+  );
   try {
-    execSync(`npm run lint:staged`, {
+    execSync(`npx oxlint --fix ${relFiles.join(" ")}`, {
       cwd: "openresto-frontend",
       stdio: "inherit",
     });


### PR DESCRIPTION
## Summary

The pre-commit hook ran the frontend linter as `npm run lint:staged` (= `oxlint --fix`) with **no file arguments**, so oxlint scanned the entire project and `--fix` rewrote every file with a fixable issue — including files the developer never staged. The collateral changes leaked into the working tree (the re-add step only re-stages originally-staged files), and occasionally oxlint mangled source files it had no business touching.

This came up while working on #259: committing only `DatePicker.test.tsx` caused oxlint to auto-rewrite `openresto-frontend/hooks/use-app-theme.ts` (badly merging a duplicate import) — a change that would have broken the build if not caught.

## Fix

Scope `oxlint --fix` to the staged frontend files, mirroring how the **Prettier** and **dotnet format** steps in the same script already work:

```js
const relFiles = frontendFiles.map((f) => `"${f.slice("openresto-frontend/".length)}"`);
execSync(`npx oxlint --fix ${relFiles.join(" ")}`, { cwd: "openresto-frontend", stdio: "inherit" });
```

The `lint:staged` npm script is intentionally left in place — it's still useful for manual full-project runs.

## Validation

- ✅ Staged a single frontend file (`DatePicker.test.tsx`) and confirmed `use-app-theme.ts` (which has a fixable duplicate import) was **not** touched — working tree stayed clean for unstaged files.
- ✅ Confirmed the staged file itself is still linted/autofixed correctly.
- ✅ Confirmed the hook still **exits non-zero** when oxlint reports an unfixable error (staged a file with `no-unused-vars` → hook aborted with exit code 1).

## Out of scope (flagged)

`openresto-frontend/hooks/use-app-theme.ts` has a genuine duplicate-import that oxlint "fixes" badly. That's a real source bug, not a pre-commit bug — worth a separate fix. This PR merely ensures such auto-fixes can no longer sneak into unrelated commits.

## Changes

- `scripts/pre-commit.js` — ~10-line edit in section 3 (scope frontend linter to staged files + explanatory comment).