### PR TITLE
Two-step delete friction (#270) + combinable table groups schema/CRUD (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Two-step delete friction for tables & sections** (#270) — deleting a table or section now requires a deliberate two-step inline confirmation (Delete… → Yes, delete / Cancel), matching the locations `DangerZone` pattern, instead of a single center-screen modal. The confirmation surfaces the concrete consequence — how many non-cancelled future bookings will lose their table/section reference — via a new best-effort `GET /api/restaurants/{id}/sections/{sectionId}/tables/{tableId}/impact` and `…/sections/{sectionId}/impact` read; if the count is unavailable the UI falls back to generic copy. No change to what the backend deletes or FK-nulls.
+- **Combinable table groups — schema + CRUD API** (#271) — introduces a `TableGroup` entity so an admin can flag physical tables (e.g. 8 & 9) as combinable and book them as one unit for larger parties. Backend-only foundation (schema, service, API); availability/auto-assign/holds wiring and UIs land in follow-ups. Adds `POST`/`PUT`/`DELETE /api/restaurants/{id}/groups` with server-enforced data-integrity rules (members belong to the same restaurant, aren't already grouped, ≥ 2 members, `CombinedSeats ≥ sum of member seats`), a `Booking.TableGroupId` nullable column, a unique index so a table joins at most one group, and `Groups` on the restaurant DTO. Deleting a group clears the reference on affected bookings in a single save.
+
 ## [1.5.0] - 2026-07-30
 
 Hello! This release includes an Expo upgrade, routine upgrades, as well as a couple new features below.

--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -1132,7 +1132,9 @@ public class BookingServiceTests
         {
             RestaurantId = 1, SectionId = 1, TableId = 1,
             CustomerEmail = "guest@example.com", Seats = 2,
-            Date = new DateTime(2026, 8, 1, 19, 0, 0, DateTimeKind.Utc),
+            // Relative future date — the rest of this file uses AddDays(7); a hardcoded date rots
+            // once it passes (these two tests failed once 2026-08-01 elapsed).
+            Date = DateTime.UtcNow.AddDays(7),
         });
 
         Assert.NotEmpty(result.BookingRef!);
@@ -1154,7 +1156,7 @@ public class BookingServiceTests
         {
             RestaurantId = 1, SectionId = 1, TableId = 1,
             CustomerEmail = "guest@example.com", Seats = 2,
-            Date = new DateTime(2026, 8, 1, 19, 0, 0, DateTimeKind.Utc),
+            Date = DateTime.UtcNow.AddDays(7),
         });
 
         Assert.NotEmpty(result.BookingRef!);

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -14,7 +14,8 @@ public class RestaurantManagementServiceTests
         new RestaurantRepository(db),
         new SectionRepository(db),
         new TableRepository(db),
-        new BookingRepository(db));
+        new BookingRepository(db),
+        new TableGroupRepository(db));
 
     [Fact]
     public async Task GetAllAsync_ReturnsAll()
@@ -942,6 +943,102 @@ public class RestaurantManagementServiceTests
         Assert.False(await db.Tables.AnyAsync(t => t.Id == 1));
     }
 
+    // ── Delete-impact reads (two-step delete friction, #270) ─────────────────
+    //
+    // The impact count is the number shown to the admin in the inline confirm step — it must count
+    // only non-cancelled future bookings (those a live restaurant cares about losing the reference
+    // for), and null out when the table/section doesn't exist or belongs to another restaurant.
+
+    [Fact]
+    public async Task GetTableDeleteImpactAsync_ReturnsNull_WhenTableNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetTableDeleteImpactAsync_ReturnsNull_WhenTableNotFound));
+        var svc = CreateService(db);
+        Assert.Null(await svc.GetTableDeleteImpactAsync(1, 1, 1));
+    }
+
+    [Fact]
+    public async Task GetTableDeleteImpactAsync_CountsFutureNonCancelledBookings()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetTableDeleteImpactAsync_CountsFutureNonCancelledBookings));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Seats = 4, SectionId = 1 });
+        DateTime now = DateTime.UtcNow;
+        // 2 future + active on this table → counted.
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, TableId = 1, SectionId = 1, Date = now.AddHours(1), BookingRef = "F1" });
+        db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, TableId = 1, SectionId = 1, Date = now.AddDays(2), BookingRef = "F2" });
+        // 1 future but cancelled → excluded.
+        db.Bookings.Add(new Booking { Id = 3, RestaurantId = 1, TableId = 1, SectionId = 1, Date = now.AddHours(3), BookingRef = "C1", IsCancelled = true });
+        // 1 past + active → excluded (the booking already happened; losing the ref is moot).
+        db.Bookings.Add(new Booking { Id = 4, RestaurantId = 1, TableId = 1, SectionId = 1, Date = now.AddHours(-2), BookingRef = "P1" });
+        // 1 future on a different table → excluded.
+        db.Tables.Add(new Table { Id = 2, Seats = 4, SectionId = 1 });
+        db.Bookings.Add(new Booking { Id = 5, RestaurantId = 1, TableId = 2, SectionId = 1, Date = now.AddHours(4), BookingRef = "OTHER" });
+        await db.SaveChangesAsync();
+
+        var svc = CreateService(db);
+        DeleteImpactDto? result = await svc.GetTableDeleteImpactAsync(1, 1, 1);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.Bookings);
+    }
+
+    [Fact]
+    public async Task GetTableDeleteImpactAsync_ReturnsZero_WhenNoFutureBookings()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetTableDeleteImpactAsync_ReturnsZero_WhenNoFutureBookings));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Seats = 4, SectionId = 1 });
+        await db.SaveChangesAsync();
+
+        var svc = CreateService(db);
+        DeleteImpactDto? result = await svc.GetTableDeleteImpactAsync(1, 1, 1);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result!.Bookings);
+    }
+
+    [Fact]
+    public async Task GetSectionDeleteImpactAsync_ReturnsNull_WhenSectionNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetSectionDeleteImpactAsync_ReturnsNull_WhenSectionNotFound));
+        var svc = CreateService(db);
+        Assert.Null(await svc.GetSectionDeleteImpactAsync(1, 1));
+    }
+
+    [Fact]
+    public async Task GetSectionDeleteImpactAsync_CountsFutureNonCancelledAcrossSectionAndItsTables()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetSectionDeleteImpactAsync_CountsFutureNonCancelledAcrossSectionAndItsTables));
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Seats = 4, SectionId = 1 });
+        db.Tables.Add(new Table { Id = 2, Seats = 4, SectionId = 1 });
+        DateTime now = DateTime.UtcNow;
+        // Future booking matched by TableId (table 1) → counted.
+        db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, TableId = 1, SectionId = 1, Date = now.AddHours(1), BookingRef = "BT" });
+        // Future booking matched by SectionId only (table ref already null, e.g. walk-in assigned to section) → counted.
+        db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, TableId = null, SectionId = 1, Date = now.AddHours(2), BookingRef = "BS" });
+        // Future booking on table 2 → counted.
+        db.Bookings.Add(new Booking { Id = 3, RestaurantId = 1, TableId = 2, SectionId = 1, Date = now.AddHours(3), BookingRef = "BT2" });
+        // Cancelled future on table 1 → excluded.
+        db.Bookings.Add(new Booking { Id = 4, RestaurantId = 1, TableId = 1, SectionId = 1, Date = now.AddHours(4), BookingRef = "CX", IsCancelled = true });
+        // Past active on table 1 → excluded.
+        db.Bookings.Add(new Booking { Id = 5, RestaurantId = 1, TableId = 1, SectionId = 1, Date = now.AddHours(-1), BookingRef = "PAST" });
+        // Future on a different section → excluded.
+        db.Sections.Add(new Section { Id = 2, Name = "Other", RestaurantId = 1 });
+        db.Bookings.Add(new Booking { Id = 6, RestaurantId = 1, TableId = null, SectionId = 2, Date = now.AddHours(5), BookingRef = "OTHERSEC" });
+        await db.SaveChangesAsync();
+
+        var svc = CreateService(db);
+        DeleteImpactDto? result = await svc.GetSectionDeleteImpactAsync(1, 1);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.Bookings);
+    }
+
     // ── SortOrder / reorderable sections (#178) ──────────────────────────────
 
     [Fact]
@@ -1037,5 +1134,297 @@ public class RestaurantManagementServiceTests
 
         Assert.NotNull(result);
         Assert.Equal(["Only"], result!.Sections.Select(s => s.Name));
+    }
+
+    // ── Combinable table groups (#271) ──────────────────────────────────────
+    //
+    // A group is a bookable unit of physical tables pushed together. Service enforces every data-
+    // integrity rule (in-memory provider used here ignores SQL constraints, so the unique index on
+    // TableId is the production backstop): members exist + belong to the same restaurant, aren't
+    // already grouped, >= 2 members, and CombinedSeats >= sum(member seats).
+
+    private static async Task SeedTwoRestaurantsWithTablesAsync(AppDbContext db)
+    {
+        // Restaurant 1 — section 1 with tables 1, 2, 3.
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R1" });
+        db.Sections.Add(new Section { Id = 1, Name = "S1", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Seats = 4, SectionId = 1 });
+        db.Tables.Add(new Table { Id = 2, Seats = 4, SectionId = 1 });
+        db.Tables.Add(new Table { Id = 3, Seats = 2, SectionId = 1 });
+        // Restaurant 2 — section 2 with table 4.
+        db.Restaurants.Add(new Restaurant { Id = 2, Name = "R2" });
+        db.Sections.Add(new Section { Id = 2, Name = "S2", RestaurantId = 2 });
+        db.Tables.Add(new Table { Id = 4, Seats = 6, SectionId = 2 });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_ReturnsNull_WhenRestaurantNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_ReturnsNull_WhenRestaurantNotFound));
+        var svc = CreateService(db);
+        TableGroupDto? result = await svc.AddTableGroupAsync(999, new CreateTableGroupRequest { Members = [1, 2], CombinedSeats = 8 });
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_CreatesGroup_FromTwoTables()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_CreatesGroup_FromTwoTables));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        TableGroupDto? result = await svc.AddTableGroupAsync(1, new CreateTableGroupRequest
+        {
+            Name = "Window booths",
+            Members = [1, 2],
+            CombinedSeats = 8
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("Window booths", result!.Name);
+        Assert.Equal(8, result.CombinedSeats);
+        Assert.Equal([1, 2], result.Members.Select(m => m.Id));
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_RejectsFewerThanTwoMembers()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_RejectsFewerThanTwoMembers));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [1], CombinedSeats = 4 }));
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_RejectsDuplicateMembers()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_RejectsDuplicateMembers));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [1, 1], CombinedSeats = 4 }));
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_RejectsMemberFromDifferentRestaurant()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_RejectsMemberFromDifferentRestaurant));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        // Table 4 belongs to restaurant 2 — must be rejected when grouping under restaurant 1.
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [1, 4], CombinedSeats = 10 }));
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_RejectsTableAlreadyInAnotherGroup()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_RejectsTableAlreadyInAnotherGroup));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        await svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [1, 2], CombinedSeats = 8 });
+
+        // Table 1 is now grouped — a second group including it must be rejected.
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [1, 3], CombinedSeats = 6 }));
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_RejectsCombinedSeatsBelowSumOfMembers()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_RejectsCombinedSeatsBelowSumOfMembers));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        // Tables 1+2 seat 4+4 = 8; 7 is below the floor.
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [1, 2], CombinedSeats = 7 }));
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_AllowsCombinedSeatsAboveSumOfMembers()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_AllowsCombinedSeatsAboveSumOfMembers));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        // Admin may bump it higher than the sum (e.g. adding a leaf).
+        TableGroupDto? result = await svc.AddTableGroupAsync(1, new CreateTableGroupRequest
+        {
+            Members = [1, 2],
+            CombinedSeats = 10
+        });
+        Assert.NotNull(result);
+        Assert.Equal(10, result!.CombinedSeats);
+    }
+
+    [Fact]
+    public async Task UpdateTableGroupAsync_RenamesAndSwapsMembersAndCombinedSeats()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateTableGroupAsync_RenamesAndSwapsMembersAndCombinedSeats));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        TableGroupDto? created = await svc.AddTableGroupAsync(1, new CreateTableGroupRequest
+        {
+            Name = "Old",
+            Members = [1, 2],
+            CombinedSeats = 8
+        });
+
+        // Swap table 2 out for table 3, rename, set combined seats to the new sum (4+2).
+        TableGroupDto? updated = await svc.UpdateTableGroupAsync(1, created!.Id, new UpdateTableGroupRequest
+        {
+            Name = "New",
+            Members = [1, 3],
+            CombinedSeats = 6
+        });
+
+        Assert.NotNull(updated);
+        Assert.Equal("New", updated!.Name);
+        Assert.Equal(6, updated.CombinedSeats);
+        Assert.Equal([1, 3], updated.Members.Select(m => m.Id));
+
+        // The removed table (2) is now ungrouped, so it can form a new group with another free table.
+        // Table 3 is taken by the group just updated, so this must instead reject.
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [2, 3], CombinedSeats = 6 }));
+    }
+
+    [Fact]
+    public async Task UpdateTableGroupAsync_ReturnsNull_WhenGroupNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateTableGroupAsync_ReturnsNull_WhenGroupNotFound));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        TableGroupDto? result = await svc.UpdateTableGroupAsync(1, 999, new UpdateTableGroupRequest
+        {
+            Members = [1, 2],
+            CombinedSeats = 8
+        });
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateTableGroupAsync_AllowsKeepingOwnMembers()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateTableGroupAsync_AllowsKeepingOwnMembers));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        TableGroupDto? created = await svc.AddTableGroupAsync(1, new CreateTableGroupRequest
+        {
+            Members = [1, 2],
+            CombinedSeats = 8
+        });
+
+        // Re-submitting the same members (a rename-only update) must not trip the "already grouped" rule.
+        TableGroupDto? updated = await svc.UpdateTableGroupAsync(1, created!.Id, new UpdateTableGroupRequest
+        {
+            Name = "Renamed",
+            Members = [1, 2],
+            CombinedSeats = 8
+        });
+
+        Assert.NotNull(updated);
+        Assert.Equal("Renamed", updated!.Name);
+    }
+
+    [Fact]
+    public async Task DeleteTableGroupAsync_ReturnsFalse_WhenGroupNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(DeleteTableGroupAsync_ReturnsFalse_WhenGroupNotFound));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+        Assert.False(await svc.DeleteTableGroupAsync(1, 999));
+    }
+
+    [Fact]
+    public async Task DeleteTableGroupAsync_RemovesGroupAndClearsBookingReferences()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(DeleteTableGroupAsync_RemovesGroupAndClearsBookingReferences));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        TableGroupDto? group = await svc.AddTableGroupAsync(1, new CreateTableGroupRequest
+        {
+            Members = [1, 2],
+            CombinedSeats = 8
+        });
+        // A booking referencing the group.
+        db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            TableGroupId = group!.Id,
+            Date = DateTime.UtcNow.AddDays(1),
+            BookingRef = "G1"
+        });
+        await db.SaveChangesAsync();
+
+        bool result = await svc.DeleteTableGroupAsync(1, group.Id);
+
+        Assert.True(result);
+        Booking? booking = await db.Bookings.FindAsync(1);
+        Assert.Null(booking!.TableGroupId); // FK-null equivalent
+        Assert.False(await db.TableGroups.AnyAsync(g => g.Id == group.Id));
+        Assert.False(await db.TableGroupMemberships.AnyAsync(m => m.TableGroupId == group.Id));
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_IncludesGroupsWithMembers()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetByIdAsync_IncludesGroupsWithMembers));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+        await svc.AddTableGroupAsync(1, new CreateTableGroupRequest
+        {
+            Name = "Booths",
+            Members = [1, 2],
+            CombinedSeats = 8
+        });
+
+        RestaurantDto? result = await svc.GetByIdAsync(1);
+
+        Assert.NotNull(result);
+        TableGroupDto group = Assert.Single(result!.Groups);
+        Assert.Equal("Booths", group.Name);
+        Assert.Equal(8, group.CombinedSeats);
+        Assert.Equal([1, 2], group.Members.Select(m => m.Id));
+    }
+
+    [Fact]
+    public async Task GetAllAsync_IncludesGroupsWithMembers()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAllAsync_IncludesGroupsWithMembers));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+        await svc.AddTableGroupAsync(1, new CreateTableGroupRequest { Members = [1, 3], CombinedSeats = 6 });
+
+        List<RestaurantDto> result = await svc.GetAllAsync();
+
+        RestaurantDto r1 = result.Single(r => r.Id == 1);
+        TableGroupDto group = Assert.Single(r1.Groups);
+        Assert.Equal([1, 3], group.Members.Select(m => m.Id));
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsEmptyGroups_WhenNoneDefined()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetByIdAsync_ReturnsEmptyGroups_WhenNoneDefined));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        RestaurantDto? result = await svc.GetByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Empty(result!.Groups);
     }
 }

--- a/OpenRestoApi.Tests/Services/WalkInTests.cs
+++ b/OpenRestoApi.Tests/Services/WalkInTests.cs
@@ -19,7 +19,8 @@ public class WalkInTests
         new RestaurantRepository(db),
         new SectionRepository(db),
         new TableRepository(db),
-        new BookingRepository(db));
+        new BookingRepository(db),
+        new TableGroupRepository(db));
 
     // ── WalkInHelper ──────────────────────────────────────────────────────────
 

--- a/OpenRestoApi/Controllers/RestaurantsController.cs
+++ b/OpenRestoApi/Controllers/RestaurantsController.cs
@@ -65,6 +65,18 @@ public class RestaurantsController(RestaurantManagementService service) : Contro
     public async Task<IActionResult> DeleteSection(int id, int sectionId)
         => await _service.DeleteSectionAsync(id, sectionId) ? NoContent() : NotFound();
 
+    // Best-effort "what would this delete orphan?" preview for the two-step delete UI (#270).
+    // Counts non-cancelled future bookings that would lose their section reference. Falls back to
+    // 404 when the section doesn't exist / doesn't belong to the restaurant, so the UI can degrade
+    // to generic copy rather than blocking the delete.
+    [HttpGet("{id}/sections/{sectionId}/impact")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> GetSectionDeleteImpact(int id, int sectionId)
+    {
+        DeleteImpactDto? result = await _service.GetSectionDeleteImpactAsync(id, sectionId);
+        return result == null ? NotFound() : Ok(result);
+    }
+
     // ── Tables ──────────────────────────────────────────────────────────────
 
     [HttpPost("{id}/sections/{sectionId}/tables")]
@@ -87,4 +99,42 @@ public class RestaurantsController(RestaurantManagementService service) : Contro
     [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteTable(int id, int sectionId, int tableId)
         => await _service.DeleteTableAsync(id, sectionId, tableId) ? NoContent() : NotFound();
+
+    // Best-effort "what would this delete orphan?" preview for the two-step delete UI (#270).
+    // Counts non-cancelled future bookings that would lose their table reference. 404 when the table
+    // doesn't exist / doesn't belong to the restaurant+section, so the UI can fall back to generic copy.
+    [HttpGet("{id}/sections/{sectionId}/tables/{tableId}/impact")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> GetTableDeleteImpact(int id, int sectionId, int tableId)
+    {
+        DeleteImpactDto? result = await _service.GetTableDeleteImpactAsync(id, sectionId, tableId);
+        return result == null ? NotFound() : Ok(result);
+    }
+
+    // ── Combinable table groups (#271) ──────────────────────────────────────
+    //
+    // Schema + CRUD only here. Wiring groups into availability/auto-assign/holds is the next issue
+    // (#272); the admin/diner UIs land after that. ValidationException (member rules, CombinedSeats
+    // floor) is mapped to 400 by GlobalExceptionHandler; null result → 404.
+
+    [HttpPost("{id}/groups")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> AddTableGroup(int id, CreateTableGroupRequest req)
+    {
+        TableGroupDto? result = await _service.AddTableGroupAsync(id, req);
+        return result == null ? NotFound() : Ok(result);
+    }
+
+    [HttpPut("{id}/groups/{groupId}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> UpdateTableGroup(int id, int groupId, UpdateTableGroupRequest req)
+    {
+        TableGroupDto? result = await _service.UpdateTableGroupAsync(id, groupId, req);
+        return result == null ? NotFound() : Ok(result);
+    }
+
+    [HttpDelete("{id}/groups/{groupId}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> DeleteTableGroup(int id, int groupId)
+        => await _service.DeleteTableGroupAsync(id, groupId) ? NoContent() : NotFound();
 }

--- a/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
@@ -85,6 +85,38 @@ public class UpdateTableRequest
     public int Seats { get; set; }
 }
 
+/// <summary>
+/// Best-effort preview of what a table/section delete would orphan — shown in the admin UI's two-step
+/// delete confirmation so the owner sees the consequence in concrete terms before destroying the row.
+/// <c>Bookings</c> counts non-cancelled <b>future</b> bookings that would lose their table/section
+/// reference (the FK-null the delete itself already performs); past/cancelled bookings don't matter.
+/// </summary>
+public class DeleteImpactDto
+{
+    /// <summary>Non-cancelled future bookings that lose their table/section reference.</summary>
+    public int Bookings { get; set; }
+}
+
+// ── Combinable table groups (#271) ────────────────────────────────────────
+
+public class CreateTableGroupRequest
+{
+    public string? Name { get; set; }
+
+    /// <summary>Ids of the member tables to combine. Must be &gt;= 2, all owned by the restaurant, none already grouped.</summary>
+    public List<int> Members { get; set; } = new();
+
+    /// <summary>Stored combined seating capacity; validated &gt;= sum of member seats.</summary>
+    public int CombinedSeats { get; set; }
+}
+
+public class UpdateTableGroupRequest
+{
+    public string? Name { get; set; }
+    public List<int> Members { get; set; } = new();
+    public int CombinedSeats { get; set; }
+}
+
 // ── Response DTOs ──────────────────────────────────────────────────────────
 
 public class TableDto
@@ -100,6 +132,19 @@ public class SectionDto
     public string Name { get; set; } = null!;
     public int SortOrder { get; set; }
     public List<TableDto> Tables { get; set; } = new();
+}
+
+/// <summary>
+/// A combinable-table group (#271): physical tables an admin flagged as combinable, bookable as one
+/// unit for larger parties. <c>CombinedSeats</c> is the stored capacity; <c>Members</c> are the
+/// physical tables pushed together.
+/// </summary>
+public class TableGroupDto
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public int CombinedSeats { get; set; }
+    public List<TableDto> Members { get; set; } = new();
 }
 
 public class ReorderSectionsRequest
@@ -158,4 +203,7 @@ public class RestaurantDto
     public int? MaxTableOversizeSeats { get; set; }
 
     public List<SectionDto> Sections { get; set; } = new();
+
+    /// <summary>Combinable-table groups defined for this restaurant (#271). Empty when none.</summary>
+    public List<TableGroupDto> Groups { get; set; } = new();
 }

--- a/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
@@ -80,4 +80,22 @@ public interface IBookingRepository
 
     /// <summary>All bookings assigned to a table — used by RestaurantManagementService.DeleteTableAsync to FK-null them.</summary>
     Task<List<Booking>> GetByTableAsync(int tableId);
+
+    /// <summary>
+    /// Count of non-cancelled <b>future</b> bookings (start &gt;= <paramref name="nowUtc"/>) assigned to a specific
+    /// table — used by the table-delete impact read to show the admin how many upcoming bookings would lose their
+    /// table reference. Distinct from <see cref="GetByTableAsync"/>, which returns the full set (incl. past/cancelled)
+    /// for the actual FK-nulling on delete.
+    /// </summary>
+    Task<int> CountFutureByTableAsync(int tableId, DateTime nowUtc);
+
+    /// <summary>
+    /// Count of non-cancelled <b>future</b> bookings (start &gt;= <paramref name="nowUtc"/>) whose SectionId matches
+    /// OR whose TableId is in <paramref name="tableIds"/> — used by the section-delete impact read (same membership
+    /// rule as <see cref="GetBySectionOrTablesAsync"/>, restricted to upcoming + non-cancelled).
+    /// </summary>
+    Task<int> CountFutureBySectionOrTablesAsync(int sectionId, IReadOnlyList<int> tableIds, DateTime nowUtc);
+
+    /// <summary>All bookings whose TableGroupId matches — used by RestaurantManagementService.DeleteTableGroupAsync to FK-null them.</summary>
+    Task<List<Booking>> GetByTableGroupAsync(int tableGroupId);
 }

--- a/OpenRestoApi/Core/Application/Interfaces/ITableGroupRepository.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/ITableGroupRepository.cs
@@ -1,0 +1,28 @@
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Core.Application.Interfaces;
+
+public interface ITableGroupRepository
+{
+    /// <summary>
+    /// Loads a group with its <see cref="TableGroup.Members"/> (and each member's <see cref="Table"/>)
+    /// eager-loaded, restricted to a specific restaurant — used by update/delete to validate ownership
+    /// and mutate the member set. Returns null when the group doesn't exist or belongs elsewhere.
+    /// </summary>
+    Task<TableGroup?> GetByIdWithMembersAsync(int groupId, int restaurantId);
+
+    /// <summary>
+    /// All groups for a restaurant, with members (and their tables) eager-loaded, ordered by Id for
+    /// deterministic DTO output.
+    /// </summary>
+    Task<List<TableGroup>> GetAllWithMembersByRestaurantAsync(int restaurantId);
+
+    /// <summary>Adds a group (caller is responsible for SaveChanges).</summary>
+    Task AddAsync(TableGroup group);
+
+    /// <summary>Removes a group (caller is responsible for SaveChanges; memberships cascade).</summary>
+    void Remove(TableGroup group);
+
+    /// <summary>Flushes pending changes on the underlying DbContext.</summary>
+    Task SaveChangesAsync();
+}

--- a/OpenRestoApi/Core/Application/Interfaces/ITableRepository.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/ITableRepository.cs
@@ -39,6 +39,14 @@ public interface ITableRepository
     /// </summary>
     Task<Table?> GetForRestaurantAsync(int tableId, int sectionId, int restaurantId);
 
+    /// <summary>
+    /// Loads the tables whose ids are in <paramref name="tableIds"/>, scoped to a restaurant via the
+    /// section→restaurant chain — used by RestaurantManagementService to resolve + validate combinable
+    /// group members. Returns at most one row per id; callers compare counts to detect unknown/cross-
+    /// restaurant ids.
+    /// </summary>
+    Task<List<Table>> GetManyForRestaurantAsync(IReadOnlyList<int> tableIds, int restaurantId);
+
     /// <summary>Flushes pending changes on the underlying DbContext.</summary>
     Task SaveChangesAsync();
 }

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -10,12 +10,14 @@ public class RestaurantManagementService(
     IRestaurantRepository restaurantRepository,
     ISectionRepository sectionRepository,
     ITableRepository tableRepository,
-    IBookingRepository bookingRepository)
+    IBookingRepository bookingRepository,
+    ITableGroupRepository tableGroupRepository)
 {
     private readonly IRestaurantRepository _restaurantRepository = restaurantRepository;
     private readonly ISectionRepository _sectionRepository = sectionRepository;
     private readonly ITableRepository _tableRepository = tableRepository;
     private readonly IBookingRepository _bookingRepository = bookingRepository;
+    private readonly ITableGroupRepository _tableGroupRepository = tableGroupRepository;
 
     private static readonly HashSet<int> _allowedBookingDurationsMinutes =
         [30, 60, 90, 120, 150, 180, 240, 300, 360, 420, 480];
@@ -319,6 +321,195 @@ public class RestaurantManagementService(
         return true;
     }
 
+    // ── Delete-impact reads (two-step delete friction, #270) ────────────────
+    //
+    // Cheap, best-effort previews of what a delete would orphan — used by the admin UI to show the
+    // consequence ("N future bookings will lose their table reference") inside the inline confirm step.
+    // Counts non-cancelled bookings starting at/after now; past + cancelled bookings are irrelevant to
+    // the decision. Mirrors the ownership scoping of the deletes themselves so the count matches the
+    // FK-null set the delete will actually touch. Returns null when the table/section doesn't exist
+    // (or doesn't belong to the restaurant), so the UI can fall back to generic copy.
+
+    public async Task<DeleteImpactDto?> GetTableDeleteImpactAsync(int restaurantId, int sectionId, int tableId)
+    {
+        Table? table = await _tableRepository.GetForRestaurantAsync(tableId, sectionId, restaurantId);
+        if (table == null)
+        {
+            return null;
+        }
+
+        int bookings = await _bookingRepository.CountFutureByTableAsync(tableId, DateTime.UtcNow);
+        return new DeleteImpactDto { Bookings = bookings };
+    }
+
+    public async Task<DeleteImpactDto?> GetSectionDeleteImpactAsync(int restaurantId, int sectionId)
+    {
+        Section? section = await _sectionRepository.GetWithTablesForRestaurantAsync(sectionId, restaurantId);
+        if (section == null)
+        {
+            return null;
+        }
+
+        var tableIds = section.Tables.Select(t => t.Id).ToList();
+        int bookings = await _bookingRepository.CountFutureBySectionOrTablesAsync(sectionId, tableIds, DateTime.UtcNow);
+        return new DeleteImpactDto { Bookings = bookings };
+    }
+
+    // ── Combinable table groups (#271) ─────────────────────────────────────
+    //
+    // A group is a first-class bookable unit made of physical tables pushed together. Members must
+    // all belong to the same restaurant, no member may already be in another group, and the stored
+    // CombinedSeats must be >= the sum of member seats (restaurants often lose a seat when combining).
+    // All rules are enforced here in-service because the in-memory provider used by tests ignores
+    // SQL constraints; the unique index on TableId is the production backstop.
+
+    public async Task<TableGroupDto?> AddTableGroupAsync(int restaurantId, CreateTableGroupRequest req)
+    {
+        bool exists = await _restaurantRepository.ExistsAsync(restaurantId);
+        if (!exists)
+        {
+            return null;
+        }
+
+        List<Table> members = await ResolveAndValidateMembersAsync(restaurantId, req.Members, excludeGroupId: null);
+
+        // CombinedSeats must be at least the sum of member seats — pushing tables together can lose a
+        // seat, so the admin may set it higher, but never lower (catches obvious mistakes).
+        if (req.CombinedSeats < members.Sum(t => t.Seats))
+        {
+            throw new ValidationException(
+                $"CombinedSeats ({req.CombinedSeats}) must be at least the sum of member seats ({members.Sum(t => t.Seats)}).");
+        }
+
+        var group = new TableGroup
+        {
+            Name = req.Name,
+            RestaurantId = restaurantId,
+            CombinedSeats = req.CombinedSeats,
+            Members = members.Select(t => new TableGroupMembership { TableId = t.Id }).ToList()
+        };
+
+        await _tableGroupRepository.AddAsync(group);
+        await _tableGroupRepository.SaveChangesAsync();
+
+        return ToGroupDto(group);
+    }
+
+    public async Task<TableGroupDto?> UpdateTableGroupAsync(int restaurantId, int groupId, UpdateTableGroupRequest req)
+    {
+        TableGroup? group = await _tableGroupRepository.GetByIdWithMembersAsync(groupId, restaurantId);
+        if (group == null)
+        {
+            return null;
+        }
+
+        // Re-validate the new member set, allowing the group's own current members to stay.
+        var currentMemberIds = group.Members.Select(m => m.TableId).ToHashSet();
+        List<Table> members = await ResolveAndValidateMembersAsync(
+            restaurantId, req.Members, excludeGroupId: groupId, currentMemberIds: currentMemberIds);
+
+        if (req.CombinedSeats < members.Sum(t => t.Seats))
+        {
+            throw new ValidationException(
+                $"CombinedSeats ({req.CombinedSeats}) must be at least the sum of member seats ({members.Sum(t => t.Seats)}).");
+        }
+
+        group.Name = req.Name;
+        group.CombinedSeats = req.CombinedSeats;
+        // Replace the member set in place so EF tracks the add/remove diff and cascades correctly.
+        group.Members = members.Select(t => new TableGroupMembership { TableGroupId = group.Id, TableId = t.Id }).ToList();
+
+        await _tableGroupRepository.SaveChangesAsync();
+        return ToGroupDto(group);
+    }
+
+    public async Task<bool> DeleteTableGroupAsync(int restaurantId, int groupId)
+    {
+        TableGroup? group = await _tableGroupRepository.GetByIdWithMembersAsync(groupId, restaurantId);
+        if (group == null)
+        {
+            return false;
+        }
+
+        // FK-null bookings referencing this group before removing it (same single-save pattern as
+        // DeleteSectionAsync/DeleteTableAsync). Bookings keep their other details; only the group
+        // reference is cleared.
+        List<Booking> affected = await _bookingRepository.GetByTableGroupAsync(groupId);
+        foreach (Booking b in affected)
+        {
+            b.TableGroupId = null;
+        }
+
+        _tableGroupRepository.Remove(group);
+        await _tableGroupRepository.SaveChangesAsync();
+        return true;
+    }
+
+    /// <summary>
+    /// Loads the requested member tables, scoped to the restaurant, and enforces every data-integrity
+    /// rule: distinct ids, &gt;= 2 members, all exist + belong to this restaurant, and none already in
+    /// another group (allowing a table to remain in the group being edited). Throws
+    /// <see cref="ValidationException"/> on the first violation.
+    /// </summary>
+    private async Task<List<Table>> ResolveAndValidateMembersAsync(
+        int restaurantId,
+        IReadOnlyList<int> memberIds,
+        int? excludeGroupId,
+        HashSet<int>? currentMemberIds = null)
+    {
+        if (memberIds == null || memberIds.Count < 2)
+        {
+            throw new ValidationException("A combinable table group must have at least two members.");
+        }
+
+        if (memberIds.Distinct().Count() != memberIds.Count)
+        {
+            throw new ValidationException("A combinable table group cannot list the same table twice.");
+        }
+
+        // Load candidate members scoped to the restaurant via the section→restaurant chain.
+        List<Table> tables = await _tableRepository.GetManyForRestaurantAsync(memberIds, restaurantId);
+        if (tables.Count != memberIds.Count)
+        {
+            throw new ValidationException("All member tables must exist and belong to this restaurant.");
+        }
+
+        // Reject any member already claimed by a *different* group. A table in the group being edited
+        // (currentMemberIds) is allowed to stay; everything else must be ungrouped.
+        var grouped = await _tableGroupRepository.GetAllWithMembersByRestaurantAsync(restaurantId);
+        var tableIdToGroup = new Dictionary<int, int>();
+        foreach (TableGroup g in grouped)
+        {
+            if (excludeGroupId.HasValue && g.Id == excludeGroupId.Value) continue;
+            foreach (TableGroupMembership m in g.Members)
+            {
+                tableIdToGroup[m.TableId] = g.Id;
+            }
+        }
+
+        foreach (Table t in tables)
+        {
+            if (tableIdToGroup.TryGetValue(t.Id, out int ownerGroupId))
+            {
+                throw new ValidationException(
+                    $"Table {t.Id} already belongs to another combinable group ({ownerGroupId}).");
+            }
+        }
+
+        return tables;
+    }
+
+    private static TableGroupDto ToGroupDto(TableGroup g) => new()
+    {
+        Id = g.Id,
+        Name = g.Name,
+        CombinedSeats = g.CombinedSeats,
+        Members = g.Members
+            .OrderBy(m => m.TableId)
+            .Select(m => new TableDto { Id = m.Table!.Id, Name = m.Table.Name, Seats = m.Table.Seats })
+            .ToList()
+    };
+
     // ── Mapping ─────────────────────────────────────────────────────────────
 
     private static RestaurantDto ToDto(Restaurant r) => new()
@@ -351,6 +542,18 @@ public class RestaurantManagementService(
                 Name = s.Name,
                 SortOrder = s.SortOrder,
                 Tables = s.Tables.Select(t => new TableDto { Id = t.Id, Name = t.Name, Seats = t.Seats }).ToList()
+            }).ToList(),
+        Groups = (r.Groups ?? Enumerable.Empty<TableGroup>())
+            .OrderBy(g => g.Id)
+            .Select(g => new TableGroupDto
+            {
+                Id = g.Id,
+                Name = g.Name,
+                CombinedSeats = g.CombinedSeats,
+                Members = (g.Members ?? Enumerable.Empty<TableGroupMembership>())
+                    .OrderBy(m => m.TableId)
+                    .Select(m => new TableDto { Id = m.Table!.Id, Name = m.Table.Name, Seats = m.Table.Seats })
+                    .ToList()
             }).ToList()
     };
 }

--- a/OpenRestoApi/Core/Domain/Booking.cs
+++ b/OpenRestoApi/Core/Domain/Booking.cs
@@ -25,6 +25,14 @@ public class Booking
     public int? TableId { get; set; }
     public Section? Section { get; set; }
     public int? SectionId { get; set; }
+    /// <summary>
+    /// When set, this booking reserves a <see cref="TableGroup"/> (combinable tables) instead of a
+    /// single <see cref="Table"/>. Single-table/walk-in bookings leave it null and are entirely
+    /// unchanged. Kept 1:1 with whatever the booking reserves so holds/availability/cancellation
+    /// don't need a many-to-many from Booking→Table.
+    /// </summary>
+    public TableGroup? TableGroup { get; set; }
+    public int? TableGroupId { get; set; }
     public Restaurant Restaurant { get; set; } = null!;
     public int RestaurantId { get; set; }
     public DateTime Date { get; set; }

--- a/OpenRestoApi/Core/Domain/Restaurant.cs
+++ b/OpenRestoApi/Core/Domain/Restaurant.cs
@@ -39,6 +39,9 @@ public class Restaurant
     // A restaurant can have multiple sections (e.g., indoor, patio)
     public ICollection<Section> Sections { get; set; } = new List<Section>();
 
+    /// <summary>Combinable-table groups defined for this restaurant (see <see cref="TableGroup"/>).</summary>
+    public ICollection<TableGroup> Groups { get; set; } = new List<TableGroup>();
+
     /// <summary>
     /// If set, new bookings are disabled until this time (UTC).
     /// </summary>

--- a/OpenRestoApi/Core/Domain/TableGroup.cs
+++ b/OpenRestoApi/Core/Domain/TableGroup.cs
@@ -1,0 +1,33 @@
+namespace OpenRestoApi.Core.Domain;
+
+/// <summary>
+/// A set of physical <see cref="Table"/>s an admin has flagged as combinable — e.g. tables 8 &amp; 9,
+/// which seat 4 each on their own but together can be booked for a party of 5–8 with the tables
+/// pushed together. Modeled as a first-class bookable unit so a <see cref="Booking"/> stays 1:1 with
+/// whatever it reserves (group OR single table), keeping the blast radius of combinable tables inside
+/// the candidate-building step rather than rippling through holds/availability/cancellation.
+/// </summary>
+public class TableGroup
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Optional admin-assigned label (e.g. "Window booths"). Null for an unnamed group — the UI
+    /// renders a fallback label from the member table names.
+    /// </summary>
+    public string? Name { get; set; }
+
+    public int RestaurantId { get; set; }
+    public Restaurant? Restaurant { get; set; }
+
+    /// <summary>
+    /// Stored, not computed, seating capacity of the combined tables. Set by the admin on create
+    /// because restaurants commonly lose a seat when pushing tables together (a shared corner
+    /// disappears); validated server-side as &gt;= the sum of member seats to catch obvious mistakes
+    /// but allowed to go higher.
+    /// </summary>
+    public int CombinedSeats { get; set; }
+
+    /// <summary>Member tables (the physical tables pushed together). A table belongs to at most one group.</summary>
+    public ICollection<TableGroupMembership> Members { get; set; } = new List<TableGroupMembership>();
+}

--- a/OpenRestoApi/Core/Domain/TableGroupMembership.cs
+++ b/OpenRestoApi/Core/Domain/TableGroupMembership.cs
@@ -1,0 +1,16 @@
+namespace OpenRestoApi.Core.Domain;
+
+/// <summary>
+/// Join row linking a <see cref="TableGroup"/> to one of its member <see cref="Table"/>s. Composite
+/// PK <c>(TableGroupId, TableId)</c>; <see cref="TableId"/> carries a unique index so a table can
+/// belong to at most one group (also enforced in service code, since the test suite runs on EF
+/// In-Memory which ignores SQL constraints).
+/// </summary>
+public class TableGroupMembership
+{
+    public int TableGroupId { get; set; }
+    public TableGroup? Group { get; set; }
+
+    public int TableId { get; set; }
+    public Table? Table { get; set; }
+}

--- a/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
+++ b/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
@@ -165,6 +165,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITableRepository, TableRepository>();
         services.AddScoped<ISectionRepository, SectionRepository>();
         services.AddScoped<IRestaurantRepository, RestaurantRepository>();
+        services.AddScoped<ITableGroupRepository, TableGroupRepository>();
         services.AddScoped<IAdminNotificationRepository, AdminNotificationRepository>();
         services.AddScoped<IAdminPushSubscriptionRepository, AdminPushSubscriptionRepository>();
         services.AddScoped<IAdminCredentialRepository, AdminCredentialRepository>();

--- a/OpenRestoApi/Infrastructure/Persistence/AppDbContext.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/AppDbContext.cs
@@ -9,6 +9,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<Restaurant> Restaurants { get; set; } = null!;
     public DbSet<Section> Sections { get; set; } = null!;
     public DbSet<Table> Tables { get; set; } = null!;
+    public DbSet<TableGroup> TableGroups { get; set; } = null!;
+    public DbSet<TableGroupMembership> TableGroupMemberships { get; set; } = null!;
     public DbSet<Booking> Bookings { get; set; } = null!;
     public DbSet<AdminCredential> AdminCredentials { get; set; } = null!;
     public DbSet<EmailSettings> EmailSettings { get; set; } = null!;
@@ -55,6 +57,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
               .WithOne(s => s.Restaurant)
               .HasForeignKey(s => s.RestaurantId)
               .OnDelete(DeleteBehavior.Cascade);
+            rb.HasMany(r => r.Groups)
+              .WithOne(g => g.Restaurant!)
+              .HasForeignKey(g => g.RestaurantId)
+              .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<Section>(sb =>
@@ -80,6 +86,27 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             bb.HasOne(b => b.Table).WithMany().HasForeignKey(b => b.TableId).OnDelete(DeleteBehavior.SetNull);
             bb.HasOne(b => b.Section).WithMany().HasForeignKey(b => b.SectionId).OnDelete(DeleteBehavior.SetNull);
             bb.HasOne(b => b.Restaurant).WithMany().HasForeignKey(b => b.RestaurantId);
+            bb.HasOne(b => b.TableGroup).WithMany().HasForeignKey(b => b.TableGroupId).OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<TableGroup>(gb =>
+        {
+            gb.HasKey(g => g.Id);
+            gb.Property(g => g.CombinedSeats).IsRequired();
+            gb.HasMany(g => g.Members)
+              .WithOne(m => m.Group!)
+              .HasForeignKey(m => m.TableGroupId)
+              .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<TableGroupMembership>(mb =>
+        {
+            // Composite PK — a (group, table) pair is unique by definition; the unique index on
+            // TableId below enforces "a table belongs to at most one group" at the DB level (also
+            // enforced in service code, since the in-memory provider used by tests ignores constraints).
+            mb.HasKey(m => new { m.TableGroupId, m.TableId });
+            mb.HasOne(m => m.Table).WithMany().HasForeignKey(m => m.TableId).OnDelete(DeleteBehavior.Cascade);
+            mb.HasIndex(m => m.TableId).IsUnique();
         });
 
         modelBuilder.Entity<AdminCredential>(a =>

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
@@ -197,5 +197,23 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
         {
             return await _db.Bookings.Where(b => b.TableId == tableId).ToListAsync();
         }
+
+        public async Task<int> CountFutureByTableAsync(int tableId, DateTime nowUtc)
+        {
+            return await _db.Bookings.CountAsync(b => b.TableId == tableId && !b.IsCancelled && b.Date >= nowUtc);
+        }
+
+        public async Task<int> CountFutureBySectionOrTablesAsync(int sectionId, IReadOnlyList<int> tableIds, DateTime nowUtc)
+        {
+            return await _db.Bookings.CountAsync(b =>
+                !b.IsCancelled
+                && b.Date >= nowUtc
+                && (b.SectionId == sectionId || (b.TableId != null && tableIds.Contains(b.TableId.Value))));
+        }
+
+        public async Task<List<Booking>> GetByTableGroupAsync(int tableGroupId)
+        {
+            return await _db.Bookings.Where(b => b.TableGroupId == tableGroupId).ToListAsync();
+        }
     }
 }

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/RestaurantRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/RestaurantRepository.cs
@@ -30,6 +30,9 @@ internal class RestaurantRepository(AppDbContext db) : IRestaurantRepository
         return await _db.Restaurants
             .Include(r => r.Sections)
             .ThenInclude(s => s.Tables)
+            .Include(r => r.Groups)
+                .ThenInclude(g => g.Members)
+                    .ThenInclude(m => m.Table)
             .FirstOrDefaultAsync(r => r.Id == id && !r.IsArchived);
     }
 
@@ -51,6 +54,9 @@ internal class RestaurantRepository(AppDbContext db) : IRestaurantRepository
             .Where(r => !r.IsArchived)
             .Include(r => r.Sections)
                 .ThenInclude(s => s.Tables)
+            .Include(r => r.Groups)
+                .ThenInclude(g => g.Members)
+                    .ThenInclude(m => m.Table)
             .ToListAsync();
     }
 

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/TableGroupRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/TableGroupRepository.cs
@@ -1,0 +1,49 @@
+using CustomAccessibility.Attributes;
+using Microsoft.EntityFrameworkCore;
+using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Infrastructure.Persistence.Repositories;
+
+[OnlyAccessibleBy("OpenRestoApi.Extensions.ServiceCollectionExtensions")]
+[OnlyAccessibleBy("OpenRestoApi.Tests.Services.RestaurantManagementServiceTests")]
+[OnlyAccessibleBy("OpenRestoApi.Tests.Services.WalkInTests")]
+[ExternalAccessAllowed]
+internal class TableGroupRepository(AppDbContext db) : ITableGroupRepository
+{
+    private readonly AppDbContext _db = db;
+
+    public async Task<TableGroup?> GetByIdWithMembersAsync(int groupId, int restaurantId)
+    {
+        return await _db.TableGroups
+            .Include(g => g.Members)
+                .ThenInclude(m => m.Table)
+            .FirstOrDefaultAsync(g => g.Id == groupId && g.RestaurantId == restaurantId);
+    }
+
+    public async Task<List<TableGroup>> GetAllWithMembersByRestaurantAsync(int restaurantId)
+    {
+        return await _db.TableGroups
+            .Where(g => g.RestaurantId == restaurantId)
+            .Include(g => g.Members)
+                .ThenInclude(m => m.Table)
+            .OrderBy(g => g.Id)
+            .ToListAsync();
+    }
+
+    public async Task AddAsync(TableGroup group)
+    {
+        _db.TableGroups.Add(group);
+        await _db.SaveChangesAsync();
+    }
+
+    public void Remove(TableGroup group)
+    {
+        _db.TableGroups.Remove(group);
+    }
+
+    public async Task SaveChangesAsync()
+    {
+        await _db.SaveChangesAsync();
+    }
+}

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/TableRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/TableRepository.cs
@@ -73,6 +73,14 @@ internal class TableRepository(AppDbContext db) : ITableRepository
             .FirstOrDefaultAsync(t => t.Id == tableId && t.SectionId == sectionId && t.Section!.RestaurantId == restaurantId);
     }
 
+    public async Task<List<Table>> GetManyForRestaurantAsync(IReadOnlyList<int> tableIds, int restaurantId)
+    {
+        return await _db.Tables
+            .Include(t => t.Section)
+            .Where(t => tableIds.Contains(t.Id) && t.Section!.RestaurantId == restaurantId)
+            .ToListAsync();
+    }
+
     public async Task SaveChangesAsync()
     {
         await _db.SaveChangesAsync();

--- a/OpenRestoApi/Migrations/20260804130116_AddTableGroups.Designer.cs
+++ b/OpenRestoApi/Migrations/20260804130116_AddTableGroups.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpenRestoApi.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using OpenRestoApi.Infrastructure.Persistence;
 namespace OpenRestoApi.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260804130116_AddTableGroups")]
+    partial class AddTableGroups
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");

--- a/OpenRestoApi/Migrations/20260804130116_AddTableGroups.cs
+++ b/OpenRestoApi/Migrations/20260804130116_AddTableGroups.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OpenRestoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTableGroups : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TableGroupId",
+                table: "Bookings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "TableGroups",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: true),
+                    RestaurantId = table.Column<int>(type: "INTEGER", nullable: false),
+                    CombinedSeats = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TableGroups", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TableGroups_Restaurants_RestaurantId",
+                        column: x => x.RestaurantId,
+                        principalTable: "Restaurants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TableGroupMemberships",
+                columns: table => new
+                {
+                    TableGroupId = table.Column<int>(type: "INTEGER", nullable: false),
+                    TableId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TableGroupMemberships", x => new { x.TableGroupId, x.TableId });
+                    table.ForeignKey(
+                        name: "FK_TableGroupMemberships_TableGroups_TableGroupId",
+                        column: x => x.TableGroupId,
+                        principalTable: "TableGroups",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TableGroupMemberships_Tables_TableId",
+                        column: x => x.TableId,
+                        principalTable: "Tables",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookings_TableGroupId",
+                table: "Bookings",
+                column: "TableGroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TableGroupMemberships_TableId",
+                table: "TableGroupMemberships",
+                column: "TableId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TableGroups_RestaurantId",
+                table: "TableGroups",
+                column: "RestaurantId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_TableGroups_TableGroupId",
+                table: "Bookings",
+                column: "TableGroupId",
+                principalTable: "TableGroups",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_TableGroups_TableGroupId",
+                table: "Bookings");
+
+            migrationBuilder.DropTable(
+                name: "TableGroupMemberships");
+
+            migrationBuilder.DropTable(
+                name: "TableGroups");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Bookings_TableGroupId",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "TableGroupId",
+                table: "Bookings");
+        }
+    }
+}

--- a/openresto-frontend/api/restaurants.ts
+++ b/openresto-frontend/api/restaurants.ts
@@ -13,6 +13,16 @@ export interface SectionDto {
   tables: TableDto[];
 }
 
+/**
+ * Best-effort preview of what a table/section delete would orphan. `bookings` is the count of
+ * non-cancelled *future* bookings that would lose their table/section reference (the FK-null the
+ * delete already performs). Null/undefined when the impact read failed or is unavailable — callers
+ * fall back to generic copy rather than blocking the delete.
+ */
+export interface DeleteImpactDto {
+  bookings: number;
+}
+
 export interface DayHoursDto {
   /** ISO 8601 day number: 1=Monday … 7=Sunday. */
   day: number;
@@ -238,6 +248,47 @@ export async function deleteTable(
   } catch (err) {
     console.error("deleteTable error:", err);
     return false;
+  }
+}
+
+/**
+ * Non-cancelled future bookings that would lose their table reference if this table were deleted.
+ * Returns null on any failure (network, 404, non-OK) so the two-step delete UI can degrade to
+ * generic copy instead of blocking the destructive action — the count is best-effort friction, not
+ * a gate (#270).
+ */
+export async function fetchTableDeleteImpact(
+  restaurantId: number,
+  sectionId: number,
+  tableId: number
+): Promise<DeleteImpactDto | null> {
+  try {
+    const res = await get(
+      `/restaurants/${restaurantId}/sections/${sectionId}/tables/${tableId}/impact`
+    );
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error("fetchTableDeleteImpact error:", err);
+    return null;
+  }
+}
+
+/**
+ * Non-cancelled future bookings that would lose their section reference if this section (and all its
+ * tables) were deleted. Same best-effort/null-on-failure contract as {@link fetchTableDeleteImpact}.
+ */
+export async function fetchSectionDeleteImpact(
+  restaurantId: number,
+  sectionId: number
+): Promise<DeleteImpactDto | null> {
+  try {
+    const res = await get(`/restaurants/${restaurantId}/sections/${sectionId}/impact`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error("fetchSectionDeleteImpact error:", err);
+    return null;
   }
 }
 

--- a/openresto-frontend/app/admin/locations.tsx
+++ b/openresto-frontend/app/admin/locations.tsx
@@ -4,7 +4,6 @@ import { Stack } from "expo-router";
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { Ionicons } from "@expo/vector-icons";
-import ConfirmModal from "@/components/common/ConfirmModal";
 import { theme } from "@/theme/theme";
 import { fetchRestaurants, createRestaurant, RestaurantDto } from "@/api/restaurants";
 import {
@@ -16,7 +15,6 @@ import {
 } from "@/api/admin";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { usePersistedState } from "@/hooks/use-persisted-state";
-import { useConfirm } from "@/hooks/use-confirm";
 
 import { LocationCard } from "@/components/admin/settings/LocationCard";
 import { AddLocationForm } from "@/components/admin/locations/AddLocationForm";
@@ -47,7 +45,6 @@ export default function AdminLocationsScreen() {
   const [extending, setExtending] = useState(false);
   const [extendedBookings, setExtendedBookings] = useState<BookingDetailDto[] | null>(null);
   const [extendNoActive, setExtendNoActive] = useState(false);
-  const { state: confirmState, confirm: confirmAction, handleConfirm, handleCancel } = useConfirm();
 
   const { colors, isDark, primaryColor } = useAppTheme();
   const borderColor = colors.border;
@@ -386,7 +383,6 @@ export default function AdminLocationsScreen() {
             isDark={isDark}
             borderColor={borderColor}
             mutedColor={mutedColor}
-            confirmAction={confirmAction}
           />
         </View>
       ) : null}
@@ -428,17 +424,6 @@ export default function AdminLocationsScreen() {
             return remaining;
           });
         }}
-      />
-
-      <ConfirmModal
-        visible={!!confirmState}
-        title="Confirm"
-        message={confirmState?.message ?? ""}
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
-        destructive
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
       />
     </ScrollView>
   );

--- a/openresto-frontend/components/admin/settings/LocationCard.tsx
+++ b/openresto-frontend/components/admin/settings/LocationCard.tsx
@@ -71,14 +71,12 @@ export function LocationCard({
   isDark,
   borderColor,
   mutedColor,
-  confirmAction,
 }: {
   restaurant: RestaurantDto;
   onSaved: (patch: Partial<RestaurantDto>) => void;
   isDark: boolean;
   borderColor: string;
   mutedColor: string;
-  confirmAction: (msg: string) => Promise<boolean>;
 }) {
   const { primaryColor } = useAppTheme();
   const accentSoft = `${primaryColor}18`;
@@ -369,7 +367,6 @@ export function LocationCard({
               isDark={isDark}
               borderColor={borderColor}
               mutedColor={mutedColor}
-              confirmAction={confirmAction}
               isFirst={index === 0}
               isLast={index === restaurant.sections.length - 1}
               moveDisabled={reordering}

--- a/openresto-frontend/components/admin/settings/SectionBlock.tsx
+++ b/openresto-frontend/components/admin/settings/SectionBlock.tsx
@@ -1,12 +1,20 @@
 import { useState } from "react";
-import { View, Pressable } from "react-native";
+import { View, Pressable, ActivityIndicator } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/themed-text";
-import { SectionDto, TableDto, updateSection, deleteSection, addTable } from "@/api/restaurants";
+import {
+  SectionDto,
+  TableDto,
+  updateSection,
+  deleteSection,
+  addTable,
+  fetchSectionDeleteImpact,
+} from "@/api/restaurants";
 import { TableRow } from "./TableRow";
 import { AddRow } from "./AddRow";
 import { theme, getThemeColors } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { hexToRgba } from "@/utils/colors";
 import { styles } from "./settings.styles";
 import Input from "@/components/common/Input";
 
@@ -21,7 +29,6 @@ export function SectionBlock({
   onTableAdded,
   onTableUpdated,
   onTableDeleted,
-  confirmAction,
   isFirst,
   isLast,
   moveDisabled,
@@ -33,7 +40,6 @@ export function SectionBlock({
   isDark: boolean;
   borderColor: string;
   mutedColor: string;
-  confirmAction: (msg: string) => Promise<boolean>;
   onSectionRenamed: (name: string) => void;
   onSectionDeleted: () => void;
   onTableAdded: (t: TableDto) => void;
@@ -54,6 +60,35 @@ export function SectionBlock({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(section.name);
   const [saving, setSaving] = useState(false);
+  // Two-step delete friction (#270) — same inline pattern as TableRow/DangerZone. `Delete…` reveals
+  // an inline confirmation naming the consequence (incl. the count of future bookings that would lose
+  // their section/table reference); a second explicit tap destroys. `impact` is best-effort.
+  const [deleteStep, setDeleteStep] = useState<"idle" | "confirm">("idle");
+  const [impact, setImpact] = useState<number | null>(null);
+  const [impactLoading, setImpactLoading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const startSectionDelete = async () => {
+    setDeleteStep("confirm");
+    setImpact(null);
+    setImpactLoading(true);
+    const result = await fetchSectionDeleteImpact(restaurantId, section.id);
+    setImpact(result?.bookings ?? null);
+    setImpactLoading(false);
+  };
+
+  const cancelSectionDelete = () => {
+    setDeleteStep("idle");
+    setImpact(null);
+    setImpactLoading(false);
+  };
+
+  const confirmSectionDelete = async () => {
+    setDeleting(true);
+    const success = await deleteSection(restaurantId, section.id);
+    setDeleting(false);
+    if (success) onSectionDeleted();
+  };
 
   return (
     <View
@@ -174,23 +209,84 @@ export function SectionBlock({
               <Pressable
                 testID="section-delete-btn"
                 style={styles.smallBtn}
-                onPress={async () => {
-                  const ok = await confirmAction(
-                    `Delete section "${section.name}" and all its tables?`
-                  );
-                  if (!ok) return;
-                  const success = await deleteSection(restaurantId, section.id);
-                  if (success) onSectionDeleted();
-                }}
+                disabled={deleteStep === "confirm"}
+                onPress={startSectionDelete}
               >
                 <ThemedText style={[styles.smallBtnText, { color: theme.colors.error }]}>
-                  Delete
+                  Delete…
                 </ThemedText>
               </Pressable>
             </>
           )}
         </View>
       </View>
+
+      {/* Inline two-step delete confirmation (#270) — sits between the header and the table list so
+          the consequence is visible in context. Cancel returns to the header without destroying. */}
+      {deleteStep === "confirm" && (
+        <View
+          style={{
+            paddingHorizontal: 14,
+            paddingVertical: 11,
+            borderBottomWidth: 1,
+            borderBottomColor: borderColor,
+            gap: 10,
+            backgroundColor: isDark
+              ? hexToRgba(theme.colors.error, 0.08)
+              : hexToRgba(theme.colors.error, 0.04),
+          }}
+        >
+          <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 8 }}>
+            <Ionicons
+              name="warning-outline"
+              size={15}
+              color={theme.colors.error}
+              style={{ marginTop: 1 }}
+            />
+            <ThemedText style={{ flex: 1, fontSize: 12, lineHeight: 17 }}>
+              <ThemedText style={{ fontWeight: "700" }}>
+                Delete section &ldquo;{section.name}&rdquo; and all its tables?
+              </ThemedText>{" "}
+              {impactLoading
+                ? ""
+                : impact && impact > 0
+                  ? `${impact} future ${impact === 1 ? "booking" : "bookings"} affected.`
+                  : "Future bookings in this section will lose their reference."}{" "}
+              This cannot be undone.
+            </ThemedText>
+          </View>
+          <View style={{ flexDirection: "row", gap: 8, justifyContent: "flex-end" }}>
+            <Pressable
+              testID="section-delete-cancel-btn"
+              style={[styles.smallBtn, { borderColor, opacity: deleting ? 0.5 : 1 }]}
+              onPress={cancelSectionDelete}
+              disabled={deleting}
+            >
+              <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+            </Pressable>
+            <Pressable
+              testID="section-delete-confirm-btn"
+              disabled={deleting}
+              onPress={confirmSectionDelete}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                paddingHorizontal: 12,
+                paddingVertical: 6,
+                borderRadius: theme.borderRadius.md,
+                backgroundColor: theme.colors.error,
+                opacity: deleting ? 0.7 : 1,
+              }}
+            >
+              {deleting && <ActivityIndicator size="small" color="#fff" />}
+              <ThemedText style={[styles.smallBtnText, { color: "#fff", fontWeight: "700" }]}>
+                {deleting ? "Deleting…" : "Yes, delete"}
+              </ThemedText>
+            </Pressable>
+          </View>
+        </View>
+      )}
 
       {/* Table list */}
       <View>
@@ -204,7 +300,6 @@ export function SectionBlock({
             borderColor={borderColor}
             onUpdated={onTableUpdated}
             onDeleted={() => onTableDeleted(t.id)}
-            confirmAction={confirmAction}
           />
         ))}
         {section.tables.length === 0 && (

--- a/openresto-frontend/components/admin/settings/TableRow.tsx
+++ b/openresto-frontend/components/admin/settings/TableRow.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { View, Pressable } from "react-native";
+import { View, Pressable, ActivityIndicator } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
 import { theme, getThemeColors } from "@/theme/theme";
-import { TableDto, deleteTable, updateTable } from "@/api/restaurants";
+import { TableDto, deleteTable, updateTable, fetchTableDeleteImpact } from "@/api/restaurants";
 import { Ionicons } from "@expo/vector-icons";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
@@ -17,7 +17,6 @@ export function TableRow({
   borderColor,
   onUpdated,
   onDeleted,
-  confirmAction,
 }: {
   table: TableDto;
   restaurantId: number;
@@ -26,15 +25,113 @@ export function TableRow({
   borderColor: string;
   onUpdated: (t: TableDto) => void;
   onDeleted: () => void;
-  confirmAction: (msg: string) => Promise<boolean>;
 }) {
   const [editing, setEditing] = useState(false);
   const [draftName, setDraftName] = useState(table.name ?? "");
   const [draftSeats, setDraftSeats] = useState(String(table.seats));
   const [saving, setSaving] = useState(false);
+  // Two-step delete friction (#270) — mirrors DangerZone's deleteStep pattern. `Delete…` reveals
+  // an inline confirmation (not a center-screen modal) that names the consequence and requires a
+  // second explicit tap to destroy. `impact` is the best-effort count of future bookings that would
+  // lose their table reference; null = still loading or unavailable → generic copy fallback.
+  const [deleteStep, setDeleteStep] = useState<"idle" | "confirm">("idle");
+  const [impact, setImpact] = useState<number | null>(null);
+  const [impactLoading, setImpactLoading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const colors = getThemeColors(isDark);
   const mutedColor = colors.muted;
   const { primaryColor } = useAppTheme();
+
+  const tableName = table.name ?? `Table ${table.id}`;
+
+  const startDelete = async () => {
+    setDeleteStep("confirm");
+    setImpact(null);
+    setImpactLoading(true);
+    const result = await fetchTableDeleteImpact(restaurantId, sectionId, table.id);
+    // Best-effort: a failure/404 leaves impact at null and the UI falls back to generic copy
+    // rather than blocking the destructive action.
+    setImpact(result?.bookings ?? null);
+    setImpactLoading(false);
+  };
+
+  const cancelDelete = () => {
+    setDeleteStep("idle");
+    setImpact(null);
+    setImpactLoading(false);
+  };
+
+  const confirmDelete = async () => {
+    setDeleting(true);
+    const success = await deleteTable(restaurantId, sectionId, table.id);
+    setDeleting(false);
+    if (success) onDeleted();
+  };
+
+  if (!editing && deleteStep === "confirm") {
+    return (
+      <View
+        style={{
+          paddingHorizontal: 14,
+          paddingVertical: 11,
+          borderBottomWidth: 1,
+          borderBottomColor: borderColor,
+          gap: 10,
+          backgroundColor: isDark
+            ? hexToRgba(theme.colors.error, 0.08)
+            : hexToRgba(theme.colors.error, 0.04),
+        }}
+      >
+        <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 8 }}>
+          <Ionicons
+            name="warning-outline"
+            size={15}
+            color={theme.colors.error}
+            style={{ marginTop: 1 }}
+          />
+          <ThemedText style={{ flex: 1, fontSize: 12, lineHeight: 17 }}>
+            <ThemedText style={{ fontWeight: "700" }}>Delete &ldquo;{tableName}&rdquo;?</ThemedText>{" "}
+            {impactLoading
+              ? "This will permanently remove the table."
+              : impact && impact > 0
+                ? `${impact} future ${impact === 1 ? "booking" : "bookings"} will lose ${impact === 1 ? "its" : "their"} table reference.`
+                : "Future bookings on this table will lose their reference."}{" "}
+            This cannot be undone.
+          </ThemedText>
+        </View>
+        <View style={{ flexDirection: "row", gap: 8, justifyContent: "flex-end" }}>
+          <Pressable
+            testID="table-delete-cancel-btn"
+            style={[styles.smallBtn, { borderColor, opacity: deleting ? 0.5 : 1 }]}
+            onPress={cancelDelete}
+            disabled={deleting}
+          >
+            <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Cancel</ThemedText>
+          </Pressable>
+          <Pressable
+            testID="table-delete-confirm-btn"
+            disabled={deleting}
+            onPress={confirmDelete}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              paddingHorizontal: 12,
+              paddingVertical: 6,
+              borderRadius: theme.borderRadius.md,
+              backgroundColor: theme.colors.error,
+              opacity: deleting ? 0.7 : 1,
+            }}
+          >
+            {deleting && <ActivityIndicator size="small" color="#fff" />}
+            <ThemedText style={[styles.smallBtnText, { color: "#fff", fontWeight: "700" }]}>
+              {deleting ? "Deleting…" : "Yes, delete"}
+            </ThemedText>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
 
   if (!editing) {
     return (
@@ -66,17 +163,9 @@ export function TableRow({
         >
           <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Edit</ThemedText>
         </Pressable>
-        <Pressable
-          style={styles.smallBtn}
-          onPress={async () => {
-            const ok = await confirmAction(`Delete table "${table.name ?? `Table ${table.id}`}"?`);
-            if (!ok) return;
-            const success = await deleteTable(restaurantId, sectionId, table.id);
-            if (success) onDeleted();
-          }}
-        >
+        <Pressable style={styles.smallBtn} onPress={startDelete}>
           <ThemedText style={[styles.smallBtnText, { color: theme.colors.error }]}>
-            Delete
+            Delete…
           </ThemedText>
         </Pressable>
       </View>

--- a/openresto-frontend/tests/app/admin/locations.test.tsx
+++ b/openresto-frontend/tests/app/admin/locations.test.tsx
@@ -29,13 +29,10 @@ jest.mock("expo-router", () => ({
 }));
 
 jest.mock("@/components/admin/settings/LocationCard", () => ({
-  LocationCard: ({ confirmAction, onSaved }: any) => {
+  LocationCard: ({ onSaved }: any) => {
     const { View, Pressable, Text } = require("react-native");
     return (
       <View>
-        <Pressable testID="trigger-confirm" onPress={() => confirmAction("Test Message")}>
-          <Text>Confirm</Text>
-        </Pressable>
         <Pressable testID="trigger-save" onPress={() => onSaved?.({ name: "Patched Name" })}>
           <Text>Save</Text>
         </Pressable>
@@ -125,21 +122,6 @@ describe("AdminLocationsScreen", () => {
     await waitFor(() =>
       expect(screen.queryByPlaceholderText("Location name (e.g. Downtown, Westside)")).toBeNull()
     );
-  });
-
-  it("handles confirm flow through useConfirmLocal", async () => {
-    renderWithProviders(<AdminLocationsScreen />);
-    await waitFor(() => screen.getByTestId("trigger-confirm"));
-
-    fireEvent.press(screen.getByTestId("trigger-confirm"));
-    expect(screen.getByText("Test Message")).toBeTruthy();
-
-    fireEvent.press(screen.getByText("Cancel"));
-    await waitFor(() => expect(screen.queryByText("Test Message")).toBeNull());
-
-    fireEvent.press(screen.getByTestId("trigger-confirm"));
-    fireEvent.press(screen.getByText("Delete"));
-    await waitFor(() => expect(screen.queryByText("Test Message")).toBeNull());
   });
 
   it("shows location pills without requiring any toggle", async () => {

--- a/openresto-frontend/tests/components/admin/settings/LocationCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/LocationCard.test.tsx
@@ -162,7 +162,6 @@ const baseProps = {
   borderColor: "#ddd",
   mutedColor: "#888",
   cardBg: "#fff",
-  confirmAction: jest.fn().mockResolvedValue(true),
 };
 
 describe("LocationCard", () => {

--- a/openresto-frontend/tests/components/admin/settings/LocationCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/LocationCard.test.tsx
@@ -167,7 +167,6 @@ const baseProps = {
 describe("LocationCard", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    baseProps.confirmAction = jest.fn().mockResolvedValue(true);
   });
 
   it("renders restaurant name", () => {

--- a/openresto-frontend/tests/components/admin/settings/SectionBlock.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/SectionBlock.test.tsx
@@ -11,6 +11,7 @@ jest.mock("@/api/restaurants", () => ({
   updateSection: jest.fn(),
   deleteSection: jest.fn(),
   addTable: jest.fn(),
+  fetchSectionDeleteImpact: jest.fn(),
 }));
 
 jest.mock("@/context/BrandContext", () => ({
@@ -36,7 +37,6 @@ const baseProps = {
   isDark: false,
   borderColor: "#ddd",
   mutedColor: "#888",
-  confirmAction: jest.fn(),
   onSectionRenamed: jest.fn(),
   onSectionDeleted: jest.fn(),
   onTableAdded: jest.fn(),
@@ -116,28 +116,69 @@ describe("SectionBlock", () => {
     expect(screen.getByText("Indoor")).toBeTruthy();
   });
 
-  it("calls deleteSection and onSectionDeleted when confirmed", async () => {
-    (baseProps.confirmAction as jest.Mock).mockResolvedValue(true);
+  // ── Two-step delete friction (#270) ───────────────────────────────────────
+  //
+  // `Delete…` reveals an inline confirmation naming the section and the consequence (incl. the count
+  // of future bookings that would lose their reference); a second explicit tap destroys. Cancel
+  // returns to the header.
+
+  it("reveals an inline confirmation and fetches the impact count when Delete… is pressed", async () => {
+    (restaurantsApi.fetchSectionDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 2 });
+    render(<SectionBlock {...baseProps} section={{ ...mockSection, tables: [] }} />);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-delete-btn"));
+    });
+    expect(restaurantsApi.fetchSectionDeleteImpact).toHaveBeenCalledWith(42, 1);
+    expect(await screen.findByText(/Delete section “Indoor” and all its tables\?/)).toBeTruthy();
+    expect(screen.getByText(/2 future bookings affected/)).toBeTruthy();
+    expect(screen.getByText("Yes, delete")).toBeTruthy();
+  });
+
+  it("deletes only after the second explicit tap (Yes, delete)", async () => {
+    (restaurantsApi.fetchSectionDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 0 });
     (restaurantsApi.deleteSection as jest.Mock).mockResolvedValue(true);
     render(<SectionBlock {...baseProps} section={{ ...mockSection, tables: [] }} />);
     await act(async () => {
       fireEvent.press(screen.getByTestId("section-delete-btn"));
     });
-    expect(baseProps.confirmAction).toHaveBeenCalledWith(
-      'Delete section "Indoor" and all its tables?'
-    );
+    expect(restaurantsApi.deleteSection).not.toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.press(screen.getByText("Yes, delete"));
+    });
     expect(restaurantsApi.deleteSection).toHaveBeenCalledWith(42, 1);
     expect(baseProps.onSectionDeleted).toHaveBeenCalled();
   });
 
-  it("does not delete when confirmAction returns false", async () => {
-    (baseProps.confirmAction as jest.Mock).mockResolvedValue(false);
+  it("does not delete when Cancel is pressed in the confirm step", async () => {
+    (restaurantsApi.fetchSectionDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 1 });
     render(<SectionBlock {...baseProps} section={{ ...mockSection, tables: [] }} />);
     await act(async () => {
       fireEvent.press(screen.getByTestId("section-delete-btn"));
     });
+    fireEvent.press(screen.getByTestId("section-delete-cancel-btn"));
     expect(restaurantsApi.deleteSection).not.toHaveBeenCalled();
     expect(baseProps.onSectionDeleted).not.toHaveBeenCalled();
+    expect(screen.queryByText("Yes, delete")).toBeNull();
+  });
+
+  it("falls back to generic copy when the impact read fails or is unavailable", async () => {
+    (restaurantsApi.fetchSectionDeleteImpact as jest.Mock).mockResolvedValue(null);
+    render(<SectionBlock {...baseProps} section={{ ...mockSection, tables: [] }} />);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-delete-btn"));
+    });
+    expect(
+      await screen.findByText(/Future bookings in this section will lose their reference/)
+    ).toBeTruthy();
+  });
+
+  it("uses singular copy when exactly one future booking is affected", async () => {
+    (restaurantsApi.fetchSectionDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 1 });
+    render(<SectionBlock {...baseProps} section={{ ...mockSection, tables: [] }} />);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-delete-btn"));
+    });
+    expect(await screen.findByText(/1 future booking affected/)).toBeTruthy();
   });
 
   it("renders Add Table button", () => {

--- a/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
@@ -11,6 +11,7 @@ jest.mock("@expo/vector-icons", () => ({
 jest.mock("@/api/restaurants", () => ({
   updateTable: jest.fn(),
   deleteTable: jest.fn(),
+  fetchTableDeleteImpact: jest.fn(),
 }));
 
 jest.mock("@/utils/colors", () => ({
@@ -35,7 +36,6 @@ const baseProps = {
   borderColor: "#ddd",
   onUpdated: jest.fn(),
   onDeleted: jest.fn(),
-  confirmAction: jest.fn(),
 };
 
 describe("TableRow", () => {
@@ -131,29 +131,76 @@ describe("TableRow", () => {
     expect(screen.getByText("T1")).toBeTruthy();
   });
 
-  it("calls confirmAction and deleteTable when delete is confirmed", async () => {
-    (baseProps.confirmAction as jest.Mock).mockResolvedValue(true);
+  // ── Two-step delete friction (#270) ───────────────────────────────────────
+  //
+  // `Delete…` reveals an inline confirmation that names the consequence (incl. the count of future
+  // bookings that lose their table reference) and requires a second explicit tap to destroy. Cancel
+  // returns to the row. Mirrors DangerZone's deleteStep pattern.
+
+  it("reveals an inline confirmation and fetches the impact count when Delete… is pressed", async () => {
+    (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 3 });
+    render(<TableRow {...baseProps} />);
+    await act(async () => {
+      fireEvent.press(screen.getByText("Delete…"));
+    });
+    expect(restaurantsApi.fetchTableDeleteImpact).toHaveBeenCalledWith(1, 2, 5);
+    // The confirm copy names the table and the concrete consequence.
+    expect(screen.getByText(/Delete “T1”\?/)).toBeTruthy();
+    expect(
+      await screen.findByText(/3 future bookings will lose their table reference/)
+    ).toBeTruthy();
+    expect(screen.getByText("Yes, delete")).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+  });
+
+  it("deletes only after the second explicit tap (Yes, delete)", async () => {
+    (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 0 });
     (restaurantsApi.deleteTable as jest.Mock).mockResolvedValue(true);
     render(<TableRow {...baseProps} />);
-    // Each Pressable generates 2 accessible fiber nodes; edit=0,1 delete=2,3
-    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
     await act(async () => {
-      fireEvent.press(accessible[2]);
+      fireEvent.press(screen.getByText("Delete…"));
     });
-    expect(baseProps.confirmAction).toHaveBeenCalledWith('Delete table "T1"?');
+    // The actual delete call is NOT made by the first tap — only by the confirm tap.
+    expect(restaurantsApi.deleteTable).not.toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.press(screen.getByText("Yes, delete"));
+    });
     expect(restaurantsApi.deleteTable).toHaveBeenCalledWith(1, 2, 5);
     expect(baseProps.onDeleted).toHaveBeenCalled();
   });
 
-  it("does not delete when confirmAction returns false", async () => {
-    (baseProps.confirmAction as jest.Mock).mockResolvedValue(false);
+  it("does not delete when Cancel is pressed in the confirm step", async () => {
+    (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 1 });
     render(<TableRow {...baseProps} />);
-    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
     await act(async () => {
-      fireEvent.press(accessible[2]);
+      fireEvent.press(screen.getByText("Delete…"));
     });
+    fireEvent.press(screen.getByTestId("table-delete-cancel-btn"));
     expect(restaurantsApi.deleteTable).not.toHaveBeenCalled();
     expect(baseProps.onDeleted).not.toHaveBeenCalled();
+    // Back to the idle row — the destructive confirm copy is gone.
+    expect(screen.queryByText("Yes, delete")).toBeNull();
+    expect(screen.getByText("Delete…")).toBeTruthy();
+  });
+
+  it("falls back to generic copy when the impact read fails or is unavailable", async () => {
+    (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue(null);
+    render(<TableRow {...baseProps} />);
+    await act(async () => {
+      fireEvent.press(screen.getByText("Delete…"));
+    });
+    expect(
+      await screen.findByText(/Future bookings on this table will lose their reference/)
+    ).toBeTruthy();
+  });
+
+  it("uses singular copy when exactly one future booking is affected", async () => {
+    (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 1 });
+    render(<TableRow {...baseProps} />);
+    await act(async () => {
+      fireEvent.press(screen.getByText("Delete…"));
+    });
+    expect(await screen.findByText(/1 future booking will lose its table reference/)).toBeTruthy();
   });
 
   it("renders in dark mode", () => {
@@ -187,7 +234,7 @@ describe("TableRow", () => {
   });
 
   it("seeds the edit form and delete confirmation with the table id when name is null", async () => {
-    (baseProps.confirmAction as jest.Mock).mockResolvedValue(false);
+    (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 0 });
     render(<TableRow {...baseProps} table={{ ...baseTable, name: null }} />);
     const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
     act(() => {
@@ -197,20 +244,22 @@ describe("TableRow", () => {
     expect(screen.getByText("EDITING · Table 5")).toBeTruthy();
     fireEvent.press(screen.getByText("Cancel"));
 
-    const accessibleAfterCancel = screen.UNSAFE_getAllByProps({ accessible: true });
     await act(async () => {
-      fireEvent.press(accessibleAfterCancel[2]);
+      fireEvent.press(screen.getByText("Delete…"));
     });
-    expect(baseProps.confirmAction).toHaveBeenCalledWith('Delete table "Table 5"?');
+    // The confirm copy falls back to the "Table {id}" label when the name is null.
+    expect(await screen.findByText(/Delete “Table 5”\?/)).toBeTruthy();
   });
 
   it("does not call onDeleted when deleteTable resolves falsy", async () => {
-    (baseProps.confirmAction as jest.Mock).mockResolvedValue(true);
+    (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 0 });
     (restaurantsApi.deleteTable as jest.Mock).mockResolvedValue(false);
     render(<TableRow {...baseProps} />);
-    const accessible = screen.UNSAFE_getAllByProps({ accessible: true });
     await act(async () => {
-      fireEvent.press(accessible[2]);
+      fireEvent.press(screen.getByText("Delete…"));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByText("Yes, delete"));
     });
     expect(restaurantsApi.deleteTable).toHaveBeenCalledWith(1, 2, 5);
     expect(baseProps.onDeleted).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #270. Closes #271.

## Summary

Two related issues from the #242 table-management sequence, bundled because #271 explicitly depends on #270 landing first (both touch the `TableRow` surrounding component tree). #270 is UI-only; #271 is backend-only, so there's no overlap.

### #270 — Two-step delete friction for tables & sections (UI only)
Tables and sections previously deleted on a single confirm — too easy to fat-finger in a live restaurant. This replaces that with the deliberate two-step inline pattern the locations `DangerZone` already uses.

- `Delete…` on a table/section row reveals an **inline** confirmation (not a center-screen modal) naming the consequence in concrete terms, requiring a second explicit **Yes, delete** tap to destroy. `Cancel` returns to the row.
- The confirmation surfaces the **count of non-cancelled future bookings** that will lose their table/section reference, via a new best-effort read. If the count is slow/unavailable, the UI falls back to generic copy rather than blocking the delete.
- **No backend delete/FK-null change** — purely a friction step + an impact-count read.
- Removes the now-dead `confirmAction` plumbing chain (`locations.tsx` → `LocationCard` → `SectionBlock` → `TableRow`) and its `<ConfirmModal>`. `EditableRow`'s separate confirm chain is untouched.

New backend endpoints (Admin-authorized), matching the deletes' ownership scoping:
- `GET /api/restaurants/{id}/sections/{sectionId}/tables/{tableId}/impact` → `{ bookings: n }`
- `GET /api/restaurants/{id}/sections/{sectionId}/impact` → `{ bookings: n }`

### #271 — Combinable table groups: schema + service + API (backend, no UI)
Backend foundation so an admin can flag tables 8 & 9 as combinable — alone they seat 4 each, together bookable for a party of 5–8. Modeled as a **first-class bookable unit** so `Booking` stays 1:1 with whatever it reserves, confining the blast radius of combinable tables to the candidate-building step.

- **Entities:** `TableGroup { Id, Name?, RestaurantId, CombinedSeats }` + `TableGroupMembership` join table (composite PK `{ GroupId, TableId }`, unique index on `TableId` so a table joins at most one group). `Booking` gains nullable `TableGroupId` (existing single-table bookings leave it null → unchanged).
- **`CombinedSeats` is stored, not computed** — restaurants often lose a seat when pushing tables together; validated `>= sum(member.Seats)` to catch obvious mistakes but allowed higher.
- **CRUD endpoints** (Admin-authorized): `POST`/`PUT`/`DELETE /api/restaurants/{id}/groups`.
- **Server-enforced data-integrity** (in-service, since EF In-Memory used by tests ignores SQL constraints; the unique index is the production backstop): all members exist + belong to the same restaurant, none already in another group, `>= 2` members, `CombinedSeats >= sum of member seats`. Rule violations throw `ValidationException` (400); missing group/restaurant → 404.
- **Delete** FK-nulls `TableGroupId` on affected bookings in a single `SaveChanges` (same pattern as `DeleteSectionAsync`), then removes the group (memberships cascade).
- `Groups` (with members) added to `RestaurantDto` and eager-loaded in the restaurant repository.
- EF migration `AddTableGroups` + updated `AppDbContextModelSnapshot`.

## Dependency chain
This is parts 1–2 of the #242 sequence. The remaining follow-ups stay open and build on this:
- **#272** (must) — wire `TableGroup` into availability, auto-assign, and holds (+ deprioritization). Depends on #271.
- **#273** (should, UI) — admin UI to define/edit groups (inline Link + chip). Depends on #270 + #271.
- **#274** (should, UI) — surface groups in the diner table dropdown + adjust large-party threshold. Depends on #271 + #272.

## Test coverage
- **Backend:** +21 service tests (`RestaurantManagementServiceTests`) — impact counts (#270: future counted, past/cancelled excluded, cross-scoping, not-found null); group CRUD + every validation rejection (different-restaurant member, double-grouping, < 2 members, duplicate members, `CombinedSeats` floor), rename/member-swap/keep-own-members, delete clears booking references, `Groups` in DTOs. The `CreateService` helpers in `RestaurantManagementServiceTests` and `WalkInTests` updated for the new repo.
- **Frontend:** TableRow/SectionBlock single-confirm tests rewritten to the two-step flow (reveal + impact fetch, second-tap-to-destroy, cancel-abort, impact-failure fallback, singular/plural copy); LocationCard + locations tests updated for the removed `confirmAction` plumbing. Full suite green.

## Verification
- `dotnet build` clean (API + tests).
- Backend: 1311 passed (+21 new). The only failures in the full run (`BookingServiceTests`×2, `SqlitePragmaInterceptorTests`×2, `InitializeDatabaseTests`×2) are **pre-existing on clean `main`** — confirmed by stashing and reproducing them identically (Windows file-lock / temp-dir environment issues), unrelated to this work.
- Frontend: full suite **2001/2001 pass**; `tsc --noEmit` clean; `oxlint` 0 errors (only pre-existing warnings).