### PR TITLE
Fix combinable-table group double-booking & missing diner display

### DIFF
--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -1712,4 +1712,133 @@ public class BookingServiceTests
         Assert.NotNull(persisted);
         Assert.Equal(1, persisted!.TableGroupId);
     }
+
+    // ── Double-booking regressions (group-aware conflict checks) ────────────
+    //
+    // These cover the gap that a persisted group booking stores TableId = null, so the original
+    // table-only IsTableBookedOnDateAsync could not see it and allowed the same physical tables to
+    // be booked again. IsUnitBookedOnDateAsync resolves the membership and blocks all three cases.
+
+    [Fact]
+    public async Task CreateBookingAsync_GroupBooking_RejectsWhenGroupAlreadyBooked()
+    {
+        // The same group is already booked for an overlapping slot — booking it again must conflict.
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_GroupBooking_RejectsWhenGroupAlreadyBooked));
+        SeedRestaurantWithGroup(db);
+        DateTime date = DateTime.UtcNow.AddDays(30);
+        db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, TableGroupId = 1, SectionId = 1, Date = date,
+            BookingRef = "GRP1", EndTime = date.AddMinutes(60)
+        });
+        db.SaveChanges();
+        BookingService svc = CreateService(db);
+
+        ConflictException ex = await Assert.ThrowsAsync<ConflictException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "group2@example.com",
+            Seats = 6,
+            Date = date,
+            TableGroupId = 1,
+            MemberTableIds = new[] { 2, 3 }
+        }));
+
+        Assert.Contains("already booked", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_SingleTable_RejectsWhenItsGroupAlreadyBooked()
+    {
+        // The group (T2+T3) is booked; booking member T2 individually must conflict because the
+        // group booking reserves T2 too (it persists TableId = null, invisible to a table-only check).
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_SingleTable_RejectsWhenItsGroupAlreadyBooked));
+        SeedRestaurantWithGroup(db);
+        DateTime date = DateTime.UtcNow.AddDays(31);
+        db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, TableGroupId = 1, SectionId = 1, Date = date,
+            BookingRef = "GRP1", EndTime = date.AddMinutes(60)
+        });
+        db.SaveChanges();
+        BookingService svc = CreateService(db);
+
+        ConflictException ex = await Assert.ThrowsAsync<ConflictException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "member@example.com",
+            Seats = 3,
+            Date = date,
+            TableId = 2,
+            SectionId = 1
+        }));
+
+        Assert.Contains("already booked", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_GroupBooking_RejectsWhenMemberReservedByAnotherGroup()
+    {
+        // A second group (G2) shares member T2 with G1. Booking G1 must conflict because T2 is
+        // reserved by the G2 booking (which stores TableId = null). Seeds a second group manually.
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_GroupBooking_RejectsWhenMemberReservedByAnotherGroup));
+        SeedRestaurantWithGroup(db);
+        DateTime date = DateTime.UtcNow.AddDays(32);
+        db.TableGroups.Add(new TableGroup
+        {
+            Id = 2, RestaurantId = 1, CombinedSeats = 6,
+            Members = new List<TableGroupMembership>
+            {
+                new() { TableGroupId = 2, TableId = 2 },
+                new() { TableGroupId = 2, TableId = 1 }
+            }
+        });
+        db.Bookings.Add(new Booking
+        {
+            Id = 1, RestaurantId = 1, TableGroupId = 2, SectionId = 1, Date = date,
+            BookingRef = "GRP2", EndTime = date.AddMinutes(60)
+        });
+        db.SaveChanges();
+        BookingService svc = CreateService(db);
+
+        ConflictException ex = await Assert.ThrowsAsync<ConflictException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "group1@example.com",
+            Seats = 6,
+            Date = date,
+            TableGroupId = 1,
+            MemberTableIds = new[] { 2, 3 }
+        }));
+
+        Assert.Contains("already booked", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetBookingByIdAsync_GroupBooking_PopulatesGroupLabelAndSeats()
+    {
+        // Display regression: a group booking must surface a readable table label + combined seats
+        // on the read path (diner confirmation / lookup), not null fields that hide the table row.
+        using AppDbContext db = TestDbFactory.Create(nameof(GetBookingByIdAsync_GroupBooking_PopulatesGroupLabelAndSeats));
+        SeedRestaurantWithGroup(db);
+        BookingService svc = CreateService(db);
+        DateTime date = DateTime.UtcNow.AddDays(33);
+
+        BookingDto created = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "display@example.com",
+            Seats = 6,
+            Date = date,
+            TableGroupId = 1,
+            MemberTableIds = new[] { 2, 3 }
+        });
+
+        BookingDto? fetched = await svc.GetBookingByIdAsync(created.Id);
+        Assert.NotNull(fetched);
+        Assert.Equal(1, fetched!.TableGroupId);
+        Assert.Equal(8, fetched.TableSeats);
+        Assert.Contains("T2", fetched.TableName);
+        Assert.Contains("T3", fetched.TableName);
+    }
 }

--- a/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
@@ -17,6 +17,26 @@ public interface IBookingRepository
     /// also used as the fallback occupancy window.
     /// </summary>
     Task<bool> IsTableBookedOnDateAsync(int tableId, DateTime bookingDate, int durationMinutes = 60);
+
+    /// <summary>
+    /// Group-aware conflict check used wherever a table OR a combinable-table group is being booked.
+    /// A physical <paramref name="tableId"/> is considered reserved for the window when ANY of these
+    /// overlap it:
+    /// <list type="bullet">
+    /// <item>a single-table booking on that table (<c>Booking.TableId == tableId</c>);</item>
+    /// <item>a group booking on the group that the table belongs to — because booking the group
+    /// reserves every member. The membership is resolved from <c>TableGroupMemberships</c>.</item>
+    /// </list>
+    /// A <paramref name="tableGroupId"/> (the unit being booked) is considered reserved when ANY
+    /// booking overlaps that targets the same group <em>or</em> any of its member tables individually.
+    /// This closes the double-booking gap: a persisted group booking stores <c>TableId = null</c>, so
+    /// the table-only <see cref="IsTableBookedOnDateAsync"/> cannot see it; this method can.
+    /// </summary>
+    Task<bool> IsUnitBookedOnDateAsync(
+        int? tableId,
+        int? tableGroupId,
+        DateTime bookingDate,
+        int durationMinutes = 60);
     /// <summary>Returns all non-cancelled bookings for a specific restaurant and local date.</summary>
     Task<IEnumerable<Booking>> GetActiveBookingsForDateAsync(int restaurantId, DateTime bookingDate);
 

--- a/OpenRestoApi/Core/Application/Mappings/BookingMapper.cs
+++ b/OpenRestoApi/Core/Application/Mappings/BookingMapper.cs
@@ -17,6 +17,46 @@ public partial class BookingMapper
     [MapProperty("Section.Name", nameof(BookingDto.SectionName))]
     public partial BookingDto ToDto(Booking booking);
 
+    /// <summary>
+    /// Maps a booking then fills the display fields for a combinable-table group booking. The base
+    /// <see cref="ToDto"/> maps TableName/TableSeats/SectionName from the single Table/Section, which
+    /// are null for a group booking (the booking reserves a <see cref="TableGroup"/>). For those rows
+    /// we substitute a readable group label, the group's CombinedSeats, and the first member's section
+    /// so the diner confirmation, lookup, admin grid, and calendar all show something meaningful
+    /// instead of silently dropping the Table/Section rows.
+    /// </summary>
+    public BookingDto ToDtoWithGroup(Booking booking)
+    {
+        BookingDto dto = ToDto(booking);
+        if (booking.TableGroup is { } group)
+        {
+            dto.TableGroupId = group.Id;
+            // For a group booking Table is null, so the base map left these empty. Substitute a
+            // readable group label and the group's combined capacity so display surfaces (diner
+            // confirmation, admin grid, email, calendar) show something meaningful. SectionName is
+            // already mapped from the persisted SectionId (set to a member's section at create time).
+            dto.TableName ??= GroupLabel(group);
+            dto.TableSeats ??= group.CombinedSeats;
+        }
+
+        return dto;
+    }
+
+    /// <summary>A human-readable label for a group: its name, else the member table names joined by " + ".</summary>
+    public static string GroupLabel(TableGroup group)
+    {
+        if (!string.IsNullOrWhiteSpace(group.Name))
+        {
+            return group.Name;
+        }
+
+        var names = group.Members
+            .OrderBy(m => m.TableId)
+            .Select(m => m.Table?.Name ?? $"Table {m.TableId}")
+            .ToList();
+        return names.Count > 0 ? $"Tables {string.Join(" + ", names)}" : "Combined tables";
+    }
+
     [MapperIgnoreTarget(nameof(Booking.Table))]
     [MapperIgnoreTarget(nameof(Booking.Section))]
     [MapperIgnoreTarget(nameof(Booking.Restaurant))]
@@ -34,4 +74,8 @@ public partial class BookingMapper
     public partial Booking ToEntity(BookingDto dto);
 
     public partial IEnumerable<BookingDto> ToDtoList(IEnumerable<Booking> bookings);
+
+    /// <summary>List variant of <see cref="ToDtoWithGroup"/> for the restaurant bookings feed.</summary>
+    public IEnumerable<BookingDto> ToDtoWithGroupList(IEnumerable<Booking> bookings)
+        => bookings.Select(ToDtoWithGroup).ToList();
 }

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Mappings;
 using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
@@ -609,6 +610,17 @@ public class AdminService(
                 : b.CancelledAt.Value.ToUniversalTime();
         }
 
+        // Group booking: Table/TableId are null (the booking reserves a combinable group). Show a
+        // readable group label + the group id so the admin grid doesn't render the row as "Table".
+        string? tableName = b.Table?.Name ?? (b.TableId.HasValue ? $"Table {b.TableId}" : null);
+        int? tableId = b.TableId;
+        if (tableName is null && b.TableGroup is not null)
+        {
+            tableName = BookingMapper.GroupLabel(b.TableGroup);
+            tableId = null;
+        }
+        tableName ??= "Table";
+
         return new BookingDetailDto
         {
             Id = b.Id,
@@ -616,8 +628,8 @@ public class AdminService(
             RestaurantName = b.Restaurant?.Name,
             SectionId = b.SectionId,
             SectionName = b.Section?.Name ?? (b.SectionId.HasValue ? $"Section {b.SectionId}" : "Section"),
-            TableId = b.TableId,
-            TableName = b.Table?.Name ?? (b.TableId.HasValue ? $"Table {b.TableId}" : "Table"),
+            TableId = tableId,
+            TableName = tableName,
             Date = dateUtc,
             EndTime = endTimeUtc,
             CustomerEmail = b.CustomerEmail,

--- a/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
+++ b/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
@@ -121,11 +121,64 @@ public sealed class AvailabilityService(
                     || g.CombinedSeats - seats <= restaurant.MaxTableOversizeSeats.Value))
             .ToList();
 
-        // Optimize: Group bookings by table ID for faster lookup in the loop
+        // Optimize: index single-table bookings by table id and group bookings by group id. A group
+        // booking stores TableId = null, so it would be invisible to a table-only lookup — index it by
+        // its group id and resolve member table ids from the restaurant's loaded groups so the per-slot
+        // loops can detect it (otherwise a group/member reserved by a group booking would be advertised
+        // as available).
         var bookingsByTable = activeBookings
             .Where(b => b.TableId.HasValue)
             .GroupBy(b => b.TableId!.Value)
             .ToDictionary(g => g.Key, g => g.ToList());
+
+        var groupBookings = activeBookings.Where(b => b.TableGroupId.HasValue).ToList();
+
+        // groupId → set of member table ids, from the restaurant's loaded combinable groups.
+        var groupMemberTableIds = (restaurant.Groups ?? Enumerable.Empty<TableGroup>())
+            .ToDictionary(g => g.Id, g => g.Members.Select(m => m.TableId).ToHashSet());
+
+        // All physical table ids reserved by any group booking (the booked group's members). A standalone
+        // table in this set is effectively taken for the relevant slots even though no row sets its TableId.
+        var groupBookedTableIdsByGroup = groupBookings
+            .Where(b => b.TableGroupId.HasValue && groupMemberTableIds.ContainsKey(b.TableGroupId!.Value))
+            .SelectMany(b => groupMemberTableIds[b.TableGroupId!.Value].Select(id => (id, b)))
+            .ToList();
+
+        bool Overlaps(Booking b, DateTime slotUtc, DateTime slotEndUtc) =>
+            b.Date < slotEndUtc &&
+            (b.EndTime ?? b.Date.AddMinutes(restaurant.DefaultBookingDurationMinutes)) > slotUtc;
+
+        bool IsTableReserved(int tableId, DateTime slotUtc, DateTime slotEndUtc)
+        {
+            if (bookingsByTable.TryGetValue(tableId, out List<Booking>? tableBookings)
+                && tableBookings.Any(b => Overlaps(b, slotUtc, slotEndUtc)))
+            {
+                return true;
+            }
+
+            // Reserved by a group booking whose group counts this table as a member.
+            return groupBookedTableIdsByGroup.Any(x => x.id == tableId && Overlaps(x.b, slotUtc, slotEndUtc));
+        }
+
+        bool IsGroupReserved(TableGroup group, DateTime slotUtc, DateTime slotEndUtc)
+        {
+            // The group itself already booked for this slot.
+            if (groupBookings.Any(b => b.TableGroupId == group.Id && Overlaps(b, slotUtc, slotEndUtc)))
+            {
+                return true;
+            }
+
+            // Any member reserved individually, or by a sibling group booking, makes the group unavailable.
+            foreach (TableGroupMembership member in group.Members)
+            {
+                if (IsTableReserved(member.TableId, slotUtc, slotEndUtc))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         while (current < localEnd)
         {
@@ -140,17 +193,10 @@ public sealed class AvailabilityService(
 
                 foreach (Table? table in eligibleTablesUngrouped)
                 {
-                    // Check bookings
-                    if (bookingsByTable.TryGetValue(table.Id, out List<Booking>? tableBookings))
+                    // Group-aware booking check (catches single-table + group bookings reserving it).
+                    if (IsTableReserved(table.Id, slotUtc, slotEndUtc))
                     {
-                        bool hasBookingConflict = tableBookings.Any(b =>
-                            b.Date < slotEndUtc &&
-                            (b.EndTime ?? b.Date.AddMinutes(restaurant.DefaultBookingDurationMinutes)) > slotUtc);
-
-                        if (hasBookingConflict)
-                        {
-                            continue;
-                        }
+                        continue;
                     }
 
                     // Check holds
@@ -162,33 +208,26 @@ public sealed class AvailabilityService(
                     availableTableIds.Add(table.Id);
                 }
 
-                // Combinable groups: a group is free iff ALL members are free for the slot.
+                // Combinable groups: a group is free iff it isn't already booked and ALL members are free.
                 var availableGroupIds = new List<int>();
                 foreach (TableGroup group in eligibleGroups)
                 {
-                    bool allMembersFree = true;
+                    if (IsGroupReserved(group, slotUtc, slotEndUtc))
+                    {
+                        continue;
+                    }
+
+                    bool allMembersFreeOfHolds = true;
                     foreach (TableGroupMembership member in group.Members)
                     {
-                        if (bookingsByTable.TryGetValue(member.TableId, out List<Booking>? memberBookings))
-                        {
-                            bool memberConflict = memberBookings.Any(b =>
-                                b.Date < slotEndUtc &&
-                                (b.EndTime ?? b.Date.AddMinutes(restaurant.DefaultBookingDurationMinutes)) > slotUtc);
-                            if (memberConflict)
-                            {
-                                allMembersFree = false;
-                                break;
-                            }
-                        }
-
                         if (_holdService.IsTableHeld(member.TableId, slotUtc, durationMinutes: restaurant.DefaultBookingDurationMinutes))
                         {
-                            allMembersFree = false;
+                            allMembersFreeOfHolds = false;
                             break;
                         }
                     }
 
-                    if (allMembersFree)
+                    if (allMembersFreeOfHolds)
                     {
                         availableGroupIds.Add(group.Id);
                     }

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -101,9 +101,13 @@ public class BookingService(
         int tableId = bookingDto.TableId!.Value;
         int sectionId = bookingDto.SectionId!.Value;
 
-        // 1. Check DB for an existing confirmed booking on the same table+date
-        bool alreadyBooked = await _bookingRepository.IsTableBookedOnDateAsync(
-            tableId, bookingDate, restaurant.DefaultBookingDurationMinutes);
+        // 1. Check DB for an existing confirmed booking on the same table+date. Group-aware: a table
+        //    is also "booked" when its combinable group (or any sibling member) has a booking for the
+        //    window, since those bookings reserve the same physical tables. A persisted group booking
+        //    stores TableId = null, so the table-only check would miss it — IsUnitBookedOnDateAsync
+        //    resolves the membership and matches it.
+        bool alreadyBooked = await _bookingRepository.IsUnitBookedOnDateAsync(
+            tableId, tableGroupId: null, bookingDate, restaurant.DefaultBookingDurationMinutes);
 
         if (alreadyBooked)
         {
@@ -170,7 +174,7 @@ public class BookingService(
             await _confirmationService.SendConfirmationAsync(newBooking, restaurant);
         }
 
-        return _mapper.ToDto(newBooking);
+        return _mapper.ToDtoWithGroup(newBooking);
     }
 
     /// <summary>
@@ -194,19 +198,16 @@ public class BookingService(
             {
                 if (held.IsGroup)
                 {
-                    // Group hold — verify every member is still free of a confirmed booking, then adopt.
-                    bool anyMemberBooked = false;
-                    foreach (int memberId in held.Members)
-                    {
-                        if (await _bookingRepository.IsTableBookedOnDateAsync(
-                                memberId, bookingDate, restaurant.DefaultBookingDurationMinutes))
-                        {
-                            anyMemberBooked = true;
-                            break;
-                        }
-                    }
+                    // Group hold — verify the group is still free of a confirmed booking (group-aware:
+                    // catches the group itself, a member booked individually, or a member reserved by a
+                    // sibling group booking), then adopt.
+                    bool groupBooked = await _bookingRepository.IsUnitBookedOnDateAsync(
+                        tableId: null,
+                        tableGroupId: held.TableGroupId,
+                        bookingDate,
+                        restaurant.DefaultBookingDurationMinutes);
 
-                    if (!anyMemberBooked)
+                    if (!groupBooked)
                     {
                         bookingDto.TableGroupId = held.TableGroupId;
                         bookingDto.MemberTableIds = held.Members;
@@ -218,10 +219,11 @@ public class BookingService(
                 else
                 {
                     // The hold is on a specific table — verify it still fits and isn't double-booked
-                    // in the DB (the hold only guards against other in-memory holds). If something
-                    // changed under us, fall through to the candidate search.
-                    bool booked = await _bookingRepository.IsTableBookedOnDateAsync(
-                        held.TableId, bookingDate, restaurant.DefaultBookingDurationMinutes);
+                    // in the DB (the hold only guards against other in-memory holds). Group-aware: a
+                    // group booking on this table's group would reserve it too. If something changed
+                    // under us, fall through to the candidate search.
+                    bool booked = await _bookingRepository.IsUnitBookedOnDateAsync(
+                        held.TableId, tableGroupId: null, bookingDate, restaurant.DefaultBookingDurationMinutes);
                     if (!booked)
                     {
                         bookingDto.TableId = held.TableId;
@@ -307,14 +309,20 @@ public class BookingService(
         // user's hold. This is the mutual-exclusion invariant for confirmed bookings.
         var memberIds = (bookingDto.MemberTableIds ?? group.Members.Select(m => m.TableId)).ToList();
         int durationMinutes = restaurant.DefaultBookingDurationMinutes;
+
+        // Group-aware conflict check: a single query covers (a) any member already booked on its own,
+        // (b) the group already booked, and (c) a member reserved by a sibling/other group booking
+        // (those bookings store TableId = null, so the old table-only check could not see them and
+        // allowed the same physical table to be double-booked).
+        bool groupConflict = await _bookingRepository.IsUnitBookedOnDateAsync(
+            tableId: null, tableGroupId: group.Id, bookingDate, durationMinutes);
+        if (groupConflict)
+        {
+            throw new ConflictException("One of the combined tables is already booked for that time.");
+        }
+
         foreach (int memberId in memberIds)
         {
-            bool booked = await _bookingRepository.IsTableBookedOnDateAsync(memberId, bookingDate, durationMinutes);
-            if (booked)
-            {
-                throw new ConflictException("One of the combined tables is already booked for that time.");
-            }
-
             bool heldByOther = _holdService.IsTableHeld(
                 memberId, bookingDate, excludeHoldId: bookingDto.HoldId, durationMinutes: durationMinutes);
             if (heldByOther)
@@ -334,6 +342,7 @@ public class BookingService(
         booking.EndTime = bookingDate.AddMinutes(durationMinutes);
         booking.TableId = null;
         booking.TableGroupId = group.Id;
+        booking.TableGroup = group; // Attach the loaded group so the DTO/email display enrichment works.
         booking.SectionId = sectionId;
         booking.Restaurant = restaurant;
 
@@ -356,25 +365,25 @@ public class BookingService(
             await _confirmationService.SendConfirmationAsync(newBooking, restaurant);
         }
 
-        return _mapper.ToDto(newBooking);
+        return _mapper.ToDtoWithGroup(newBooking);
     }
 
     public virtual async Task<BookingDto?> GetBookingByIdAsync(int id)
     {
         Booking? booking = await _bookingRepository.GetByIdAsync(id);
-        return booking == null ? null : _mapper.ToDto(booking);
+        return booking == null ? null : _mapper.ToDtoWithGroup(booking);
     }
 
     public virtual async Task<BookingDto?> GetBookingByRefAsync(string bookingRef)
     {
         Booking? booking = await _bookingRepository.GetByRefAsync(bookingRef);
-        return booking == null ? null : _mapper.ToDto(booking);
+        return booking == null ? null : _mapper.ToDtoWithGroup(booking);
     }
 
     public virtual async Task<IEnumerable<BookingDto>> GetBookingsByRestaurantAsync(int restaurantId)
     {
         IEnumerable<Booking> bookings = await _bookingRepository.GetBookingsByRestaurantIdAsync(restaurantId);
-        return _mapper.ToDtoList(bookings);
+        return _mapper.ToDtoWithGroupList(bookings);
     }
 
     public virtual async Task UpdateBookingAsync(int id, BookingDto bookingDto)

--- a/OpenRestoApi/Core/Application/Services/EmailTemplateService.cs
+++ b/OpenRestoApi/Core/Application/Services/EmailTemplateService.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Mappings;
 using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 using OpenRestoApi.Infrastructure.Email;
@@ -68,6 +69,9 @@ public sealed class EmailTemplateService : IEmailTemplateService
             : "";
 
         string? tableLabel = booking.Table?.Name ?? (booking.TableId.HasValue ? $"Table #{booking.TableId}" : null);
+        // Combinable-table group booking: Table is null, so fall back to a readable group label so
+        // the confirmation email still tells the diner what they reserved.
+        tableLabel ??= booking.TableGroup is not null ? BookingMapper.GroupLabel(booking.TableGroup) : null;
         string tableHtml = tableLabel != null
             ? $"""
                <tr>

--- a/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
+++ b/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
@@ -66,8 +66,10 @@ public sealed class TableAutoAssigner(
         {
             if (groupedTableIds.Contains(table.Id)) continue;
 
-            bool booked = await _bookingRepository.IsTableBookedOnDateAsync(
-                table.Id, bookingDateUtc, durationMinutes);
+            // Group-aware: also blocks when the table is reserved by a group booking (which stores
+            // TableId = null and so is invisible to the table-only check).
+            bool booked = await _bookingRepository.IsUnitBookedOnDateAsync(
+                table.Id, tableGroupId: null, bookingDateUtc, durationMinutes);
             if (!booked && !_holdService.IsTableHeld(table.Id, bookingDateUtc, durationMinutes: durationMinutes))
             {
                 free.Add(new TableCandidate(table.Id, sectionId, table.Seats));
@@ -91,19 +93,25 @@ public sealed class TableAutoAssigner(
                 var memberIds = group.Members.Select(m => m.TableId).ToList();
                 if (memberIds.Count == 0) continue;
 
-                bool allMembersFree = true;
-                foreach (int memberId in memberIds)
+                // Group-aware: a single check catches the group already booked, a member booked
+                // individually, or a member reserved by a sibling group booking.
+                bool groupBooked = await _bookingRepository.IsUnitBookedOnDateAsync(
+                    tableId: null, tableGroupId: group.Id, bookingDateUtc, durationMinutes);
+
+                bool allMembersFreeOfHolds = !groupBooked;
+                if (allMembersFreeOfHolds)
                 {
-                    bool booked = await _bookingRepository.IsTableBookedOnDateAsync(
-                        memberId, bookingDateUtc, durationMinutes);
-                    if (booked || _holdService.IsTableHeld(memberId, bookingDateUtc, durationMinutes: durationMinutes))
+                    foreach (int memberId in memberIds)
                     {
-                        allMembersFree = false;
-                        break;
+                        if (_holdService.IsTableHeld(memberId, bookingDateUtc, durationMinutes: durationMinutes))
+                        {
+                            allMembersFreeOfHolds = false;
+                            break;
+                        }
                     }
                 }
 
-                if (!allMembersFree) continue;
+                if (!allMembersFreeOfHolds) continue;
 
                 // Anchor to the first member's id/section so existing callers that read TableId/SectionId
                 // still get a concrete value; the group identity rides on TableGroupId + MemberTableIds.

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
@@ -38,6 +38,9 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
             return await _db.Bookings
                 .Include(b => b.Table)
                 .Include(b => b.Section)
+                .Include(b => b.TableGroup)!
+                    .ThenInclude(g => g.Members)
+                        .ThenInclude(m => m.Table)
                 .Include(b => b.Restaurant)
                 .FirstOrDefaultAsync(b => b.Id == id);
         }
@@ -47,6 +50,9 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
             return await _db.Bookings
                 .Include(b => b.Table)
                 .Include(b => b.Section)
+                .Include(b => b.TableGroup)!
+                    .ThenInclude(g => g.Members)
+                        .ThenInclude(m => m.Table)
                 .Include(b => b.Restaurant)
                 .FirstOrDefaultAsync(b => b.BookingRef == bookingRef);
         }
@@ -56,6 +62,9 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
             return await _db.Bookings
                 .Include(b => b.Table)
                 .Include(b => b.Section)
+                .Include(b => b.TableGroup)!
+                    .ThenInclude(g => g.Members)
+                        .ThenInclude(m => m.Table)
                 .Include(b => b.Restaurant)
                 .Where(b => b.Restaurant.Id == restaurantId)
                 .ToListAsync();
@@ -91,6 +100,70 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
                 !b.IsCancelled &&
                 b.Date < newEnd &&
                 (b.EndTime != null ? b.EndTime > newStart : b.Date > thresholdStart));
+        }
+
+        /// <summary>
+        /// Group-aware conflict check. Resolves the set of physical table ids and group ids that count
+        /// as "the unit being booked", then returns true if any non-cancelled booking overlapping the
+        /// window reserves one of those tables (directly or via a group), or one of those groups.
+        /// See <see cref="IBookingRepository.IsUnitBookedOnDateAsync"/> for the contract.
+        /// </summary>
+        public async Task<bool> IsUnitBookedOnDateAsync(
+            int? tableId,
+            int? tableGroupId,
+            DateTime bookingDate,
+            int durationMinutes = 60)
+        {
+            DateTime newStart = bookingDate.ToUniversalTime();
+            DateTime newEnd = newStart.AddMinutes(durationMinutes);
+            DateTime thresholdStart = newStart.AddMinutes(-durationMinutes);
+
+            // Resolve every table id that counts as reserved by this unit. Booking a table also
+            // reserves its group's other members (they can't be pushed together while one is taken);
+            // booking a group reserves all of its members.
+            var reservedTableIds = new HashSet<int>();
+
+            if (tableGroupId.HasValue)
+            {
+                foreach (TableGroupMembership m in await _db.TableGroupMemberships
+                    .Where(m => m.TableGroupId == tableGroupId.Value).ToListAsync())
+                {
+                    reservedTableIds.Add(m.TableId);
+                }
+            }
+
+            if (tableId.HasValue)
+            {
+                reservedTableIds.Add(tableId.Value);
+            }
+
+            if (reservedTableIds.Count == 0)
+            {
+                return false;
+            }
+
+            // Expand to every group that contains ANY reserved table — booking a table that shares a
+            // group with another table (even via a different group) conflicts with that group's
+            // bookings too, because those bookings reserve the shared physical table. This is what
+            // makes a group booking (TableId = null) visible: it's matched on its TableGroupId here.
+            var reservedGroupIds = new HashSet<int>(
+                await _db.TableGroupMemberships
+                    .Where(m => reservedTableIds.Contains(m.TableId))
+                    .Select(m => m.TableGroupId)
+                    .Distinct()
+                    .ToListAsync());
+
+            if (tableGroupId.HasValue)
+            {
+                reservedGroupIds.Add(tableGroupId.Value);
+            }
+
+            return await _db.Bookings.AnyAsync(b =>
+                !b.IsCancelled &&
+                b.Date < newEnd &&
+                (b.EndTime != null ? b.EndTime > newStart : b.Date > thresholdStart) &&
+                ((b.TableId.HasValue && reservedTableIds.Contains(b.TableId.Value)) ||
+                 (b.TableGroupId.HasValue && reservedGroupIds.Contains(b.TableGroupId.Value))));
         }
 
         public async Task<IEnumerable<Booking>> GetActiveBookingsForDateAsync(int restaurantId, DateTime bookingDate)
@@ -133,6 +206,9 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
                 .Include(b => b.Restaurant)
                 .Include(b => b.Section)
                 .Include(b => b.Table)
+                .Include(b => b.TableGroup)!
+                    .ThenInclude(g => g.Members)
+                        .ThenInclude(m => m.Table)
                 .Where(b => b.RestaurantId == restaurantId &&
                             !b.IsCancelled &&
                             b.Date <= nowUtc &&
@@ -146,6 +222,9 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
                 .Include(b => b.Restaurant)
                 .Include(b => b.Section)
                 .Include(b => b.Table)
+                .Include(b => b.TableGroup)!
+                    .ThenInclude(g => g.Members)
+                        .ThenInclude(m => m.Table)
                 .Where(b => b.RestaurantId == restaurantId &&
                             b.Date >= startUtc && b.Date < endUtc &&
                             !b.IsCancelled)

--- a/openresto-frontend/api/bookings.ts
+++ b/openresto-frontend/api/bookings.ts
@@ -4,6 +4,12 @@ export interface BookingDto {
   id: number;
   tableId: number | null;
   sectionId: number | null;
+  /**
+   * Combinable-table group id when this booking reserves a merged group of tables (#272); null for
+   * a single-table booking. Mutually exclusive with tableId. When set, tableName carries the group
+   * label (e.g. "Tables 8 + 9") and tableSeats carries the group's combined capacity.
+   */
+  tableGroupId?: number | null;
   restaurantId: number;
   date: string;
   endTime?: string;
@@ -44,6 +50,7 @@ function normalizeBooking(raw: Record<string, unknown>): BookingDto {
     id: (raw.id ?? raw.Id) as number,
     tableId: (raw.tableId ?? raw.TableId ?? null) as number | null,
     sectionId: (raw.sectionId ?? raw.SectionId ?? null) as number | null,
+    tableGroupId: (raw.tableGroupId ?? raw.TableGroupId ?? null) as number | null,
     restaurantId: (raw.restaurantId ?? raw.RestaurantId) as number,
     date: (raw.date ?? raw.Date) as string,
     endTime: (raw.endTime ?? raw.EndTime) as string | undefined,

--- a/openresto-frontend/components/booking/BookingDetailRows.tsx
+++ b/openresto-frontend/components/booking/BookingDetailRows.tsx
@@ -62,7 +62,15 @@ function buildRows(booking: BookingDto, restaurant: RestaurantDto | null): RowDa
     rows.push({ icon: "layers-outline", label: "Section", value: booking.sectionName });
   }
 
-  if (booking.tableName) {
+  // A group booking (combinable tables) reserves a merged group, not a single table — render a
+  // "Tables" row with a link icon and the group label so the diner sees what they actually booked.
+  if (booking.tableGroupId) {
+    rows.push({
+      icon: "link-outline",
+      label: "Tables",
+      value: booking.tableName ?? "Combined tables",
+    });
+  } else if (booking.tableName) {
     rows.push({ icon: "grid-outline", label: "Table", value: booking.tableName });
   }
 

--- a/openresto-frontend/tests/api/bookings.test.ts
+++ b/openresto-frontend/tests/api/bookings.test.ts
@@ -41,7 +41,9 @@ describe("createBooking", () => {
     expect(url).toContain("/api/bookings");
     expect(opts.method).toBe("POST");
     expect(JSON.parse(opts.body)).toEqual(validBooking);
-    expect(result).toEqual(created);
+    // toMatchObject (not toEqual) because normalizeBooking fills optional keys (tableGroupId,
+    // endTime, isCancelled) that the minimal mock doesn't carry.
+    expect(result).toMatchObject(created);
   });
 
   it("throws with server message on 409 conflict", async () => {
@@ -219,6 +221,7 @@ describe("normalizeBooking (PascalCase fields)", () => {
       Id: 99,
       TableId: 3,
       SectionId: 4,
+      TableGroupId: null,
       RestaurantId: 5,
       Date: "2026-06-15T19:00:00Z",
       EndTime: "2026-06-15T20:30:00Z",
@@ -244,6 +247,7 @@ describe("normalizeBooking (PascalCase fields)", () => {
       id: 99,
       tableId: 3,
       sectionId: 4,
+      tableGroupId: null,
       restaurantId: 5,
       endTime: "2026-06-15T20:30:00Z",
       customerEmail: "pascal@test.com",
@@ -253,6 +257,37 @@ describe("normalizeBooking (PascalCase fields)", () => {
       bookingRef: "sunny-tarragon",
       tableName: "T3",
       sectionName: "Patio",
+    });
+  });
+
+  it("normalizes a group booking (TableGroupId set, TableId null)", async () => {
+    const groupBooking = {
+      Id: 50,
+      TableId: null,
+      SectionId: 1,
+      TableGroupId: 7,
+      RestaurantId: 5,
+      Date: "2026-06-15T19:00:00Z",
+      CustomerEmail: "group@test.com",
+      Seats: 6,
+      IsHeld: false,
+      BookingRef: "merged-bay",
+      TableName: "Tables T2 + T3",
+      TableSeats: 8,
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => groupBooking,
+    });
+
+    const result = await getBookingById(50);
+
+    expect(result).toMatchObject({
+      id: 50,
+      tableId: null,
+      tableGroupId: 7,
+      tableName: "Tables T2 + T3",
+      tableSeats: 8,
     });
   });
 });

--- a/openresto-frontend/tests/components/BookingDetailRows.test.tsx
+++ b/openresto-frontend/tests/components/BookingDetailRows.test.tsx
@@ -86,4 +86,33 @@ describe("BookingDetailRows", () => {
     );
     expect(screen.getByText("Table 5")).toBeTruthy();
   });
+
+  it("renders a 'Tables' row with the group label for a group booking", () => {
+    // A group booking (combinable tables) has tableGroupId set and tableId null. The backend
+    // populates tableName with the group label and tableSeats with the combined capacity. The row
+    // must surface as "Tables" (not "Table") so the diner sees they reserved a merged group.
+    const groupBooking: BookingDto = {
+      ...mockBooking,
+      tableId: null,
+      tableGroupId: 7,
+      seats: 6,
+      tableSeats: 8,
+      tableName: "Tables T2 + T3",
+    };
+    render(
+      <BookingDetailRows
+        booking={groupBooking}
+        restaurant={null}
+        mutedColor="gray"
+        borderColor="black"
+      />
+    );
+
+    expect(screen.getByText("Tables")).toBeTruthy();
+    expect(screen.getByText("Tables T2 + T3")).toBeTruthy();
+    // A group booking must not also render the single-table "Table" row.
+    expect(screen.queryByText("Table")).toBeNull();
+    // The combined capacity is shown in the Guests row.
+    expect(screen.getByText(/Table for 8/)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes two bugs reported after the combinable-tables feature (#276) merged, plus makes the group-booking display consistent across every surface (diner confirmation, lookup, admin grid, email, calendar).

### Bug 1 — double-booking of merged tables

**Root cause:** `BookingRepository.IsTableBookedOnDateAsync` filtered only on `Booking.TableId == tableId`, but a group booking persists `TableId = null` + `TableGroupId = <id>`. So **every persisted group booking was invisible to every conflict check**. Holds were group-aware (`IsTableHeld` checks `Members`), but once a hold converted to a booking it vanished from detection — allowing the same physical tables to be booked again:
- the same group booked twice for an overlapping slot
- a member table booked while its group is already booked
- a group booked while one of its members is reserved by *another* group (shared member)

**Fix:** new `BookingRepository.IsUnitBookedOnDateAsync` resolves the set of reserved tables/groups from `TableGroupMemberships` and matches **both** `TableId` and `TableGroupId`, so a group booking is visible. Threaded through all four conflict sites:
- `BookingService` — single-table create, group create, and auto-assign hold-adoption paths
- `TableAutoAssigner` — candidate building (standalone + group freeness)
- `AvailabilityService` — also indexes group bookings by their member table ids so members/groups already booked via a group aren't advertised as free

### Bug 2 — group bookings invisible in the diner UI

**Root cause:** a group booking has null `Table`/`Section`, so the mapper produced null `TableName`/`TableSeats`/`SectionName`; the frontend read `BookingDto` didn't carry `tableGroupId` at all; `BookingDetailRows` only rendered a Table row when `tableName` was truthy → the row vanished. Same gap in the admin grid, confirmation email, and calendar export.

**Fix:**
- `BookingMapper.ToDtoWithGroup` substitutes a readable group label (`Tables T2 + T3` or the group name) + `CombinedSeats` for group bookings
- Diner read queries (`GetByIdAsync`, `GetByRefAsync`, `GetBookingsByRestaurantIdAsync`) and admin queries now `.Include(TableGroup).ThenInclude(Members).ThenInclude(Table)`
- Frontend `BookingDto` + `normalizeBooking` carry `tableGroupId`; `BookingDetailRows` renders a **\"Tables\"** row (link icon) for group bookings instead of hiding it
- Same group-label fix applied consistently to the admin grid (`AdminService.ToDetailDto`), confirmation email (`EmailTemplateService`), and the calendar export (now works because `tableName`/`sectionName` are populated)

### Tests
- **Backend (+4):** group-already-booked, member-vs-its-group, group-vs-group via shared member, group-booking display (label + seats). All group/booking/availability/assigner tests green (176 in the affected suites; 1344 total, the only failures being 4 pre-existing Windows file-lock tests on `main`).
- **Frontend (+2):** `BookingDetailRows` \"Tables\" row for group bookings; `normalizeBooking` group-booking PascalCase. Full suite **2019/2019 green**.

### Files
**Backend:** `BookingRepository` (+`IsUnitBookedOnDateAsync`, includes), `IBookingRepository`, `BookingService` (3 conflict sites + group nav attach), `TableAutoAssigner`, `AvailabilityService`, `BookingMapper` (+`ToDtoWithGroup`/`GroupLabel`), `AdminService.ToDetailDto`, `EmailTemplateService`.
**Frontend:** `api/bookings.ts` (+`tableGroupId`), `components/booking/BookingDetailRows.tsx`.