### PR TITLE
Redesign table/section settings UI for consistency

### DIFF
--- a/openresto-frontend/components/admin/settings/AddRow.tsx
+++ b/openresto-frontend/components/admin/settings/AddRow.tsx
@@ -25,21 +25,34 @@ export function AddRow({
 
   const { primaryColor } = useAppTheme();
 
+  // Collapsed — a self-sized filled-primary pill, aligned right (matches the Add CTA pattern in
+  // HighlightsCard: `alignSelf: flex-start` there is left; here we right-align per the settings
+  // table/section layout). Keeps the verbatim label so callers' tests keep resolving it.
   if (!open) {
     return (
       <Pressable
-        style={[
-          styles.addBtn,
-          { backgroundColor: "transparent", borderWidth: 1, borderColor: primaryColor },
-        ]}
+        style={{
+          backgroundColor: primaryColor,
+          borderRadius: 10,
+          paddingHorizontal: 14,
+          paddingVertical: 8,
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 6,
+          alignSelf: "flex-end",
+        }}
         onPress={() => setOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel={label}
       >
-        <Ionicons name="add-circle-outline" size={16} color={primaryColor} />
-        <ThemedText style={[styles.addBtnText, { color: primaryColor }]}>{label}</ThemedText>
+        <Ionicons name="add" size={16} color="#fff" />
+        <ThemedText style={{ fontSize: 13, fontWeight: "600", color: "#fff" }}>{label}</ThemedText>
       </Pressable>
     );
   }
 
+  // Expanded — inputs + a right-aligned footer: filled-primary text Add and a bordered close (X)
+  // icon so the dismiss affordance is consistent with the rest of the row actions.
   return (
     <View style={styles.addForm}>
       <View style={{ flexDirection: "row", gap: 12 }}>
@@ -62,7 +75,9 @@ export function AddRow({
           </View>
         )}
       </View>
-      <View style={styles.rowActions}>
+      <View
+        style={{ flexDirection: "row", gap: 8, justifyContent: "flex-end", alignItems: "center" }}
+      >
         <Pressable
           onPress={async () => {
             if (!name.trim()) return;
@@ -74,21 +89,29 @@ export function AddRow({
             setOpen(false);
           }}
           disabled={saving || !name.trim()}
-          style={[styles.actionBtn, { backgroundColor: primaryColor }]}
+          style={[styles.actionBtn, { backgroundColor: primaryColor, opacity: saving ? 0.6 : 1 }]}
         >
           <ThemedText style={[styles.actionBtnText, { color: "#fff" }]}>
             {saving ? "Adding…" : "Add"}
           </ThemedText>
         </Pressable>
         <Pressable
-          style={styles.smallBtn}
+          style={{
+            padding: 6,
+            borderRadius: 8,
+            borderWidth: 1,
+            borderColor: theme.colors.border.light,
+          }}
           onPress={() => {
             setOpen(false);
             setName("");
             setExtra("");
           }}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel add"
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
         >
-          <Ionicons name="close-outline" size={20} color={theme.colors.muted.light} />
+          <Ionicons name="close" size={16} color={theme.colors.muted.light} />
         </Pressable>
       </View>
     </View>

--- a/openresto-frontend/components/admin/settings/RowIconButton.tsx
+++ b/openresto-frontend/components/admin/settings/RowIconButton.tsx
@@ -1,0 +1,52 @@
+import { type ComponentProps } from "react";
+import { Pressable, type ViewStyle, type StyleProp } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+export interface RowIconButtonProps {
+  /** Ionicons glyph name. */
+  name: ComponentProps<typeof Ionicons>["name"];
+  onPress?: () => void;
+  color: string;
+  testID?: string;
+  accessibilityLabel: string;
+  accessibilityHint?: string;
+  disabled?: boolean;
+  /** Optional size override; defaults to 16 (the row-action icon convention). */
+  size?: number;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Shared presentational icon button for the table/section settings cards. Wraps a bare
+ * `<Ionicons>` in a consistent tappable target (`padding: 6`, rounded, generous `hitSlop`)
+ * so every row-level action — edit, delete, combine, move — shares identical chrome.
+ * Matches the inline `<Pressable style={{ padding: 6 }}>` pattern used by SocialLinkRow /
+ * HighlightsCard, but de-duplicated so all three settings components stay in lockstep.
+ */
+export function RowIconButton({
+  name,
+  onPress,
+  color,
+  testID,
+  accessibilityLabel,
+  accessibilityHint,
+  disabled = false,
+  size = 16,
+  style,
+}: RowIconButtonProps) {
+  return (
+    <Pressable
+      testID={testID}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled }}
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      style={[{ padding: 6, borderRadius: 8, opacity: disabled ? 0.5 : 1 }, style]}
+    >
+      <Ionicons name={name} size={size} color={color} />
+    </Pressable>
+  );
+}

--- a/openresto-frontend/components/admin/settings/SectionBlock.tsx
+++ b/openresto-frontend/components/admin/settings/SectionBlock.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/api/restaurants";
 import { TableRow, TableRowGroupContext } from "./TableRow";
 import { AddRow } from "./AddRow";
+import { RowIconButton } from "./RowIconButton";
 import { theme, getThemeColors } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
@@ -226,7 +227,9 @@ export function SectionBlock({
         },
       ]}
     >
-      {/* Section header — surface background with border-bottom */}
+      {/* Section header — surface background with border-bottom. Name + count subtitle on the
+          left, a tidy cluster of icon actions on the right (consistent with the table tiles and
+          the rest of the settings cards). Editing state swaps to a name Input + text Save/Cancel. */}
       <View
         style={{
           flexDirection: "row",
@@ -239,8 +242,8 @@ export function SectionBlock({
           borderBottomColor: borderColor,
         }}
       >
-        {/* Left: name / edit input */}
-        <View style={{ flex: 1 }}>
+        {/* Left: name / edit input + count subtitle */}
+        <View style={{ flex: 1, gap: 2 }}>
           {editing ? (
             <Input
               value={draft}
@@ -249,20 +252,20 @@ export function SectionBlock({
               autoFocus
             />
           ) : (
-            <ThemedText style={styles.editableValue}>{section.name}</ThemedText>
+            <>
+              <ThemedText style={styles.editableValue}>{section.name}</ThemedText>
+              <ThemedText style={{ fontSize: 12, color: mutedColor }}>
+                {section.tables.length} tables · {totalSeats} seats
+                {sectionGroups.length > 0
+                  ? ` · ${sectionGroups.length} combinable group${sectionGroups.length > 1 ? "s" : ""}`
+                  : ""}
+              </ThemedText>
+            </>
           )}
         </View>
 
-        {/* Right: tables count + edit/save/delete actions */}
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-          {!editing && (
-            <ThemedText style={{ fontSize: 12, color: mutedColor }}>
-              {section.tables.length} tables · {totalSeats} seats
-              {sectionGroups.length > 0
-                ? ` · ${sectionGroups.length} combinable group${sectionGroups.length > 1 ? "s" : ""}`
-                : ""}
-            </ThemedText>
-          )}
+        {/* Right: edit/save/delete actions */}
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
           {editing ? (
             <>
               <Pressable
@@ -289,58 +292,46 @@ export function SectionBlock({
             </>
           ) : (
             <>
-              <Pressable
+              <RowIconButton
                 testID="section-move-up-btn"
-                accessibilityLabel={`Move ${section.name} section up`}
-                accessibilityHint="Moves this section earlier in the display order"
-                style={{ padding: 6 }}
+                name="arrow-up-outline"
+                color={isFirst ? mutedColor : primaryColor}
                 disabled={isFirst || moveDisabled}
                 onPress={() => {
                   if (!isFirst) onMoveUp();
                 }}
-              >
-                <Ionicons
-                  name="arrow-up-outline"
-                  size={16}
-                  color={isFirst ? mutedColor : primaryColor}
-                />
-              </Pressable>
-              <Pressable
+                accessibilityLabel={`Move ${section.name} section up`}
+                accessibilityHint="Moves this section earlier in the display order"
+              />
+              <RowIconButton
                 testID="section-move-down-btn"
-                accessibilityLabel={`Move ${section.name} section down`}
-                accessibilityHint="Moves this section later in the display order"
-                style={{ padding: 6 }}
+                name="arrow-down-outline"
+                color={isLast ? mutedColor : primaryColor}
                 disabled={isLast || moveDisabled}
                 onPress={() => {
                   if (!isLast) onMoveDown();
                 }}
-              >
-                <Ionicons
-                  name="arrow-down-outline"
-                  size={16}
-                  color={isLast ? mutedColor : primaryColor}
-                />
-              </Pressable>
-              <Pressable
+                accessibilityLabel={`Move ${section.name} section down`}
+                accessibilityHint="Moves this section later in the display order"
+              />
+              <RowIconButton
                 testID="section-edit-btn"
-                style={styles.smallBtn}
+                name="pencil-outline"
+                color={primaryColor}
                 onPress={() => {
                   setDraft(section.name);
                   setEditing(true);
                 }}
-              >
-                <ThemedText style={[styles.smallBtnText, { color: primaryColor }]}>Edit</ThemedText>
-              </Pressable>
-              <Pressable
+                accessibilityLabel={`Rename ${section.name} section`}
+              />
+              <RowIconButton
                 testID="section-delete-btn"
-                style={styles.smallBtn}
+                name="trash-outline"
+                color={theme.colors.error}
                 disabled={deleteStep === "confirm"}
                 onPress={startSectionDelete}
-              >
-                <ThemedText style={[styles.smallBtnText, { color: theme.colors.error }]}>
-                  Delete…
-                </ThemedText>
-              </Pressable>
+                accessibilityLabel={`Delete ${section.name} section`}
+              />
             </>
           )}
         </View>
@@ -505,8 +496,9 @@ export function SectionBlock({
           );
         })()}
 
-      {/* Table list */}
-      <View>
+      {/* Table list — tiles with breathing room (rows are now rounded surface tiles, not
+          divider-separated). */}
+      <View style={{ padding: 12, gap: 8 }}>
         {section.tables.map((t) => (
           <TableRow
             key={t.id}
@@ -527,24 +519,50 @@ export function SectionBlock({
           />
         ))}
         {section.tables.length === 0 && (
-          <ThemedText style={[styles.emptyNote, { color: mutedColor, padding: 12 }]}>
-            No tables yet.
-          </ThemedText>
+          <View
+            style={{
+              padding: 20,
+              alignItems: "center",
+              gap: 6,
+              borderWidth: 1,
+              borderColor,
+              borderRadius: 10,
+              borderStyle: "dashed" as const,
+            }}
+          >
+            <Ionicons name="grid-outline" size={22} color={mutedColor} />
+            <ThemedText style={{ fontSize: 13, color: mutedColor }}>No tables yet.</ThemedText>
+          </View>
         )}
       </View>
 
-      {/* Per-group combined-seats edit trigger (#273) — a small affordance under each group's rows.
-          Rendered after the table list so it doesn't interfere with row mapping. */}
+      {/* Per-group combined-seats edit trigger (#273) — a compact bordered chip under each group. */}
       {sectionGroups.map((g) => (
         <Pressable
           key={`group-edit-${g.id}`}
           testID={`group-edit-btn-${g.id}`}
-          style={{ paddingHorizontal: 14, paddingVertical: 6 }}
+          accessibilityRole="button"
+          accessibilityLabel={`Edit ${groupLabel(g)} combined seats`}
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 6,
+            alignSelf: "flex-start",
+            marginHorizontal: 12,
+            marginBottom: 8,
+            paddingHorizontal: 10,
+            paddingVertical: 6,
+            borderRadius: theme.borderRadius.md,
+            borderWidth: 1,
+            borderColor: hexToRgba(primaryColor, 0.4),
+            backgroundColor: hexToRgba(primaryColor, 0.06),
+          }}
           onPress={() => {
             setEditingGroupId(g.id);
             setDraftCombinedSeats(String(g.combinedSeats));
           }}
         >
+          <Ionicons name="create-outline" size={13} color={primaryColor} />
           <ThemedText style={{ fontSize: 11, color: primaryColor, fontWeight: "600" }}>
             Edit &ldquo;{groupLabel(g)}&rdquo; combined seats
           </ThemedText>
@@ -552,7 +570,7 @@ export function SectionBlock({
       ))}
 
       {/* Add table */}
-      <View style={{ padding: 12 }}>
+      <View style={{ padding: 12, paddingTop: 0 }}>
         <AddRow
           label="Add Table"
           placeholder="Table name (e.g. T1, Booth 1)"

--- a/openresto-frontend/components/admin/settings/TableRow.tsx
+++ b/openresto-frontend/components/admin/settings/TableRow.tsx
@@ -8,10 +8,11 @@ import { Ionicons } from "@expo/vector-icons";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
 import { styles } from "./settings.styles";
+import { RowIconButton } from "./RowIconButton";
 
 /**
  * Group membership context for a table row (#273). When present, the row renders inside a
- * combinable group: a ⛓ chip with the group label and an Unlink button instead of Link.
+ * combinable group: a ⛓ chip with the group label and a remove (unlink) affordance.
  */
 export interface TableRowGroupContext {
   id: number;
@@ -75,6 +76,10 @@ export function TableRow({
   const { primaryColor } = useAppTheme();
 
   const tableName = table.name ?? `Table ${table.id}`;
+  // Surface tokens shared with SocialLinkRow / HighlightsCard so the table tiles are visually
+  // indistinguishable from the rest of the settings cards.
+  const surface2 = isDark ? "#252729" : "#f9fafb";
+  const cardBg = isDark ? "#1e2022" : "#ffffff";
 
   const startDelete = async () => {
     setDeleteStep("confirm");
@@ -100,8 +105,8 @@ export function TableRow({
     if (success) onDeleted();
   };
 
-  // Selection mode (#273): render a checkable row for combining tables into a group. Already-grouped
-  // tables (disabledInSelection) are shown disabled with their chip; standalone tables are selectable.
+  // Selection mode (#273): render a checkable tile for combining tables into a group. Already-grouped
+  // tables (disabledInSelection) are shown disabled with their chip; standalone tiles are selectable.
   if (selectionMode) {
     const isGrouped = !!group || disabledInSelection;
     return (
@@ -112,13 +117,13 @@ export function TableRow({
         style={{
           flexDirection: "row",
           alignItems: "center",
-          paddingHorizontal: 14,
-          paddingVertical: 11,
-          borderBottomWidth: 1,
-          borderBottomColor: borderColor,
-          gap: 10,
+          gap: 12,
+          padding: 12,
+          borderWidth: 1,
+          borderColor,
+          borderRadius: 10,
           opacity: isGrouped ? 0.45 : 1,
-          backgroundColor: selected ? hexToRgba(primaryColor, 0.08) : "transparent",
+          backgroundColor: selected ? hexToRgba(primaryColor, 0.08) : surface2,
         }}
       >
         <Ionicons
@@ -126,47 +131,55 @@ export function TableRow({
           size={16}
           color={isGrouped ? mutedColor : primaryColor}
         />
-        <ThemedText style={{ flex: 1, fontSize: 13, fontWeight: "600" }} numberOfLines={1}>
-          {table.name ?? `T${table.id}`}
-        </ThemedText>
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 4, minWidth: 36 }}>
-          <Ionicons name="people-outline" size={11} color={mutedColor} />
-          <ThemedText style={{ fontSize: 12, color: mutedColor }}>{table.seats}</ThemedText>
-        </View>
-        {isGrouped && group && (
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              gap: 4,
-              backgroundColor: hexToRgba(primaryColor, 0.12),
-              paddingHorizontal: 8,
-              paddingVertical: 3,
-              borderRadius: theme.borderRadius.full,
-            }}
-          >
-            <Ionicons name="link" size={11} color={primaryColor} />
-            <ThemedText style={{ fontSize: 11, color: primaryColor, fontWeight: "600" }}>
-              {group.label}
+        <View style={{ flex: 1 }}>
+          <ThemedText style={{ fontSize: 14, fontWeight: "600" }} numberOfLines={1}>
+            {table.name ?? `T${table.id}`}
+          </ThemedText>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 4, marginTop: 2 }}>
+            <Ionicons name="people-outline" size={12} color={mutedColor} />
+            <ThemedText style={{ fontSize: 12, color: mutedColor }}>
+              {table.seats} seat{table.seats === 1 ? "" : "s"}
             </ThemedText>
+            {isGrouped && group && (
+              <View
+                testID={`table-group-chip-${table.id}`}
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 4,
+                  marginLeft: 6,
+                  backgroundColor: hexToRgba(primaryColor, 0.12),
+                  paddingHorizontal: 8,
+                  paddingVertical: 2,
+                  borderRadius: theme.borderRadius.full,
+                }}
+              >
+                <Ionicons name="link" size={11} color={primaryColor} />
+                <ThemedText style={{ fontSize: 11, color: primaryColor, fontWeight: "600" }}>
+                  {group.label}
+                </ThemedText>
+              </View>
+            )}
           </View>
-        )}
+        </View>
       </Pressable>
     );
   }
 
+  // Inline two-step delete confirmation (#270) — a tinted tile that replaces the row so the
+  // consequence is visible in context. Cancel returns to the row without destroying.
   if (!editing && deleteStep === "confirm") {
     return (
       <View
         style={{
-          paddingHorizontal: 14,
-          paddingVertical: 11,
-          borderBottomWidth: 1,
-          borderBottomColor: borderColor,
+          padding: 12,
+          borderWidth: 1,
+          borderColor: hexToRgba(theme.colors.error, 0.4),
+          borderRadius: 10,
           gap: 10,
           backgroundColor: isDark
-            ? hexToRgba(theme.colors.error, 0.08)
-            : hexToRgba(theme.colors.error, 0.04),
+            ? hexToRgba(theme.colors.error, 0.1)
+            : hexToRgba(theme.colors.error, 0.05),
         }}
       >
         <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 8 }}>
@@ -220,83 +233,119 @@ export function TableRow({
     );
   }
 
+  // Default row — a surface tile (matches SocialLinkRow / HighlightsCard): leading icon square,
+  // name + seats subtitle, trailing cluster of icon actions. Grouped rows append a remove-on-the-chip
+  // and skip the combine action.
   if (!editing) {
     return (
       <View
         style={{
           flexDirection: "row",
           alignItems: "center",
-          paddingHorizontal: group ? 12 : 14,
-          paddingVertical: 11,
-          borderBottomWidth: 1,
-          borderBottomColor: borderColor,
-          gap: 10,
-          backgroundColor: group
-            ? isDark
-              ? hexToRgba(primaryColor, 0.1)
-              : hexToRgba(primaryColor, 0.06)
-            : "transparent",
+          gap: 12,
+          padding: 12,
+          backgroundColor: surface2,
+          borderWidth: 1,
+          borderColor,
+          borderRadius: 10,
         }}
       >
-        <ThemedText style={{ flex: 1, fontSize: 13, fontWeight: "600" }} numberOfLines={1}>
-          {table.name ?? `T${table.id}`}
-        </ThemedText>
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 4, minWidth: 36 }}>
-          <Ionicons name="people-outline" size={11} color={mutedColor} />
-          <ThemedText style={{ fontSize: 12, color: mutedColor }}>{table.seats}</ThemedText>
-        </View>
-        {group ? (
-          <>
-            <View
-              testID={`table-group-chip-${table.id}`}
-              style={{
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 4,
-                backgroundColor: hexToRgba(primaryColor, 0.14),
-                paddingHorizontal: 8,
-                paddingVertical: 3,
-                borderRadius: theme.borderRadius.full,
-              }}
-            >
-              <Ionicons name="link" size={11} color={primaryColor} />
-              <ThemedText style={{ fontSize: 11, color: primaryColor, fontWeight: "600" }}>
-                {group.label}
-              </ThemedText>
-            </View>
-            <Pressable
-              testID={`table-unlink-btn-${table.id}`}
-              style={styles.smallBtn}
-              onPress={onUnlink}
-            >
-              <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Unlink</ThemedText>
-            </Pressable>
-          </>
-        ) : (
-          <Pressable testID={`table-link-btn-${table.id}`} style={styles.smallBtn} onPress={onLink}>
-            <ThemedText style={[styles.smallBtnText, { color: primaryColor }]}>Link</ThemedText>
-          </Pressable>
-        )}
-        <Pressable
-          style={styles.smallBtn}
-          onPress={() => {
-            setDraftName(table.name ?? "");
-            setDraftSeats(String(table.seats));
-            setEditing(true);
+        {/* Leading icon square */}
+        <View
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 10,
+            backgroundColor: cardBg,
+            borderWidth: 1,
+            borderColor,
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
           }}
         >
-          <ThemedText style={[styles.smallBtnText, { color: mutedColor }]}>Edit</ThemedText>
-        </Pressable>
-        <Pressable style={styles.smallBtn} onPress={startDelete}>
-          <ThemedText style={[styles.smallBtnText, { color: theme.colors.error }]}>
-            Delete…
+          <Ionicons name={group ? "link" : "grid-outline"} size={18} color={primaryColor} />
+        </View>
+
+        {/* Title + subtitle (seats, and the group chip when grouped) */}
+        <View style={{ flex: 1 }}>
+          <ThemedText style={{ fontSize: 14, fontWeight: "600" }} numberOfLines={1}>
+            {table.name ?? `T${table.id}`}
           </ThemedText>
-        </Pressable>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 6, marginTop: 2 }}>
+            <Ionicons name="people-outline" size={12} color={mutedColor} />
+            <ThemedText style={{ fontSize: 12, color: mutedColor }}>
+              {table.seats} seat{table.seats === 1 ? "" : "s"}
+            </ThemedText>
+            {group && (
+              <View
+                testID={`table-group-chip-${table.id}`}
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 4,
+                  marginLeft: 4,
+                  backgroundColor: hexToRgba(primaryColor, 0.14),
+                  paddingLeft: 8,
+                  paddingRight: 2,
+                  paddingVertical: 2,
+                  borderRadius: theme.borderRadius.full,
+                }}
+              >
+                <Ionicons name="link" size={11} color={primaryColor} />
+                <ThemedText style={{ fontSize: 11, color: primaryColor, fontWeight: "600" }}>
+                  {group.label}
+                </ThemedText>
+                <Pressable
+                  testID={`table-unlink-btn-${table.id}`}
+                  onPress={onUnlink}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Remove ${tableName} from group`}
+                  hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+                  style={{ padding: 2 }}
+                >
+                  <Ionicons name="close" size={12} color={primaryColor} />
+                </Pressable>
+              </View>
+            )}
+          </View>
+        </View>
+
+        {/* Trailing icon actions */}
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+          {!group && (
+            <RowIconButton
+              testID={`table-link-btn-${table.id}`}
+              name="link-outline"
+              color={primaryColor}
+              onPress={onLink}
+              accessibilityLabel={`Combine ${tableName} into a group`}
+            />
+          )}
+          <RowIconButton
+            testID={`table-edit-btn-${table.id}`}
+            name="pencil-outline"
+            color={mutedColor}
+            onPress={() => {
+              setDraftName(table.name ?? "");
+              setDraftSeats(String(table.seats));
+              setEditing(true);
+            }}
+            accessibilityLabel={`Edit ${tableName}`}
+          />
+          <RowIconButton
+            testID={`table-delete-btn-${table.id}`}
+            name="trash-outline"
+            color={theme.colors.error}
+            onPress={startDelete}
+            accessibilityLabel={`Delete ${tableName}`}
+          />
+        </View>
       </View>
     );
   }
 
-  // Edit mode — full-width inline form
+  // Edit mode — full-width inline form (kept intact; Save/Cancel are text buttons by design).
   return (
     <View
       style={{

--- a/openresto-frontend/components/admin/settings/settings.styles.ts
+++ b/openresto-frontend/components/admin/settings/settings.styles.ts
@@ -116,19 +116,7 @@ export const styles = StyleSheet.create({
     ...theme.buttonSizes.small,
   },
   smallBtnText: { ...theme.typography.label, fontWeight: "600" },
-  deleteText: { ...theme.typography.label, color: theme.colors.error },
-  addBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: theme.spacing.sm,
-    ...theme.buttonSizes.secondary, // Changed from primary for better hierarchy
-    borderRadius: theme.borderRadius.md,
-    backgroundColor: theme.colors.primary,
-  },
-  addBtnText: { ...theme.typography.bodyBold, color: "#fff", fontSize: 14 },
   addForm: { gap: theme.spacing.sm, paddingTop: theme.spacing.sm },
-  addSaveBtn: { flex: 1 },
   cancelBtn: { ...theme.buttonSizes.secondary, borderRadius: theme.borderRadius.md },
   cancelBtnText: { ...theme.typography.label },
   actionBtn: {
@@ -141,28 +129,6 @@ export const styles = StyleSheet.create({
   sectionBlock: {
     paddingBottom: theme.spacing.md,
   },
-  tableList: {
-    paddingLeft: theme.spacing.md,
-    borderLeftWidth: 2,
-    marginLeft: 4,
-    gap: 2,
-  },
-  emptyNote: {
-    ...theme.typography.label,
-    fontStyle: "italic",
-    paddingVertical: theme.spacing.sm,
-    opacity: 0.5,
-  },
-  tableItemRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: theme.spacing.sm,
-    gap: theme.spacing.sm,
-  },
-  tableInfo: { flex: 1, flexDirection: "row", alignItems: "center", gap: theme.spacing.sm },
-  tableName: { ...theme.typography.bodyBold, fontWeight: "500" },
-  tableSeats: { ...theme.typography.caption },
-  tableEditFields: { flex: 1, flexDirection: "row", gap: theme.spacing.sm },
   flex1: { flex: 1 },
   flex2: { flex: 2 },
   infoForm: { gap: theme.spacing.md },

--- a/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
@@ -46,7 +46,7 @@ describe("TableRow", () => {
   it("renders table name and seats in view mode", () => {
     render(<TableRow {...baseProps} />);
     expect(screen.getByText("T1")).toBeTruthy();
-    expect(screen.getByText("4")).toBeTruthy();
+    expect(screen.getByText("4 seats")).toBeTruthy();
   });
 
   it("renders table id fallback when name is null", () => {
@@ -57,7 +57,7 @@ describe("TableRow", () => {
   it("enters edit mode when pencil button is pressed", () => {
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     expect(screen.getByDisplayValue("T1")).toBeTruthy();
     expect(screen.getByDisplayValue("4")).toBeTruthy();
@@ -66,7 +66,7 @@ describe("TableRow", () => {
   it("shows Cancel and Save buttons in edit mode", () => {
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     expect(screen.getByText("Cancel")).toBeTruthy();
     expect(screen.getByText("Save")).toBeTruthy();
@@ -77,7 +77,7 @@ describe("TableRow", () => {
     (restaurantsApi.updateTable as jest.Mock).mockResolvedValue(updatedTable);
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     fireEvent.changeText(screen.getByDisplayValue("T1"), "T1-Updated");
     fireEvent.changeText(screen.getByDisplayValue("4"), "2");
@@ -94,7 +94,7 @@ describe("TableRow", () => {
   it("does not save when seats is not a valid number", async () => {
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     fireEvent.changeText(screen.getByDisplayValue("4"), "abc");
     await act(async () => {
@@ -106,7 +106,7 @@ describe("TableRow", () => {
   it("does not save when seats is 0", async () => {
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     fireEvent.changeText(screen.getByDisplayValue("4"), "0");
     await act(async () => {
@@ -118,7 +118,7 @@ describe("TableRow", () => {
   it("cancels edit mode when Cancel is pressed", () => {
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     fireEvent.press(screen.getByText("Cancel"));
     expect(screen.getByText("T1")).toBeTruthy();
@@ -134,7 +134,7 @@ describe("TableRow", () => {
     (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 3 });
     render(<TableRow {...baseProps} />);
     await act(async () => {
-      fireEvent.press(screen.getByText("Delete…"));
+      fireEvent.press(screen.getByTestId("table-delete-btn-5"));
     });
     expect(restaurantsApi.fetchTableDeleteImpact).toHaveBeenCalledWith(1, 2, 5);
     // The confirm copy names the table and the concrete consequence.
@@ -151,7 +151,7 @@ describe("TableRow", () => {
     (restaurantsApi.deleteTable as jest.Mock).mockResolvedValue(true);
     render(<TableRow {...baseProps} />);
     await act(async () => {
-      fireEvent.press(screen.getByText("Delete…"));
+      fireEvent.press(screen.getByTestId("table-delete-btn-5"));
     });
     // The actual delete call is NOT made by the first tap — only by the confirm tap.
     expect(restaurantsApi.deleteTable).not.toHaveBeenCalled();
@@ -166,21 +166,21 @@ describe("TableRow", () => {
     (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 1 });
     render(<TableRow {...baseProps} />);
     await act(async () => {
-      fireEvent.press(screen.getByText("Delete…"));
+      fireEvent.press(screen.getByTestId("table-delete-btn-5"));
     });
     fireEvent.press(screen.getByTestId("table-delete-cancel-btn"));
     expect(restaurantsApi.deleteTable).not.toHaveBeenCalled();
     expect(baseProps.onDeleted).not.toHaveBeenCalled();
     // Back to the idle row — the destructive confirm copy is gone.
     expect(screen.queryByText("Yes, delete")).toBeNull();
-    expect(screen.getByText("Delete…")).toBeTruthy();
+    expect(screen.getByTestId("table-delete-btn-5")).toBeTruthy();
   });
 
   it("falls back to generic copy when the impact read fails or is unavailable", async () => {
     (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue(null);
     render(<TableRow {...baseProps} />);
     await act(async () => {
-      fireEvent.press(screen.getByText("Delete…"));
+      fireEvent.press(screen.getByTestId("table-delete-btn-5"));
     });
     expect(
       await screen.findByText(/Future bookings on this table will lose their reference/)
@@ -191,7 +191,7 @@ describe("TableRow", () => {
     (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 1 });
     render(<TableRow {...baseProps} />);
     await act(async () => {
-      fireEvent.press(screen.getByText("Delete…"));
+      fireEvent.press(screen.getByTestId("table-delete-btn-5"));
     });
     expect(await screen.findByText(/1 future booking will lose its table reference/)).toBeTruthy();
   });
@@ -201,26 +201,26 @@ describe("TableRow", () => {
     expect(screen.getByText("T1")).toBeTruthy();
   });
 
-  it("renders tableIcon with seats=1 (person-outline branch)", () => {
+  it("renders the seats count for seats=1 (singular)", () => {
     render(<TableRow {...baseProps} table={{ ...baseTable, seats: 1 }} />);
-    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("1 seat")).toBeTruthy();
   });
 
-  it("renders tableIcon with seats=8 (apps-outline branch)", () => {
+  it("renders the seats count for seats=8 (plural)", () => {
     render(<TableRow {...baseProps} table={{ ...baseTable, seats: 8 }} />);
-    expect(screen.getByText("8")).toBeTruthy();
+    expect(screen.getByText("8 seats")).toBeTruthy();
   });
 
-  it("renders tableIcon with seats=10 (albums-outline branch)", () => {
+  it("renders the seats count for seats=10 (plural)", () => {
     render(<TableRow {...baseProps} table={{ ...baseTable, seats: 10 }} />);
-    expect(screen.getByText("10")).toBeTruthy();
+    expect(screen.getByText("10 seats")).toBeTruthy();
   });
 
   it("falls back to the default primary color when the brand has none", () => {
     (useBrand as jest.Mock).mockReturnValueOnce({ primaryColor: "", appName: "Open Resto" });
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     expect(screen.getByText("Save")).toBeTruthy();
   });
@@ -229,14 +229,14 @@ describe("TableRow", () => {
     (restaurantsApi.fetchTableDeleteImpact as jest.Mock).mockResolvedValue({ bookings: 0 });
     render(<TableRow {...baseProps} table={{ ...baseTable, name: null }} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     expect(screen.getByDisplayValue("")).toBeTruthy();
     expect(screen.getByText("EDITING · Table 5")).toBeTruthy();
     fireEvent.press(screen.getByText("Cancel"));
 
     await act(async () => {
-      fireEvent.press(screen.getByText("Delete…"));
+      fireEvent.press(screen.getByTestId("table-delete-btn-5"));
     });
     // The confirm copy falls back to the "Table {id}" label when the name is null.
     expect(await screen.findByText(/Delete “Table 5”\?/)).toBeTruthy();
@@ -247,7 +247,7 @@ describe("TableRow", () => {
     (restaurantsApi.deleteTable as jest.Mock).mockResolvedValue(false);
     render(<TableRow {...baseProps} />);
     await act(async () => {
-      fireEvent.press(screen.getByText("Delete…"));
+      fireEvent.press(screen.getByTestId("table-delete-btn-5"));
     });
     await act(async () => {
       fireEvent.press(screen.getByText("Yes, delete"));
@@ -259,7 +259,7 @@ describe("TableRow", () => {
   it("renders the edit-mode background in dark mode", () => {
     render(<TableRow {...baseProps} isDark />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     expect(screen.getByText("Save")).toBeTruthy();
   });
@@ -269,7 +269,7 @@ describe("TableRow", () => {
     (restaurantsApi.updateTable as jest.Mock).mockResolvedValue(updatedTable);
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     fireEvent.changeText(screen.getByDisplayValue("T1"), "   ");
     await act(async () => {
@@ -285,7 +285,7 @@ describe("TableRow", () => {
     (restaurantsApi.updateTable as jest.Mock).mockResolvedValue(null);
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     await act(async () => {
       fireEvent.press(screen.getByText("Save"));
@@ -303,7 +303,7 @@ describe("TableRow", () => {
     );
     render(<TableRow {...baseProps} />);
     act(() => {
-      fireEvent.press(screen.getByText("Edit"));
+      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     act(() => {
       fireEvent.press(screen.getByText("Save"));
@@ -316,13 +316,12 @@ describe("TableRow", () => {
 
   // ── Combinable table groups (#273) ────────────────────────────────────────
 
-  it("renders a Link button on standalone (ungrouped) tables", () => {
+  it("renders a combine (link) action on standalone (ungrouped) tables", () => {
     render(<TableRow {...baseProps} />);
     expect(screen.getByTestId("table-link-btn-5")).toBeTruthy();
-    expect(screen.getByText("Link")).toBeTruthy();
   });
 
-  it("renders the group chip and Unlink button when the table is a group member", () => {
+  it("renders the group chip and a remove (unlink) affordance when the table is a group member", () => {
     render(
       <TableRow
         {...baseProps}
@@ -333,8 +332,7 @@ describe("TableRow", () => {
     expect(screen.getByTestId("table-group-chip-5")).toBeTruthy();
     expect(screen.getByText("Tables 5 + 6 (8 combined)")).toBeTruthy();
     expect(screen.getByTestId("table-unlink-btn-5")).toBeTruthy();
-    expect(screen.getByText("Unlink")).toBeTruthy();
-    // No Link button on a grouped table.
+    // No combine action on a grouped table.
     expect(screen.queryByTestId("table-link-btn-5")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

A focused UI/UX refresh of the admin **table & section settings** so they match the rest of the app's design language (`SocialLinkRow` / `HighlightsCard`). Pure visual — no API, data-model, or behavior changes. The two-step inline delete confirmation is preserved.

### Before → after

**Table rows** — were divider strips with bare colored-text buttons (`Link` / `Edit` / `Delete…`) that read as floating text. Now rounded **surface tiles**: a leading 36×36 icon square, name + `people-outline · N seats` subtitle, and a tidy trailing cluster of icon actions.

**Delete** — the user-called-out "ugly" bit. Red text `Delete…` with no icon is now a **trash-icon** trigger, matching every other destructive affordance in the app (`HighlightsCard`, `SocialLinkRow`, `EditableRow`). The two-step inline confirm (warning banner + `Yes, delete`) is unchanged.

**Section header** — the count line (`2 tables · 6 seats · 1 combinable group`) moves to a muted **subtitle under the name**, freeing the right side into a clean icon cluster (move up/down, rename, delete) instead of a mix of bare `padding:6` arrows + text buttons.

**Group chip** — gains an inline **remove (X)** affordance on the chip (standard tag UX), replacing the separate `Unlink` text button.

**Add buttons** — `Add Table` / `Add Section` were full-width outlined bars (visually heavy). Now **self-sized filled-primary pills, right-aligned** — consistent with the `Add` CTA in `HighlightsCard`. The expanded form's dismiss `X` gets consistent bordered chrome.

**Empty section** — bare italic `No tables yet.` → a **dashed-border tile** (matches the `HighlightsCard` empty state).

**Consistency** — new shared `RowIconButton` so every row-level action (edit / delete / combine / move) shares identical tappable chrome. Pluralized seat counts (`1 seat` / `4 seats`).

### Files
- `components/admin/settings/RowIconButton.tsx` — **new** shared presentational icon button.
- `components/admin/settings/TableRow.tsx` — surface tiles + icon actions + chip-with-remove.
- `components/admin/settings/SectionBlock.tsx` — header subtitle + icon cluster + dashed empty state + group-edit chip.
- `components/admin/settings/AddRow.tsx` — right-aligned filled Add pill + consistent X.
- `components/admin/settings/settings.styles.ts` — removed dead tokens (`tableList`, `tableName`, `addBtn`, `emptyNote`, …).
- `tests/components/admin/settings/TableRow.test.tsx` — migrated text-based `Edit`/`Delete…` presses to the new testIDs; updated seat-count assertions.

### Verification
- `npm run lint` — 0 errors.
- `npx prettier --check` — clean.
- `npx tsc --noEmit` — clean.
- `npm test` — **2017/2017 passing** (148 suites).

No backend changes.