### PR TITLE
Validate social links, highlights, and menu URLs (#263)

### DIFF
--- a/OpenRestoApi.Tests/Integration/HighlightsControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/HighlightsControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using OpenRestoApi.Core.Application.DTOs;
 
 namespace OpenRestoApi.Tests.Integration;
@@ -139,5 +140,110 @@ public class HighlightsControllerTests(TestWebAppFactory factory) : IClassFixtur
         HttpClient client = _factory.CreateAuthenticatedClient();
         HttpResponseMessage response = await client.DeleteAsync("/api/highlights/99999");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ── Validation (Create) ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_EmptyTitle_Returns400()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/highlights", new
+        {
+            title = "   ",
+            body = "Body",
+            iconKey = "star-outline",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("title cannot be empty", body.GetProperty("message").GetString()!);
+    }
+
+    [Fact]
+    public async Task Create_OversizedTitle_Returns400()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/highlights", new
+        {
+            title = new string('A', 61),
+            body = "Body",
+            iconKey = "star-outline",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_OversizedBody_Returns400()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/highlights", new
+        {
+            title = "Ok",
+            body = new string('B', 501),
+            iconKey = "star-outline",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("asdf")]
+    public async Task Create_InvalidLink_Returns400(string link)
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/highlights", new
+        {
+            title = "Ok",
+            body = "Body",
+            iconKey = "star-outline",
+            sortOrder = 0,
+            link = link,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("valid absolute URL", body.GetProperty("message").GetString()!);
+    }
+
+    [Fact]
+    public async Task Create_UnknownIconKey_Returns400()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/highlights", new
+        {
+            title = "Ok",
+            body = "Body",
+            iconKey = "not-a-real-icon",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("Icon key", body.GetProperty("message").GetString()!);
+    }
+
+    [Fact]
+    public async Task Create_ValidHighlightWithLink_Returns201()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/highlights", new
+        {
+            title = "Award Winner",
+            body = "We won!",
+            iconKey = "trophy-outline",
+            sortOrder = 0,
+            link = "https://example.com/awards",
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        HighlightDto? dto = await response.Content.ReadFromJsonAsync<HighlightDto>();
+        Assert.NotNull(dto);
+        Assert.Equal("https://example.com/awards", dto.Link);
     }
 }

--- a/OpenRestoApi.Tests/Integration/SocialLinksControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/SocialLinksControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using OpenRestoApi.Core.Application.DTOs;
 
 namespace OpenRestoApi.Tests.Integration;
@@ -137,5 +138,91 @@ public class SocialLinksControllerTests(TestWebAppFactory factory) : IClassFixtu
         HttpClient client = _factory.CreateAuthenticatedClient();
         HttpResponseMessage response = await client.DeleteAsync("/api/social-links/99999");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ── Validation (Create) ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_EmptyLabel_Returns400()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/social-links", new
+        {
+            label = "   ",
+            url = "https://example.com",
+            iconKey = "link-outline",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("label cannot be empty", body.GetProperty("message").GetString()!);
+    }
+
+    [Fact]
+    public async Task Create_OversizedLabel_Returns400()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/social-links", new
+        {
+            label = new string('A', 61),
+            url = "https://example.com",
+            iconKey = "link-outline",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("asdf")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("/media/menu-1.pdf")]
+    public async Task Create_InvalidUrl_Returns400(string url)
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/social-links", new
+        {
+            label = "Ok",
+            url = url,
+            iconKey = "link-outline",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("valid absolute URL", body.GetProperty("message").GetString()!);
+    }
+
+    [Fact]
+    public async Task Create_UnknownIconKey_Returns400()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/social-links", new
+        {
+            label = "Ok",
+            url = "https://example.com",
+            iconKey = "not-a-real-icon",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        JsonElement body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Contains("Icon key", body.GetProperty("message").GetString()!);
+    }
+
+    [Fact]
+    public async Task Create_TelUrl_Returns201()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/social-links", new
+        {
+            label = "Call us",
+            url = "tel:+15551234567",
+            iconKey = "call-outline",
+            sortOrder = 0,
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 }

--- a/OpenRestoApi.Tests/Services/HighlightServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/HighlightServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using OpenRestoApi.Core.Application.DTOs;
+using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Domain;
 using OpenRestoApi.Infrastructure.Persistence;
@@ -226,5 +227,198 @@ public class HighlightServiceTests
         bool result = await svc.DeleteAsync(9999);
 
         Assert.False(result);
+    }
+
+    // ── Validation (CreateAsync) ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateAsync_RejectsEmptyTitle(string? title)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_RejectsEmptyTitle)}_{title}");
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = title!,
+            Body = "body",
+            IconKey = "star-outline",
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("title cannot be empty", ex.Message);
+        Assert.Equal(0, await db.Highlights.CountAsync());
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsOversizedTitle()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_RejectsOversizedTitle));
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = new string('A', 61),
+            Body = "body",
+            IconKey = "star-outline",
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("title cannot exceed 60", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsOversizedBody()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_RejectsOversizedBody));
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = "Ok",
+            Body = new string('B', 501),
+            IconKey = "star-outline",
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("body cannot exceed 500", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("not-a-real-icon")]
+    [InlineData("")]
+    public async Task CreateAsync_RejectsUnknownIconKey(string iconKey)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_RejectsUnknownIconKey)}_{iconKey}");
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = "Ok",
+            Body = "body",
+            IconKey = iconKey,
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("Icon key", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("asdf")]                    // bare string, not a URL
+    [InlineData("javascript:alert(1)")]     // dangerous scheme
+    [InlineData("ftp://example.com")]       // disallowed scheme
+    public async Task CreateAsync_RejectsInvalidLink(string link)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_RejectsInvalidLink)}_{link}");
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = "Ok",
+            Body = "body",
+            IconKey = "star-outline",
+            SortOrder = 0,
+            Link = link,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("valid absolute URL", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("mailto:hello@example.com")]
+    [InlineData("tel:+15551234567")]
+    public async Task CreateAsync_AcceptsValidLinkSchemes(string link)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_AcceptsValidLinkSchemes)}_{link}");
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = "Ok",
+            Body = "body",
+            IconKey = "star-outline",
+            SortOrder = 0,
+            Link = link,
+        };
+
+        HighlightDto result = await svc.CreateAsync(req);
+
+        Assert.Equal(link, result.Link);
+    }
+
+    [Fact]
+    public async Task CreateAsync_TrimsTitleBodyAndLink()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_TrimsTitleBodyAndLink));
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new CreateHighlightRequest
+        {
+            Title = "  Award Winner  ",
+            Body = "  body text  ",
+            IconKey = "trophy-outline",
+            SortOrder = 0,
+            Link = "  https://example.com  ",
+        };
+
+        HighlightDto result = await svc.CreateAsync(req);
+
+        Assert.Equal("Award Winner", result.Title);
+        Assert.Equal("body text", result.Body);
+        Assert.Equal("https://example.com", result.Link);
+    }
+
+    // ── Validation (UpdateAsync) ────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_RejectsInvalidLink()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_RejectsInvalidLink));
+        db.Highlights.Add(new RestaurantHighlight
+        {
+            Title = "Old",
+            Body = "old body",
+            SortOrder = 0,
+            Link = "https://old.example.com",
+        });
+        await db.SaveChangesAsync();
+        int id = db.Highlights.First().Id;
+
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new UpdateHighlightRequest
+        {
+            Title = "New",
+            Body = "new body",
+            IconKey = "star-outline",
+            SortOrder = 0,
+            Link = "javascript:alert(1)",
+        };
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.UpdateAsync(id, req));
+
+        // Entity unchanged — validation throws before assignment.
+        RestaurantHighlight stored = await db.Highlights.FirstAsync();
+        Assert.Equal("https://old.example.com", stored.Link);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RejectsEmptyTitle()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_RejectsEmptyTitle));
+        db.Highlights.Add(new RestaurantHighlight { Title = "Old", Body = "b", SortOrder = 0 });
+        await db.SaveChangesAsync();
+        int id = db.Highlights.First().Id;
+
+        var svc = new HighlightService(new HighlightRepository(db));
+        var req = new UpdateHighlightRequest
+        {
+            Title = "   ",
+            Body = "b",
+            IconKey = "star-outline",
+            SortOrder = 0,
+        };
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.UpdateAsync(id, req));
     }
 }

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -292,6 +292,66 @@ public class RestaurantManagementServiceTests
         Assert.Null(result.MenuUrl);
     }
 
+    [Theory]
+    [InlineData("asdf")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("ftp://example.com/menu.pdf")]
+    [InlineData("mailto:hello@example.com")]
+    public async Task UpdateAsync_RejectsInvalidMenuUrl(string menuUrl)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(UpdateAsync_RejectsInvalidMenuUrl)}_{menuUrl}");
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            MenuUrl = menuUrl,
+        }));
+
+        // Unchanged — validation throws before assignment.
+        Assert.Null((await db.Restaurants.FindAsync(1))!.MenuUrl);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_AcceptsServedMenuPath()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_AcceptsServedMenuPath));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        // The /media/menu-<id>.pdf path is written by MediaService.UploadMenuAsync and must
+        // not be rejected by URL validation (it's a relative served-file path, not absolute).
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            MenuUrl = "/media/menu-1.pdf?v=123",
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("/media/menu-1.pdf?v=123", result.MenuUrl);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_AcceptsExternalHttpsMenuUrl()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_AcceptsExternalHttpsMenuUrl));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R", Timezone = "UTC" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.UpdateAsync(1, new UpdateRestaurantRequest
+        {
+            Name = "R",
+            MenuUrl = "https://example.com/menu.pdf",
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("https://example.com/menu.pdf", result.MenuUrl);
+    }
+
     [Fact]
     public async Task UpdateAsync_Keeps_Description_WhenNull()
     {

--- a/OpenRestoApi.Tests/Services/SocialLinkServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/SocialLinkServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using OpenRestoApi.Core.Application.DTOs;
+using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Domain;
 using OpenRestoApi.Infrastructure.Persistence;
@@ -148,5 +149,191 @@ public class SocialLinkServiceTests
         bool result = await svc.DeleteAsync(9999);
 
         Assert.False(result);
+    }
+
+    // ── Validation (CreateAsync) ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateAsync_RejectsEmptyLabel(string? label)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_RejectsEmptyLabel)}_{label}");
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new CreateSocialLinkRequest
+        {
+            Label = label!,
+            Url = "https://example.com",
+            IconKey = "link-outline",
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("label cannot be empty", ex.Message);
+        Assert.Equal(0, await db.SocialLinks.CountAsync());
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsOversizedLabel()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_RejectsOversizedLabel));
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new CreateSocialLinkRequest
+        {
+            Label = new string('A', 61),
+            Url = "https://example.com",
+            IconKey = "link-outline",
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("cannot exceed 60", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateAsync_RejectsEmptyUrl(string? url)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_RejectsEmptyUrl)}_{url}");
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new CreateSocialLinkRequest
+        {
+            Label = "Ok",
+            Url = url!,
+            IconKey = "link-outline",
+            SortOrder = 0,
+        };
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+    }
+
+    [Theory]
+    [InlineData("asdf")]                    // bare string, not a URL
+    [InlineData("javascript:alert(1)")]     // dangerous scheme
+    [InlineData("/media/menu-1.pdf")]       // relative path (social links need absolute)
+    [InlineData("ftp://example.com")]       // disallowed scheme
+    public async Task CreateAsync_RejectsInvalidUrl(string url)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_RejectsInvalidUrl)}_{url}");
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new CreateSocialLinkRequest
+        {
+            Label = "Ok",
+            Url = url,
+            IconKey = "link-outline",
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("valid absolute URL", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("not-a-real-icon")]
+    [InlineData("")]
+    public async Task CreateAsync_RejectsUnknownIconKey(string iconKey)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_RejectsUnknownIconKey)}_{iconKey}");
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new CreateSocialLinkRequest
+        {
+            Label = "Ok",
+            Url = "https://example.com",
+            IconKey = iconKey,
+            SortOrder = 0,
+        };
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Contains("Icon key", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("mailto:hello@example.com")]
+    [InlineData("tel:+15551234567")]
+    [InlineData("sms:+15551234567")]
+    public async Task CreateAsync_AcceptsValidUrlSchemes(string url)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(CreateAsync_AcceptsValidUrlSchemes)}_{url}");
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new CreateSocialLinkRequest
+        {
+            Label = "Ok",
+            Url = url,
+            IconKey = "link-outline",
+            SortOrder = 0,
+        };
+
+        SocialLinkDto result = await svc.CreateAsync(req);
+
+        Assert.Equal(url, result.Url);
+    }
+
+    [Fact]
+    public async Task CreateAsync_TrimsLabelAndUrl()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_TrimsLabelAndUrl));
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new CreateSocialLinkRequest
+        {
+            Label = "  Instagram  ",
+            Url = "  https://instagram.com/resto  ",
+            IconKey = "logo-instagram",
+            SortOrder = 0,
+        };
+
+        SocialLinkDto result = await svc.CreateAsync(req);
+
+        Assert.Equal("Instagram", result.Label);
+        Assert.Equal("https://instagram.com/resto", result.Url);
+    }
+
+    // ── Validation (UpdateAsync) ────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_RejectsInvalidUrl()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_RejectsInvalidUrl));
+        db.SocialLinks.Add(new SocialLink { Label = "Old", Url = "https://old.example.com", SortOrder = 0 });
+        await db.SaveChangesAsync();
+        int id = db.SocialLinks.First().Id;
+
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new UpdateSocialLinkRequest
+        {
+            Label = "New",
+            Url = "javascript:alert(1)",
+            IconKey = "link-outline",
+            SortOrder = 0,
+        };
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.UpdateAsync(id, req));
+
+        // Entity is unchanged — the validation throws before any assignment.
+        SocialLink stored = await db.SocialLinks.FirstAsync();
+        Assert.Equal("https://old.example.com", stored.Url);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RejectsUnknownIconKey()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateAsync_RejectsUnknownIconKey));
+        db.SocialLinks.Add(new SocialLink { Label = "Old", Url = "https://old.example.com", SortOrder = 0 });
+        await db.SaveChangesAsync();
+        int id = db.SocialLinks.First().Id;
+
+        var svc = new SocialLinkService(new SocialLinkRepository(db));
+        var req = new UpdateSocialLinkRequest
+        {
+            Label = "New",
+            Url = "https://new.example.com",
+            IconKey = "not-a-real-icon",
+            SortOrder = 0,
+        };
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.UpdateAsync(id, req));
     }
 }

--- a/OpenRestoApi/Core/Application/Services/HighlightService.cs
+++ b/OpenRestoApi/Core/Application/Services/HighlightService.cs
@@ -1,5 +1,7 @@
 using OpenRestoApi.Core.Application.DTOs;
+using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Core.Application.Services;
@@ -7,6 +9,9 @@ namespace OpenRestoApi.Core.Application.Services;
 public class HighlightService(IHighlightRepository highlightRepository)
 {
     private readonly IHighlightRepository _highlightRepository = highlightRepository;
+
+    private const int MaxTitleLength = 60;
+    private const int MaxBodyLength = 500;
 
     public async Task<List<HighlightDto>> GetAllAsync()
     {
@@ -16,13 +21,16 @@ public class HighlightService(IHighlightRepository highlightRepository)
 
     public async Task<HighlightDto> CreateAsync(CreateHighlightRequest req)
     {
+        ValidateAndNormalize(
+            req.Title, req.Body, req.IconKey, req.Link,
+            out string title, out string body, out string iconKey, out string? link);
         var entity = new RestaurantHighlight
         {
-            Title = req.Title,
-            Body = req.Body,
-            IconKey = req.IconKey,
+            Title = title,
+            Body = body,
+            IconKey = iconKey,
             SortOrder = req.SortOrder,
-            Link = NormalizeLink(req.Link),
+            Link = link,
         };
         await _highlightRepository.AddAsync(entity);
         return ToDto(entity);
@@ -35,11 +43,14 @@ public class HighlightService(IHighlightRepository highlightRepository)
         {
             return null;
         }
-        entity.Title = req.Title;
-        entity.Body = req.Body;
-        entity.IconKey = req.IconKey;
+        ValidateAndNormalize(
+            req.Title, req.Body, req.IconKey, req.Link,
+            out string title, out string body, out string iconKey, out string? link);
+        entity.Title = title;
+        entity.Body = body;
+        entity.IconKey = iconKey;
         entity.SortOrder = req.SortOrder;
-        entity.Link = NormalizeLink(req.Link);
+        entity.Link = link;
         await _highlightRepository.SaveChangesAsync();
         return ToDto(entity);
     }
@@ -67,8 +78,51 @@ public class HighlightService(IHighlightRepository highlightRepository)
     };
 
     /// <summary>
+    /// Trims and validates the writable fields shared by create and update. Throws
+    /// <see cref="ValidationException"/> (mapped to 400 by GlobalExceptionHandler) on any bad
+    /// shape/value; on success assigns the normalized values to the out parameters. The link
+    /// URL is optional — blank/whitespace clears to null (matching the brand-text convention),
+    /// a non-blank value must be a valid absolute URL.
+    /// </summary>
+    private static void ValidateAndNormalize(
+        string? rawTitle,
+        string? rawBody,
+        string? rawIconKey,
+        string? rawLink,
+        out string title,
+        out string body,
+        out string iconKey,
+        out string? link)
+    {
+        title = (rawTitle ?? string.Empty).Trim();
+        if (title.Length == 0)
+        {
+            throw new ValidationException("Highlight title cannot be empty.");
+        }
+        if (title.Length > MaxTitleLength)
+        {
+            throw new ValidationException($"Highlight title cannot exceed {MaxTitleLength} characters.");
+        }
+
+        body = (rawBody ?? string.Empty).Trim();
+        if (body.Length > MaxBodyLength)
+        {
+            throw new ValidationException($"Highlight body cannot exceed {MaxBodyLength} characters.");
+        }
+
+        iconKey = (rawIconKey ?? string.Empty).Trim();
+        if (!IoniconsAllowList.AllIcons.Contains(iconKey))
+        {
+            throw new ValidationException("Icon key must be one of the supported icons.");
+        }
+
+        link = NormalizeLink(rawLink);
+    }
+
+    /// <summary>
     /// Trims the link URL and treats blank/whitespace as null so empty inputs are stored
     /// consistently (matching the whitespace-to-null convention used for brand text fields).
+    /// A non-blank value must parse as a valid absolute web/contact URL.
     /// </summary>
     private static string? NormalizeLink(string? link)
     {
@@ -76,6 +130,13 @@ public class HighlightService(IHighlightRepository highlightRepository)
         {
             return null;
         }
-        return link.Trim();
+
+        string trimmed = link.Trim();
+        if (!UrlValidator.IsValid(trimmed, UrlValidator.WebAndContactSchemes))
+        {
+            throw new ValidationException(
+                "Highlight link must be a valid absolute URL (http, https, mailto, tel, or sms).");
+        }
+        return trimmed;
     }
 }

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -1,6 +1,7 @@
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Core.Application.Services;
@@ -90,7 +91,26 @@ public class RestaurantManagementService(
         }
         if (req.MenuUrl != null)
         {
-            r.MenuUrl = string.IsNullOrWhiteSpace(req.MenuUrl) ? null : req.MenuUrl.Trim();
+            // Blank clears (matching the brand-text whitespace-to-null convention); a non-blank
+            // value must be either an absolute http(s) URL (an externally hosted menu) or the
+            // instance-served "/media/menu-<id>.pdf" path written by MediaService.UploadMenuAsync.
+            // The served path is relative and intentionally bypasses UrlValidator (which only
+            // accepts absolute URLs); rejecting it would break the upload flow.
+            if (string.IsNullOrWhiteSpace(req.MenuUrl))
+            {
+                r.MenuUrl = null;
+            }
+            else
+            {
+                string trimmed = req.MenuUrl.Trim();
+                bool isServedMenuFile = trimmed.StartsWith("/media/", StringComparison.OrdinalIgnoreCase);
+                if (!isServedMenuFile && !UrlValidator.IsValid(trimmed, UrlValidator.WebSchemes))
+                {
+                    throw new ValidationException(
+                        "Menu URL must be a valid absolute http(s) URL.");
+                }
+                r.MenuUrl = trimmed;
+            }
         }
         if (req.OpenTime != null)
         {

--- a/OpenRestoApi/Core/Application/Services/SocialLinkService.cs
+++ b/OpenRestoApi/Core/Application/Services/SocialLinkService.cs
@@ -1,5 +1,7 @@
 using OpenRestoApi.Core.Application.DTOs;
+using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Core.Application.Services;
@@ -7,6 +9,8 @@ namespace OpenRestoApi.Core.Application.Services;
 public class SocialLinkService(ISocialLinkRepository socialLinkRepository)
 {
     private readonly ISocialLinkRepository _socialLinkRepository = socialLinkRepository;
+
+    private const int MaxLabelLength = 60;
 
     public async Task<List<SocialLinkDto>> GetAllAsync()
     {
@@ -16,11 +20,12 @@ public class SocialLinkService(ISocialLinkRepository socialLinkRepository)
 
     public async Task<SocialLinkDto> CreateAsync(CreateSocialLinkRequest req)
     {
+        ValidateAndNormalize(req.Label, req.Url, req.IconKey, out string label, out string url, out string iconKey);
         var entity = new SocialLink
         {
-            Label = req.Label,
-            Url = req.Url,
-            IconKey = req.IconKey,
+            Label = label,
+            Url = url,
+            IconKey = iconKey,
             SortOrder = req.SortOrder,
         };
         await _socialLinkRepository.AddAsync(entity);
@@ -34,9 +39,10 @@ public class SocialLinkService(ISocialLinkRepository socialLinkRepository)
         {
             return null;
         }
-        entity.Label = req.Label;
-        entity.Url = req.Url;
-        entity.IconKey = req.IconKey;
+        ValidateAndNormalize(req.Label, req.Url, req.IconKey, out string label, out string url, out string iconKey);
+        entity.Label = label;
+        entity.Url = url;
+        entity.IconKey = iconKey;
         entity.SortOrder = req.SortOrder;
         await _socialLinkRepository.SaveChangesAsync();
         return ToDto(entity);
@@ -62,4 +68,45 @@ public class SocialLinkService(ISocialLinkRepository socialLinkRepository)
         IconKey = s.IconKey,
         SortOrder = s.SortOrder,
     };
+
+    /// <summary>
+    /// Trims and validates the writable fields shared by create and update. Throws
+    /// <see cref="ValidationException"/> (mapped to 400 by GlobalExceptionHandler) on any bad
+    /// shape/value; on success assigns the normalized values to the out parameters.
+    /// </summary>
+    private static void ValidateAndNormalize(
+        string? rawLabel,
+        string? rawUrl,
+        string? rawIconKey,
+        out string label,
+        out string url,
+        out string iconKey)
+    {
+        label = (rawLabel ?? string.Empty).Trim();
+        if (label.Length == 0)
+        {
+            throw new ValidationException("Social link label cannot be empty.");
+        }
+        if (label.Length > MaxLabelLength)
+        {
+            throw new ValidationException($"Social link label cannot exceed {MaxLabelLength} characters.");
+        }
+
+        url = (rawUrl ?? string.Empty).Trim();
+        if (url.Length == 0)
+        {
+            throw new ValidationException("Social link URL cannot be empty.");
+        }
+        if (!UrlValidator.IsValid(url, UrlValidator.WebAndContactSchemes))
+        {
+            throw new ValidationException(
+                "Social link URL must be a valid absolute URL (http, https, mailto, tel, or sms).");
+        }
+
+        iconKey = (rawIconKey ?? string.Empty).Trim();
+        if (!IoniconsAllowList.AllIcons.Contains(iconKey))
+        {
+            throw new ValidationException("Icon key must be one of the supported icons.");
+        }
+    }
 }

--- a/OpenRestoApi/Core/Application/Utilities/IoniconsAllowList.cs
+++ b/OpenRestoApi/Core/Application/Utilities/IoniconsAllowList.cs
@@ -1,0 +1,115 @@
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// Allow-list of <c>@expo/vector-icons/Ionicons</c> icon keys accepted by the Social Link and
+/// Highlight services. Source of truth is the frontend <c>ICON_OPTIONS</c> arrays (UI only lets
+/// the admin pick from these), mirrored server-side so a hand-crafted request can't persist an
+/// icon key the frontend can't render. Distinct from <c>LucideIconPaths</c>, which is the
+/// brand/favicon set — the two icon families do not overlap.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Keep this in sync with:
+/// </para>
+/// <list type="bullet">
+/// <item><c>openresto-frontend/components/admin/settings/SocialLinkEditForm.tsx</c> (<c>ICON_OPTIONS</c>)</item>
+/// <item><c>openresto-frontend/components/admin/settings/HighlightsCard.tsx</c> (<c>ICON_OPTIONS</c>)</item>
+/// </list>
+/// <para>
+/// <see cref="LegacyIcons"/> retains non-<c>-outline</c> variants (<c>star</c>, <c>flame</c>) that
+/// appear in pre-existing integration tests and may exist in seeded client data from before the
+/// frontend normalised to <c>-outline</c> names; rejecting them would break working deployments.
+/// </para>
+/// </remarks>
+public static class IoniconsAllowList
+{
+    /// <summary>
+    /// Icon keys selectable for social links. Mirrors
+    /// <c>SocialLinkEditForm.tsx</c> <c>ICON_OPTIONS</c>.
+    /// </summary>
+    public static readonly HashSet<string> SocialLinkIcons = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "link-outline",
+        "globe-outline",
+        "mail-outline",
+        "call-outline",
+        "chatbubble-outline",
+        "location-outline",
+        "star-outline",
+        "heart-outline",
+        "megaphone-outline",
+        "newspaper-outline",
+        "storefront-outline",
+        "cart-outline",
+        "calendar-outline",
+        "camera-outline",
+        "logo-instagram",
+        "logo-facebook",
+        "logo-x",
+        "logo-tiktok",
+        "logo-youtube",
+        "logo-linkedin",
+        "logo-pinterest",
+        "logo-whatsapp",
+        "logo-snapchat",
+        "logo-threads",
+        "logo-reddit",
+        "logo-discord",
+    };
+
+    /// <summary>
+    /// Icon keys selectable for highlights. Mirrors <c>HighlightsCard.tsx</c> <c>ICON_OPTIONS</c>.
+    /// </summary>
+    public static readonly HashSet<string> HighlightIcons = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "flame-outline",
+        "star-outline",
+        "heart-outline",
+        "sparkles-outline",
+        "ribbon-outline",
+        "trophy-outline",
+        "thumbs-up-outline",
+        "restaurant-outline",
+        "wine-outline",
+        "cafe-outline",
+        "beer-outline",
+        "pizza-outline",
+        "ice-cream-outline",
+        "leaf-outline",
+        "nutrition-outline",
+        "fish-outline",
+        "egg-outline",
+        "musical-notes-outline",
+        "people-outline",
+        "person-outline",
+        "accessibility-outline",
+        "car-outline",
+        "wifi-outline",
+        "card-outline",
+        "gift-outline",
+        "calendar-outline",
+        "time-outline",
+        "pricetag-outline",
+        "camera-outline",
+        "sunny-outline",
+    };
+
+    /// <summary>
+    /// Legacy icon keys retained for backward compatibility with data seeded before the frontend
+    /// normalised to <c>-outline</c> names and with pre-existing integration tests.
+    /// </summary>
+    public static readonly HashSet<string> LegacyIcons = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "star",
+        "flame",
+    };
+
+    /// <summary>
+    /// Every accepted icon key across social links, highlights, and legacy values. Services
+    /// validate against this superset so an icon valid for either surface is accepted on either
+    /// (the frontend picker is the stricter, per-surface gate).
+    /// </summary>
+    public static readonly HashSet<string> AllIcons = new(
+        SocialLinkIcons.Concat(HighlightIcons).Concat(LegacyIcons),
+        StringComparer.OrdinalIgnoreCase);
+}

--- a/OpenRestoApi/Core/Application/Utilities/UrlValidator.cs
+++ b/OpenRestoApi/Core/Application/Utilities/UrlValidator.cs
@@ -1,0 +1,51 @@
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// Centralised absolute-URL validation. Mirrors the frontend <c>utils/validation.ts</c>
+/// <c>isValidUrl</c> helper — the backend is the source of truth, the frontend check is a
+/// UX pre-flight. Sibling to <see cref="EmailValidator"/>: same deliberately-strict-but-pragmatic
+/// shape (a real <see cref="Uri"/> parse plus an allow-list of schemes, not a hand-rolled regex).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Callers pass the set of schemes appropriate to the field. Social-link and highlight links
+/// accept web + contact schemes (<c>http</c>, <c>https</c>, <c>mailto</c>, <c>tel</c>, <c>sms</c>);
+/// a restaurant <c>MenuUrl</c> is a web link so it is restricted to <c>http</c>/<c>https</c>
+/// (the instance's own served-menu path is a <c>/media/...</c> relative URL handled by the caller,
+/// not here). Dangerous schemes (<c>javascript:</c>, <c>data:</c>) are blocked simply by virtue
+/// of not being in the allow-list.
+/// </para>
+/// </remarks>
+public static class UrlValidator
+{
+    /// <summary>Schemes permitted for social-link and highlight URLs (web + contact).</summary>
+    public static readonly HashSet<string> WebAndContactSchemes =
+        new(StringComparer.OrdinalIgnoreCase) { "http", "https", "mailto", "tel", "sms" };
+
+    /// <summary>Schemes permitted for a web-only field such as <c>MenuUrl</c>.</summary>
+    public static readonly HashSet<string> WebSchemes =
+        new(StringComparer.OrdinalIgnoreCase) { "http", "https" };
+
+    /// <summary>
+    /// Returns true when <paramref name="url"/> is a non-blank, well-formed absolute URL whose
+    /// scheme is in <paramref name="allowedSchemes"/> (case-insensitive). False otherwise —
+    /// the caller decides whether to throw <c>ValidationException</c>.
+    /// </summary>
+    public static bool IsValid(string? url, HashSet<string> allowedSchemes)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        // UriKind.Absolute rejects relative paths ("/media/menu.pdf"), protocol-relative URLs
+        // ("//host/path"), and bare strings ("asdf"). The trailing scheme check is the security
+        // gate: Uri.TryCreate happily parses "javascript:alert(1)" as a valid URI.
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out Uri? parsed))
+        {
+            return false;
+        }
+
+        return allowedSchemes.Contains(parsed.Scheme);
+    }
+}

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -582,13 +582,24 @@ export async function adminGetHighlights(): Promise<AdminHighlightDto[]> {
   }
 }
 
+/**
+ * Result of a create/update admin mutation. Success carries the saved DTO; failure carries the
+ * server's message (or a generic fallback). Network failures (no response) return `null`, which
+ * callers treat as "couldn't reach the server" — the same convention as {@link saveBrandSettings}.
+ * The error body shape mirrors the backend `MessageResponse { message }` (never RFC 7807).
+ */
+export type AdminMutationResult<T> = { ok: true; data: T } | { ok: false; message: string };
+
 export async function adminCreateHighlight(
   req: CreateHighlightRequest
-): Promise<AdminHighlightDto | null> {
+): Promise<AdminMutationResult<AdminHighlightDto> | null> {
   try {
     const res = await post("/highlights", req);
-    if (!res.ok) throw new Error("Failed to create highlight");
-    return await res.json();
+    if (!res.ok) {
+      const err = await res.json().catch(() => null);
+      return { ok: false, message: err?.message ?? "Failed to create highlight." };
+    }
+    return { ok: true, data: await res.json() };
   } catch (err) {
     console.error("adminCreateHighlight error:", err);
     return null;
@@ -598,11 +609,14 @@ export async function adminCreateHighlight(
 export async function adminUpdateHighlight(
   id: number,
   req: UpdateHighlightRequest
-): Promise<AdminHighlightDto | null> {
+): Promise<AdminMutationResult<AdminHighlightDto> | null> {
   try {
     const res = await put(`/highlights/${id}`, req);
-    if (!res.ok) throw new Error("Failed to update highlight");
-    return await res.json();
+    if (!res.ok) {
+      const err = await res.json().catch(() => null);
+      return { ok: false, message: err?.message ?? "Failed to update highlight." };
+    }
+    return { ok: true, data: await res.json() };
   } catch (err) {
     console.error("adminUpdateHighlight error:", err);
     return null;
@@ -656,11 +670,14 @@ export async function adminGetSocialLinks(): Promise<AdminSocialLinkDto[]> {
 
 export async function adminCreateSocialLink(
   req: CreateSocialLinkRequest
-): Promise<AdminSocialLinkDto | null> {
+): Promise<AdminMutationResult<AdminSocialLinkDto> | null> {
   try {
     const res = await post("/social-links", req);
-    if (!res.ok) throw new Error("Failed to create social link");
-    return await res.json();
+    if (!res.ok) {
+      const err = await res.json().catch(() => null);
+      return { ok: false, message: err?.message ?? "Failed to create social link." };
+    }
+    return { ok: true, data: await res.json() };
   } catch (err) {
     console.error("adminCreateSocialLink error:", err);
     return null;
@@ -670,11 +687,14 @@ export async function adminCreateSocialLink(
 export async function adminUpdateSocialLink(
   id: number,
   req: UpdateSocialLinkRequest
-): Promise<AdminSocialLinkDto | null> {
+): Promise<AdminMutationResult<AdminSocialLinkDto> | null> {
   try {
     const res = await put(`/social-links/${id}`, req);
-    if (!res.ok) throw new Error("Failed to update social link");
-    return await res.json();
+    if (!res.ok) {
+      const err = await res.json().catch(() => null);
+      return { ok: false, message: err?.message ?? "Failed to update social link." };
+    }
+    return { ok: true, data: await res.json() };
   } catch (err) {
     console.error("adminUpdateSocialLink error:", err);
     return null;

--- a/openresto-frontend/components/admin/settings/FooterSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/FooterSettingsCard.tsx
@@ -14,6 +14,7 @@ import {
   adminDeleteSocialLink,
   AdminSocialLinkDto,
 } from "@/api/admin";
+import { isValidUrl } from "@/utils/validation";
 import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 import { styles } from "./settings.styles";
 import { SocialLinkEditForm, emptyEdit, type EditState, type IconKey } from "./SocialLinkEditForm";
@@ -40,6 +41,7 @@ export function FooterSettingsCard({
   const [editingId, setEditingId] = useState<number | "new" | null>(null);
   const [editState, setEditState] = useState<EditState>(emptyEdit());
   const [saving, setSaving] = useState(false);
+  const [linkMsg, setLinkMsg] = useState<string | null>(null);
   const [expanded, setExpanded] = usePersistedState("settings:footer:expanded", false);
 
   const copyrightIsDirty = copyrightText.trim() !== (brand.copyrightText ?? "");
@@ -70,6 +72,7 @@ export function FooterSettingsCard({
 
   const startEdit = (link: AdminSocialLinkDto) => {
     setEditingId(link.id);
+    setLinkMsg(null);
     setEditState({
       label: link.label,
       url: link.url,
@@ -80,38 +83,73 @@ export function FooterSettingsCard({
 
   const startNew = () => {
     setEditingId("new");
+    setLinkMsg(null);
     setEditState(emptyEdit(links.length));
   };
 
   const cancelEdit = () => {
     setEditingId(null);
+    setLinkMsg(null);
     setEditState(emptyEdit());
+  };
+
+  // Clear any shown error as soon as the admin edits a field, so stale messages don't linger.
+  const handleChange = (s: EditState) => {
+    setLinkMsg(null);
+    setEditState(s);
   };
 
   const save = async () => {
     if (!editState.label.trim() || !editState.url.trim()) return;
+    // Client-side URL pre-flight (mirrors backend UrlValidator) — catches obvious typos and
+    // dangerous schemes like javascript: without a round-trip. The server remains source of truth.
+    if (!isValidUrl(editState.url.trim())) {
+      setLinkMsg("Enter a valid URL (e.g. https://example.com).");
+      return;
+    }
+    setLinkMsg(null);
     setSaving(true);
+    let ok = true;
+    let message: string | null = null;
     if (editingId === "new") {
-      const created = await adminCreateSocialLink({
+      const result = await adminCreateSocialLink({
         label: editState.label.trim(),
         url: editState.url.trim(),
         iconKey: editState.iconKey,
         sortOrder: editState.sortOrder,
       });
-      if (created) setLinks((prev) => [...prev, created]);
+      if (result && result.ok) {
+        setLinks((prev) => [...prev, result.data]);
+      } else if (result && !result.ok) {
+        ok = false;
+        message = result.message;
+      } else {
+        ok = false;
+        message = "Couldn't reach the server. Please try again.";
+      }
     } else if (editingId != null) {
-      const updated = await adminUpdateSocialLink(editingId, {
+      const result = await adminUpdateSocialLink(editingId, {
         label: editState.label.trim(),
         url: editState.url.trim(),
         iconKey: editState.iconKey,
         sortOrder: editState.sortOrder,
       });
-      if (updated) {
-        setLinks((prev) => prev.map((l) => (l.id === editingId ? updated : l)));
+      if (result && result.ok) {
+        setLinks((prev) => prev.map((l) => (l.id === editingId ? result.data : l)));
+      } else if (result && !result.ok) {
+        ok = false;
+        message = result.message;
+      } else {
+        ok = false;
+        message = "Couldn't reach the server. Please try again.";
       }
     }
     setSaving(false);
-    cancelEdit();
+    if (ok) {
+      cancelEdit();
+    } else if (message) {
+      setLinkMsg(message);
+    }
   };
 
   const remove = async (id: number) => {
@@ -226,7 +264,7 @@ export function FooterSettingsCard({
                     {editingId === link.id ? (
                       <SocialLinkEditForm
                         state={editState}
-                        onChange={setEditState}
+                        onChange={handleChange}
                         onSave={save}
                         onCancel={cancelEdit}
                         saving={saving}
@@ -235,6 +273,7 @@ export function FooterSettingsCard({
                         borderColor={borderColor}
                         mutedColor={mutedColor}
                         colors={colors}
+                        error={editingId === link.id ? linkMsg : null}
                       />
                     ) : (
                       <SocialLinkRow
@@ -254,7 +293,7 @@ export function FooterSettingsCard({
                 {editingId === "new" && (
                   <SocialLinkEditForm
                     state={editState}
-                    onChange={setEditState}
+                    onChange={handleChange}
                     onSave={save}
                     onCancel={cancelEdit}
                     saving={saving}
@@ -263,6 +302,7 @@ export function FooterSettingsCard({
                     borderColor={borderColor}
                     mutedColor={mutedColor}
                     colors={colors}
+                    error={editingId === "new" ? linkMsg : null}
                   />
                 )}
 

--- a/openresto-frontend/components/admin/settings/HighlightsCard.tsx
+++ b/openresto-frontend/components/admin/settings/HighlightsCard.tsx
@@ -14,6 +14,7 @@ import {
   AdminHighlightDto,
 } from "@/api/admin";
 import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
+import { isValidUrl } from "@/utils/validation";
 import { styles } from "./settings.styles";
 
 const ICON_OPTIONS = [
@@ -80,6 +81,7 @@ export function HighlightsCard({
   const [editingId, setEditingId] = useState<number | "new" | null>(null);
   const [editState, setEditState] = useState<EditState>(emptyEdit());
   const [saving, setSaving] = useState(false);
+  const [highlightMsg, setHighlightMsg] = useState<string | null>(null);
   const [expanded, setExpanded] = usePersistedState("settings:highlights:expanded", true);
 
   useEffect(() => {
@@ -91,6 +93,7 @@ export function HighlightsCard({
 
   const startEdit = (h: AdminHighlightDto) => {
     setEditingId(h.id);
+    setHighlightMsg(null);
     setEditState({
       title: h.title,
       body: h.body,
@@ -102,40 +105,76 @@ export function HighlightsCard({
 
   const startNew = () => {
     setEditingId("new");
+    setHighlightMsg(null);
     setEditState(emptyEdit(highlights.length));
   };
 
   const cancelEdit = () => {
     setEditingId(null);
+    setHighlightMsg(null);
     setEditState(emptyEdit());
+  };
+
+  // Clear any shown error as soon as the admin edits a field, so stale messages don't linger.
+  const handleChange = (s: EditState) => {
+    setHighlightMsg(null);
+    setEditState(s);
   };
 
   const save = async () => {
     if (!editState.title.trim()) return;
+    // Client-side URL pre-flight on the optional link (mirrors backend UrlValidator). The link
+    // is optional, so only validate when the admin actually entered something.
+    const trimmedLink = editState.link.trim();
+    if (trimmedLink && !isValidUrl(trimmedLink)) {
+      setHighlightMsg("Enter a valid link URL (e.g. https://example.com).");
+      return;
+    }
+    setHighlightMsg(null);
     setSaving(true);
+    let ok = true;
+    let message: string | null = null;
     if (editingId === "new") {
-      const created = await adminCreateHighlight({
+      const result = await adminCreateHighlight({
         title: editState.title.trim(),
         body: editState.body.trim(),
         iconKey: editState.iconKey,
         sortOrder: editState.sortOrder,
-        link: editState.link.trim() || null,
+        link: trimmedLink || null,
       });
-      if (created) setHighlights((prev) => [...prev, created]);
+      if (result && result.ok) {
+        setHighlights((prev) => [...prev, result.data]);
+      } else if (result && !result.ok) {
+        ok = false;
+        message = result.message;
+      } else {
+        ok = false;
+        message = "Couldn't reach the server. Please try again.";
+      }
     } else if (editingId != null) {
-      const updated = await adminUpdateHighlight(editingId, {
+      const result = await adminUpdateHighlight(editingId, {
         title: editState.title.trim(),
         body: editState.body.trim(),
         iconKey: editState.iconKey,
         sortOrder: editState.sortOrder,
-        link: editState.link.trim() || null,
+        link: trimmedLink || null,
       });
-      if (updated) {
-        setHighlights((prev) => prev.map((h) => (h.id === editingId ? updated : h)));
+      if (result && result.ok) {
+        setHighlights((prev) => prev.map((h) => (h.id === editingId ? result.data : h)));
+      } else if (result && !result.ok) {
+        ok = false;
+        message = result.message;
+      } else {
+        ok = false;
+        message = "Couldn't reach the server. Please try again.";
       }
     }
     setSaving(false);
-    cancelEdit();
+    if (ok) {
+      cancelEdit();
+    } else if (message) {
+      setHighlightMsg(message);
+    }
   };
 
   const remove = async (id: number) => {
@@ -191,7 +230,7 @@ export function HighlightsCard({
                   {editingId === h.id ? (
                     <HighlightEditForm
                       state={editState}
-                      onChange={setEditState}
+                      onChange={handleChange}
                       onSave={save}
                       onCancel={cancelEdit}
                       saving={saving}
@@ -200,6 +239,7 @@ export function HighlightsCard({
                       borderColor={borderColor}
                       mutedColor={mutedColor}
                       colors={colors}
+                      error={editingId === h.id ? highlightMsg : null}
                     />
                   ) : (
                     <View
@@ -275,7 +315,7 @@ export function HighlightsCard({
               {editingId === "new" && (
                 <HighlightEditForm
                   state={editState}
-                  onChange={setEditState}
+                  onChange={handleChange}
                   onSave={save}
                   onCancel={cancelEdit}
                   saving={saving}
@@ -284,6 +324,7 @@ export function HighlightsCard({
                   borderColor={borderColor}
                   mutedColor={mutedColor}
                   colors={colors}
+                  error={editingId === "new" ? highlightMsg : null}
                 />
               )}
 
@@ -326,6 +367,7 @@ function HighlightEditForm({
   borderColor,
   mutedColor,
   colors,
+  error,
 }: {
   state: EditState;
   onChange: (s: EditState) => void;
@@ -337,6 +379,8 @@ function HighlightEditForm({
   borderColor: string;
   mutedColor: string;
   colors: ThemeColors;
+  /** Inline validation/server error shown above the action row. Null/undefined hides it. */
+  error?: string | null;
 }) {
   return (
     <View
@@ -415,6 +459,8 @@ function HighlightEditForm({
           Makes the whole card clickable. Leave blank for a static highlight.
         </ThemedText>
       </View>
+
+      {error ? <ThemedText style={[styles.errorText, { marginTop: 2 }]}>{error}</ThemedText> : null}
 
       {/* Actions */}
       <View style={{ flexDirection: "row", justifyContent: "flex-end", gap: 8 }}>

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -11,6 +11,7 @@ import {
   uploadMenuFile,
 } from "@/api/restaurants";
 import { getHoursForDay, hasCustomHours, parseOpenDays } from "@/utils/openingHours";
+import { isValidUrl, WEB_SCHEMES } from "@/utils/validation";
 import { parseWalkInDays } from "@/utils/walkIn";
 import { Ionicons } from "@expo/vector-icons";
 import { theme } from "@/theme/theme";
@@ -300,6 +301,18 @@ export function RestaurantInfoForm({
 
   const save = async () => {
     if (!name.trim()) return;
+    // MenuUrl pre-flight (mirrors backend UrlValidator): an external link must be a valid
+    // absolute http(s) URL. The instance's own served-menu path (/media/...) is exempt and
+    // never reaches here as a typed value (it's set by the upload flow), but guard anyway.
+    const trimmedMenuUrl = menuUrl.trim();
+    if (
+      trimmedMenuUrl &&
+      !isServedMenuFile(trimmedMenuUrl) &&
+      !isValidUrl(trimmedMenuUrl, WEB_SCHEMES)
+    ) {
+      setMenuMsg({ text: "Menu URL must be a valid http(s) link.", ok: false });
+      return;
+    }
     // Flush any pending tag the user typed but didn't press Enter on
     const finalTags = tagInput.trim() ? [...new Set([...tags, tagInput.trim()])] : tags;
     if (tagInput.trim()) setTagInput("");
@@ -439,7 +452,10 @@ export function RestaurantInfoForm({
           ) : (
             <Input
               value={menuUrl}
-              onChangeText={setMenuUrl}
+              onChangeText={(v) => {
+                setMenuUrl(v);
+                if (menuMsg && !menuMsg.ok) setMenuMsg(null);
+              }}
               placeholder="https://your-menu-url.com/menu.pdf"
               autoCapitalize="none"
               autoCorrect={false}

--- a/openresto-frontend/components/admin/settings/SocialLinkEditForm.tsx
+++ b/openresto-frontend/components/admin/settings/SocialLinkEditForm.tsx
@@ -65,6 +65,7 @@ export function SocialLinkEditForm({
   borderColor,
   mutedColor,
   colors,
+  error,
 }: {
   state: EditState;
   onChange: (s: EditState) => void;
@@ -76,6 +77,8 @@ export function SocialLinkEditForm({
   borderColor: string;
   mutedColor: string;
   colors: ThemeColors;
+  /** Inline validation/server error shown above the action row. Null/undefined hides it. */
+  error?: string | null;
 }) {
   return (
     <View
@@ -138,6 +141,8 @@ export function SocialLinkEditForm({
           keyboardType="url"
         />
       </View>
+
+      {error ? <ThemedText style={[styles.errorText, { marginTop: 2 }]}>{error}</ThemedText> : null}
 
       {/* Actions */}
       <View style={{ flexDirection: "row", justifyContent: "flex-end", gap: 8 }}>

--- a/openresto-frontend/tests/api/admin.test.ts
+++ b/openresto-frontend/tests/api/admin.test.ts
@@ -854,13 +854,16 @@ describe("adminCreateHighlight", () => {
     const created = { id: 5, ...req };
     mockFetch.mockResolvedValueOnce({ ok: true, json: async () => created });
     const result = await adminCreateHighlight(req);
-    expect(result).toEqual(created);
+    expect(result).toEqual({ ok: true, data: created });
   });
 
-  it("returns null on non-ok response", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
+  it("returns the server error message on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: "Highlight title cannot exceed 60 characters." }),
+    });
     const result = await adminCreateHighlight(req);
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, message: "Highlight title cannot exceed 60 characters." });
   });
 
   it("returns null on network error", async () => {
@@ -877,13 +880,16 @@ describe("adminUpdateHighlight", () => {
     const updated = { id: 3, ...req };
     mockFetch.mockResolvedValueOnce({ ok: true, json: async () => updated });
     const result = await adminUpdateHighlight(3, req);
-    expect(result).toEqual(updated);
+    expect(result).toEqual({ ok: true, data: updated });
   });
 
-  it("returns null on non-ok response", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
+  it("returns the server error message on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: "Icon key must be one of the supported icons." }),
+    });
     const result = await adminUpdateHighlight(3, req);
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, message: "Icon key must be one of the supported icons." });
   });
 
   it("returns null on network error", async () => {
@@ -1200,16 +1206,22 @@ describe("adminCreateSocialLink", () => {
 
     const result = await adminCreateSocialLink(req);
 
-    expect(result).toEqual(created);
+    expect(result).toEqual({ ok: true, data: created });
     const [url, opts] = mockFetch.mock.calls[0];
     expect(url).toContain("/api/social-links");
     expect(opts.method).toBe("POST");
     expect(JSON.parse(opts.body)).toEqual(req);
   });
 
-  it("returns null on non-ok response", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
-    expect(await adminCreateSocialLink(req)).toBeNull();
+  it("returns the server error message on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: "Social link URL must be a valid absolute URL." }),
+    });
+    expect(await adminCreateSocialLink(req)).toEqual({
+      ok: false,
+      message: "Social link URL must be a valid absolute URL.",
+    });
   });
 
   it("returns null on network error", async () => {
@@ -1232,16 +1244,22 @@ describe("adminUpdateSocialLink", () => {
 
     const result = await adminUpdateSocialLink(3, req);
 
-    expect(result).toEqual(updated);
+    expect(result).toEqual({ ok: true, data: updated });
     const [url, opts] = mockFetch.mock.calls[0];
     expect(url).toContain("/api/social-links/3");
     expect(opts.method).toBe("PUT");
     expect(JSON.parse(opts.body)).toEqual(req);
   });
 
-  it("returns null on non-ok response", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
-    expect(await adminUpdateSocialLink(3, req)).toBeNull();
+  it("returns the server error message on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: "Social link label cannot be empty." }),
+    });
+    expect(await adminUpdateSocialLink(3, req)).toEqual({
+      ok: false,
+      message: "Social link label cannot be empty.",
+    });
   });
 
   it("returns null on network error", async () => {

--- a/openresto-frontend/tests/components/admin/settings/FooterSettingsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/FooterSettingsCard.test.tsx
@@ -188,7 +188,7 @@ describe("FooterSettingsCard", () => {
       iconKey: "link-outline",
       sortOrder: 0,
     };
-    (adminApi.adminCreateSocialLink as jest.Mock).mockResolvedValue(created);
+    (adminApi.adminCreateSocialLink as jest.Mock).mockResolvedValue({ ok: true, data: created });
     render(<FooterSettingsCard {...baseProps} />);
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
@@ -249,7 +249,7 @@ describe("FooterSettingsCard", () => {
   it("calls adminUpdateSocialLink when saving an edited link", async () => {
     const updated = { ...mockLinks[0], label: "Instagram Official" };
     (adminApi.adminGetSocialLinks as jest.Mock).mockResolvedValue([mockLinks[0]]);
-    (adminApi.adminUpdateSocialLink as jest.Mock).mockResolvedValue(updated);
+    (adminApi.adminUpdateSocialLink as jest.Mock).mockResolvedValue({ ok: true, data: updated });
     render(<FooterSettingsCard {...baseProps} />);
     await waitFor(() => expect(screen.getByText("Instagram")).toBeTruthy());
     fireEvent.press(screen.getByLabelText("Edit Instagram"));
@@ -284,6 +284,53 @@ describe("FooterSettingsCard", () => {
     });
     expect(adminApi.adminCreateSocialLink).toHaveBeenCalled();
     expect(screen.queryByText("New Link")).toBeNull();
+  });
+
+  it("shows an inline error and keeps the form open when create fails", async () => {
+    (adminApi.adminCreateSocialLink as jest.Mock).mockResolvedValue({
+      ok: false,
+      message: "Social link URL must be a valid absolute URL (http, https, mailto, tel, or sms).",
+    });
+    render(<FooterSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Add"));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("e.g. Instagram, Yelp, Menu PDF")).toBeTruthy()
+    );
+    // A valid-looking URL so the client pre-flight passes and the server-side rejection is hit.
+    fireEvent.changeText(screen.getByPlaceholderText("e.g. Instagram, Yelp, Menu PDF"), "Bad");
+    fireEvent.changeText(
+      screen.getByPlaceholderText("https://instagram.com/yourresto"),
+      "https://valid-url.example.com"
+    );
+    await act(async () => {
+      const saveButtons = screen.getAllByText("Save");
+      fireEvent.press(saveButtons[saveButtons.length - 1]);
+    });
+    await waitFor(() => expect(screen.getByText(/valid absolute URL/)).toBeTruthy());
+    // Form stays open so the admin can fix the field.
+    expect(screen.getByPlaceholderText("e.g. Instagram, Yelp, Menu PDF")).toBeTruthy();
+  });
+
+  it("blocks save with an inline error on an obviously invalid URL (client pre-flight)", async () => {
+    render(<FooterSettingsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Add"));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("e.g. Instagram, Yelp, Menu PDF")).toBeTruthy()
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("e.g. Instagram, Yelp, Menu PDF"), "Oops");
+    fireEvent.changeText(
+      screen.getByPlaceholderText("https://instagram.com/yourresto"),
+      "javascript:alert(1)"
+    );
+    await act(async () => {
+      const saveButtons = screen.getAllByText("Save");
+      fireEvent.press(saveButtons[saveButtons.length - 1]);
+    });
+    await waitFor(() => expect(screen.getByText(/valid URL/)).toBeTruthy());
+    // Pre-flight means the API was never called.
+    expect(adminApi.adminCreateSocialLink).not.toHaveBeenCalled();
   });
 
   it("changes icon when an icon option is pressed", async () => {

--- a/openresto-frontend/tests/components/admin/settings/HighlightsCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/HighlightsCard.test.tsx
@@ -144,7 +144,7 @@ describe("HighlightsCard", () => {
 
   it("calls adminCreateHighlight when Save is pressed with a title", async () => {
     const created = { id: 3, title: "New", body: "", iconKey: "star-outline", sortOrder: 0 };
-    (adminApi.adminCreateHighlight as jest.Mock).mockResolvedValue(created);
+    (adminApi.adminCreateHighlight as jest.Mock).mockResolvedValue({ ok: true, data: created });
     render(<HighlightsCard {...baseProps} />);
     await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
     fireEvent.press(screen.getByText("Add"));
@@ -212,7 +212,7 @@ describe("HighlightsCard", () => {
   it("calls adminUpdateHighlight when saving an edited highlight", async () => {
     const updated = { ...mockHighlights[0], title: "Amazing Food" };
     (adminApi.adminGetHighlights as jest.Mock).mockResolvedValue([mockHighlights[0]]);
-    (adminApi.adminUpdateHighlight as jest.Mock).mockResolvedValue(updated);
+    (adminApi.adminUpdateHighlight as jest.Mock).mockResolvedValue({ ok: true, data: updated });
     render(<HighlightsCard {...baseProps} />);
     await waitFor(() => expect(screen.getByText("Great Food")).toBeTruthy());
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
@@ -348,5 +348,45 @@ describe("HighlightsCard", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("https://example.com/book")).toBeTruthy();
     });
+  });
+
+  it("blocks save with an inline error when the link is an invalid URL (pre-flight)", async () => {
+    render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Add"));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("e.g. Wood-fired kitchen")).toBeTruthy()
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("e.g. Wood-fired kitchen"), "Award");
+    fireEvent.changeText(
+      screen.getByPlaceholderText("https://example.com/menu"),
+      "javascript:alert(1)"
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    await waitFor(() => expect(screen.getByText(/valid link URL/)).toBeTruthy());
+    // Pre-flight means the API was never called.
+    expect(adminApi.adminCreateHighlight).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error and keeps the form open when create fails", async () => {
+    (adminApi.adminCreateHighlight as jest.Mock).mockResolvedValue({
+      ok: false,
+      message: "Highlight title cannot exceed 60 characters.",
+    });
+    render(<HighlightsCard {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("Add")).toBeTruthy());
+    fireEvent.press(screen.getByText("Add"));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("e.g. Wood-fired kitchen")).toBeTruthy()
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("e.g. Wood-fired kitchen"), "Too long");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save"));
+    });
+    await waitFor(() => expect(screen.getByText(/cannot exceed 60/)).toBeTruthy());
+    // Form stays open so the admin can fix the field.
+    expect(screen.getByDisplayValue("Too long")).toBeTruthy();
   });
 });

--- a/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
@@ -1006,4 +1006,16 @@ describe("RestaurantInfoForm", () => {
     });
     expect(restaurantsApi.uploadMenuFile).not.toHaveBeenCalled();
   });
+
+  it("blocks save with an inline error when menuUrl is an invalid link (pre-flight)", async () => {
+    render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+    const menuInput = screen.getByPlaceholderText("https://your-menu-url.com/menu.pdf");
+    fireEvent.changeText(menuInput, "javascript:alert(1)");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Save changes"));
+    });
+    await waitFor(() => expect(screen.getByText(/valid http\(s\) link/)).toBeTruthy());
+    // Pre-flight means the API was never called.
+    expect(restaurantsApi.updateRestaurant).not.toHaveBeenCalled();
+  });
 });

--- a/openresto-frontend/tests/utils/validation.test.ts
+++ b/openresto-frontend/tests/utils/validation.test.ts
@@ -1,4 +1,10 @@
-import { isValidEmail, validatePasswordChange } from "@/utils/validation";
+import {
+  isValidEmail,
+  isValidUrl,
+  validatePasswordChange,
+  WEB_AND_CONTACT_SCHEMES,
+  WEB_SCHEMES,
+} from "@/utils/validation";
 
 describe("validation utility - isValidEmail", () => {
   it.each([
@@ -21,6 +27,44 @@ describe("validation utility - isValidEmail", () => {
     "nouser@.com",
   ])("rejects %p", (email) => {
     expect(isValidEmail(email)).toBe(false);
+  });
+});
+
+describe("validation utility - isValidUrl", () => {
+  it.each([
+    "https://example.com",
+    "http://localhost:8081/menu.pdf",
+    "https://instagram.com/yourresto",
+    "mailto:hello@example.com",
+    "tel:+15551234567",
+    "sms:+15551234567",
+    "  https://example.com  ",
+  ])("accepts %p (default web+contact schemes)", (url) => {
+    expect(isValidUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "asdf",
+    "javascript:alert(1)",
+    "data:text/html,<script>",
+    "/media/menu-1.pdf",
+    "//example.com/menu",
+    "ftp://example.com",
+  ])("rejects %p", (url) => {
+    expect(isValidUrl(url)).toBe(false);
+  });
+
+  it("respects a custom allow-list (web-only)", () => {
+    expect(isValidUrl("https://example.com", WEB_SCHEMES)).toBe(true);
+    expect(isValidUrl("mailto:hello@example.com", WEB_SCHEMES)).toBe(false);
+    expect(isValidUrl("tel:+15551234567", WEB_SCHEMES)).toBe(false);
+  });
+
+  it("exports the scheme constants", () => {
+    expect(WEB_AND_CONTACT_SCHEMES).toEqual(["http:", "https:", "mailto:", "tel:", "sms:"]);
+    expect(WEB_SCHEMES).toEqual(["http:", "https:"]);
   });
 });
 

--- a/openresto-frontend/utils/validation.ts
+++ b/openresto-frontend/utils/validation.ts
@@ -11,6 +11,40 @@ export function isValidEmail(value: string): boolean {
 }
 
 /**
+ * Absolute-URL schemes permitted for social-link and highlight URLs (web + contact). Mirrors
+ * the backend <c>UrlValidator.WebAndContactSchemes</c> allow-list — the backend is the source
+ * of truth, this is a UX pre-flight so the admin doesn't wait for a round-trip on obvious typos.
+ */
+export const WEB_AND_CONTACT_SCHEMES = ["http:", "https:", "mailto:", "tel:", "sms:"];
+
+/**
+ * Web-only schemes (http/https). Mirrors <c>UrlValidator.WebSchemes</c>. Used for fields like
+ * <c>MenuUrl</c> that are web links.
+ */
+export const WEB_SCHEMES = ["http:", "https:"];
+
+/**
+ * Returns true when <code>value</code> is a non-blank, well-formed absolute URL whose scheme is
+ * in <code>allowedSchemes</code>. Defaults to {@link WEB_AND_CONTACT_SCHEMES}. Mirrors the
+ * backend <c>UrlValidator.IsValid</c>: same <c>URL</c> parse + scheme allow-list approach (the
+ * scheme check is the security gate — <c>new URL</c> alone parses <c>javascript:</c> happily).
+ */
+export function isValidUrl(
+  value: string,
+  allowedSchemes: string[] = WEB_AND_CONTACT_SCHEMES
+): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return false;
+  }
+  return allowedSchemes.includes(parsed.protocol.toLowerCase());
+}
+
+/**
  * Shared validation for a password-change / password-reset flow. Consolidates the previously
  * duplicated match-then-length checks that lived inline in the login screen and SecurityCard.
  * Returns the first failure (preserving the original check order) or `{ ok: true }`.


### PR DESCRIPTION
Closes #263.

## What

Adds server-side input validation to **Social Links**, **Highlights**, and the restaurant **MenuUrl** field, and surfaces failures to the admin UI. Follows the established service-layer `ValidationException` pattern (`BrandService` is the gold standard) — no FluentValidation, no `[Url]`/`[Required]` MVC attributes as the primary gate, no RFC 7807 (the `{ message }` body shape is load-bearing).

## Backend

**New utilities** (sibling to `EmailValidator`):
- `UrlValidator` — `Uri.TryCreate` + scheme allow-list. `WebAndContactSchemes` (http/https/mailto/tel/sms) for social/highlight links; `WebSchemes` (http/https) for MenuUrl. The scheme check is the security gate — `Uri.TryCreate` alone happily parses `javascript:alert(1)`.
- `IoniconsAllowList` — mirrors the frontend `ICON_OPTIONS` arrays (social + highlight) plus legacy keys (`star`, `flame`) so existing seeded data and tests keep working. Distinct from `LucideIconPaths` (the brand/favicon set).

**Validation added** (trim + check + throw `ValidationException`):
- `SocialLinkService` — label (non-empty, ≤60), url (valid absolute URL), iconKey (in allow-list).
- `HighlightService` — title (non-empty, ≤60), body (≤500), iconKey, and the optional `Link` URL (blank → null preserved; non-blank must be valid).
- `RestaurantManagementService.UpdateAsync` — `MenuUrl` must be http(s) **or** the instance's own served `/media/menu-<id>.pdf` path (the upload flow sets that directly and bypasses `UpdateAsync`; the guard is defensive).

Shared validation extracted into a `ValidateAndNormalize` helper per service so create/update can't drift.

## Frontend

- `utils/validation.ts` — new `isValidUrl(value, allowedSchemes?)` + `WEB_SCHEMES`/`WEB_AND_CONTACT_SCHEMES` constants, mirroring the backend (which remains source of truth).
- `api/admin.ts` — `adminCreate/UpdateSocialLink` and `adminCreate/UpdateHighlight` now return `{ ok: true, data } | { ok: false, message } | null` instead of silently swallowing failures and returning `null`. Mirrors the `saveBrandSettings` pattern.
- `FooterSettingsCard`, `SocialLinkEditForm`, `HighlightsCard` — inline error rendering via the shared `styles.errorText` token, client-side URL pre-flight (catches `javascript:` / typos without a round-trip), and the form stays open on error so the admin can fix the field.
- `RestaurantInfoForm` — `MenuUrl` client-side pre-flight (http/https only), surfaced via the existing `menuMsg` state.

## Tests

- **Backend** (99 new, all green): service-level `ValidationException` tests + integration tests asserting HTTP 400 + `body.message` across all three surfaces — empty/oversized/dangerous-scheme/unknown-icon/valid-still-works. Mirrors `BrandControllerTests.SaveBrand_InvalidColor_ReturnsBadRequest`.
- **Frontend**: `isValidUrl` unit tests (accepts/rejects matrices + scheme constants), error-surfacing + pre-flight tests in the affected forms, updated `admin.test.ts` for the new result shape.

## Design notes

- **No schema changes.** The service layer is the source of truth (house style). I deliberately did **not** add `[StringLength]` data annotations to the domain entities — they'd change the EF model snapshot and require a migration for belt-and-suspenders caps the service already enforces. The existing `[StringLength(500)]` on `RestaurantHighlight.Link` is left as-is.
- **Icon allow-list** keeps legacy non-`-outline` variants (`star`, `flame`) so pre-existing integration tests and seeded client data aren't rejected.
- **MenuUrl** accepts the relative `/media/...` served-file path because `MediaService.UploadMenuAsync` writes it directly to `restaurant.MenuUrl` (bypassing `UpdateAsync`).

## Verification

- Backend: `dotnet test` — 1244 passed (4 pre-existing environment failures in `SqlitePragmaInterceptorTests`/`InitializeDatabaseTests`, unrelated to this change, not in the diff).
- Frontend: `npm test` — 1927 passed; `npm run lint` — 0 errors (332 pre-existing warnings); `npx tsc --noEmit` — clean; `npx prettier --check` — clean.