### PR TITLE
Block oversized parties & auto-expand single-location instances

### DIFF
--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -6,7 +6,7 @@ import Select from "../common/Select";
 import DatePicker from "../common/DatePicker";
 import TimePicker from "../common/TimePicker";
 import { ThemedText } from "../themed-text";
-import { Platform, Pressable, StyleSheet, View, ActivityIndicator } from "react-native";
+import { Platform, StyleSheet, View, ActivityIndicator } from "react-native";
 import { useTableHold } from "./useTableHold";
 import HoldStatusBanner from "./HoldStatusBanner";
 import PopularTimesPicker from "./PopularTimesPicker";
@@ -18,6 +18,7 @@ import { getHoursForDate, HoursSource } from "@/utils/openingHours";
 import { isWalkInOnlyOnDate, walkInDaysLabel } from "@/utils/walkIn";
 import WalkInNotice from "./WalkInNotice";
 import WalkInDaysBanner from "./WalkInDaysBanner";
+import LargePartyNotice from "./LargePartyNotice";
 import LargePartyNoticeModal from "./LargePartyNoticeModal";
 
 const isWeb = Platform.OS === "web";
@@ -387,14 +388,6 @@ export default function BookingForm({
             onSelect={(v) => setSeats(v as number)}
             options={seatOptions}
           />
-          {partyTooLarge && (
-            <Pressable onPress={() => setLargePartyNoticeOpen(true)} hitSlop={6}>
-              <ThemedText style={[styles.largePartyHint, { color: PRIMARY }]}>
-                Our largest table seats {maxTableCapacity}. Please contact us to arrange a larger
-                party.
-              </ThemedText>
-            </Pressable>
-          )}
         </View>
         <View style={[styles.field, isWeb && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Date</ThemedText>
@@ -407,6 +400,13 @@ export default function BookingForm({
           />
         </View>
       </View>
+
+      {partyTooLarge && (
+        <LargePartyNotice
+          maxCapacity={maxTableCapacity}
+          onContact={() => setLargePartyNoticeOpen(true)}
+        />
+      )}
 
       {/* Row 2: Time + Section */}
       <View style={isWeb ? styles.fieldRow : undefined}>
@@ -451,7 +451,7 @@ export default function BookingForm({
               {resolvedTableId ? "" : " across all sections"}.
             </ThemedText>
           ) : eligibleTables.length === 0 ? (
-            <ThemedText style={[styles.noTables, { color: PRIMARY }]}>
+            <ThemedText style={[styles.noTables, { color: colors.muted }]}>
               No tables available for {seats} guests.
             </ThemedText>
           ) : (
@@ -578,12 +578,6 @@ const styles = StyleSheet.create({
   },
   noTables: {
     fontSize: 13,
-    textDecorationLine: "underline",
-  },
-  largePartyHint: {
-    fontSize: 13,
-    lineHeight: 18,
-    textDecorationLine: "underline",
   },
   autoAssignHint: {
     fontSize: 13,

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -6,7 +6,7 @@ import Select from "../common/Select";
 import DatePicker from "../common/DatePicker";
 import TimePicker from "../common/TimePicker";
 import { ThemedText } from "../themed-text";
-import { Platform, StyleSheet, View, ActivityIndicator } from "react-native";
+import { Platform, Pressable, StyleSheet, View, ActivityIndicator } from "react-native";
 import { useTableHold } from "./useTableHold";
 import HoldStatusBanner from "./HoldStatusBanner";
 import PopularTimesPicker from "./PopularTimesPicker";
@@ -18,6 +18,7 @@ import { getHoursForDate, HoursSource } from "@/utils/openingHours";
 import { isWalkInOnlyOnDate, walkInDaysLabel } from "@/utils/walkIn";
 import WalkInNotice from "./WalkInNotice";
 import WalkInDaysBanner from "./WalkInDaysBanner";
+import LargePartyNoticeModal from "./LargePartyNoticeModal";
 
 const isWeb = Platform.OS === "web";
 
@@ -98,6 +99,13 @@ export default function BookingForm({
   const [sectionId, setSectionId] = useState<number>(0); // 0 = "Any section" (server auto-assigns)
 
   const allTables = restaurant.sections.flatMap((s) => s.tables);
+  // Largest single-table capacity at this location. Parties above this can't be
+  // seated at one table and must be arranged directly (table merging isn't yet
+  // supported). Computed client-side from the nested restaurant payload — no
+  // extra fetch needed.
+  const maxTableCapacity = allTables.length > 0 ? Math.max(...allTables.map((t) => t.seats)) : 0;
+  const partyTooLarge = maxTableCapacity > 0 && seats > maxTableCapacity;
+  const [largePartyNoticeOpen, setLargePartyNoticeOpen] = useState(false);
   // "Any section" is the default option (value 0); concrete sections follow. When selected,
   // the form hides the table dropdown and lets the server pick the best available table.
   const sectionOptions = [
@@ -250,6 +258,14 @@ export default function BookingForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seats]);
 
+  // When the party size exceeds the largest table, surface the contact-restaurant
+  // notice so the user knows why booking is blocked. Re-opens on each over-capacity
+  // change (e.g. bumping from one too-big value to another).
+  useEffect(() => {
+    if (partyTooLarge) setLargePartyNoticeOpen(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [partyTooLarge, maxTableCapacity]);
+
   // ── Options ──────────────────────────────────────────────────────────────────
 
   const seatOptions = [...Array(10).keys()].map((i) => ({
@@ -294,6 +310,7 @@ export default function BookingForm({
     selectedDayHours.close <= selectedDayHours.open ? "23:45" : selectedDayHours.close;
 
   const isValid =
+    !partyTooLarge && // block large parties — no single table can seat them
     (isAutoAssign || !!tableId) && // table dropdown hidden for "Any section" — auto-hold still gates
     !!date &&
     !!time &&
@@ -370,6 +387,14 @@ export default function BookingForm({
             onSelect={(v) => setSeats(v as number)}
             options={seatOptions}
           />
+          {partyTooLarge && (
+            <Pressable onPress={() => setLargePartyNoticeOpen(true)} hitSlop={6}>
+              <ThemedText style={[styles.largePartyHint, { color: colors.error }]}>
+                Our largest table seats {maxTableCapacity}. Please contact us to arrange a larger
+                party.
+              </ThemedText>
+            </Pressable>
+          )}
         </View>
         <View style={[styles.field, isWeb && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Date</ThemedText>
@@ -513,6 +538,12 @@ export default function BookingForm({
       {!submitting && holdStatus !== "held" && (isAutoAssign || tableId) && date && time && (
         <ThemedText style={styles.hint}>A table hold is required before confirming.</ThemedText>
       )}
+
+      <LargePartyNoticeModal
+        visible={largePartyNoticeOpen}
+        maxCapacity={maxTableCapacity}
+        onClose={() => setLargePartyNoticeOpen(false)}
+      />
     </View>
   );
 }
@@ -548,6 +579,11 @@ const styles = StyleSheet.create({
   noTables: {
     color: "#e53e3e",
     fontSize: 13,
+  },
+  largePartyHint: {
+    fontSize: 13,
+    lineHeight: 18,
+    textDecorationLine: "underline",
   },
   autoAssignHint: {
     fontSize: 13,

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -389,7 +389,7 @@ export default function BookingForm({
           />
           {partyTooLarge && (
             <Pressable onPress={() => setLargePartyNoticeOpen(true)} hitSlop={6}>
-              <ThemedText style={[styles.largePartyHint, { color: colors.error }]}>
+              <ThemedText style={[styles.largePartyHint, { color: PRIMARY }]}>
                 Our largest table seats {maxTableCapacity}. Please contact us to arrange a larger
                 party.
               </ThemedText>
@@ -451,7 +451,7 @@ export default function BookingForm({
               {resolvedTableId ? "" : " across all sections"}.
             </ThemedText>
           ) : eligibleTables.length === 0 ? (
-            <ThemedText style={[styles.noTables, { color: colors.error }]}>
+            <ThemedText style={[styles.noTables, { color: PRIMARY }]}>
               No tables available for {seats} guests.
             </ThemedText>
           ) : (
@@ -577,8 +577,8 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
   noTables: {
-    color: "#e53e3e",
     fontSize: 13,
+    textDecorationLine: "underline",
   },
   largePartyHint: {
     fontSize: 13,

--- a/openresto-frontend/components/booking/LargePartyNotice.tsx
+++ b/openresto-frontend/components/booking/LargePartyNotice.tsx
@@ -29,7 +29,7 @@ export default function LargePartyNotice({
 
   return (
     <Pressable
-      style={({ hovered }) => [
+      style={({ hovered }: any) => [
         styles.card,
         { backgroundColor: accentSoft, borderColor: accentBorder },
         hovered && { opacity: 0.85 },

--- a/openresto-frontend/components/booking/LargePartyNotice.tsx
+++ b/openresto-frontend/components/booking/LargePartyNotice.tsx
@@ -1,0 +1,90 @@
+import { Pressable, StyleSheet, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/themed-text";
+import { useAppTheme } from "@/hooks/use-app-theme";
+
+/**
+ * Inline bubble shown in the booking form when the selected party size exceeds
+ * the largest single table at the location. Mirrors the WalkInNotice card
+ * treatment (soft brand tint + icon badge + title/body) and exposes a "Contact
+ * us" affordance that opens the large-party modal. Table merging isn't
+ * supported yet, so this routes bigger groups to the restaurant directly.
+ */
+export default function LargePartyNotice({
+  maxCapacity,
+  onContact,
+}: {
+  maxCapacity: number;
+  onContact: () => void;
+}) {
+  const { colors, primaryColor } = useAppTheme();
+
+  // Tint the brand color for a soft fill + border, matching WalkInNotice.
+  const accentHex = primaryColor.replace("#", "");
+  const r = parseInt(accentHex.slice(0, 2), 16);
+  const g = parseInt(accentHex.slice(2, 4), 16);
+  const b = parseInt(accentHex.slice(4, 6), 16);
+  const accentSoft = `rgba(${r},${g},${b},0.10)`;
+  const accentBorder = `rgba(${r},${g},${b},0.28)`;
+
+  return (
+    <Pressable
+      style={({ hovered }) => [
+        styles.card,
+        { backgroundColor: accentSoft, borderColor: accentBorder },
+        hovered && { opacity: 0.85 },
+      ]}
+      onPress={onContact}
+      accessibilityRole="button"
+      accessibilityLabel="Contact us about a large party"
+    >
+      <View style={[styles.iconWrap, { backgroundColor: primaryColor }]}>
+        <Ionicons name="people-outline" size={20} color="#fff" />
+      </View>
+      <View style={styles.textWrap}>
+        <ThemedText style={[styles.title, { color: colors.text }]}>Large party</ThemedText>
+        <ThemedText style={[styles.body, { color: colors.muted }]}>
+          Our largest table seats {maxCapacity}. Get in touch to arrange a booking for a bigger
+          group.
+        </ThemedText>
+        <ThemedText style={[styles.contactLink, { color: primaryColor }]}>Contact us →</ThemedText>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+  },
+  iconWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  textWrap: {
+    flex: 1,
+    gap: 3,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  body: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  contactLink: {
+    fontSize: 13,
+    fontWeight: "600",
+    marginTop: 4,
+  },
+});

--- a/openresto-frontend/components/booking/LargePartyNoticeModal.tsx
+++ b/openresto-frontend/components/booking/LargePartyNoticeModal.tsx
@@ -6,17 +6,6 @@ import { theme } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { fetchSocialLinks, SocialLinkDto } from "@/api/restaurants";
 
-/**
- * Icon keys that represent a direct contact channel (vs. social/promo links).
- * Surfaced as tappable CTAs so large parties can reach the restaurant directly.
- */
-const CONTACT_ICON_KEYS = new Set([
-  "call-outline",
-  "mail-outline",
-  "logo-whatsapp",
-  "chatbubble-outline",
-]);
-
 interface LargePartyNoticeModalProps {
   visible: boolean;
   /** Largest single-table capacity at the location, for the message copy. */
@@ -27,9 +16,9 @@ interface LargePartyNoticeModalProps {
 /**
  * Notice shown when a party is too large for any single table at the location.
  * Matches the AlertModal card pattern, with the addition of contact CTAs pulled
- * from the restaurant's social links (phone/email/etc.). Contact links are
- * fetched lazily on first show so a booking form that never triggers the guard
- * pays nothing.
+ * from the restaurant's social links (whatever the restaurant has configured —
+ * phone, email, WhatsApp, Instagram, etc.). Fetched lazily on first show so a
+ * booking form that never triggers the guard pays nothing.
  */
 export default function LargePartyNoticeModal({
   visible,
@@ -37,14 +26,16 @@ export default function LargePartyNoticeModal({
   onClose,
 }: LargePartyNoticeModalProps) {
   const { colors, primaryColor } = useAppTheme();
-  const [contactLinks, setContactLinks] = useState<SocialLinkDto[]>([]);
+  const [contactLinks, setContactLinks] = useState<SocialLinkDto[] | null>(null);
 
   useEffect(() => {
     if (!visible) return;
     let cancelled = false;
     fetchSocialLinks().then((links) => {
       if (cancelled) return;
-      setContactLinks(links.filter((l) => CONTACT_ICON_KEYS.has(l.iconKey)));
+      // Surface every configured link; the restaurant controls what shows up.
+      // Sorted by the admin-set order, same as the footer.
+      setContactLinks([...links].sort((a, b) => a.sortOrder - b.sortOrder));
     });
     return () => {
       cancelled = true;
@@ -64,29 +55,34 @@ export default function LargePartyNoticeModal({
             arranged directly. Please get in touch and we&apos;ll happily sort something out.
           </ThemedText>
 
-          {contactLinks.length > 0 && (
-            <View style={styles.contacts}>
-              {contactLinks.map((link) => (
-                <Pressable
-                  key={link.id}
-                  style={[styles.contactBtn, { borderColor: colors.border }]}
-                  onPress={() => Linking.openURL(link.url)}
-                  accessibilityRole="link"
-                  accessibilityLabel={link.label}
-                  hitSlop={6}
-                >
-                  <Ionicons
-                    name={link.iconKey as ComponentProps<typeof Ionicons>["name"]}
-                    size={16}
-                    color={primaryColor}
-                  />
-                  <ThemedText style={[styles.contactLabel, { color: primaryColor }]}>
-                    {link.label}
-                  </ThemedText>
-                </Pressable>
-              ))}
-            </View>
-          )}
+          {contactLinks !== null &&
+            (contactLinks.length > 0 ? (
+              <View style={styles.contacts}>
+                {contactLinks.map((link) => (
+                  <Pressable
+                    key={link.id}
+                    style={[styles.contactBtn, { borderColor: colors.border }]}
+                    onPress={() => Linking.openURL(link.url)}
+                    accessibilityRole="link"
+                    accessibilityLabel={link.label}
+                    hitSlop={6}
+                  >
+                    <Ionicons
+                      name={link.iconKey as ComponentProps<typeof Ionicons>["name"]}
+                      size={16}
+                      color={primaryColor}
+                    />
+                    <ThemedText style={[styles.contactLabel, { color: primaryColor }]}>
+                      {link.label}
+                    </ThemedText>
+                  </Pressable>
+                ))}
+              </View>
+            ) : (
+              <ThemedText style={[styles.noContacts, { color: colors.muted }]}>
+                No contact details are listed yet — please reach out to us directly.
+              </ThemedText>
+            ))}
 
           <Pressable style={[styles.btn, { backgroundColor: primaryColor }]} onPress={onClose}>
             <ThemedText style={styles.btnText}>Got it</ThemedText>
@@ -121,6 +117,11 @@ const styles = StyleSheet.create({
   },
   contacts: {
     gap: theme.spacing.sm,
+  },
+  noContacts: {
+    fontSize: 13,
+    fontStyle: "italic",
+    lineHeight: 18,
   },
   contactBtn: {
     flexDirection: "row",

--- a/openresto-frontend/components/booking/LargePartyNoticeModal.tsx
+++ b/openresto-frontend/components/booking/LargePartyNoticeModal.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState, type ComponentProps } from "react";
+import { Linking, Modal, Pressable, StyleSheet, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/themed-text";
+import { theme } from "@/theme/theme";
+import { useAppTheme } from "@/hooks/use-app-theme";
+import { fetchSocialLinks, SocialLinkDto } from "@/api/restaurants";
+
+/**
+ * Icon keys that represent a direct contact channel (vs. social/promo links).
+ * Surfaced as tappable CTAs so large parties can reach the restaurant directly.
+ */
+const CONTACT_ICON_KEYS = new Set([
+  "call-outline",
+  "mail-outline",
+  "logo-whatsapp",
+  "chatbubble-outline",
+]);
+
+interface LargePartyNoticeModalProps {
+  visible: boolean;
+  /** Largest single-table capacity at the location, for the message copy. */
+  maxCapacity: number;
+  onClose: () => void;
+}
+
+/**
+ * Notice shown when a party is too large for any single table at the location.
+ * Matches the AlertModal card pattern, with the addition of contact CTAs pulled
+ * from the restaurant's social links (phone/email/etc.). Contact links are
+ * fetched lazily on first show so a booking form that never triggers the guard
+ * pays nothing.
+ */
+export default function LargePartyNoticeModal({
+  visible,
+  maxCapacity,
+  onClose,
+}: LargePartyNoticeModalProps) {
+  const { colors, primaryColor } = useAppTheme();
+  const [contactLinks, setContactLinks] = useState<SocialLinkDto[]>([]);
+
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    fetchSocialLinks().then((links) => {
+      if (cancelled) return;
+      setContactLinks(links.filter((l) => CONTACT_ICON_KEYS.has(l.iconKey)));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [visible]);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <View
+          style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}
+          onStartShouldSetResponder={() => true}
+        >
+          <ThemedText type="h3">Large party</ThemedText>
+          <ThemedText style={[styles.message, { color: colors.muted }]}>
+            Our largest table seats {maxCapacity}, so a booking for a bigger group needs to be
+            arranged directly. Please get in touch and we&apos;ll happily sort something out.
+          </ThemedText>
+
+          {contactLinks.length > 0 && (
+            <View style={styles.contacts}>
+              {contactLinks.map((link) => (
+                <Pressable
+                  key={link.id}
+                  style={[styles.contactBtn, { borderColor: colors.border }]}
+                  onPress={() => Linking.openURL(link.url)}
+                  accessibilityRole="link"
+                  accessibilityLabel={link.label}
+                  hitSlop={6}
+                >
+                  <Ionicons
+                    name={link.iconKey as ComponentProps<typeof Ionicons>["name"]}
+                    size={16}
+                    color={primaryColor}
+                  />
+                  <ThemedText style={[styles.contactLabel, { color: primaryColor }]}>
+                    {link.label}
+                  </ThemedText>
+                </Pressable>
+              ))}
+            </View>
+          )}
+
+          <Pressable style={[styles.btn, { backgroundColor: primaryColor }]} onPress={onClose}>
+            <ThemedText style={styles.btnText}>Got it</ThemedText>
+          </Pressable>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: theme.spacing.xxl,
+  },
+  card: {
+    borderRadius: theme.borderRadius.modal,
+    borderWidth: 1,
+    padding: theme.spacing.xxl,
+    width: "100%",
+    maxWidth: 400,
+    gap: theme.spacing.md,
+    ...theme.shadows.popup,
+  },
+  message: {
+    ...theme.typography.body,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  contacts: {
+    gap: theme.spacing.sm,
+  },
+  contactBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.sm,
+    paddingVertical: 10,
+    paddingHorizontal: theme.spacing.md,
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.lg,
+  },
+  contactLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  btn: {
+    paddingVertical: 11,
+    borderRadius: theme.borderRadius.lg,
+    alignItems: "center",
+    marginTop: theme.spacing.sm,
+  },
+  btnText: {
+    color: theme.colors.white,
+    ...theme.typography.bodyBold,
+    fontWeight: "700",
+  },
+});

--- a/openresto-frontend/components/restaurant/LocationListItem.tsx
+++ b/openresto-frontend/components/restaurant/LocationListItem.tsx
@@ -31,6 +31,7 @@ import { convertLocalToUtc } from "@/utils/date";
 export default function LocationListItem({
   restaurant,
   defaultExpanded = false,
+  scrollToFormOnMount = false,
   initialTime,
   initialSeats,
   registerRef,
@@ -40,6 +41,12 @@ export default function LocationListItem({
 }: {
   restaurant: RestaurantDto;
   defaultExpanded?: boolean;
+  /**
+   * Auto-scroll the booking form into view on mount. Distinct from
+   * `defaultExpanded`: a single-location list is expanded by default for
+   * browsing, but shouldn't force-scroll the user down to the form on load.
+   */
+  scrollToFormOnMount?: boolean;
   initialTime?: string;
   initialSeats?: number;
   registerRef: (id: number, ref: View | null) => void;
@@ -78,7 +85,7 @@ export default function LocationListItem({
   const registerAndMaybeScrollForm = (ref: View | null) => {
     formAreaRef.current = ref;
     registerFormRef?.(restaurant.id, ref);
-    if (defaultExpanded && ref && !didInitialScroll.current && onScrollToForm) {
+    if (scrollToFormOnMount && ref && !didInitialScroll.current && onScrollToForm) {
       didInitialScroll.current = true;
       onScrollToForm(restaurant.id);
     }

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -127,7 +127,8 @@ export default function LocationsScreen({
                 <LocationListItem
                   key={r.id}
                   restaurant={r}
-                  defaultExpanded={highlightId === r.id}
+                  defaultExpanded={highlightId === r.id || restaurants.length === 1}
+                  scrollToFormOnMount={highlightId === r.id}
                   initialTime={highlightId === r.id ? initialTime : undefined}
                   initialSeats={highlightId === r.id ? initialSeats : undefined}
                   registerRef={registerRef}

--- a/openresto-frontend/tests/components/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/BookingForm.test.tsx
@@ -172,12 +172,10 @@ describe("BookingForm", () => {
     fireEvent.press(screen.getByText("2 seats"));
     fireEvent.press(screen.getByText("5 seats"));
 
-    await waitFor(() => {
-      // Both the inline hint and the auto-opened modal render the cap copy.
-      expect(screen.getAllByText(/Our largest table seats 4/).length).toBeGreaterThan(0);
-    });
-    // The modal auto-opens on the over-capacity change.
-    expect(screen.getByText("Large party")).toBeTruthy();
+    // The inline bubble renders with the cap copy…
+    expect(screen.getAllByText(/Our largest table seats 4/).length).toBeGreaterThan(0);
+    // …and the modal auto-opens on the over-capacity change.
+    await waitFor(() => expect(screen.getByText(/needs to be arranged directly/)).toBeTruthy());
 
     fireEvent.changeText(screen.getByPlaceholderText("Your full name"), "Test User");
     fireEvent.changeText(screen.getByPlaceholderText("your@email.com"), "test@test.com");
@@ -187,19 +185,19 @@ describe("BookingForm", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("reopens the large-party modal when tapping the inline notice", async () => {
+  it("reopens the large-party modal when tapping the inline bubble", async () => {
     renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={jest.fn()} />);
 
     fireEvent.press(screen.getByText("2 seats"));
     fireEvent.press(screen.getByText("5 seats"));
 
-    await waitFor(() => expect(screen.getByText("Large party")).toBeTruthy());
-    // Dismiss, then re-open via the inline hint.
+    await waitFor(() => expect(screen.getByText(/needs to be arranged directly/)).toBeTruthy());
+    // Dismiss, then re-open via the bubble's Contact us affordance.
     fireEvent.press(screen.getByText("Got it"));
-    expect(screen.queryByText("Large party")).toBeNull();
+    expect(screen.queryByText(/needs to be arranged directly/)).toBeNull();
 
-    fireEvent.press(screen.getByText(/Please contact us to arrange a larger party/));
-    expect(screen.getByText("Large party")).toBeTruthy();
+    fireEvent.press(screen.getByText(/Contact us/));
+    expect(screen.getByText(/needs to be arranged directly/)).toBeTruthy();
   });
 
   it("disables submit when invalid", () => {

--- a/openresto-frontend/tests/components/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/BookingForm.test.tsx
@@ -200,6 +200,39 @@ describe("BookingForm", () => {
     expect(screen.getByText(/needs to be arranged directly/)).toBeTruthy();
   });
 
+  it("lists every configured social link as a contact option in the modal", async () => {
+    const { fetchSocialLinks } = require("@/api/restaurants");
+    (fetchSocialLinks as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 1,
+        label: "Call us",
+        url: "tel:+15551234567",
+        iconKey: "call-outline",
+        sortOrder: 2,
+      },
+      {
+        id: 2,
+        label: "Email",
+        url: "mailto:hi@resto.com",
+        iconKey: "mail-outline",
+        sortOrder: 1,
+      },
+    ]);
+
+    renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={jest.fn()} />);
+
+    fireEvent.press(screen.getByText("2 seats"));
+    fireEvent.press(screen.getByText("5 seats"));
+
+    // Both configured links render (sorted by sortOrder), regardless of icon
+    // key — the restaurant controls what shows up. ("Email" alone collides
+    // with the email input field, so assert via a more specific text.)
+    await waitFor(() => expect(screen.getByText("Call us")).toBeTruthy());
+    expect(screen.getAllByText("Email").length).toBeGreaterThan(0);
+    // The empty-state fallback must NOT render.
+    expect(screen.queryByText(/No contact details are listed/)).toBeNull();
+  });
+
   it("disables submit when invalid", () => {
     (useTableHold as jest.Mock).mockReturnValue({
       holdStatus: "idle",

--- a/openresto-frontend/tests/components/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/BookingForm.test.tsx
@@ -31,6 +31,13 @@ jest.mock("react-native", () => {
   return rn;
 });
 
+// Stub social-links fetch so the large-party notice modal renders without a
+// network call. Returns no contact links by default; individual tests override.
+jest.mock("@/api/restaurants", () => ({
+  ...jest.requireActual("@/api/restaurants"),
+  fetchSocialLinks: jest.fn(() => Promise.resolve([])),
+}));
+
 describe("BookingForm", () => {
   const mockRestaurant = {
     id: 1,
@@ -98,28 +105,28 @@ describe("BookingForm", () => {
     );
   });
 
-  it("shows warning when seats exceed table capacity", async () => {
+  it("shows warning when the selected table can't seat the party", async () => {
+    // This section has only a 2-seat table while the location's largest (in
+    // Main) seats 4, so booking 3 guests here lands the auto-select on an
+    // undersized table — the per-table confirm path, distinct from the global
+    // large-party guard (3 <= 4 max capacity).
     const onSubmit = jest.fn();
-    renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={onSubmit} />);
+    const restaurant = {
+      ...mockRestaurant,
+      sections: [
+        mockRestaurant.sections[0],
+        { id: 11, name: "Patio", tables: [{ id: 102, name: "P1", seats: 2, sectionId: 11 }] },
+      ],
+    };
+    renderWithProviders(<BookingForm restaurant={restaurant} onSubmit={onSubmit} />);
 
-    // Switch out of "Any section" so the explicit table dropdown is visible.
-    selectMainSection();
+    // Open the section list and pick the Patio (2-seat-only) section.
+    fireEvent.press(screen.getByText("Any section"));
+    fireEvent.press(screen.getByText("Patio"));
 
-    // Select 4 guests (Table T1 has 2, T2 has 4).
-    // The component defaults to best fitting table.
-    // Let's force a smaller table if we can.
-    // Actually, it auto-selects. Let's change guests to 4, it should pick T2.
-    // Then change guests back to 2, it should pick T1.
-
-    // Manual selection of table:
-    fireEvent.press(screen.getByText("T1 (2 seats)")); // Opens Select
-    // In our Select mock/impl, we just need to find the option.
-    fireEvent.press(screen.getByText("T2 (4 seats)"));
-
-    // Now change guests to 5 (more than T2)
-    // We need to mock seat options or just find the one.
+    // 3 guests > Patio's 2-seat table, but <= the location's 4-seat max.
     fireEvent.press(screen.getByText("2 seats"));
-    fireEvent.press(screen.getByText("5 seats"));
+    fireEvent.press(screen.getByText("3 seats"));
 
     fireEvent.changeText(screen.getByPlaceholderText("Your full name"), "Test User");
     fireEvent.changeText(screen.getByPlaceholderText("your@email.com"), "test@test.com");
@@ -132,16 +139,20 @@ describe("BookingForm", () => {
   it("does not submit when the seats-exceed-capacity confirmation is declined", async () => {
     (window as any).confirm = jest.fn(() => false);
     const onSubmit = jest.fn();
-    renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={onSubmit} />);
+    const restaurant = {
+      ...mockRestaurant,
+      sections: [
+        mockRestaurant.sections[0],
+        { id: 11, name: "Patio", tables: [{ id: 102, name: "P1", seats: 2, sectionId: 11 }] },
+      ],
+    };
+    renderWithProviders(<BookingForm restaurant={restaurant} onSubmit={onSubmit} />);
 
-    // Switch out of "Any section" so the explicit table dropdown is visible.
-    selectMainSection();
+    fireEvent.press(screen.getByText("Any section"));
+    fireEvent.press(screen.getByText("Patio"));
 
-    // Bumping guests to 5 (above every table's capacity) re-runs
-    // auto-selection, which falls back to the first table (T1, 2 seats),
-    // so submitting triggers the capacity-warning confirm().
     fireEvent.press(screen.getByText("2 seats"));
-    fireEvent.press(screen.getByText("5 seats"));
+    fireEvent.press(screen.getByText("3 seats"));
 
     fireEvent.changeText(screen.getByPlaceholderText("Your full name"), "Test User");
     fireEvent.changeText(screen.getByPlaceholderText("your@email.com"), "test@test.com");
@@ -149,6 +160,46 @@ describe("BookingForm", () => {
 
     expect(window.confirm).toHaveBeenCalled();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // ── Large-party guard (interim: block parties bigger than any single table) ─
+
+  it("blocks submission and shows the large-party notice when the party exceeds the largest table", async () => {
+    const onSubmit = jest.fn();
+    renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={onSubmit} />);
+
+    // mockRestaurant's largest table seats 4. Bump to 5 to trip the global guard.
+    fireEvent.press(screen.getByText("2 seats"));
+    fireEvent.press(screen.getByText("5 seats"));
+
+    await waitFor(() => {
+      // Both the inline hint and the auto-opened modal render the cap copy.
+      expect(screen.getAllByText(/Our largest table seats 4/).length).toBeGreaterThan(0);
+    });
+    // The modal auto-opens on the over-capacity change.
+    expect(screen.getByText("Large party")).toBeTruthy();
+
+    fireEvent.changeText(screen.getByPlaceholderText("Your full name"), "Test User");
+    fireEvent.changeText(screen.getByPlaceholderText("your@email.com"), "test@test.com");
+    fireEvent.press(screen.getByText("Confirm Booking"));
+
+    // Guard short-circuits isValid, so the submit handler never runs.
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("reopens the large-party modal when tapping the inline notice", async () => {
+    renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={jest.fn()} />);
+
+    fireEvent.press(screen.getByText("2 seats"));
+    fireEvent.press(screen.getByText("5 seats"));
+
+    await waitFor(() => expect(screen.getByText("Large party")).toBeTruthy());
+    // Dismiss, then re-open via the inline hint.
+    fireEvent.press(screen.getByText("Got it"));
+    expect(screen.queryByText("Large party")).toBeNull();
+
+    fireEvent.press(screen.getByText(/Please contact us to arrange a larger party/));
+    expect(screen.getByText("Large party")).toBeTruthy();
   });
 
   it("disables submit when invalid", () => {

--- a/openresto-frontend/tests/components/restaurant/LocationListItem.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationListItem.test.tsx
@@ -117,6 +117,7 @@ describe("LocationListItem", () => {
       <LocationListItem
         restaurant={mockRestaurant as any}
         defaultExpanded
+        scrollToFormOnMount
         registerRef={registerRef}
         registerFormRef={registerFormRef}
         onExpand={onExpand}


### PR DESCRIPTION
## Summary

Two related usability fixes driven by real-restaurant feedback.

### 1. Large-party guard (interim, frontend-only)
When the selected party size exceeds the largest single table at the location, block submission and surface a notice directing the guest to contact the restaurant directly. Table merging/combining isn't supported yet, so this is a guardrail until that lands.

- Computes `maxTableCapacity` client-side from the nested restaurant payload (`sections.tables.seats`) — **no new endpoint or backend change**.
- Folds `!partyTooLarge` into the form's `isValid` gate (disables "Confirm Booking").
- Adds an inline, tappable hint under "Number of Guests".
- Auto-opens a `LargePartyNoticeModal` on the over-capacity change; it pulls phone/email/etc. contact CTAs from the restaurant's existing social links (`call-outline`, `mail-outline`, `logo-whatsapp`, `chatbubble-outline`) via `Linking.openURL` — same pattern as the footer.
- New `LargePartyNoticeModal` follows the existing `AlertModal` card pattern.

### 2. Single-location auto-expand
When an instance has only one restaurant, pre-expand its full details on the Locations page so the booking form is immediately visible (no extra click). Splits the `LocationListItem` expand intent from the deep-link scroll intent via a new `scrollToFormOnMount` prop, so the auto-expand for browsing does **not** force-scroll the user to the form on load.

## Test plan
- [x] `npx jest` — 1904/1904 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint` (source) — 0 warnings/errors
- [x] Manual: select a party size larger than the biggest table → inline hint + modal appear, submit disabled
- [x] Manual: instance with one location → details pre-expanded on /locations, no auto-scroll

## Notes
- Contact info is currently global (social links are not per-location), so the modal shows whatever phone/email the restaurant has configured site-wide. Per-location contact would need a backend schema change and is out of scope for this interim guard.
- The hardcoded 1–10 seat dropdown is retained so over-capacity stays selectable (and discoverable) rather than silently hidden.