### PR TITLE
chore(dev): provision .NET SDK + npm deps via a SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -11,9 +11,19 @@
 # manage their own toolchain per the README's prerequisites.
 set -euo pipefail
 
+# The guard runs before the async declaration so a local machine produces no
+# output at all and the hook is a pure no-op there.
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
+
+# Provision in the background so the session is usable immediately. The trade-off
+# is a startup window where the toolchain isn't ready yet: if `dotnet` or a
+# node_modules import is missing in the first moments of a session, this is why —
+# wait for it to finish rather than concluding the environment is broken.
+# A fully cold run takes ~45s with warm apt/npm caches; the timeout below is
+# generous headroom for a container that has to download everything.
+echo '{"async": true, "asyncTimeout": 600000}'
 
 cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}"
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# SessionStart hook — provisions a fresh Claude Code on the web container so the
+# backend and frontend can be built, linted, and tested without manual setup.
+#
+# The container image ships Node but no .NET SDK, and only the frontend's
+# node_modules are pre-populated. Without this, `dotnet build` / `dotnet test`
+# are simply unavailable and the root `npm run dev` script has no dependencies.
+#
+# Local machines are left alone (see the CLAUDE_CODE_REMOTE guard) — developers
+# manage their own toolchain per the README's prerequisites.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}"
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+# ── .NET SDK ────────────────────────────────────────────────────────────────
+# Ubuntu's own dotnet-sdk-10.0 package, not the dot.net install script: the
+# environment's network policy blocks builds.dotnet.microsoft.com, so the
+# Microsoft installer cannot fetch anything. The apt index shipped in the image
+# is stale enough that install 404s on its own, hence the update first.
+DOTNET_MAJOR=10
+
+if command -v dotnet >/dev/null 2>&1 && dotnet --list-sdks | grep -q "^${DOTNET_MAJOR}\."; then
+  echo "✓ .NET ${DOTNET_MAJOR} SDK already present ($(dotnet --version))"
+else
+  echo "Installing .NET ${DOTNET_MAJOR} SDK…"
+  export DEBIAN_FRONTEND=noninteractive
+  # Third-party PPAs in the image are unreachable through the proxy and make
+  # update exit non-zero; the Ubuntu archives themselves still refresh, so don't
+  # let those warnings abort the hook.
+  $SUDO apt-get update -qq || true
+  $SUDO apt-get install -y -qq "dotnet-sdk-${DOTNET_MAJOR}.0"
+  echo "✓ .NET SDK $(dotnet --version)"
+fi
+
+# ── npm dependencies ────────────────────────────────────────────────────────
+# `npm ci`, not `npm install`: install rewrites package-lock.json here (this npm
+# strips the `libc` fields a newer npm wrote), so every session would start with
+# a dirty working tree and risk that churn riding along in an unrelated commit.
+# `ci` installs the lockfile verbatim and never writes it — the same thing CI
+# does. The full reinstall cost is paid once, since container state is cached
+# after this hook completes.
+echo "Installing root npm dependencies…"
+npm ci --no-audit --no-fund --silent
+
+echo "Installing frontend npm dependencies…"
+npm ci --prefix openresto-frontend --no-audit --no-fund --silent
+
+# ── NuGet restore ───────────────────────────────────────────────────────────
+# Warms ~/.nuget so the first `dotnet build`/`dotnet test` of the session isn't
+# paying for a cold package graph.
+echo "Restoring NuGet packages…"
+dotnet restore openresto.sln --nologo --verbosity quiet
+
+echo "✓ Environment ready — dotnet build/test and npm test are available."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "expo@claude-plugins-official": true,
     "microsoft-docs@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

Claude Code on the web containers ship Node but **no .NET SDK**, and only the frontend's `node_modules` are pre-populated. In practice that means a fresh web session cannot run `dotnet build` or `dotnet test` at all — backend changes have to be pushed and verified through CI instead of locally — and the root `npm run dev` script has no dependencies to run with.

This adds a `SessionStart` hook that provisions the container: .NET 10 SDK, root + frontend npm dependencies, and a warmed NuGet cache. It runs **asynchronously**, so the session is usable immediately while provisioning finishes in the background. Local machines are untouched — the hook exits immediately unless `CLAUDE_CODE_REMOTE` is set, so developers keep managing their own toolchain per the README's prerequisites.

Three environment-specific details shaped the implementation and are worth knowing:

- **The SDK comes from Ubuntu's `dotnet-sdk-10.0` package, not the `dot.net` install script.** The network policy blocks `builds.dotnet.microsoft.com`, so the Microsoft installer can't fetch anything. The apt index in the image is also stale enough that installing without an `apt-get update` first 404s — and that update exits non-zero on unreachable third-party PPAs (deadsnakes, ondrej/php), so its failure is tolerated while the install itself is not.
- **npm deps install with `ci`, not `install`.** The container's npm rewrites `package-lock.json` (stripping `libc` fields a newer npm wrote), so `npm install` would leave every session starting on a dirty working tree and risk that churn riding along in an unrelated commit. `npm ci` installs the lockfile verbatim and never writes it, matching what CI already does.
- **The SDK check reads `dotnet --list-sdks`, not `command -v dotnet`.** The image ships the .NET runtime host with zero SDKs installed, so a `command -v` check would wrongly conclude the toolchain was already present and skip the install.

## Related issue

No issue — developer-environment tooling, split out of #281 at the request of the repo owner.

## Scope

- [ ] API (OpenRestoApi)
- [ ] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

- `.claude/hooks/session-start.sh` (new, executable) — remote-only, idempotent, non-interactive, async:
  1. Installs the .NET 10 SDK if no 10.x SDK is present.
  2. `npm ci` at the repo root and in `openresto-frontend`.
  3. `dotnet restore openresto.sln` so the first build of the session isn't paying for a cold package graph.
- `.claude/settings.json` — registers the hook under `hooks.SessionStart`, merged alongside the existing `enabledPlugins` block.

## Execution mode: asynchronous

Provisioning runs in the background so the session starts immediately. A fully cold run takes **~45s** with warm apt/npm caches; the `asyncTimeout` is set to 10 minutes as headroom for a container that has to download everything from scratch.

The trade-off is a brief startup window where the toolchain isn't ready yet. The script documents this at the top so it isn't mistaken for a broken environment: a missing `dotnet` or `node_modules` import in the first moments of a session means the hook is still running. The `CLAUDE_CODE_REMOTE` guard deliberately sits *ahead* of the async declaration, so a local machine still produces no output at all.

## Testing

Validated by uninstalling the SDK and deleting both `node_modules` trees first, to make each run a genuine cold-container test rather than a no-op against an already-provisioned box.

- [x] Cold run installs the SDK + both dependency trees and exits 0 (~45s)
- [x] Async declaration is the first line of stdout, before any provisioning output
- [x] Second run detects the existing SDK and skips the install (idempotent)
- [x] Working tree is clean after the hook — no lockfile churn (this is what `npm ci` buys; verified `npm install` did dirty it)
- [x] No-ops with `CLAUDE_CODE_REMOTE` unset — zero output, not even the async JSON
- [x] Frontend lint/format pass afterwards (`npm run check`, `prettier --check`)
- [x] Frontend tests pass afterwards (`BookingForm` — 3 suites / 61 tests)
- [x] Backend tests pass afterwards (`TableAutoAssignerTests` — 8 tests)
- [ ] CI passes (build, migration-check)

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

Note: this only takes effect for future sessions once it's merged to `main`.