### PR TITLE
Validate seats with dropdowns + [Range] bounds (FE + BE)

### DIFF
--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -5,6 +5,7 @@ using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Interfaces;
 using OpenRestoApi.Core.Application.Mappings;
 using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 using OpenRestoApi.Infrastructure.Persistence;
 using OpenRestoApi.Infrastructure.Persistence.Repositories;
@@ -1411,12 +1412,12 @@ public class BookingServiceTests
         SeedMultiTableRestaurant(db);
         BookingService svc = CreateService(db);
 
-        // 100 seats — no table fits.
+        // 8 seats — no table fits (largest in SeedMultiTableRestaurant is 6).
         ConflictException ex = await Assert.ThrowsAsync<ConflictException>(() => svc.CreateBookingAsync(new BookingDto
         {
             RestaurantId = 1,
             CustomerEmail = "guest@example.com",
-            Seats = 100,
+            Seats = 8,
             Date = DateTime.UtcNow.AddDays(11)
         }));
 
@@ -1840,5 +1841,28 @@ public class BookingServiceTests
         Assert.Equal(8, fetched.TableSeats);
         Assert.Contains("T2", fetched.TableName);
         Assert.Contains("T3", fetched.TableName);
+    }
+
+    // ── Party-size validation (defense in depth behind the DTO [Range]) ──────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-2)]
+    [InlineData(BookingLimits.MaxSeats + 1)]
+    public async Task CreateBookingAsync_RejectsSeatsOutOfRange(int seats)
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_RejectsSeatsOutOfRange) + seats);
+        TestSeed.BasicRestaurant(db);
+        BookingService svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            CustomerEmail = "x@example.com",
+            Seats = seats,
+            Date = DateTime.UtcNow.AddDays(40),
+            TableId = 1,
+            SectionId = 1
+        }));
     }
 }

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 using OpenRestoApi.Infrastructure.Persistence;
 using OpenRestoApi.Infrastructure.Persistence.Repositories;
@@ -1426,5 +1427,53 @@ public class RestaurantManagementServiceTests
 
         Assert.NotNull(result);
         Assert.Empty(result!.Groups);
+    }
+
+    // ── Seats validation (defense in depth behind the DTO [Range] annotations) ──────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(BookingLimits.MaxSeats + 1)]
+    public async Task AddTableAsync_RejectsSeatsOutOfRange(int seats)
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableAsync_RejectsSeatsOutOfRange) + seats);
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.AddTableAsync(1, 1, "T1", seats));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    [InlineData(BookingLimits.MaxSeats + 1)]
+    public async Task UpdateTableAsync_RejectsSeatsOutOfRange(int seats)
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(UpdateTableAsync_RejectsSeatsOutOfRange) + seats);
+        db.Restaurants.Add(new Restaurant { Id = 1, Name = "R" });
+        db.Sections.Add(new Section { Id = 1, Name = "S", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        await db.SaveChangesAsync();
+        var svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() => svc.UpdateTableAsync(1, 1, 1, "T1", seats));
+    }
+
+    [Fact]
+    public async Task AddTableGroupAsync_RejectsCombinedSeatsAboveMax()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(AddTableGroupAsync_RejectsCombinedSeatsAboveMax));
+        await SeedTwoRestaurantsWithTablesAsync(db);
+        var svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            svc.AddTableGroupAsync(1, new CreateTableGroupRequest
+            {
+                Members = [1, 2],
+                CombinedSeats = BookingLimits.MaxSeats + 1
+            }));
     }
 }

--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel.DataAnnotations;
+using OpenRestoApi.Core.Application.Utilities;
+
 namespace OpenRestoApi.Core.Application.DTOs;
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
@@ -70,6 +73,8 @@ public class AdminCreateBookingRequest
     public DateTime Date { get; set; }
     public string CustomerEmail { get; set; } = null!;
     public string? CustomerName { get; set; }
+
+    [Range(BookingLimits.MinSeats, BookingLimits.MaxSeats)]
     public int Seats { get; set; }
 }
 
@@ -81,6 +86,8 @@ public class AdminUpdateBookingRequest
     public int? SectionId { get; set; }
     public int? TableId { get; set; }
     public DateTime? Date { get; set; }
+
+    [Range(BookingLimits.MinSeats, BookingLimits.MaxSeats)]
     public int? Seats { get; set; }
     public string? CustomerEmail { get; set; }
     public string? CustomerName { get; set; }

--- a/OpenRestoApi/Core/Application/DTOs/BookingDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/BookingDto.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel.DataAnnotations;
+using OpenRestoApi.Core.Application.Utilities;
+
 namespace OpenRestoApi.Core.Application.DTOs;
 
 public class CancelBookingByRefRequest
@@ -25,6 +28,8 @@ public class BookingDto
     public DateTime Date { get; set; }
     public string? CustomerEmail { get; set; }
     public string? CustomerName { get; set; }
+    /// <summary>Party size. Bounded to [<see cref="BookingLimits.MinSeats"/>, <see cref="BookingLimits.MaxSeats"/>] on create.</summary>
+    [Range(BookingLimits.MinSeats, BookingLimits.MaxSeats)]
     public int Seats { get; set; }
     public bool isHeld { get; set; }
     public string? SpecialRequests { get; set; }

--- a/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel.DataAnnotations;
+using OpenRestoApi.Core.Application.Utilities;
+
 namespace OpenRestoApi.Core.Application.DTOs;
 
 // ── Request types ──────────────────────────────────────────────────────────
@@ -76,12 +79,16 @@ public class UpdateSectionRequest
 public class CreateTableRequest
 {
     public string? Name { get; set; }
+
+    [Range(BookingLimits.MinSeats, BookingLimits.MaxSeats)]
     public int Seats { get; set; }
 }
 
 public class UpdateTableRequest
 {
     public string? Name { get; set; }
+
+    [Range(BookingLimits.MinSeats, BookingLimits.MaxSeats)]
     public int Seats { get; set; }
 }
 
@@ -106,7 +113,8 @@ public class CreateTableGroupRequest
     /// <summary>Ids of the member tables to combine. Must be &gt;= 2, all owned by the restaurant, none already grouped.</summary>
     public List<int> Members { get; set; } = new();
 
-    /// <summary>Stored combined seating capacity; validated &gt;= sum of member seats.</summary>
+    /// <summary>Stored combined seating capacity; validated &gt;= sum of member seats and &lt;= <see cref="BookingLimits.MaxSeats"/>.</summary>
+    [Range(BookingLimits.MinSeats, BookingLimits.MaxSeats)]
     public int CombinedSeats { get; set; }
 }
 
@@ -114,6 +122,8 @@ public class UpdateTableGroupRequest
 {
     public string? Name { get; set; }
     public List<int> Members { get; set; } = new();
+
+    [Range(BookingLimits.MinSeats, BookingLimits.MaxSeats)]
     public int CombinedSeats { get; set; }
 }
 

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -69,6 +69,15 @@ public class BookingService(
                 : "This location accepts walk-ins only on the selected day. Please choose another day or just come in.");
         }
 
+        // Party size guard — defense in depth behind the DTO [Range] annotation. Rejects 0/negative
+        // or absurdly large parties with a clear message; without this, a 0-seat booking on a concrete
+        // table would pass the upper-bound capacity check and persist.
+        if (bookingDto.Seats < BookingLimits.MinSeats || bookingDto.Seats > BookingLimits.MaxSeats)
+        {
+            throw new ValidationException(
+                $"Party size must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.");
+        }
+
         // A combinable-table group booking (#272) selected explicitly takes precedence: route it
         // before the TableId/SectionId + auto-assign logic, which assumes a single table. (Auto-assign
         // that resolves to a group sets TableGroupId too and re-enters this branch below.)

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -280,6 +280,8 @@ public class RestaurantManagementService(
             return null;
         }
 
+        ValidateSeats(seats);
+
         var table = new Table { Name = name, Seats = seats, SectionId = sectionId };
         await _tableRepository.AddAsync(table);
 
@@ -295,11 +297,42 @@ public class RestaurantManagementService(
             return null;
         }
 
+        ValidateSeats(seats);
+
         table.Name = name;
         table.Seats = seats;
         await _tableRepository.SaveChangesAsync();
 
         return new TableDto { Id = table.Id, Name = table.Name, Seats = table.Seats };
+    }
+
+    /// <summary>
+    /// Validates a table/group seating capacity. Defense in depth behind the DTO [Range] annotation
+    /// — a direct service call (e.g. from a seeder or test) bypasses model binding, so this catches
+    /// 0/negative/oversized values at the service boundary too.
+    /// </summary>
+    private static void ValidateSeats(int seats)
+    {
+        if (seats < BookingLimits.MinSeats || seats > BookingLimits.MaxSeats)
+        {
+            throw new ValidationException(
+                $"Seats must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.");
+        }
+    }
+
+    /// <summary>
+    /// Validates a combinable group's CombinedSeats: absolute bounds first, then the contextual
+    /// floor (sum of member seats). Split from <see cref="ValidateSeats"/> because the group floor
+    /// depends on the resolved member set.
+    /// </summary>
+    private static void ValidateCombinedSeats(int combinedSeats, int memberSeatsSum)
+    {
+        ValidateSeats(combinedSeats);
+        if (combinedSeats < memberSeatsSum)
+        {
+            throw new ValidationException(
+                $"CombinedSeats ({combinedSeats}) must be at least the sum of member seats ({memberSeatsSum}).");
+        }
     }
 
     public async Task<bool> DeleteTableAsync(int restaurantId, int sectionId, int tableId)
@@ -373,13 +406,9 @@ public class RestaurantManagementService(
 
         List<Table> members = await ResolveAndValidateMembersAsync(restaurantId, req.Members, excludeGroupId: null);
 
-        // CombinedSeats must be at least the sum of member seats — pushing tables together can lose a
-        // seat, so the admin may set it higher, but never lower (catches obvious mistakes).
-        if (req.CombinedSeats < members.Sum(t => t.Seats))
-        {
-            throw new ValidationException(
-                $"CombinedSeats ({req.CombinedSeats}) must be at least the sum of member seats ({members.Sum(t => t.Seats)}).");
-        }
+        // CombinedSeats must be within bounds and at least the sum of member seats — pushing tables
+        // together can lose a seat, so the admin may set it higher, but never lower (catches mistakes).
+        ValidateCombinedSeats(req.CombinedSeats, members.Sum(t => t.Seats));
 
         var group = new TableGroup
         {
@@ -408,11 +437,7 @@ public class RestaurantManagementService(
         List<Table> members = await ResolveAndValidateMembersAsync(
             restaurantId, req.Members, excludeGroupId: groupId, currentMemberIds: currentMemberIds);
 
-        if (req.CombinedSeats < members.Sum(t => t.Seats))
-        {
-            throw new ValidationException(
-                $"CombinedSeats ({req.CombinedSeats}) must be at least the sum of member seats ({members.Sum(t => t.Seats)}).");
-        }
+        ValidateCombinedSeats(req.CombinedSeats, members.Sum(t => t.Seats));
 
         group.Name = req.Name;
         group.CombinedSeats = req.CombinedSeats;

--- a/OpenRestoApi/Core/Application/Utilities/BookingLimits.cs
+++ b/OpenRestoApi/Core/Application/Utilities/BookingLimits.cs
@@ -1,0 +1,22 @@
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// Centralized bounds for seat/party-size and table-capacity values, so the DTO annotations,
+/// service guards, and frontend dropdowns all agree on a single source of truth.
+/// </summary>
+public static class BookingLimits
+{
+    /// <summary>
+    /// Smallest allowed value for a booking party size or a table/group seating capacity.
+    /// A booking must reserve at least one seat; a table must seat at least one guest.
+    /// </summary>
+    public const int MinSeats = 1;
+
+    /// <summary>
+    /// Largest allowed party size (and per-table/group capacity). Mirrors the diner-facing seat
+    /// picker's hard cap so a direct API POST can't bypass it. Parties larger than this should be
+    /// handled by the restaurant directly (the diner UI shows a "contact us" notice past the
+    /// location's effective capacity, which is always &lt;= this ceiling).
+    /// </summary>
+    public const int MaxSeats = 50;
+}

--- a/openresto-frontend/components/admin/settings/AddRow.tsx
+++ b/openresto-frontend/components/admin/settings/AddRow.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { View, Pressable } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
+import Select, { type SelectOption } from "@/components/common/Select";
 import { theme } from "@/theme/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -12,11 +13,18 @@ export function AddRow({
   placeholder,
   onAdd,
   extraPlaceholder,
+  extraOptions,
 }: {
   label: string;
   placeholder?: string;
   onAdd: (name: string, extra?: string) => Promise<void>;
   extraPlaceholder?: string;
+  /**
+   * When provided, the extra field renders as a dropdown (Select) constrained to these options
+   * rather than a free-text numeric input. Used for the add-table "Seats" field so a value can't be
+   * typed that the server would reject.
+   */
+  extraOptions?: SelectOption[];
 }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
@@ -66,12 +74,21 @@ export function AddRow({
         </View>
         {extraPlaceholder && (
           <View style={{ flex: 1 }}>
-            <Input
-              value={extra}
-              onChangeText={setExtra}
-              placeholder={extraPlaceholder}
-              keyboardType="numeric"
-            />
+            {extraOptions ? (
+              <Select
+                selectedValue={extra || undefined}
+                onSelect={(v) => setExtra(String(v))}
+                options={extraOptions}
+                placeholder={extraPlaceholder}
+              />
+            ) : (
+              <Input
+                value={extra}
+                onChangeText={setExtra}
+                placeholder={extraPlaceholder}
+                keyboardType="numeric"
+              />
+            )}
           </View>
         )}
       </View>

--- a/openresto-frontend/components/admin/settings/SectionBlock.tsx
+++ b/openresto-frontend/components/admin/settings/SectionBlock.tsx
@@ -20,8 +20,10 @@ import { RowIconButton } from "./RowIconButton";
 import { theme, getThemeColors } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
+import { buildSeatOptions } from "@/utils/seatOptions";
 import { styles } from "./settings.styles";
 import Input from "@/components/common/Input";
+import Select from "@/components/common/Select";
 
 export function SectionBlock({
   section,
@@ -472,11 +474,11 @@ export function SectionBlock({
               </ThemedText>
               <View style={{ flexDirection: "row", gap: 8, alignItems: "center" }}>
                 <View style={{ flex: 1 }}>
-                  <Input
-                    value={draftCombinedSeats}
-                    onChangeText={setDraftCombinedSeats}
+                  <Select
+                    selectedValue={parseInt(draftCombinedSeats, 10) || undefined}
+                    onSelect={(v) => setDraftCombinedSeats(String(v))}
+                    options={buildSeatOptions()}
                     placeholder={String(g.combinedSeats)}
-                    keyboardType="numeric"
                   />
                 </View>
                 <Pressable style={styles.smallBtn} onPress={() => setEditingGroupId(null)}>
@@ -575,6 +577,7 @@ export function SectionBlock({
           label="Add Table"
           placeholder="Table name (e.g. T1, Booth 1)"
           extraPlaceholder="Seats"
+          extraOptions={buildSeatOptions()}
           onAdd={async (name, extra) => {
             const seats = parseInt(extra ?? "2", 10);
             const result = await addTable(restaurantId, section.id, {

--- a/openresto-frontend/components/admin/settings/TableRow.tsx
+++ b/openresto-frontend/components/admin/settings/TableRow.tsx
@@ -2,11 +2,13 @@ import { useState } from "react";
 import { View, Pressable, ActivityIndicator } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
+import Select from "@/components/common/Select";
 import { theme, getThemeColors } from "@/theme/theme";
 import { TableDto, deleteTable, updateTable, fetchTableDeleteImpact } from "@/api/restaurants";
 import { Ionicons } from "@expo/vector-icons";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
+import { buildSeatOptions } from "@/utils/seatOptions";
 import { styles } from "./settings.styles";
 import { RowIconButton } from "./RowIconButton";
 
@@ -61,7 +63,7 @@ export function TableRow({
 }) {
   const [editing, setEditing] = useState(false);
   const [draftName, setDraftName] = useState(table.name ?? "");
-  const [draftSeats, setDraftSeats] = useState(String(table.seats));
+  const [draftSeats, setDraftSeats] = useState(table.seats);
   const [saving, setSaving] = useState(false);
   // Two-step delete friction (#270) — mirrors DangerZone's deleteStep pattern. `Delete…` reveals
   // an inline confirmation (not a center-screen modal) that names the consequence and requires a
@@ -328,7 +330,7 @@ export function TableRow({
             color={mutedColor}
             onPress={() => {
               setDraftName(table.name ?? "");
-              setDraftSeats(String(table.seats));
+              setDraftSeats(table.seats);
               setEditing(true);
             }}
             accessibilityLabel={`Edit ${tableName}`}
@@ -374,11 +376,11 @@ export function TableRow({
           <ThemedText style={{ fontSize: 11, fontWeight: "600", color: mutedColor }}>
             SEATS
           </ThemedText>
-          <Input
-            value={draftSeats}
-            onChangeText={setDraftSeats}
-            placeholder="4"
-            keyboardType="numeric"
+          <Select
+            selectedValue={draftSeats}
+            onSelect={(v) => setDraftSeats(v as number)}
+            options={buildSeatOptions()}
+            placeholder="Seats"
           />
         </View>
       </View>
@@ -392,12 +394,10 @@ export function TableRow({
           style={[styles.actionBtn, { backgroundColor: primaryColor, paddingHorizontal: 16 }]}
           disabled={saving}
           onPress={async () => {
-            const seats = parseInt(draftSeats, 10);
-            if (isNaN(seats) || seats < 1) return;
             setSaving(true);
             const result = await updateTable(restaurantId, sectionId, table.id, {
               name: draftName.trim() || undefined,
-              seats,
+              seats: draftSeats,
             });
             setSaving(false);
             if (result) {

--- a/openresto-frontend/tests/components/admin/settings/SectionBlock.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/SectionBlock.test.tsx
@@ -199,7 +199,13 @@ describe("SectionBlock", () => {
     fireEvent.press(screen.getByText("Add Table"));
 
     fireEvent.changeText(screen.getByPlaceholderText("Table name (e.g. T1, Booth 1)"), "T3");
-    fireEvent.changeText(screen.getByPlaceholderText("Seats"), "4");
+    // Seats is now a dropdown — open it (placeholder "Seats") and pick "4 seats". The option list
+    // renders inside the modal; a table tile subtitle may also show "4 seats", so pick the modal
+    // option (the last match, since the modal appends after the tiles).
+    fireEvent.press(screen.getByText("Seats"));
+    await act(async () => {
+      fireEvent.press(screen.getAllByText("4 seats").pop()!);
+    });
 
     await act(async () => {
       fireEvent.press(screen.getByText("Add"));
@@ -209,7 +215,7 @@ describe("SectionBlock", () => {
     expect(baseProps.onTableAdded).toHaveBeenCalledWith(newTable);
   });
 
-  it("uses default seats 2 when extra is non-numeric", async () => {
+  it("uses default seats 2 when the seats dropdown is left untouched", async () => {
     const newTable = { id: 21, name: "T4", seats: 2 };
     (restaurantsApi.addTable as jest.Mock).mockResolvedValue(newTable);
 
@@ -252,7 +258,11 @@ describe("SectionBlock", () => {
     render(<SectionBlock {...baseProps} />);
     fireEvent.press(screen.getByText("Add Table"));
     fireEvent.changeText(screen.getByPlaceholderText("Table name (e.g. T1, Booth 1)"), "T3");
-    fireEvent.changeText(screen.getByPlaceholderText("Seats"), "4");
+    // Seats dropdown — pick "4 seats" (last match = the modal option; a table tile may also show it).
+    fireEvent.press(screen.getByText("Seats"));
+    await act(async () => {
+      fireEvent.press(screen.getAllByText("4 seats").pop()!);
+    });
     await act(async () => {
       fireEvent.press(screen.getByText("Add"));
     });
@@ -269,7 +279,7 @@ describe("SectionBlock", () => {
     render(<SectionBlock {...baseProps} />);
     fireEvent.press(screen.getByText("Add Table"));
     fireEvent.changeText(screen.getByPlaceholderText("Table name (e.g. T1, Booth 1)"), "T4");
-    fireEvent.changeText(screen.getByPlaceholderText("Seats"), "2");
+    // Seats left at default (2) — no selection needed.
     await act(async () => {
       fireEvent.press(screen.getByText("Add"));
     });
@@ -277,13 +287,12 @@ describe("SectionBlock", () => {
     expect(baseProps.onTableAdded).not.toHaveBeenCalled();
   });
 
-  it("uses default seats of 2 when extra is NaN", async () => {
+  it("uses default seats of 2 when the seats dropdown is left untouched", async () => {
     const newTable = { id: 21, name: "T5", seats: 2 };
     (restaurantsApi.addTable as jest.Mock).mockResolvedValue(newTable);
     render(<SectionBlock {...baseProps} />);
     fireEvent.press(screen.getByText("Add Table"));
     fireEvent.changeText(screen.getByPlaceholderText("Table name (e.g. T1, Booth 1)"), "T5");
-    fireEvent.changeText(screen.getByPlaceholderText("Seats"), "abc");
     await act(async () => {
       fireEvent.press(screen.getByText("Add"));
     });
@@ -431,7 +440,11 @@ describe("SectionBlock", () => {
     await act(async () => {
       fireEvent.press(screen.getByTestId("group-edit-btn-1"));
     });
-    fireEvent.changeText(screen.getByDisplayValue("6"), "8");
+    // Combined-seats is now a dropdown seeded with the current value (6). Open it and pick "8 seats".
+    fireEvent.press(screen.getByText("6 seats"));
+    await act(async () => {
+      fireEvent.press(screen.getByText("8 seats"));
+    });
     await act(async () => {
       fireEvent.press(screen.getByTestId("group-save-combined-btn"));
     });

--- a/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/TableRow.test.tsx
@@ -60,7 +60,8 @@ describe("TableRow", () => {
       fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     expect(screen.getByDisplayValue("T1")).toBeTruthy();
-    expect(screen.getByDisplayValue("4")).toBeTruthy();
+    // SEATS is now a dropdown; its trigger shows the selected label.
+    expect(screen.getByText("4 seats")).toBeTruthy();
   });
 
   it("shows Cancel and Save buttons in edit mode", () => {
@@ -80,7 +81,13 @@ describe("TableRow", () => {
       fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
     fireEvent.changeText(screen.getByDisplayValue("T1"), "T1-Updated");
-    fireEvent.changeText(screen.getByDisplayValue("4"), "2");
+    // Open the seats dropdown and pick "2 seats".
+    act(() => {
+      fireEvent.press(screen.getByText("4 seats"));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByText("2 seats"));
+    });
     await act(async () => {
       fireEvent.press(screen.getByText("Save"));
     });
@@ -91,28 +98,22 @@ describe("TableRow", () => {
     expect(baseProps.onUpdated).toHaveBeenCalledWith(updatedTable);
   });
 
-  it("does not save when seats is not a valid number", async () => {
+  it("saves with the unchanged seats when the dropdown is not touched", async () => {
+    // The dropdown can no longer produce an invalid seats value (options are constrained), so the
+    // relevant invariant is that the seeded value persists through save when untouched.
+    const updatedTable = { id: 5, name: "T1", seats: 4 };
+    (restaurantsApi.updateTable as jest.Mock).mockResolvedValue(updatedTable);
     render(<TableRow {...baseProps} />);
     act(() => {
       fireEvent.press(screen.getByTestId("table-edit-btn-5"));
     });
-    fireEvent.changeText(screen.getByDisplayValue("4"), "abc");
     await act(async () => {
       fireEvent.press(screen.getByText("Save"));
     });
-    expect(restaurantsApi.updateTable).not.toHaveBeenCalled();
-  });
-
-  it("does not save when seats is 0", async () => {
-    render(<TableRow {...baseProps} />);
-    act(() => {
-      fireEvent.press(screen.getByTestId("table-edit-btn-5"));
+    expect(restaurantsApi.updateTable).toHaveBeenCalledWith(1, 2, 5, {
+      name: "T1",
+      seats: 4,
     });
-    fireEvent.changeText(screen.getByDisplayValue("4"), "0");
-    await act(async () => {
-      fireEvent.press(screen.getByText("Save"));
-    });
-    expect(restaurantsApi.updateTable).not.toHaveBeenCalled();
   });
 
   it("cancels edit mode when Cancel is pressed", () => {

--- a/openresto-frontend/utils/seatOptions.ts
+++ b/openresto-frontend/utils/seatOptions.ts
@@ -1,0 +1,25 @@
+/**
+ * Seat-count dropdown options shared by every seats/capacity picker (admin table editor, add-table
+ * form, combinable-group combined-seats editor). Matches the backend BookingLimits bounds so the
+ * frontend can never offer a value the server will reject — see OpenRestoApi BookingLimits.cs.
+ */
+export const MIN_SEATS = 1;
+export const MAX_SEATS = 50;
+
+export interface SeatOption {
+  label: string;
+  value: number;
+}
+
+/**
+ * Build seat-count options from `min` (inclusive) to `max` (inclusive). Defaults to the global
+ * [MIN_SEATS, MAX_SEATS] range; callers can narrow it (e.g. a group's combined-seats editor may
+ * want a floor above the sum of member seats).
+ */
+export function buildSeatOptions(min: number = MIN_SEATS, max: number = MAX_SEATS): SeatOption[] {
+  const options: SeatOption[] = [];
+  for (let i = min; i <= max; i++) {
+    options.push({ label: `${i} seat${i === 1 ? "" : "s"}`, value: i });
+  }
+  return options;
+}


### PR DESCRIPTION
## Summary

Replaces the remaining free-text seats inputs with constrained **dropdowns** and adds **server-side validation** so an invalid seat count can't be entered or persisted — across every feature touched this session.

### Frontend — dropdowns instead of raw text fields
Three admin-settings inputs were free-text numeric `Input`s with weak validation (one had none at all):
- `TableRow` edit-table **SEATS** (min 1 only, no max, silent abort)
- `AddRow` add-table **Seats** (no validation)
- `SectionBlock` combinable-group **combined-seats** editor (min 1 only, no max)

All three now use the shared `Select` dropdown constrained to **[1, 50]** via a new `buildSeatOptions()` helper (`utils/seatOptions.ts`). The diner `BookingForm` and admin booking modals already used dropdowns — those were left as-is.

`AddRow` gains an optional `extraOptions` prop so it renders a `Select` when options are provided (seats) and falls back to a text input otherwise, keeping it generic.

### Backend — defense in depth
- New **`BookingLimits`** constant (`MinSeats=1`, `MaxSeats=50`) — the single source of truth shared by the DTO annotations, service guards, and the FE helper.
- **`[Range(1, 50)]`** on `Seats` across `BookingDto`, `CreateTableRequest`, `UpdateTableRequest`, `CreateTableGroupRequest`, `UpdateTableGroupRequest`, `AdminCreateBookingRequest`, `AdminUpdateBookingRequest`. `[ApiController]` turns these into automatic **400** responses at every entry point.
- **Service-level guards** where a direct call bypasses model binding:
  - `BookingService.CreateBookingAsync` rejects out-of-range party size (it previously had **no** `Seats > 0` guard at all — 0/negative bookings could persist).
  - `RestaurantManagementService` `AddTable`/`UpdateTable` validate seats; `AddTableGroup`/`UpdateTableGroup` validate `CombinedSeats` (absolute bounds + the existing sum-of-members floor) via a shared `ValidateCombinedSeats` helper.

### Tests
- **Backend (+7):** seats out-of-range (0, negative, over-max) rejected on booking create, table add/update, and group combined-seats. 1354 pass (only the 4 pre-existing Windows file-lock tests fail, same as `main`).
- **Frontend:** updated seats assertions to drive the dropdown (open + pick an option) instead of typing into a text field. **2018/2018 pass.**

Lint/tsc/prettier clean.

### Files
- **Backend:** `BookingLimits.cs` (new), `BookingDto.cs`, `RestaurantDto.cs`, `AdminDto.cs` (`[Range]`), `BookingService.cs` + `RestaurantManagementService.cs` (guards).
- **Frontend:** `seatOptions.ts` (new), `TableRow.tsx`, `AddRow.tsx`, `SectionBlock.tsx` (dropdowns).