### PR TITLE
Claude/seats validation dropdowns

### DIFF
--- a/openresto-frontend/components/admin/settings/RowTextButton.tsx
+++ b/openresto-frontend/components/admin/settings/RowTextButton.tsx
@@ -1,0 +1,63 @@
+import { type ComponentProps } from "react";
+import { Pressable, type StyleProp, type ViewStyle } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/themed-text";
+
+export interface RowTextButtonProps {
+  label: string;
+  onPress?: () => void;
+  color: string;
+  testID?: string;
+  accessibilityLabel?: string;
+  disabled?: boolean;
+  /** Optional leading Ionicons glyph rendered before the label. */
+  icon?: ComponentProps<typeof Ionicons>["name"];
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Small bordered text-pill button that pairs visually with {@link RowIconButton} in a row's trailing
+ * action cluster. Used for the primary, non-destructive "Edit" affordance so it reads as a real
+ * button (the user asked for a proper Edit button instead of a bare pencil icon), while destructive
+ * actions (delete) stay icon-only. Matches RowIconButton's tappable target and the shared 8px radius
+ * so the cluster stays tight and consistent.
+ */
+export function RowTextButton({
+  label,
+  onPress,
+  color,
+  testID,
+  accessibilityLabel,
+  disabled = false,
+  icon,
+  style,
+}: RowTextButtonProps) {
+  return (
+    <Pressable
+      testID={testID}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityState={{ disabled }}
+      hitSlop={{ top: 6, bottom: 6, left: 4, right: 4 }}
+      style={({ pressed }) => [
+        {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 4,
+          paddingVertical: 4,
+          paddingHorizontal: 8,
+          borderRadius: 8,
+          borderWidth: 1,
+          borderColor: color,
+          opacity: disabled ? 0.5 : pressed ? 0.6 : 1,
+        },
+        style,
+      ]}
+    >
+      {icon ? <Ionicons name={icon} size={13} color={color} /> : null}
+      <ThemedText style={{ fontSize: 12, fontWeight: "600", color }}>{label}</ThemedText>
+    </Pressable>
+  );
+}

--- a/openresto-frontend/components/admin/settings/SectionBlock.tsx
+++ b/openresto-frontend/components/admin/settings/SectionBlock.tsx
@@ -17,6 +17,7 @@ import {
 import { TableRow, TableRowGroupContext } from "./TableRow";
 import { AddRow } from "./AddRow";
 import { RowIconButton } from "./RowIconButton";
+import { RowTextButton } from "./RowTextButton";
 import { theme, getThemeColors } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
@@ -266,8 +267,8 @@ export function SectionBlock({
           )}
         </View>
 
-        {/* Right: edit/save/delete actions */}
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+        {/* Right: edit/save/delete actions — gap 8 to match the table-row trailing cluster. */}
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
           {editing ? (
             <>
               <Pressable
@@ -316,9 +317,10 @@ export function SectionBlock({
                 accessibilityLabel={`Move ${section.name} section down`}
                 accessibilityHint="Moves this section later in the display order"
               />
-              <RowIconButton
+              <RowTextButton
                 testID="section-edit-btn"
-                name="pencil-outline"
+                label="Edit"
+                icon="pencil-outline"
                 color={primaryColor}
                 onPress={() => {
                   setDraft(section.name);

--- a/openresto-frontend/components/admin/settings/TableRow.tsx
+++ b/openresto-frontend/components/admin/settings/TableRow.tsx
@@ -11,6 +11,7 @@ import { hexToRgba } from "@/utils/colors";
 import { buildSeatOptions } from "@/utils/seatOptions";
 import { styles } from "./settings.styles";
 import { RowIconButton } from "./RowIconButton";
+import { RowTextButton } from "./RowTextButton";
 
 /**
  * Group membership context for a table row (#273). When present, the row renders inside a
@@ -313,8 +314,9 @@ export function TableRow({
           </View>
         </View>
 
-        {/* Trailing icon actions */}
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+        {/* Trailing actions — mix of text pill (Edit) and icon buttons (combine/delete); gap 8 keeps
+            the cluster tight and visually balanced across the two button types. */}
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
           {!group && (
             <RowIconButton
               testID={`table-link-btn-${table.id}`}
@@ -324,9 +326,10 @@ export function TableRow({
               accessibilityLabel={`Combine ${tableName} into a group`}
             />
           )}
-          <RowIconButton
+          <RowTextButton
             testID={`table-edit-btn-${table.id}`}
-            name="pencil-outline"
+            label="Edit"
+            icon="pencil-outline"
             color={mutedColor}
             onPress={() => {
               setDraftName(table.name ?? "");

--- a/openresto-frontend/components/common/Select.tsx
+++ b/openresto-frontend/components/common/Select.tsx
@@ -1,6 +1,6 @@
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
-import { Modal, Pressable, StyleSheet, FlatList, TouchableOpacity } from "react-native";
+import { Modal, Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { useState } from "react";
 import { theme } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -45,39 +45,46 @@ export default function Select({
           onPress={() => setModalVisible(false)}
         >
           <ThemedView style={[styles.modalView, { borderColor }]}>
-            <FlatList
-              data={options}
-              keyExtractor={(item) => item.value.toString()}
-              style={styles.list}
-              ItemSeparatorComponent={() => (
-                <ThemedView style={[styles.separator, { backgroundColor: dividerColor }]} />
-              )}
-              renderItem={({ item }) => (
-                <TouchableOpacity
-                  style={[
-                    styles.option,
-                    item.value === selectedValue && { backgroundColor: `${primaryColor}14` },
-                  ]}
-                  onPress={() => {
-                    Haptics.selectionAsync();
-                    onSelect(item.value);
-                    setModalVisible(false);
-                  }}
-                >
-                  <ThemedText
-                    style={[
-                      styles.optionText,
-                      item.value === selectedValue && { color: primaryColor, fontWeight: "600" },
+            {/*
+              Plain ScrollView over FlatList: option counts are small (max ~50 for seat pickers),
+              so virtualization buys nothing, and react-native-web's FlatList scroll container
+              intercepts the touch-start of a tap (treating it as a potential drag) so the option's
+              onPress never fires — the modal just dismisses on pointer-up. A ScrollView with
+              nestedScrollEnabled + direct Pressable rows is reliable cross-platform.
+            */}
+            <ScrollView style={styles.list} nestedScrollEnabled>
+              {options.map((item, i) => (
+                <View key={item.value.toString()}>
+                  <Pressable
+                    style={({ pressed }) => [
+                      styles.option,
+                      item.value === selectedValue && { backgroundColor: `${primaryColor}14` },
+                      pressed && { opacity: 0.6 },
                     ]}
+                    onPress={() => {
+                      Haptics.selectionAsync();
+                      onSelect(item.value);
+                      setModalVisible(false);
+                    }}
                   >
-                    {item.label}
-                  </ThemedText>
-                  {item.value === selectedValue && (
-                    <ThemedText style={[styles.checkmark, { color: primaryColor }]}>✓</ThemedText>
+                    <ThemedText
+                      style={[
+                        styles.optionText,
+                        item.value === selectedValue && { color: primaryColor, fontWeight: "600" },
+                      ]}
+                    >
+                      {item.label}
+                    </ThemedText>
+                    {item.value === selectedValue && (
+                      <ThemedText style={[styles.checkmark, { color: primaryColor }]}>✓</ThemedText>
+                    )}
+                  </Pressable>
+                  {i < options.length - 1 && (
+                    <ThemedView style={[styles.separator, { backgroundColor: dividerColor }]} />
                   )}
-                </TouchableOpacity>
-              )}
-            />
+                </View>
+              ))}
+            </ScrollView>
           </ThemedView>
         </Pressable>
       </Modal>


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

## Related issue

Closes #

## Scope

- [ ] API (OpenRestoApi)
- [ ] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

-

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [ ] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [ ] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed
