### PR TITLE
chore(deps): bump low-risk dependencies (no known vulnerabilities found)

### DIFF
--- a/OpenRestoApi/OpenRestoApi.csproj
+++ b/OpenRestoApi/OpenRestoApi.csproj
@@ -13,12 +13,12 @@
 
   <ItemGroup>
     <PackageReference Include="csulpizi.CustomAccessibility" Version="1.0.3" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.15.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.16.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
+<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" PrivateAssets="all" />

--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -1383,9 +1383,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1540,10 +1540,124 @@
       }
     },
     "node_modules/@expo-google-fonts/material-symbols": {
-      "version": "0.4.41",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.41.tgz",
-      "integrity": "sha512-BKNSJ6oFGWi+aXu6PF+1EdI43J8Ag+Sm7Ste1SXYmC2eYOJasyjXHkKjgkIieBB1eDZQJSPWuPv421Vg6N5tCQ==",
+      "version": "0.4.42",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.42.tgz",
+      "integrity": "sha512-KZmHZRcthJ3KFZZlpzHjopA9guZgWR9fb3uVZlTR0BNlvG2pw1bnYBCpkze2PB0vRllwGhAM7lWXsfmcWCbXYg==",
       "license": "MIT AND Apache-2.0"
+    },
+    "node_modules/@expo/cli": {
+      "version": "56.1.21",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.21.tgz",
+      "integrity": "sha512-5Z8lqBsQsxz0HCkrjxD8ogJZmOqlBbigMqvi6oZkJd/lIS/+VA+/33qfL9ljorJGXpxWMtB3+bdvyPbimsEa9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/config": "~56.0.13",
+        "@expo/config-plugins": "~56.0.14",
+        "@expo/devcert": "^1.2.1",
+        "@expo/env": "~2.3.1",
+        "@expo/image-utils": "^0.10.4",
+        "@expo/inline-modules": "^0.0.14",
+        "@expo/json-file": "^10.2.0",
+        "@expo/log-box": "^56.0.14",
+        "@expo/metro": "~56.0.0",
+        "@expo/metro-config": "~56.0.18",
+        "@expo/metro-file-map": "^56.0.3",
+        "@expo/osascript": "^2.6.0",
+        "@expo/package-manager": "^1.12.1",
+        "@expo/plist": "^0.7.0",
+        "@expo/prebuild-config": "^56.0.21",
+        "@expo/require-utils": "^56.1.6",
+        "@expo/router-server": "^56.0.17",
+        "@expo/schema-utils": "^56.0.2",
+        "@expo/spawn-async": "^1.8.0",
+        "@expo/ws-tunnel": "^2.0.0",
+        "@expo/xcpretty": "^4.4.4",
+        "@react-native/dev-middleware": "0.85.3",
+        "accepts": "^1.3.8",
+        "agent-cli-detector": "^0.1.2",
+        "arg": "^5.0.2",
+        "bplist-creator": "0.1.0",
+        "bplist-parser": "^0.3.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.3.0",
+        "compression": "^1.7.4",
+        "connect": "^3.7.0",
+        "debug": "^4.3.4",
+        "dnssd-advertise": "^1.1.6",
+        "expo-server": "^56.0.5",
+        "fetch-nodeshim": "^0.4.10",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "lan-network": "^0.2.1",
+        "multitars": "^1.0.0",
+        "node-forge": "^1.3.3",
+        "npm-package-arg": "^11.0.0",
+        "ora": "^3.4.0",
+        "picomatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "progress": "^2.0.3",
+        "prompts": "^2.3.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "send": "^0.19.0",
+        "slugify": "^1.3.4",
+        "stacktrace-parser": "^0.1.10",
+        "structured-headers": "^0.4.1",
+        "terminal-link": "^2.1.1",
+        "toqr": "^0.1.1",
+        "wrap-ansi": "^7.0.0",
+        "ws": "^8.12.1",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "expo-internal": "main.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "expo-router": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-router": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/cli/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
@@ -1555,15 +1669,15 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "56.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-56.0.12.tgz",
-      "integrity": "sha512-8X+FtflatWdFqBFlPxtyNRaj2dzMCPzi5wImO8IbhOLRKQVWyXdoLb26j0WjpWZaN1qo3Kf90t5yIcWdbbnfVA==",
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-56.0.13.tgz",
+      "integrity": "sha512-Fi1J1mjD3O2qDQsUPTHhsFXoHduZ5gSkWvCeyKxyp3R9fXgXrmhbpo6T+lZJG8x2t6xL1P/SIc6bLdsTJkKaOg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~56.0.13",
+        "@expo/config-plugins": "~56.0.14",
         "@expo/config-types": "^56.0.7",
         "@expo/json-file": "^10.2.0",
-        "@expo/require-utils": "^56.1.5",
+        "@expo/require-utils": "^56.1.6",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -1573,15 +1687,15 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "56.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.13.tgz",
-      "integrity": "sha512-BWtRkvUKLb4xaMLTRXmrHPHl+RI5nKF2MKJEXODHmLtVgUlXOz66XSCU4bEvjfr8yYTx+8DQ0JO54Y7Y0kwokA==",
+      "version": "56.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.14.tgz",
+      "integrity": "sha512-pdjBwH67BF1dnim4N/OxgBshhil27eu3C9uuhwzzK2Bnzl6bIcdt9WjEVuMXluFnEpWe0ws5sxE8NvBR5Ms7bQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^56.0.7",
         "@expo/json-file": "~10.2.0",
         "@expo/plist": "^0.7.0",
-        "@expo/require-utils": "^56.1.5",
+        "@expo/require-utils": "^56.1.6",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -1651,9 +1765,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.4.2.tgz",
-      "integrity": "sha512-28pqaEqwnmLduZ00Pq9HkSzE5wbj1MTwp5/n8nm8rD8MCjR9eUnVOwmNksPI3Be2ReAPO/DbPn1puy0mvoocsQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.3.1.tgz",
+      "integrity": "sha512-JvBdZa5OkTd+dGEtt3fLW9OF6RlIp9SNu9VyMSiWPV5szMDTSAYbX8Uj3cRvZcU1zzaRbqnTSsHk2AE8WXHfxQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -1671,9 +1785,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.19.8.tgz",
-      "integrity": "sha512-zM0UMJLxYJnYq0+IzASGUYwQulENnC4qmXCAwJYmjD66AG+qTfyab4yTmL2gbiWyBAsWv0vPtP+ahEhtsT2CjQ==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.19.9.tgz",
+      "integrity": "sha512-gphqoJt5dXPfq6iWFwSLKFcUi6gDnBy9GM4XuKkKbjQEqGyBH6v2iS16Oht6xfCBWkRSy28CNFsm8lKmoJVP2g==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "^2.3.1",
@@ -1693,12 +1807,12 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.10.3.tgz",
-      "integrity": "sha512-FgVp21Q05GRi08XwkzdZbBb/sBgCcP66snxlyN/HyisdtTcSbTr1qV5wkXYjq+6Q1xllXiKLmCwjDvydoN2vyg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.10.4.tgz",
+      "integrity": "sha512-QGdC9eeNyF7vozMV77wQQwX4z3ZJK8D707WSTcBTE/XI19T41g5NtGVM/BMqb1oBV+zSZlNwpOA6bXbbvtC2UA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^56.1.5",
+        "@expo/require-utils": "^56.1.6",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
@@ -1776,19 +1890,19 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "56.0.17",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.17.tgz",
-      "integrity": "sha512-kxCDDCTPbd29gqVhic7fGAPzXbW+fNWerDeXNJdaoO7rutEwogEeud7UHpX4G0fZNMbio1eM5mAQa+edCm/IRw==",
+      "version": "56.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.18.tgz",
+      "integrity": "sha512-X7ephejQE7YjL4401ObdfpluL0enEmLK4ZjMLJrhtkFh0ksZI7jQMvUHxLXZzCHD0SlMXa/RdB9abnWsOj1E5A==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~56.0.12",
+        "@expo/config": "~56.0.13",
         "@expo/env": "~2.3.1",
         "@expo/json-file": "~10.2.0",
         "@expo/metro": "~56.0.0",
-        "@expo/require-utils": "^56.1.5",
+        "@expo/require-utils": "^56.1.6",
         "@expo/spawn-async": "^1.8.0",
         "@jridgewell/gen-mapping": "^0.3.13",
         "@jridgewell/remapping": "^2.3.5",
@@ -1814,20 +1928,6 @@
         }
       }
     },
-    "node_modules/@expo/metro-config/node_modules/@expo/env": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.3.1.tgz",
-      "integrity": "sha512-JvBdZa5OkTd+dGEtt3fLW9OF6RlIp9SNu9VyMSiWPV5szMDTSAYbX8Uj3cRvZcU1zzaRbqnTSsHk2AE8WXHfxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "debug": "^4.3.4",
-        "getenv": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.12.0"
-      }
-    },
     "node_modules/@expo/metro-file-map": {
       "version": "56.0.3",
       "resolved": "https://registry.npmjs.org/@expo/metro-file-map/-/metro-file-map-56.0.3.tgz",
@@ -1843,9 +1943,9 @@
       }
     },
     "node_modules/@expo/metro-runtime": {
-      "version": "56.0.17",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-56.0.17.tgz",
-      "integrity": "sha512-mYZXMOX3SYqF4VC4G3eVq8+Hd0YfEjs/sSf2eKpqJl54fDtBxeJIu5DLHg9YIMsICPhUZ/r73syEm0835ZEM+g==",
+      "version": "56.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-56.0.18.tgz",
+      "integrity": "sha512-j/y6F0uigTn5H/sfN1v/Db+ecrbb14sLsejBEQ7tNyKajrqM86D+yLTUqTP0KdufYqcXc/DfGVa+UmtvcdlIaA==",
       "license": "MIT",
       "dependencies": {
         "@expo/log-box": "^56.0.14",
@@ -1947,27 +2047,27 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "56.0.20",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.20.tgz",
-      "integrity": "sha512-S8K1lg1cqREpnUtWAhDSOitTVJssFVhJAAdtNSi1mZaG/HL5QHUB+dogHIHijfdWKBj4KPGGjBfo6GqdmzzgtA==",
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.21.tgz",
+      "integrity": "sha512-HjhcxGsi6OoDSQxxw06tRq27gRXfXLYlsiXj3cH0R4GKiNK4yQAINKUFup4R3DtYxYNde87eHaNX28IMBCm9qA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~56.0.12",
-        "@expo/config-plugins": "~56.0.13",
+        "@expo/config": "~56.0.13",
+        "@expo/config-plugins": "~56.0.14",
         "@expo/config-types": "^56.0.7",
-        "@expo/image-utils": "^0.10.3",
+        "@expo/image-utils": "^0.10.4",
         "@expo/json-file": "^10.2.0",
         "@react-native/normalize-colors": "0.85.3",
         "debug": "^4.3.1",
-        "expo-modules-autolinking": "~56.0.20",
+        "expo-modules-autolinking": "~56.0.21",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "56.1.5",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.5.tgz",
-      "integrity": "sha512-3wsdJLSpELhRPEMZCCREqAAFRGG23BUWJHGKIUxyqGkWvy5KPdzlBxGlVVb/6h9gNOflqgTtvTWaP2EuHoQ1HQ==",
+      "version": "56.1.6",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.6.tgz",
+      "integrity": "sha512-e68r6X+c7yPxJP0gac/CaJc/RCHeLB2Bf4MyCuqfNM4YXfl1ONmQbQlRL0RbwBfEHn6A6UZKj+5UX9j0Im646g==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -1975,10 +2075,44 @@
         "@babel/plugin-transform-modules-commonjs": "^7.24.8"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/router-server": {
+      "version": "56.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-56.0.17.tgz",
+      "integrity": "sha512-ogGX5cxqAXIzMmstjwZ03QAjCU8cFOU5yooDSbqPDVxscbnzsxV8oquHSMUsqiEy3vlyZp5S5HVPnCsrjoCDqw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "@expo/metro-runtime": "^56.0.18",
+        "expo": "*",
+        "expo-constants": "^56.0.22",
+        "expo-font": "^56.0.7",
+        "expo-router": "*",
+        "expo-server": "^56.0.5",
+        "react": "*",
+        "react-dom": "*",
+        "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@expo/metro-runtime": {
+          "optional": true
+        },
+        "expo-router": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-server-dom-webpack": {
           "optional": true
         }
       }
@@ -2014,9 +2148,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/ui": {
-      "version": "56.0.22",
-      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-56.0.22.tgz",
-      "integrity": "sha512-B6CXc+WJg2GE4KF6LrCPTf+ozMWKMG9TAVc//gQYUsLzFZzm0vCgUqXRiaNJ6BukpHoZPLKsQZ95VsSyTVda3A==",
+      "version": "56.0.23",
+      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-56.0.23.tgz",
+      "integrity": "sha512-NEYz6dYmGU51mwtx/ce5FpsyN1HJSG600mNafdzR9dWYfgAbP/bZQurXC3M6EFXdh+cI4HArJ/ltLDeM+spVqw==",
       "license": "MIT",
       "dependencies": {
         "sf-symbols-typescript": "^2.1.0",
@@ -2644,9 +2778,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
-      "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
+      "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
       "cpu": [
         "arm"
       ],
@@ -2661,9 +2795,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
-      "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
+      "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
       "cpu": [
         "arm64"
       ],
@@ -2678,9 +2812,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
-      "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
+      "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
       "cpu": [
         "arm64"
       ],
@@ -2695,9 +2829,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
-      "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
+      "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
       "cpu": [
         "x64"
       ],
@@ -2712,9 +2846,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
-      "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
+      "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
       "cpu": [
         "x64"
       ],
@@ -2729,9 +2863,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
-      "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
+      "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
       "cpu": [
         "arm"
       ],
@@ -2746,9 +2880,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
-      "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
+      "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
       "cpu": [
         "arm"
       ],
@@ -2763,9 +2897,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
-      "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
+      "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
       "cpu": [
         "arm64"
       ],
@@ -2780,9 +2914,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
-      "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
+      "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
       "cpu": [
         "arm64"
       ],
@@ -2797,9 +2931,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
-      "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
+      "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
       "cpu": [
         "ppc64"
       ],
@@ -2814,9 +2948,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
-      "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
+      "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
       "cpu": [
         "riscv64"
       ],
@@ -2831,9 +2965,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
-      "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
+      "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2848,9 +2982,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
-      "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
+      "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
       "cpu": [
         "s390x"
       ],
@@ -2865,9 +2999,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
-      "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
+      "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
       "cpu": [
         "x64"
       ],
@@ -2882,9 +3016,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
-      "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
+      "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
       "cpu": [
         "x64"
       ],
@@ -2899,9 +3033,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
-      "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
+      "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
       "cpu": [
         "arm64"
       ],
@@ -2916,9 +3050,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
-      "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
+      "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
       "cpu": [
         "arm64"
       ],
@@ -2933,9 +3067,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
-      "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
+      "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
       "cpu": [
         "ia32"
       ],
@@ -2950,9 +3084,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
-      "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
+      "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
       "cpu": [
         "x64"
       ],
@@ -2967,37 +3101,37 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
-      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
-      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.2.0",
-        "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-slot": "1.3.0"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3015,9 +3149,9 @@
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
-      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3030,9 +3164,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
-      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3045,24 +3179,24 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.20.tgz",
-      "integrity": "sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.6",
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.2.0",
-        "@radix-ui/react-dismissable-layer": "1.1.16",
-        "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.13",
-        "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-portal": "1.1.14",
-        "@radix-ui/react-presence": "1.1.8",
-        "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-slot": "1.3.0",
-        "@radix-ui/react-use-controllable-state": "1.2.4",
-        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -3082,9 +3216,9 @@
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
-      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3097,16 +3231,16 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.16.tgz",
-      "integrity": "sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.6",
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-use-callback-ref": "1.1.2",
-        "@radix-ui/react-use-effect-event": "0.0.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3124,9 +3258,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
-      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3139,14 +3273,14 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.13.tgz",
-      "integrity": "sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-use-callback-ref": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3164,12 +3298,12 @@
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
-      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.2"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3182,13 +3316,13 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.14.tgz",
-      "integrity": "sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-use-layout-effect": "1.1.2"
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3206,12 +3340,12 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
-      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.2"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3229,12 +3363,12 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
-      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.3.0"
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3252,22 +3386,22 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.16.tgz",
-      "integrity": "sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.6",
-        "@radix-ui/react-collection": "1.1.12",
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.2.0",
-        "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-use-callback-ref": "1.1.2",
-        "@radix-ui/react-use-controllable-state": "1.2.4",
-        "@radix-ui/react-use-is-hydrated": "0.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3285,12 +3419,12 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
-      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.3"
+        "@radix-ui/react-compose-refs": "1.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3303,19 +3437,19 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.18.tgz",
-      "integrity": "sha512-1zq2XkQkK/KfbZn84edytYpOLquhNalra5LXc3NAMKhNRSGtyXqjMv6OyC9jlSuNKpqvQtsb57WKoICNk1v/sQ==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
+      "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.6",
-        "@radix-ui/react-context": "1.2.0",
-        "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-presence": "1.1.8",
-        "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.16",
-        "@radix-ui/react-use-controllable-state": "1.2.4"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3333,9 +3467,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
-      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3348,14 +3482,14 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
-      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.6",
-        "@radix-ui/react-use-effect-event": "0.0.3",
-        "@radix-ui/react-use-layout-effect": "1.1.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3368,12 +3502,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
-      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.2"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3386,9 +3520,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
-      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3401,9 +3535,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -4044,9 +4178,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -4289,47 +4423,22 @@
       }
     },
     "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4696,9 +4805,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "56.0.17",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-56.0.17.tgz",
-      "integrity": "sha512-yanAlbzaMMNqnju/uMnZsf3ltgssG71UubkfD+2iMaoXGNIj+TODEs9hF12jrTX2lzq/zH0HWSuRLZLNalf8fw==",
+      "version": "56.0.18",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-56.0.18.tgz",
+      "integrity": "sha512-QHEa3AasSFjnA08ciQkKKdVKWPRc2ye6UvxwCweYr3rKATBwTUVOuA0mzRD2PFVdB16R9yqgHROpiqL+K4A0Ww==",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.20.5",
@@ -4747,7 +4856,7 @@
       "peerDependencies": {
         "@babel/runtime": "^7.20.0",
         "expo": "*",
-        "expo-widgets": "^56.0.22",
+        "expo-widgets": "^56.0.24",
         "react-refresh": ">=0.14.0 <1.0.0"
       },
       "peerDependenciesMeta": {
@@ -4809,9 +4918,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
-      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.6.tgz",
+      "integrity": "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4839,9 +4948,9 @@
       }
     },
     "node_modules/bplist-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
-      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
       "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.x"
@@ -5607,9 +5716,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.395",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
-      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
+      "version": "1.5.398",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+      "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -6179,31 +6288,31 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "56.0.16",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.16.tgz",
-      "integrity": "sha512-6G1yfBKG3J16HBgF2ehdd1iZBlRmbDF/lB7SG30v4jojgvN03HZkENHujKfuGuBqDBlzkkXjZvpxRVvIUQTAMQ==",
+      "version": "56.0.17",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.17.tgz",
+      "integrity": "sha512-CuknE6i0BOcMPzJezNDLLorHyIdV9dOo6d2FZcTnPIDHrlv0/Xg0XnNUWreQISfde5J3rtYnBgatwnrQI+AsIA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^56.1.20",
-        "@expo/config": "~56.0.12",
-        "@expo/config-plugins": "~56.0.13",
+        "@expo/cli": "^56.1.21",
+        "@expo/config": "~56.0.13",
+        "@expo/config-plugins": "~56.0.14",
         "@expo/devtools": "~56.0.2",
         "@expo/dom-webview": "~56.0.6",
-        "@expo/fingerprint": "^0.19.8",
+        "@expo/fingerprint": "^0.19.9",
         "@expo/local-build-cache-provider": "^56.0.10",
         "@expo/log-box": "^56.0.14",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~56.0.17",
+        "@expo/metro-config": "~56.0.18",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~56.0.17",
-        "expo-asset": "~56.0.20",
-        "expo-constants": "~56.0.21",
+        "babel-preset-expo": "~56.0.18",
+        "expo-asset": "~56.0.21",
+        "expo-constants": "~56.0.22",
         "expo-file-system": "~56.0.8",
         "expo-font": "~56.0.7",
         "expo-keep-awake": "~56.0.3",
-        "expo-modules-autolinking": "~56.0.20",
-        "expo-modules-core": "~56.0.21",
+        "expo-modules-autolinking": "~56.0.21",
+        "expo-modules-core": "~56.0.22",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -6241,13 +6350,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "56.0.20",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.20.tgz",
-      "integrity": "sha512-pjVw3JDiaq6Ee15UbDeZpiGNAHJqfOZwY61VPlFiznuuj7f/b2tvegujeIEu2+p6C2/tioZGGD6zWQuJ9Ob3uQ==",
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.21.tgz",
+      "integrity": "sha512-0p5JByDPy6MxB1S2TBoz38r6I8IYx6z5uD/e00nc0sc9f8xRpcZPCJALbOsGW8PjOwXNfTyEE9KsC6xTLjC2ZA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.10.3",
-        "expo-constants": "~56.0.21"
+        "@expo/image-utils": "^0.10.4",
+        "expo-constants": "~56.0.22"
       },
       "peerDependencies": {
         "expo": "*",
@@ -6256,9 +6365,9 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "56.0.21",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.21.tgz",
-      "integrity": "sha512-q9LkK9tNTW2z/5hXgpwWoCXO1fBrqn4FgwTiLerM9WOu1wtg99NevAtG3BEG8t5Awtub+NsLidiFZzBat45RKw==",
+      "version": "56.0.22",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.22.tgz",
+      "integrity": "sha512-XNRssTBSGDR3gsaYhhp513WdpPsLi89wgfYT0wLsCtMY8vXAgXR4jNlaYGXFCnvNVbx9gEDSBHOSntqRK1i8Lw==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "~2.3.1"
@@ -6266,20 +6375,6 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-constants/node_modules/@expo/env": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.3.1.tgz",
-      "integrity": "sha512-JvBdZa5OkTd+dGEtt3fLW9OF6RlIp9SNu9VyMSiWPV5szMDTSAYbX8Uj3cRvZcU1zzaRbqnTSsHk2AE8WXHfxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "debug": "^4.3.4",
-        "getenv": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.12.0"
       }
     },
     "node_modules/expo-file-system": {
@@ -6357,12 +6452,12 @@
       }
     },
     "node_modules/expo-linking": {
-      "version": "56.0.15",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-56.0.15.tgz",
-      "integrity": "sha512-V3tkCxHIWO624ayw2L5Nfi0/bPgYy/0MgmoQR7g3FAKF4nyAayK8IhgAInz4MZ5Ao5Bb+5uZWDdUaS4yyEb+Gw==",
+      "version": "56.0.16",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-56.0.16.tgz",
+      "integrity": "sha512-rI/ZE22t0sgYqnE0WnDUbld/vTzOiTxEX/uKuNFGTIUZ9tmes/nvcqJufEMqRV7u6REUEIBCFxbROOBibvwG4g==",
       "license": "MIT",
       "dependencies": {
-        "expo-constants": "~56.0.20",
+        "expo-constants": "~56.0.22",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -6371,12 +6466,12 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "56.0.20",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.20.tgz",
-      "integrity": "sha512-bIUaHtWlqQpculjhN1wERVBoVeRCefkW3zXY/SqiXSm/6uofZy3NRF1t5Co44lmBQczAs/lFR7BwA8lmUiGMnw==",
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.21.tgz",
+      "integrity": "sha512-DG0ykIaC4cTXmEL49x7b8Pet/ZCcoNgQ00ooeroH/p8TKLMRs/KULiv9kiHWZRL3n0E0llsaHSvfKj9fAsaI/A==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^56.1.5",
+        "@expo/require-utils": "^56.1.6",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.1.0",
         "commander": "^7.2.0"
@@ -6386,9 +6481,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "56.0.21",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.21.tgz",
-      "integrity": "sha512-lT413DZFuX/cSsOqGtZnqtyCGlY3F3FFDiVhwzB8wX4Ei9HZYPXhV59Mm8SNJquo8+JfLRi3arv3z5U4MqJRcA==",
+      "version": "56.0.22",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.22.tgz",
+      "integrity": "sha512-VmkVNpbjC+gTny1pvxyxu90LafGpMdhUB5TRSpe+So4ICrZCwcWBADjWc0JVBHKdFCMOaWBMskuIHI/RcNhEtQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "0.2.2",
@@ -6416,15 +6511,15 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "56.2.15",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-56.2.15.tgz",
-      "integrity": "sha512-VdPIBuJ0D2cv4gCulU5slhDlF9ocDNXsne03qu5AcTYROLIctlYDAzzLax7lSKZLP6GI6+Xw+I2dN7QMjC9UCA==",
+      "version": "56.2.16",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-56.2.16.tgz",
+      "integrity": "sha512-0sewrYoaRwnQ715zejum5Xv2sTSkKKU4EznbVlYXdTQJsO3RkJiOd47WAISa9M04qvBlAs+wFaeuvgiNEMg2QA==",
       "license": "MIT",
       "dependencies": {
         "@expo/log-box": "^56.0.14",
-        "@expo/metro-runtime": "^56.0.17",
+        "@expo/metro-runtime": "^56.0.18",
         "@expo/schema-utils": "^56.0.2",
-        "@expo/ui": "^56.0.22",
+        "@expo/ui": "^56.0.23",
         "@radix-ui/react-slot": "^1.2.0",
         "@radix-ui/react-tabs": "^1.1.12",
         "@react-native-masked-view/masked-view": "^0.3.2",
@@ -6444,7 +6539,7 @@
         "react-fast-compare": "^3.2.2",
         "react-is": "^19.1.0",
         "react-native-drawer-layout": "^4.2.2",
-        "react-native-screens": "^4.25.2",
+        "react-native-screens": "^4.26.0",
         "server-only": "^0.0.1",
         "sf-symbols-typescript": "^2.1.0",
         "shallowequal": "^1.1.0",
@@ -6453,18 +6548,18 @@
       },
       "peerDependencies": {
         "@expo/log-box": "^56.0.14",
-        "@expo/metro-runtime": "^56.0.17",
+        "@expo/metro-runtime": "^56.0.18",
         "@testing-library/react-native": ">= 13.2.0",
         "expo": "*",
-        "expo-constants": "^56.0.21",
-        "expo-linking": "^56.0.15",
+        "expo-constants": "^56.0.22",
+        "expo-linking": "^56.0.16",
         "react": "*",
         "react-dom": "*",
         "react-native": "*",
         "react-native-gesture-handler": "*",
         "react-native-reanimated": "*",
         "react-native-safe-area-context": ">= 5.4.0",
-        "react-native-screens": "^4.25.2",
+        "react-native-screens": "^4.26.0",
         "react-native-web": "*",
         "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
       },
@@ -6499,13 +6594,13 @@
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "56.0.13",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-56.0.13.tgz",
-      "integrity": "sha512-8+ytfHX4/B5sj97N4PIzm4IP/7uDbbYTsY/vOMWa7ASTVkGZB+pXB23dBwBu7TcKx5w9Wt0NkaPAwy6dhNEdag==",
+      "version": "56.0.14",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-56.0.14.tgz",
+      "integrity": "sha512-7cc09zKllBrmDGpbkVDiq09JBdpzyZMboOYNOd7Q+h4YbCbvkAW4WmZtxXLpZUEeBrc2uakxWyrz5nwcuHqMoQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~56.0.13",
-        "@expo/image-utils": "^0.10.3",
+        "@expo/config-plugins": "~56.0.14",
+        "@expo/image-utils": "^0.10.4",
         "xml2js": "0.6.0"
       },
       "peerDependencies": {
@@ -6560,156 +6655,13 @@
       }
     },
     "node_modules/expo-web-browser": {
-      "version": "56.0.5",
-      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-56.0.5.tgz",
-      "integrity": "sha512-kaN+wcR5lHwPCH1IgrU1XyPUQvBRzdF1TMp65uAF9iUCyipqYnmrvV87eqAmrdkFFopWVgU7FcxPu1UZw+gvUQ==",
+      "version": "56.0.6",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-56.0.6.tgz",
+      "integrity": "sha512-+5Zg0JHETAB1+vNu0Bb4+WiUB50MViwcaJKt16sz5GJTrnutcJvwFeXr6oJ7Pw73sp+DjxkIDGSHDq8SAmFRSg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/cli": {
-      "version": "56.1.20",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.20.tgz",
-      "integrity": "sha512-xWkKvOBkOE3G/PpU29fjmAjKpCIqTIVSxG8oA+E6pYUElcPZ9gRofAdTE321lUoJVHwEjKmpn93EHqsajItDTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/code-signing-certificates": "^0.0.6",
-        "@expo/config": "~56.0.12",
-        "@expo/config-plugins": "~56.0.13",
-        "@expo/devcert": "^1.2.1",
-        "@expo/env": "~2.3.1",
-        "@expo/image-utils": "^0.10.3",
-        "@expo/inline-modules": "^0.0.14",
-        "@expo/json-file": "^10.2.0",
-        "@expo/log-box": "^56.0.14",
-        "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~56.0.17",
-        "@expo/metro-file-map": "^56.0.3",
-        "@expo/osascript": "^2.6.0",
-        "@expo/package-manager": "^1.12.1",
-        "@expo/plist": "^0.7.0",
-        "@expo/prebuild-config": "^56.0.20",
-        "@expo/require-utils": "^56.1.5",
-        "@expo/router-server": "^56.0.16",
-        "@expo/schema-utils": "^56.0.2",
-        "@expo/spawn-async": "^1.8.0",
-        "@expo/ws-tunnel": "^2.0.0",
-        "@expo/xcpretty": "^4.4.4",
-        "@react-native/dev-middleware": "0.85.3",
-        "accepts": "^1.3.8",
-        "agent-cli-detector": "^0.1.2",
-        "arg": "^5.0.2",
-        "bplist-creator": "0.1.0",
-        "bplist-parser": "^0.3.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.3.0",
-        "compression": "^1.7.4",
-        "connect": "^3.7.0",
-        "debug": "^4.3.4",
-        "dnssd-advertise": "^1.1.6",
-        "expo-server": "^56.0.5",
-        "fetch-nodeshim": "^0.4.10",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "lan-network": "^0.2.1",
-        "multitars": "^1.0.0",
-        "node-forge": "^1.3.3",
-        "npm-package-arg": "^11.0.0",
-        "ora": "^3.4.0",
-        "picomatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "progress": "^2.0.3",
-        "prompts": "^2.3.2",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "send": "^0.19.0",
-        "slugify": "^1.3.4",
-        "stacktrace-parser": "^0.1.10",
-        "structured-headers": "^0.4.1",
-        "terminal-link": "^2.1.1",
-        "toqr": "^0.1.1",
-        "wrap-ansi": "^7.0.0",
-        "ws": "^8.12.1",
-        "zod": "^3.25.76"
-      },
-      "bin": {
-        "expo-internal": "main.js"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "expo-router": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo-router": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/router-server": {
-      "version": "56.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-56.0.16.tgz",
-      "integrity": "sha512-df5BI5GFnSKqAhuALTPIbuHisd4CUhuYam7pwF9Dt1D6BinPctsteWWDm/sEGXdLVhsub4NPI7tvUHo/HWL7aA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "@expo/metro-runtime": "^56.0.16",
-        "expo": "*",
-        "expo-constants": "^56.0.20",
-        "expo-font": "^56.0.7",
-        "expo-router": "*",
-        "expo-server": "^56.0.5",
-        "react": "*",
-        "react-dom": "*",
-        "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
-      },
-      "peerDependenciesMeta": {
-        "@expo/metro-runtime": {
-          "optional": true
-        },
-        "expo-router": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-server-dom-webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/env": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.3.1.tgz",
-      "integrity": "sha512-JvBdZa5OkTd+dGEtt3fLW9OF6RlIp9SNu9VyMSiWPV5szMDTSAYbX8Uj3cRvZcU1zzaRbqnTSsHk2AE8WXHfxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "debug": "^4.3.4",
-        "getenv": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.12.0"
-      }
-    },
-    "node_modules/expo/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/expo/node_modules/ansi-styles": {
@@ -6722,15 +6674,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/expo/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/expo/node_modules/pretty-format": {
@@ -6949,9 +6892,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -7004,6 +6947,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9872,6 +9816,19 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
+    "node_modules/metro/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/metro/node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -9893,15 +9850,6 @@
         "hermes-estree": "0.35.0"
       }
     },
-    "node_modules/metro/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/metro/node_modules/mime-types": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
@@ -9916,6 +9864,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/metro/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/metro/node_modules/source-map": {
@@ -9986,9 +9943,9 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10002,6 +9959,15 @@
       "dependencies": {
         "mime-db": "1.52.0"
       },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10026,12 +9992,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -10099,9 +10065,9 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10436,9 +10402,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
-      "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
+      "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10451,25 +10417,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.75.0",
-        "@oxlint/binding-android-arm64": "1.75.0",
-        "@oxlint/binding-darwin-arm64": "1.75.0",
-        "@oxlint/binding-darwin-x64": "1.75.0",
-        "@oxlint/binding-freebsd-x64": "1.75.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.75.0",
-        "@oxlint/binding-linux-arm64-musl": "1.75.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.75.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.75.0",
-        "@oxlint/binding-linux-x64-gnu": "1.75.0",
-        "@oxlint/binding-linux-x64-musl": "1.75.0",
-        "@oxlint/binding-openharmony-arm64": "1.75.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.75.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.75.0",
-        "@oxlint/binding-win32-x64-msvc": "1.75.0"
+        "@oxlint/binding-android-arm-eabi": "1.76.0",
+        "@oxlint/binding-android-arm64": "1.76.0",
+        "@oxlint/binding-darwin-arm64": "1.76.0",
+        "@oxlint/binding-darwin-x64": "1.76.0",
+        "@oxlint/binding-freebsd-x64": "1.76.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.76.0",
+        "@oxlint/binding-linux-arm64-musl": "1.76.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.76.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-musl": "1.76.0",
+        "@oxlint/binding-openharmony-arm64": "1.76.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.76.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.76.0",
+        "@oxlint/binding-win32-x64-msvc": "1.76.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -10707,35 +10673,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -10786,9 +10752,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -11667,9 +11633,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -11889,6 +11855,18 @@
         "bplist-creator": "0.1.0",
         "bplist-parser": "0.3.1",
         "plist": "^3.0.5"
+      }
+    },
+    "node_modules/simple-plist/node_modules/bplist-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
+      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
       }
     },
     "node_modules/simple-swizzle": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -96,15 +109,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.9.0",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -118,22 +131,6 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -200,9 +197,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -277,16 +274,19 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/tree-kill": {


### PR DESCRIPTION
## Summary

Routine dependency audit across the backend (NuGet) and frontend/root (npm). No security vulnerabilities were found in either ecosystem, so this PR contains only low-risk, non-breaking version bumps plus a full report of what's left outdated.

## Related issue

Closes #

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `OpenRestoApi.csproj`: `Magick.NET-Q8-AnyCPU` 14.15.0 → 14.16.0 (patch, bug fixes only — both versions confirmed free of NuGet security advisories)
- `OpenRestoApi.csproj`: `System.IdentityModel.Tokens.Jwt` 8.19.2 → 8.22.0 (minor, no breaking changes; no advisory affects the old or new version)
- `package-lock.json` (root) / `openresto-frontend/package-lock.json`: refreshed to bring in-range patch/minor bumps already permitted by existing `package.json` ranges (`playwright`/`@playwright/test`, `oxlint`, `prettier`, `concurrently`) — no `package.json` range changes

## Audit results

**npm audit**: 0 vulnerabilities (root and frontend, all severities).

**NuGet advisory check** (manual, since Dependabot/`dotnet list package --vulnerable` aren't available in this environment): no CVEs affect any currently pinned backend package version.
- `MailKit` 4.17.0 is already past the fix for CVE-2026-41319 (STARTTLS response injection, fixed in 4.16.0) — no action needed, already latest.
- `Magick.NET-Q8-AnyCPU`: several historical CVEs exist for this package, but only fixed as of 14.14.0+; 14.15.0 (before this PR) and 14.16.0 (after) are both clean.
- No advisories found for `csulpizi.CustomAccessibility`, `Riok.Mapperly`, `WebPush`, EF Core/ASP.NET Core 10.0.10, coverlet, Moq, or xunit — all already at latest stable.

**Intentionally not touched** (major/breaking, needs dedicated migration effort + real device/browser testing this environment can't do):
- `expo` 56.0.17 → 57.0.8 and the full `expo-*` family (major SDK bump)
- `react-native` 0.85.3 → 0.86.2, `react-native-reanimated` 4.3.1 → 4.5.3, `react-native-worklets` 0.8.3 → 0.11.3 (version-coupled to the Expo SDK)
- `jest` 29.7.0 → 30.4.2, `jest-expo` 56.0.5 → 57.0.2, `@types/jest` 29.5.14 → 30.0.0
- `@testing-library/react-native` 13.3.3 → 14.0.1
- `typescript` 5.9.3 → 7.0.2
- `concurrently` 9.2.4 → 10.0.4 (root devDependency)

**Not verifiable locally**: `dotnet` is not installed in this sandbox and the network proxy blocks `builds.dotnet.microsoft.com`, so the backend change could not be compiled/tested here — relying on CI to validate the build.

The `Microsoft.CodeAnalysis.CSharp.Workspaces`/`Workspaces.MSBuild` pin (5.3.0, deliberately held back per the comment in `OpenRestoApi.csproj` to unify Roslyn versions for `dotnet ef migrations add`) was left as-is since verifying a bump requires inspecting `project.assets.json` with `dotnet restore`, which isn't available here.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally (not run — `dotnet` unavailable in this environment; relying on CI)
- [x] Frontend tests/build pass locally (`npm test` — 147 suites / 1927 tests passed after the lockfile refresh)
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed (not applicable — dependency versions only)


---
_Generated by [Claude Code](https://claude.ai/code/session_017Rwq9WCttUdLTXFTTQFpNG)_