### PR TITLE
test: achieve 100% unit test coverage - backend services

### DIFF
--- a/OpenRestoApi.Tests/Extensions/InitializeDatabaseTests.cs
+++ b/OpenRestoApi.Tests/Extensions/InitializeDatabaseTests.cs
@@ -451,6 +451,70 @@ public sealed class InitializeDatabaseTests : IDisposable
     }
 
     [Fact]
+    public void DiagnoseDbState_SkipsFileSizeProbing_WhenDbFileIsNullOrEmpty()
+    {
+        // The connection string parsing in InitializeDatabase can hand DiagnoseDbState a null
+        // or empty dbFile (e.g. a malformed "Data Source=" segment) — it must skip the
+        // main/-wal/-shm FileInfo probing entirely rather than throwing on Path.GetFullPath(null).
+        using AppDbContext db = new(new DbContextOptionsBuilder<AppDbContext>().UseSqlite("Data Source=:memory:").Options);
+        db.Database.OpenConnection();
+
+        Exception? exWithNull = Record.Exception(() => InvokeDiagnoseDbState(db, null, NullLogger.Instance));
+        Exception? exWithEmpty = Record.Exception(() => InvokeDiagnoseDbState(db, string.Empty, NullLogger.Instance));
+
+        Assert.Null(exWithNull);
+        Assert.Null(exWithEmpty);
+    }
+
+    [Fact]
+    public void DiagnoseDbState_LogsOk_WhenIntegrityCheckReportsHealthyDatabase()
+    {
+        Directory.CreateDirectory(_tempDir);
+        string dbFile = Path.Combine(_tempDir, "healthy.db");
+
+        using (SqliteConnection seed = new($"Data Source={dbFile}"))
+        {
+            seed.Open();
+            using SqliteCommand create = seed.CreateCommand();
+            create.CommandText = "CREATE TABLE Healthy (Id INTEGER PRIMARY KEY)";
+            create.ExecuteNonQuery();
+        }
+
+        using AppDbContext db = new(new DbContextOptionsBuilder<AppDbContext>().UseSqlite($"Data Source={dbFile}").Options);
+
+        Exception? ex = Record.Exception(() => InvokeDiagnoseDbState(db, dbFile, NullLogger.Instance));
+
+        Assert.Null(ex);
+    }
+
+    // ── ApplicationStopping WAL checkpoint ───────────────────────────────────────
+
+    [Fact]
+    public async Task ApplicationStopping_ChecksPointsWal_WithoutThrowing()
+    {
+        Directory.CreateDirectory(_tempDir);
+        string dbFile = Path.Combine(_tempDir, "openresto.db");
+        string connectionString = $"Data Source={dbFile}";
+        using WebApplication app = BuildApp(connectionString, new Dictionary<string, string?>
+        {
+            ["Admin:Email"] = "admin@openresto.com",
+            ["Admin:Password"] = "password123",
+        });
+
+        app.InitializeDatabase(connectionString, app.Configuration);
+
+        // Fires the ApplicationStopping.Register callback registered inside InitializeDatabase,
+        // which opens its own scope and issues a best-effort WAL checkpoint on shutdown.
+        Exception? ex = Record.Exception(() => app.Lifetime.StopApplication());
+
+        Assert.Null(ex);
+
+        using var scope = app.Services.CreateScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        Assert.True(await db.AdminCredentials.AnyAsync());
+    }
+
+    [Fact]
     public void DiagnoseDbState_LogsFailure_WhenIntegrityCheckReportsCorruption()
     {
         Directory.CreateDirectory(_tempDir);

--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -50,6 +50,20 @@ public class AdminServiceTests : IDisposable
             _emailServiceMock.Object);
     }
 
+    private AdminService CreateServiceWithNotifications(INotificationQueue notificationQueue)
+    {
+        return new AdminService(
+            new BookingRepository(_db),
+            new BookingFilterRepository(_db),
+            new RestaurantRepository(_db),
+            new SectionRepository(_db),
+            new TableRepository(_db),
+            _holdServiceMock.Object,
+            _emailServiceMock.Object,
+            brandService: null,
+            notificationQueue: notificationQueue);
+    }
+
     private void SeedBase(int restaurantId = 1)
     {
         _db.Restaurants.Add(new Restaurant { Id = restaurantId, Name = "Test", Timezone = "UTC" });
@@ -561,6 +575,79 @@ public class AdminServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ExtendBookingAsync_UsesStoredEndTime_WhenAlreadyValid()
+    {
+        // Covers the "no fallback needed" branch: EndTime is present and after Date, so it
+        // must be used as-is rather than recomputed from the restaurant's configured duration.
+        AdminService svc = CreateService();
+        SeedBase(1);
+        DateTime date = DateTime.UtcNow;
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = date, EndTime = date.AddMinutes(30), BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+
+        DateTime? newEnd = await svc.ExtendBookingAsync(1, 15);
+
+        Assert.Equal(date.AddMinutes(45), newEnd);
+    }
+
+    [Fact]
+    public async Task ExtendBookingAsync_FallsBackToSixtyMinutes_WhenRestaurantNoLongerExists()
+    {
+        // ExtendBookingAsync fetches the booking via FindByIdAsync (no eager-loaded Restaurant
+        // navigation) and then looks up the restaurant separately — an orphaned RestaurantId
+        // legitimately returns null here, exercising the `?? 60` default duration fallback. FK
+        // enforcement (on by default for this connection) is disabled so the dangling
+        // RestaurantId can be inserted at all.
+        AdminService svc = CreateService();
+        DateTime date = DateTime.UtcNow;
+        await _db.Database.ExecuteSqlRawAsync("PRAGMA foreign_keys=OFF");
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 999, SectionId = null, TableId = null, Date = date, EndTime = date.AddHours(-1), BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+
+        DateTime? newEnd = await svc.ExtendBookingAsync(1, 30);
+
+        Assert.Equal(date.AddMinutes(60).AddMinutes(30), newEnd);
+    }
+
+    [Fact]
+    public async Task CancelBookingAsync_NotifiesQueue_WithRestaurantName_WhenRestaurantExists()
+    {
+        SeedBase(1);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow.AddHours(1), BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+
+        var notificationQueue = new Mock<INotificationQueue>();
+        AdminService svc = CreateServiceWithNotifications(notificationQueue.Object);
+
+        Assert.True(await svc.CancelBookingAsync(1));
+
+        notificationQueue.Verify(n => n.EnqueueBookingCancelled(It.IsAny<Booking>(), "Test"), Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelBookingAsync_UsesEmptyRestaurantName_WhenRestaurantNoLongerExists()
+    {
+        // The re-fetch inside the notification branch (GetByIdAsync) Include()s the required
+        // Restaurant navigation, which EF Core compiles to an inner join — deleting the
+        // restaurant row directly makes that re-fetch return null entirely, driving both the
+        // `withRestaurant ?? booking` and `?.Restaurant?.Name ?? ""` fallbacks. FK enforcement
+        // (on by default for this connection) is turned off first so the raw DELETE doesn't
+        // cascade-remove the booking along with its restaurant.
+        SeedBase(1);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow.AddHours(1), BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+        await _db.Database.ExecuteSqlRawAsync("PRAGMA foreign_keys=OFF");
+        await _db.Database.ExecuteSqlRawAsync("DELETE FROM Restaurants WHERE Id = 1");
+
+        var notificationQueue = new Mock<INotificationQueue>();
+        AdminService svc = CreateServiceWithNotifications(notificationQueue.Object);
+
+        Assert.True(await svc.CancelBookingAsync(1));
+
+        notificationQueue.Verify(n => n.EnqueueBookingCancelled(It.IsAny<Booking>(), ""), Times.Once);
+    }
+
+    [Fact]
     public async Task AdminUpdateBookingAsync_Throws_WhenSeatsExceedCapacity()
     {
         AdminService svc = CreateService();
@@ -862,6 +949,18 @@ public class AdminServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task PurgeBookingAsync_DeletesBooking_AndReturnsTrue()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+
+        Assert.True(await svc.PurgeBookingAsync(1));
+        Assert.Null(await _db.Bookings.FindAsync(1));
+    }
+
+    [Fact]
     public async Task RestoreBookingAsync_ReturnsNull_WhenNotFound()
     {
         AdminService svc = CreateService();
@@ -876,6 +975,60 @@ public class AdminServiceTests : IDisposable
         _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, IsCancelled = false, BookingRef = "B1" });
         await _db.SaveChangesAsync();
         await Assert.ThrowsAsync<BusinessRuleException>(() => svc.RestoreBookingAsync(1));
+    }
+
+    [Fact]
+    public async Task RestoreBookingAsync_ReactivatesCancelledBooking()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow,
+            IsCancelled = true, CancelledAt = DateTime.UtcNow, BookingRef = "B1",
+        });
+        await _db.SaveChangesAsync();
+
+        BookingDetailDto? result = await svc.RestoreBookingAsync(1);
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsCancelled);
+        Booking inDb = await _db.Bookings.SingleAsync(b => b.Id == 1);
+        Assert.False(inDb.IsCancelled);
+        Assert.Null(inDb.CancelledAt);
+    }
+
+    [Fact]
+    public async Task CancelBookingAsync_ReturnsTrue_WhenAlreadyCancelled()
+    {
+        // Idempotent re-cancel: IsCancelled short-circuits the "already passed" guard so a
+        // second cancel attempt on the same booking succeeds instead of throwing.
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow.AddDays(-3),
+            IsCancelled = true, CancelledAt = DateTime.UtcNow.AddDays(-2), BookingRef = "B1",
+        });
+        await _db.SaveChangesAsync();
+
+        Assert.True(await svc.CancelBookingAsync(1));
+    }
+
+    [Fact]
+    public async Task ExtendBookingAsync_FallsBackToRestaurantConfiguredDuration_WhenEndTimeMissing()
+    {
+        AdminService svc = CreateService();
+        _db.Restaurants.Add(new Restaurant { Id = 1, Name = "Test", Timezone = "UTC", DefaultBookingDurationMinutes = 90 });
+        _db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        _db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        DateTime date = DateTime.UtcNow;
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = date, EndTime = null, BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+
+        DateTime? newEnd = await svc.ExtendBookingAsync(1, 30);
+
+        Assert.Equal(date.AddMinutes(90).AddMinutes(30), newEnd);
     }
 
     [Fact]
@@ -928,6 +1081,28 @@ public class AdminServiceTests : IDisposable
         await _db.SaveChangesAsync();
 
         await Assert.ThrowsAsync<BusinessRuleException>(() => svc.AdminUpdateBookingAsync(1, new AdminUpdateBookingRequest { TableId = 2, Seats = 3 }));
+    }
+
+    [Fact]
+    public async Task AdminUpdateBookingAsync_SkipsSeatsCapacityCheck_WhenResolvedTableNoLongerExists()
+    {
+        // booking.TableId points at a table row that no longer exists (removed directly here,
+        // bypassing the normal DeleteTableAsync FK-null flow) — resolvedTableId still carries a
+        // value, but FindByIdAsync(999) returns null, so the capacity guard must be skipped
+        // instead of throwing a NullReferenceException on currentTable.Seats. FK enforcement
+        // (on by default for this connection) is disabled so the dangling TableId can be
+        // inserted at all.
+        AdminService svc = CreateService();
+        SeedBase(1);
+        await _db.Database.ExecuteSqlRawAsync("PRAGMA foreign_keys=OFF");
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 999, Date = DateTime.UtcNow, BookingRef = "B1", Seats = 2 });
+        await _db.SaveChangesAsync();
+
+        var req = new AdminUpdateBookingRequest { Seats = 6 };
+        BookingDetailDto? result = await svc.AdminUpdateBookingAsync(1, req);
+
+        Assert.NotNull(result);
+        Assert.Equal(6, result!.Seats);
     }
 
     [Fact]
@@ -1234,6 +1409,14 @@ public class AdminServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateRestaurantAsync_AllowsNullAddress()
+    {
+        AdminService svc = CreateService();
+        RestaurantDto r = await svc.CreateRestaurantAsync("New", null);
+        Assert.Null(r.Address);
+    }
+
+    [Fact]
     public async Task DeleteRestaurantAsync_ReturnsFalse_WhenNotFound()
     {
         AdminService svc = CreateService();
@@ -1306,6 +1489,76 @@ public class AdminServiceTests : IDisposable
         BookingDetailDto? result = await svc.GetBookingAsync(1);
         Assert.Equal(DateTimeKind.Utc, result!.Date.Kind);
         Assert.Equal(DateTimeKind.Utc, result.EndTime!.Value.Kind);
+    }
+
+    [Fact]
+    public async Task ToDetailDto_HandlesUtcKind_ForCancelledAt()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow.AddHours(-2),
+            BookingRef = "B1", IsCancelled = true, CancelledAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        BookingDetailDto? result = await svc.GetBookingAsync(1);
+
+        Assert.NotNull(result!.CancelledAt);
+        Assert.Equal(DateTimeKind.Utc, result.CancelledAt!.Value.Kind);
+    }
+
+    [Fact]
+    public async Task ToDetailDto_SpecifiesUtcKind_ForCancelledAt_WhenStoredAsUnspecified()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        DateTime unspecifiedCancelledAt = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Unspecified);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow.AddHours(-2),
+            BookingRef = "B1", IsCancelled = true, CancelledAt = unspecifiedCancelledAt,
+        });
+        await _db.SaveChangesAsync();
+
+        BookingDetailDto? result = await svc.GetBookingAsync(1);
+
+        Assert.NotNull(result!.CancelledAt);
+        Assert.Equal(DateTimeKind.Utc, result.CancelledAt!.Value.Kind);
+    }
+
+    [Fact]
+    public async Task ToDetailDto_UsesGenericFallbackNames_WhenTableAndSectionUnassigned()
+    {
+        AdminService svc = CreateService();
+        _db.Restaurants.Add(new Restaurant { Id = 1, Name = "Test", Timezone = "UTC" });
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = null, TableId = null, Date = DateTime.UtcNow, BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+
+        BookingDetailDto? result = await svc.GetBookingAsync(1);
+
+        Assert.Equal("Section", result!.SectionName);
+        Assert.Equal("Table", result.TableName);
+    }
+
+    [Fact]
+    public async Task ToDetailDto_UsesIdQualifiedFallbackNames_WhenTableAndSectionRowsAreMissing()
+    {
+        // SectionId/TableId are set but no matching row exists (e.g. removed independently of
+        // the normal delete flow) — the fallback must include the numeric id for identifiability.
+        // FK enforcement (on by default for this connection) is disabled so the dangling ids
+        // can be inserted at all.
+        AdminService svc = CreateService();
+        _db.Restaurants.Add(new Restaurant { Id = 1, Name = "Test", Timezone = "UTC" });
+        await _db.Database.ExecuteSqlRawAsync("PRAGMA foreign_keys=OFF");
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 42, TableId = 99, Date = DateTime.UtcNow, BookingRef = "B1" });
+        await _db.SaveChangesAsync();
+
+        BookingDetailDto? result = await svc.GetBookingAsync(1);
+
+        Assert.Equal("Section 42", result!.SectionName);
+        Assert.Equal("Table 99", result.TableName);
     }
 
     [Fact]

--- a/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Exceptions;
@@ -615,6 +616,179 @@ public class AvailabilityServiceTests
         AvailabilityResponseDto saturday = await svc.GetAvailabilityAsync(
             1, new DateTime(2026, 10, 10, 0, 0, 0, DateTimeKind.Utc), 2);
         Assert.Empty(saturday.Slots);
+    }
+
+    [Fact]
+    public async Task GetAvailabilityAsync_TreatsEveryDayAsOpen_WhenOpenDaysHasNoRecognizableEntries()
+    {
+        // If every OpenDays entry fails to parse, openDaysList ends up empty after the `d > 0`
+        // filter — the `openDaysList.Count > 0 && ...` guard short-circuits false in that case,
+        // so the day-of-week check is skipped entirely rather than wrongly closing every day.
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAvailabilityAsync_TreatsEveryDayAsOpen_WhenOpenDaysHasNoRecognizableEntries));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1, Name = "Test", OpenTime = "11:00", CloseTime = "13:00", Timezone = "UTC",
+            OpenDays = "notaday,alsobogus",
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 2, SectionId = 1 });
+        db.SaveChanges();
+
+        var svc = new AvailabilityService(new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+
+        AvailabilityResponseDto monday = await svc.GetAvailabilityAsync(
+            1, new DateTime(2026, 10, 12, 0, 0, 0, DateTimeKind.Utc), 2);
+        Assert.NotEmpty(monday.Slots);
+
+        AvailabilityResponseDto saturday = await svc.GetAvailabilityAsync(
+            1, new DateTime(2026, 10, 10, 0, 0, 0, DateTimeKind.Utc), 2);
+        Assert.NotEmpty(saturday.Slots);
+    }
+
+    [Theory]
+    [InlineData("tue", 2026, 10, 13)]
+    [InlineData("tues", 2026, 10, 13)]
+    [InlineData("tuesday", 2026, 10, 13)]
+    [InlineData("wed", 2026, 10, 14)]
+    [InlineData("wednesday", 2026, 10, 14)]
+    [InlineData("thu", 2026, 10, 15)]
+    [InlineData("thurs", 2026, 10, 15)]
+    [InlineData("thursday", 2026, 10, 15)]
+    [InlineData("fri", 2026, 10, 16)]
+    [InlineData("friday", 2026, 10, 16)]
+    [InlineData("sat", 2026, 10, 17)]
+    [InlineData("saturday", 2026, 10, 17)]
+    public async Task GetAvailabilityAsync_ParsesOpenDays_GivenEachAbbreviatedDayName(string abbreviation, int year, int month, int day)
+    {
+        using AppDbContext db = TestDbFactory.Create(
+            nameof(GetAvailabilityAsync_ParsesOpenDays_GivenEachAbbreviatedDayName) + "_" + abbreviation);
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1, Name = "Test", OpenTime = "11:00", CloseTime = "13:00", Timezone = "UTC",
+            OpenDays = abbreviation,
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 2, SectionId = 1 });
+        db.SaveChanges();
+
+        var svc = new AvailabilityService(new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+
+        AvailabilityResponseDto matchingDay = await svc.GetAvailabilityAsync(
+            1, new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc), 2);
+        Assert.NotEmpty(matchingDay.Slots);
+
+        // The day before is not in OpenDays, so it must report no slots.
+        AvailabilityResponseDto dayBefore = await svc.GetAvailabilityAsync(
+            1, new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc).AddDays(-1), 2);
+        Assert.Empty(dayBefore.Slots);
+    }
+
+    [Fact]
+    public async Task GetAvailabilityAsync_FallsBackTo30MinuteInterval_WhenConfiguredIntervalIsZeroOrNegative()
+    {
+        // Defends against stale/corrupt rows where BookingSlotIntervalMinutes somehow ended up
+        // 0 or negative — using it verbatim would spin the slot-generation while-loop forever.
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAvailabilityAsync_FallsBackTo30MinuteInterval_WhenConfiguredIntervalIsZeroOrNegative));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1, Name = "Test", OpenTime = "11:00", CloseTime = "12:00", Timezone = "UTC",
+            BookingSlotIntervalMinutes = -15,
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 2, SectionId = 1 });
+        db.SaveChanges();
+
+        var svc = new AvailabilityService(new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+
+        AvailabilityResponseDto result = await svc.GetAvailabilityAsync(
+            1, new DateTime(2026, 10, 10, 0, 0, 0, DateTimeKind.Utc), 2);
+
+        Assert.Equal(["11:00", "11:30"], result.Slots.Select(s => s.Time).ToList());
+    }
+
+    [Fact]
+    public async Task GetAvailabilityAsync_ReturnsNoAvailableTables_WhenRestaurantHasNoSectionsLoaded()
+    {
+        // Defensive guard: Sections defaults to an empty collection everywhere in production
+        // (repository eager-load, entity default initializer), but the null-conditional chain
+        // in the eligible-tables filter exists in case that invariant is ever violated — verify
+        // it degrades to "no tables available" instead of throwing a NullReferenceException.
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAvailabilityAsync_ReturnsNoAvailableTables_WhenRestaurantHasNoSectionsLoaded));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Test", OpenTime = "11:00", CloseTime = "12:00", Timezone = "UTC" });
+        db.SaveChanges();
+
+        var restRepoMock = new Mock<IRestaurantRepository>();
+        Restaurant restaurant = await db.Restaurants.FirstAsync();
+        restaurant.Sections = null!;
+        restRepoMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(restaurant);
+
+        var svc = new AvailabilityService(new BookingRepository(db), restRepoMock.Object, new Mock<IHoldService>().Object);
+
+        AvailabilityResponseDto result = await svc.GetAvailabilityAsync(
+            1, new DateTime(2026, 10, 10, 0, 0, 0, DateTimeKind.Utc), 2);
+
+        Assert.NotEmpty(result.Slots);
+        Assert.All(result.Slots, s => Assert.False(s.IsAvailable));
+    }
+
+    [Fact]
+    public async Task GetAvailabilityAsync_ExcludesTablesFromSectionWithNoTablesLoaded()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAvailabilityAsync_ExcludesTablesFromSectionWithNoTablesLoaded));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Test", OpenTime = "11:00", CloseTime = "12:00", Timezone = "UTC" });
+        db.Sections.Add(new Section { Id = 1, Name = "Empty", RestaurantId = 1 });
+        db.SaveChanges();
+
+        var restRepoMock = new Mock<IRestaurantRepository>();
+        Restaurant restaurant = await db.Restaurants.Include(r => r.Sections).FirstAsync();
+        restaurant.Sections.First().Tables = null!;
+        restRepoMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(restaurant);
+
+        var svc = new AvailabilityService(new BookingRepository(db), restRepoMock.Object, new Mock<IHoldService>().Object);
+
+        AvailabilityResponseDto result = await svc.GetAvailabilityAsync(
+            1, new DateTime(2026, 10, 10, 0, 0, 0, DateTimeKind.Utc), 2);
+
+        Assert.NotEmpty(result.Slots);
+        Assert.All(result.Slots, s => Assert.False(s.IsAvailable));
+    }
+
+    [Fact]
+    public async Task GetAvailabilityAsync_HonorsExplicitEndTime_OverDefaultDurationConflictWindow()
+    {
+        // Mirrors GetAvailabilityAsync_UsesRestaurantConfiguredDuration_ForConflictWindow but for
+        // the opposite branch of `b.EndTime ?? b.Date.AddMinutes(...)`: an explicit EndTime that
+        // is SHORTER than the restaurant's default duration must govern the conflict window, not
+        // the default-duration fallback.
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAvailabilityAsync_HonorsExplicitEndTime_OverDefaultDurationConflictWindow));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1, Name = "Test", OpenTime = "11:00", CloseTime = "13:00", Timezone = "UTC",
+            DefaultBookingDurationMinutes = 90,
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 2, SectionId = 1 });
+        db.SaveChanges();
+
+        // Booking has an explicit 30-minute EndTime, far shorter than the restaurant's
+        // 90-minute default — the 12:30 slot must be free since the explicit window ends there.
+        var bookingStart = new DateTime(2026, 10, 10, 12, 0, 0, DateTimeKind.Utc);
+        db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, TableId = 1, SectionId = 1, Date = bookingStart,
+            EndTime = bookingStart.AddMinutes(30), BookingRef = "B1",
+        });
+        db.SaveChanges();
+
+        var svc = new AvailabilityService(new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+
+        AvailabilityResponseDto result = await svc.GetAvailabilityAsync(1, bookingStart, 2);
+
+        TimeSlotDto slot1200 = result.Slots.First(s => s.Time == "12:00");
+        Assert.False(slot1200.IsAvailable);
+
+        TimeSlotDto slot1230 = result.Slots.First(s => s.Time == "12:30");
+        Assert.True(slot1230.IsAvailable);
     }
 
     [Fact]

--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -609,6 +609,119 @@ public class BookingServiceTests
     }
 
     [Fact]
+    public async Task CreateBookingAsync_SkipsCapacityChecks_WhenTableIdNoLongerExists()
+    {
+        // TableId/SectionId were explicitly supplied (skipping auto-assign), but the table row
+        // has since vanished (e.g. deleted between page load and submit) — GetByIdAsync returns
+        // null, so both the lower-bound and oversize capacity guards must short-circuit false
+        // rather than throwing, and the booking still lands with the caller-supplied TableId.
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_SkipsCapacityChecks_WhenTableIdNoLongerExists));
+        TestSeed.BasicRestaurant(db);
+        BookingService svc = CreateService(db);
+        var dto = new BookingDto
+        {
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 999, // does not exist
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = DateTime.UtcNow.AddDays(7)
+        };
+
+        BookingDto result = await svc.CreateBookingAsync(dto);
+
+        Assert.Equal(999, result.TableId);
+        Assert.NotEmpty(result.BookingRef!);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_FallsBackToCandidateSearch_WhenHeldTableWasBookedElsewhere()
+    {
+        // The caller's hold points at a specific table, but the DB says it's already booked
+        // (e.g. an admin recorded a walk-in on it after the hold was placed) — ResolveAutoAssignAsync
+        // must fall through past the "adopt the held table" shortcut into a fresh candidate search
+        // rather than persisting a doomed booking or throwing.
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_FallsBackToCandidateSearch_WhenHeldTableWasBookedElsewhere));
+        SeedMultiTableRestaurant(db);
+        DateTime date = DateTime.UtcNow.AddDays(13);
+
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, TableId = 2, SectionId = 1, Date = date, BookingRef = "TAKEN" });
+        db.SaveChanges();
+
+        var holdMock = new Mock<IHoldService>();
+        holdMock
+            .Setup(h => h.GetHold("hold-T2"))
+            .Returns(new HoldEntry("hold-T2", TableId: 2, SectionId: 1, RestaurantId: 1, Date: date, ExpiresAt: DateTime.UtcNow.AddMinutes(5)));
+        holdMock.Setup(h => h.IsTableHeld(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>())).Returns(false);
+        holdMock
+            .Setup(h => h.PlaceAutoHold(1, It.IsAny<IReadOnlyList<TableCandidate>>(), date, "hold-T2", It.IsAny<int>()))
+            .Returns(new AutoAssignResult("hold-fresh", DateTime.UtcNow.AddMinutes(5), 1, 1));
+        holdMock.Setup(h => h.ReleaseHold(It.IsAny<string>()));
+
+        BookingService svc = new BookingService(
+            new BookingRepository(db),
+            new TableRepository(db),
+            new SectionRepository(db),
+            new RestaurantRepository(db),
+            holdMock.Object,
+            new BookingMapper(),
+            new TableAutoAssigner(new BookingRepository(db)));
+
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = date,
+            HoldId = "hold-T2"
+        });
+
+        // The candidate search ran and assigned Table 1 (fresh hold), not the already-booked Table 2.
+        Assert.Equal(1, result.TableId);
+        holdMock.Verify(h => h.PlaceAutoHold(1, It.IsAny<IReadOnlyList<TableCandidate>>(), date, "hold-T2", It.IsAny<int>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AutoAssign_FallsBackToCandidateSearch_WhenHoldIdIsStaleOrExpired()
+    {
+        // The caller sends a HoldId, but the in-memory hold store no longer has an entry for it
+        // (it expired or was never valid) — GetHold returns null, so ResolveAutoAssignAsync must
+        // skip the "adopt held table" shortcut entirely and run the normal candidate search.
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AutoAssign_FallsBackToCandidateSearch_WhenHoldIdIsStaleOrExpired));
+        SeedMultiTableRestaurant(db);
+        DateTime date = DateTime.UtcNow.AddDays(13);
+
+        var holdMock = new Mock<IHoldService>();
+        holdMock.Setup(h => h.GetHold("stale-hold")).Returns((HoldEntry?)null);
+        holdMock.Setup(h => h.IsTableHeld(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>())).Returns(false);
+        holdMock
+            .Setup(h => h.PlaceAutoHold(1, It.IsAny<IReadOnlyList<TableCandidate>>(), date, "stale-hold", It.IsAny<int>()))
+            .Returns(new AutoAssignResult("hold-fresh", DateTime.UtcNow.AddMinutes(5), 1, 1));
+        holdMock.Setup(h => h.ReleaseHold(It.IsAny<string>()));
+
+        BookingService svc = new BookingService(
+            new BookingRepository(db),
+            new TableRepository(db),
+            new SectionRepository(db),
+            new RestaurantRepository(db),
+            holdMock.Object,
+            new BookingMapper(),
+            new TableAutoAssigner(new BookingRepository(db)));
+
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = date,
+            HoldId = "stale-hold"
+        });
+
+        Assert.Equal(1, result.TableId);
+        holdMock.Verify(h => h.PlaceAutoHold(1, It.IsAny<IReadOnlyList<TableCandidate>>(), date, "stale-hold", It.IsAny<int>()), Times.Once);
+    }
+
+    [Fact]
     public async Task CreateBookingAsync_Throws_WhenBookingInPast()
     {
         using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_Throws_WhenBookingInPast));
@@ -749,6 +862,178 @@ public class BookingServiceTests
         await svc.UpdateBookingAsync(created.Id, dto);
         Booking inDb = await db.Bookings.FirstAsync(b => b.Id == created.Id);
         Assert.Equal(date.AddMinutes(90), inDb.EndTime);
+    }
+
+    [Fact]
+    public async Task UpdateBookingAsync_SkipsCapacityCheck_WhenNoTableAssigned()
+    {
+        // booking.TableId is null (an unassigned/auto-assign-pending booking) — the ternary
+        // that resolves `table` must short-circuit to null without calling the table repository,
+        // and the capacity guard below it must be skipped entirely rather than throwing.
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateBookingAsync_SkipsCapacityCheck_WhenNoTableAssigned));
+        TestSeed.BasicRestaurant(db);
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, TableId = null, SectionId = null, Date = DateTime.UtcNow.AddHours(1), BookingRef = "B1" });
+        db.SaveChanges();
+        db.Entry((await db.Bookings.FindAsync(1))!).State = EntityState.Detached;
+
+        BookingService svc = CreateService(db);
+        var dto = new BookingDto { Id = 1, RestaurantId = 1, Date = DateTime.UtcNow.AddHours(1), Seats = 99, EndTime = null };
+
+        await svc.UpdateBookingAsync(1, dto);
+
+        Booking inDb = await db.Bookings.FirstAsync(b => b.Id == 1);
+        Assert.Equal(99, inDb.Seats);
+        Assert.NotNull(inDb.EndTime);
+    }
+
+    [Fact]
+    public async Task UpdateBookingAsync_UsesSixtyMinuteDefault_WhenRestaurantNoLongerExists()
+    {
+        // booking.RestaurantId points at a restaurant row that no longer exists (orphaned after
+        // a restaurant deletion) — GetByIdAsync returns null, so both the oversize guard and the
+        // EndTime default must fall back to the hardcoded 60-minute default instead of throwing
+        // a NullReferenceException on `restaurant.DefaultBookingDurationMinutes`.
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateBookingAsync_UsesSixtyMinuteDefault_WhenRestaurantNoLongerExists));
+        TestSeed.BasicRestaurant(db); // seeds Table 1 (4 seats) under RestaurantId 1
+        DateTime date = DateTime.UtcNow.AddHours(1);
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 999, TableId = 1, SectionId = 1, Date = date, Seats = 2, BookingRef = "B1" });
+        db.SaveChanges();
+        db.Entry((await db.Bookings.FindAsync(1))!).State = EntityState.Detached;
+
+        BookingService svc = CreateService(db);
+        var dto = new BookingDto { Id = 1, RestaurantId = 999, TableId = 1, SectionId = 1, Date = date, Seats = 2, EndTime = null };
+
+        await svc.UpdateBookingAsync(1, dto);
+
+        Booking inDb = await db.Bookings.FirstAsync(b => b.Id == 1);
+        Assert.Equal(date.AddMinutes(60), inDb.EndTime);
+    }
+
+    [Fact]
+    public async Task GetRestaurantNameAsync_ReturnsNull_WhenRestaurantNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetRestaurantNameAsync_ReturnsNull_WhenRestaurantNotFound));
+        BookingService svc = CreateService(db);
+
+        Assert.Null(await svc.GetRestaurantNameAsync(999));
+    }
+
+    [Fact]
+    public async Task GetRestaurantNameAsync_ReturnsName_WhenRestaurantFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetRestaurantNameAsync_ReturnsName_WhenRestaurantFound));
+        TestSeed.BasicRestaurant(db);
+        BookingService svc = CreateService(db);
+
+        Assert.Equal("Test Restaurant", await svc.GetRestaurantNameAsync(1));
+    }
+
+    [Fact]
+    public async Task UpdateBookingAsync_AlwaysRecomputesEndTime_EvenWhenCallerSuppliesAnAlreadyValidOne()
+    {
+        // BookingMapper.ToEntity ignores BookingDto.EndTime entirely (both as source and as a
+        // Booking.EndTime target) for updates, so `booking.EndTime` is always null immediately
+        // after mapping — the "!booking.EndTime.HasValue" guard is therefore always true and
+        // EndTime is unconditionally recomputed from the restaurant's configured duration,
+        // regardless of whatever (even a perfectly valid) EndTime the caller supplied.
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateBookingAsync_AlwaysRecomputesEndTime_EvenWhenCallerSuppliesAnAlreadyValidOne));
+        TestSeed.BasicRestaurant(db);
+        BookingService svc = CreateService(db);
+        DateTime date = DateTime.UtcNow.AddHours(1);
+        BookingDto created = await svc.CreateBookingAsync(new BookingDto { RestaurantId = 1, SectionId = 1, TableId = 1, Date = date, Seats = 2 });
+        db.Entry((await db.Bookings.FindAsync(created.Id))!).State = EntityState.Detached;
+
+        DateTime explicitValidEndTime = date.AddMinutes(45);
+        var dto = new BookingDto { Id = created.Id, RestaurantId = 1, SectionId = 1, TableId = 1, Date = date, Seats = 2, EndTime = explicitValidEndTime };
+        await svc.UpdateBookingAsync(created.Id, dto);
+
+        Booking inDb = await db.Bookings.FirstAsync(b => b.Id == created.Id);
+        // Recomputed from BasicRestaurant's default 60-minute duration, not the 45-minute value supplied.
+        Assert.Equal(date.AddMinutes(60), inDb.EndTime);
+    }
+
+    [Fact]
+    public async Task CancelBookingAsync_ReturnsFalse_WhenBookingHasNoStoredEmail()
+    {
+        // booking.CustomerEmail is null (e.g. an admin-recorded walk-in) — the `?.Trim()`
+        // null-conditional must short-circuit to null, which never string-equals a real
+        // customer-supplied email, so the lookup correctly reports "not found" instead of
+        // throwing a NullReferenceException.
+        using AppDbContext db = TestDbFactory.Create(nameof(CancelBookingAsync_ReturnsFalse_WhenBookingHasNoStoredEmail));
+        TestSeed.BasicRestaurant(db);
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, TableId = 1, SectionId = 1, Date = DateTime.UtcNow.AddHours(1), CustomerEmail = null, BookingRef = "B1" });
+        db.SaveChanges();
+
+        BookingService svc = CreateService(db);
+
+        Assert.False(await svc.CancelBookingAsync("B1", "someone@test.com"));
+    }
+
+    [Fact]
+    public async Task CancelBookingAsync_NotifiesQueue_WithRestaurantName_WhenRestaurantExists()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CancelBookingAsync_NotifiesQueue_WithRestaurantName_WhenRestaurantExists));
+        TestSeed.BasicRestaurant(db);
+        BookingService svcForCreate = CreateService(db);
+        DateTime date = DateTime.UtcNow.AddHours(1);
+        BookingDto created = await svcForCreate.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1, SectionId = 1, TableId = 1, Date = date, Seats = 2, CustomerEmail = "guest@example.com"
+        });
+
+        var notificationQueue = new Mock<INotificationQueue>();
+        BookingService svc = new BookingService(
+            new BookingRepository(db),
+            new TableRepository(db),
+            new SectionRepository(db),
+            new RestaurantRepository(db),
+            new OpenRestoApi.Infrastructure.Holds.HoldService(new UtcClock()),
+            new BookingMapper(),
+            new TableAutoAssigner(new BookingRepository(db)),
+            notificationQueue: notificationQueue.Object);
+
+        bool result = await svc.CancelBookingAsync(created.BookingRef!, "guest@example.com");
+
+        Assert.True(result);
+        notificationQueue.Verify(n => n.EnqueueBookingCancelled(It.IsAny<Booking>(), "Test Restaurant"), Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelBookingAsync_UsesEmptyRestaurantName_WhenRestaurantIsArchived()
+    {
+        // RestaurantRepository.GetByIdAsync (used here purely to name the cancellation
+        // notification) filters out archived restaurants, so a booking whose restaurant has
+        // since been archived must fall back to "" instead of the queue call throwing on a
+        // null Name. Note this is a different repository call than the one that loaded the
+        // booking itself (which still Include()s the live Restaurant row regardless of archive
+        // status), so the booking is found and cancelled normally.
+        using AppDbContext db = TestDbFactory.Create(nameof(CancelBookingAsync_UsesEmptyRestaurantName_WhenRestaurantIsArchived));
+        TestSeed.BasicRestaurant(db);
+        BookingService svcForCreate = CreateService(db);
+        DateTime date = DateTime.UtcNow.AddHours(1);
+        BookingDto created = await svcForCreate.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1, SectionId = 1, TableId = 1, Date = date, Seats = 2, CustomerEmail = "guest@example.com"
+        });
+
+        db.Restaurants.Single().IsArchived = true;
+        db.SaveChanges();
+
+        var notificationQueue = new Mock<INotificationQueue>();
+        BookingService svc = new BookingService(
+            new BookingRepository(db),
+            new TableRepository(db),
+            new SectionRepository(db),
+            new RestaurantRepository(db),
+            new OpenRestoApi.Infrastructure.Holds.HoldService(new UtcClock()),
+            new BookingMapper(),
+            new TableAutoAssigner(new BookingRepository(db)),
+            notificationQueue: notificationQueue.Object);
+
+        bool result = await svc.CancelBookingAsync(created.BookingRef!, "guest@example.com");
+
+        Assert.True(result);
+        notificationQueue.Verify(n => n.EnqueueBookingCancelled(It.IsAny<Booking>(), ""), Times.Once);
     }
 
     [Fact]

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -51,6 +51,64 @@ public class RestaurantManagementServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_HonorsCallerSuppliedOpenTimeCloseTimeOpenDaysAndTimezone()
+    {
+        // Regression test (see the comment above the mapping in CreateAsync): hours/days/
+        // timezone the client sends must be persisted, not silently reverted to the
+        // "OpenTime omitted" defaults — those defaults should only kick in when the caller
+        // truly omits the field (see CreateAsync_HandlesNestedEntities and friends, which all
+        // omit these fields and so only exercise the "use default" branch).
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_HonorsCallerSuppliedOpenTimeCloseTimeOpenDaysAndTimezone));
+        var svc = CreateService(db);
+        var dto = new RestaurantDto
+        {
+            Name = "New",
+            OpenTime = "08:00",
+            CloseTime = "20:00",
+            OpenDays = "1,3,5",
+            Timezone = "America/New_York",
+        };
+
+        RestaurantDto result = await svc.CreateAsync(dto);
+
+        Assert.Equal("08:00", result.OpenTime);
+        Assert.Equal("20:00", result.CloseTime);
+        Assert.Equal("1,3,5", result.OpenDays);
+        Assert.Equal("America/New_York", result.Timezone);
+
+        Restaurant? entity = await db.Restaurants.FindAsync(result.Id);
+        Assert.Equal("08:00", entity!.OpenTime);
+        Assert.Equal("20:00", entity.CloseTime);
+        Assert.Equal("1,3,5", entity.OpenDays);
+        Assert.Equal("America/New_York", entity.Timezone);
+    }
+
+    [Fact]
+    public async Task CreateAsync_AppliesPerDayOpenHours_FromDto()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_AppliesPerDayOpenHours_FromDto));
+        var svc = CreateService(db);
+        var dto = new RestaurantDto
+        {
+            Name = "New",
+            OpenHours =
+            [
+                new DayHoursDto { Day = 6, Open = "12:00", Close = "16:00" },
+                new DayHoursDto { Day = 7, Open = "12:00", Close = "16:00" },
+            ],
+        };
+
+        RestaurantDto result = await svc.CreateAsync(dto);
+
+        DayHoursDto saturday = result.OpenHours!.Single(h => h.Day == 6);
+        Assert.Equal("12:00", saturday.Open);
+        Assert.Equal("16:00", saturday.Close);
+
+        Restaurant? entity = await db.Restaurants.FindAsync(result.Id);
+        Assert.NotNull(entity!.OpenHoursJson);
+    }
+
+    [Fact]
     public async Task CreateAsync_AssignsSequentialSortOrder_ToBulkCreatedSections()
     {
         // Regression test (#178 review): CreateAsync previously omitted SortOrder from the
@@ -738,6 +796,21 @@ public class RestaurantManagementServiceTests
         RestaurantDto? result = await svc.GetByIdAsync(1);
         Assert.NotNull(result);
         Assert.Equal("Found", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsConfiguredWalkInDays_WhenSet()
+    {
+        // WalkInDays defaults to null on the entity — ToDto's `r.WalkInDays ?? ""` fallback is
+        // otherwise only ever exercised via the null branch across this file's other tests.
+        using AppDbContext db = TestDbFactory.Create(nameof(GetByIdAsync_ReturnsConfiguredWalkInDays_WhenSet));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "Found", Timezone = "UTC", WalkInDays = "6,7" });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.GetByIdAsync(1);
+
+        Assert.Equal("6,7", result!.WalkInDays);
     }
 
     [Fact]

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -87,7 +87,7 @@ public class AdminService(
             occupancyDates.Add(dayStart.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
         }
 
-        int maxCount = rawCounts.Count > 0 ? rawCounts.Max() : 0;
+        int maxCount = MaxOrZero(rawCounts);
         List<int> occupancyData = rawCounts
             .Select(count => maxCount > 0 ? (int)Math.Round((double)count / maxCount * 100) : 0)
             .ToList();
@@ -106,6 +106,13 @@ public class AdminService(
             TodayBookingsList = [.. todayBookingsList.OrderBy(b => b.Date)],
         };
     }
+
+    // The loop that builds rawCounts always runs exactly 7 times (i = 6..0), so it can never
+    // be empty here — the `Count > 0` guard is unreachable defensive coding for a scenario
+    // (an empty rawCounts) that this call site can't produce. Isolated into its own method so
+    // the exclusion doesn't hide coverage on GetOverviewAsync's other, genuinely-tested branches.
+    [ExcludeFromCodeCoverage(Justification = "Unreachable: the 7-iteration loop above always populates rawCounts, so Count is never 0 at this call site.")]
+    private static int MaxOrZero(List<int> counts) => counts.Count > 0 ? counts.Max() : 0;
 
     public virtual async Task<List<BookingDetailDto>> GetBookingsAsync(int? restaurantId, DateTime? bookingDate, string status, string? email = null, string? bookingRef = null)
     {

--- a/OpenRestoApi/Extensions/DatabaseExtensions.cs
+++ b/OpenRestoApi/Extensions/DatabaseExtensions.cs
@@ -56,6 +56,15 @@ public static partial class DatabaseExtensions
 
     private const string ConsolidatedMigrationId = "20260530173531_InitialCreate";
 
+    // COUNT(*) always returns exactly one row and SQLite's COUNT aggregate never yields SQL
+    // NULL, so ExecuteScalar() here can never itself return null — the `?? 0L` is unreachable
+    // ADO.NET-defensive boilerplate that no real SQLite connection can exercise. Isolated into
+    // its own method (rather than excluding the callers wholesale) so the surrounding,
+    // genuinely-tested branch logic in RemapLegacyMigrationHistory/AddColumnIfMissing keeps
+    // full coverage visibility.
+    [ExcludeFromCodeCoverage(Justification = "Unreachable: ExecuteScalar on a COUNT(*) query always returns a non-null boxed long, so the ?? 0L fallback can never run against a real SQLite connection.")]
+    private static long ExecuteScalarCount(System.Data.Common.DbCommand command) => (long)(command.ExecuteScalar() ?? 0L);
+
     private static void RemapLegacyMigrationHistory(AppDbContext db, ILogger logger)
     {
         // Only attempt this if the DB already exists (i.e. we can connect).
@@ -80,12 +89,12 @@ public static partial class DatabaseExtensions
                 // Check whether the migrations history table exists at all.
                 using var historyExistsCmd = connection.CreateCommand();
                 historyExistsCmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'";
-                var historyTableExists = (long)(historyExistsCmd.ExecuteScalar() ?? 0L) > 0;
+                var historyTableExists = ExecuteScalarCount(historyExistsCmd) > 0;
 
                 // Check whether the schema is already in place (tables exist from a previous deployment).
                 using var schemaExistsCmd = connection.CreateCommand();
                 schemaExistsCmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='AdminCredentials'";
-                var schemaExists = (long)(schemaExistsCmd.ExecuteScalar() ?? 0L) > 0;
+                var schemaExists = ExecuteScalarCount(schemaExistsCmd) > 0;
 
                 if (!schemaExists)
                 {
@@ -102,7 +111,7 @@ public static partial class DatabaseExtensions
                     p.ParameterName = "@id";
                     p.Value = ConsolidatedMigrationId;
                     checkCmd.Parameters.Add(p);
-                    initialCreateRecorded = (long)(checkCmd.ExecuteScalar() ?? 0L) > 0;
+                    initialCreateRecorded = ExecuteScalarCount(checkCmd) > 0;
                 }
 
                 if (initialCreateRecorded)
@@ -121,7 +130,7 @@ public static partial class DatabaseExtensions
                 {
                     using var countCmd = connection.CreateCommand();
                     countCmd.CommandText = "SELECT COUNT(*) FROM __EFMigrationsHistory";
-                    legacyCount = (int)(long)(countCmd.ExecuteScalar() ?? 0L);
+                    legacyCount = (int)ExecuteScalarCount(countCmd);
                 }
 
                 LogMigrationRemap(logger, legacyCount);
@@ -199,7 +208,7 @@ public static partial class DatabaseExtensions
     {
         using var checkCmd = connection.CreateCommand();
         checkCmd.CommandText = $"SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name='{column}'";
-        var exists = (long)(checkCmd.ExecuteScalar() ?? 0L) > 0;
+        var exists = ExecuteScalarCount(checkCmd) > 0;
         if (!exists)
         {
             using var alterCmd = connection.CreateCommand();


### PR DESCRIPTION
## Summary

Scheduled coverage-improvement pass targeting 5 backend files identified as having branch-coverage gaps. Adds 48 real, assertion-driven tests (no vacuous "call it for the line hit" tests) and extracts 2 genuinely unreachable branches into helper methods with `[ExcludeFromCodeCoverage]`, mirroring the existing `ThrowIfRetriesExhausted` convention in `DatabaseExtensions.cs`.

## Coverage before/after

Measured via `dotnet test openresto.sln --collect:"XPlat Code Coverage" -- ...Format=opencover`.

**Overall (backend solution):**

| Metric | Before | After |
|---|---|---|
| Tests | 1248 | 1296 (+48) |
| Line | 99.09% | 99.18% |
| Branch | 90.97% | **94.15%** |
| Method | 99.89% | 99.89% |

**Per-file branch coverage (the 5 targeted files):**

| File | Before | After |
|---|---|---|
| `AvailabilityService.cs` | 88.03% (125/142) | **100.00% (142/142)** |
| `BookingService.cs` | 85.87% (79/92) | **98.91% (91/92)** |
| `AdminService.cs` | 91.03% (142/156) | **98.05% (151/154)** |
| `RestaurantManagementService.cs` | 91.25% (73/80) | **92.50% (74/80)** |
| `DatabaseExtensions.cs` | 85.14% (63/74) | **92.19% (59/64)** |

(Branch denominators shrink slightly on two files because the excluded helper methods below remove their branches from the countable total.)

## What was added

- **AvailabilityService**: all remaining `ParseDayOfWeek` weekday abbreviations (tue/tues/tuesday, wed/wednesday, thu/thurs/thursday, fri/friday, sat/saturday), an all-invalid-`OpenDays` fallback-to-open case, a zero/negative `BookingSlotIntervalMinutes` defensive fallback, null `Sections`/`Tables` degrade-gracefully cases, and an explicit-`EndTime`-shorter-than-default-duration conflict case.
- **BookingService**: table-deleted-mid-flow capacity-check skip, auto-assign fallback when a held table gets booked elsewhere or the hold is stale, `UpdateBookingAsync` with no table assigned / orphaned restaurant, `GetRestaurantNameAsync` found case, `CancelBookingAsync` with no stored email, an archived restaurant, and the notification-queue happy path.
- **AdminService**: `ExtendBookingAsync` valid-EndTime and orphaned-restaurant fallback, `PurgeBookingAsync`/`RestoreBookingAsync` success paths, idempotent re-cancel, resolved-table-deleted capacity-check skip, null address on create, and `ToDetailDto`'s Section/Table generic vs id-qualified fallback names plus `CancelledAt` UTC-kind handling.
- **RestaurantManagementService**: `CreateAsync` now has a test proving caller-supplied `OpenTime`/`CloseTime`/`OpenDays`/`Timezone` are honored (previously **only the default-fallback branch was ever tested** — a real gap), a per-day `OpenHours` application test, and `WalkInDays` exposure via `ToDto`.
- **DatabaseExtensions**: `DiagnoseDbState` with a null/empty `dbFile`, an explicit "healthy database" `integrity_check` assertion, and a test that fires the `ApplicationStopping` WAL-checkpoint shutdown hook via `app.Lifetime.StopApplication()`.

## ExcludeFromCodeCoverage additions (with justification)

1. **`DatabaseExtensions.ExecuteScalarCount`** (new helper): `ExecuteScalar()` on a `COUNT(*)` query against SQLite always returns a non-null boxed `long` — the `?? 0L` fallback used at 5 call sites is unreachable ADO.NET boilerplate. Extracted into one small method so the exclusion doesn't hide coverage on the surrounding, genuinely-tested logic in `RemapLegacyMigrationHistory`/`AddColumnIfMissing`.
2. **`AdminService.MaxOrZero`** (new helper): the loop that builds `rawCounts` in `GetOverviewAsync` always runs exactly 7 times, so `Count > 0` can never be false at that call site.

## Known remaining gaps (investigated, not chased)

- **EF Core required-navigation `Include` → inner join**: `Booking.Restaurant` is a required FK, so `.Include(b => b.Restaurant)` compiles to an inner join — a booking can never be returned by a query with a null `Restaurant` nav. This makes a handful of `?.`/`??` fallback branches in `AdminService` (lines ~242, 302, 385) provably unreachable through any real-database test, confirmed empirically (deleting the restaurant row cascades the booking away instead of leaving it orphaned).
- **`BookingService.UpdateBookingAsync` line 264**: `BookingMapper.ToEntity` has `[MapperIgnoreTarget(EndTime)]` + `[MapperIgnoreSource(EndTime)]`, so `booking.EndTime` is always null immediately after mapping — the "already valid, don't recompute" branch of the EndTime guard is dead code. Added a pinning test (`UpdateBookingAsync_AlwaysRecomputesEndTime_EvenWhenCallerSuppliesAnAlreadyValidOne`) documenting this surprising-but-real behavior instead of forcing the unreachable branch. Pre-existing behavior, not fixed here (same spirit as the repo's existing `CheckSlotConflictIfChangedAsync` dead-code note in `AdminService`).
- **`RestaurantManagementService.cs` lines 43/69/324 and `DatabaseExtensions.cs` lines 273/280-281/293-294**: real tests were added driving both logical outcomes (verified via passing assertions), but coverlet/OpenCover appears not to record distinct branch hits for these specific shapes (simple ternaries returning a constant/array-literal, and a `PRAGMA`/`File.Exists` result that can't be forced to the "empty/exception" case without mocking ADO.NET — which would break from this codebase's established real-SQLite test convention). Documented rather than forced.

All 1296 tests pass. `dotnet build openresto.sln` — 0 errors, 8 pre-existing warnings (NuGet advisories + analyzer version notices), none introduced by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5ochLY6ujXixqTXHk6mnZ)_