### PR TITLE
chore(scripts): seed contact info and combinable groups in the demo env

### DIFF
--- a/scripts/config-snapshot.sql
+++ b/scripts/config-snapshot.sql
@@ -6,6 +6,10 @@ DELETE FROM Highlights;
 
 DELETE FROM SocialLinks;
 
+DELETE FROM TableGroupMemberships;
+
+DELETE FROM TableGroups;
+
 DELETE FROM Tables;
 
 DELETE FROM Sections;
@@ -21,6 +25,7 @@ WHERE
   name IN (
     'Highlights',
     'SocialLinks',
+    'TableGroups',
     'Tables',
     'Sections',
     'Restaurants',
@@ -39,6 +44,8 @@ INSERT INTO
     HeaderImageUrl,
     FaviconIcon,
     WebsiteUrl,
+    PhoneNumber,
+    EmailAddress,
     CopyrightText,
     Subtitle,
     HighlightsHeading,
@@ -53,6 +60,8 @@ VALUES
     '/media/hero.jpg?v=1780749336371',
     'pizza',
     'https://openres.to',
+    '+1 215 555 0100',
+    'bookings@paddyspub.example',
     NULL,
     'Philadelphia''s home of milk steak and jelly beans.',
     'What we''re known for',
@@ -78,6 +87,9 @@ VALUES
 -- OpenHoursJson is NULL so OpenTime/CloseTime apply to every day.
 -- WalkInOnly is 0 and WalkInDays is NULL so online bookings stay enabled.
 -- Description supports [label](url) inline links — see app/(user)/restaurant/[id].tsx.
+-- PhoneNumber/EmailAddress are the per-location contact override: 1 sets both, 2 sets neither
+--   (falls back to the BrandSettings pair above), 3 sets only a phone (its email still falls
+--   back) — the three states the large-party modal has to handle.
 INSERT INTO
   Restaurants (
     Id,
@@ -97,7 +109,9 @@ INSERT INTO
     WalkInOnly,
     WalkInDays,
     Description,
-    MenuUrl
+    MenuUrl,
+    PhoneNumber,
+    EmailAddress
   )
 VALUES
   (
@@ -118,7 +132,9 @@ VALUES
     0,
     NULL,
     'Philadelphia''s worst bar, now taking bookings. See our [menu](https://paddyspub.example/menu) — cash only.',
-    'https://paddyspub.example/menu'
+    'https://paddyspub.example/menu',
+    '+1 215 555 0123',
+    'philly@paddyspub.example'
   );
 
 INSERT INTO
@@ -140,7 +156,9 @@ INSERT INTO
     WalkInOnly,
     WalkInDays,
     Description,
-    MenuUrl
+    MenuUrl,
+    PhoneNumber,
+    EmailAddress
   )
 VALUES
   (
@@ -161,6 +179,8 @@ VALUES
     0,
     NULL,
     'The Alley Behind the Alley. Walk-ins welcome, online bookings for the brave.',
+    NULL,
+    NULL,
     NULL
   );
 
@@ -183,7 +203,9 @@ INSERT INTO
     WalkInOnly,
     WalkInDays,
     Description,
-    MenuUrl
+    MenuUrl,
+    PhoneNumber,
+    EmailAddress
   )
 VALUES
   (
@@ -204,7 +226,9 @@ VALUES
     0,
     NULL,
     'Open 24 hours because we lost the keys to the lock. [Reviews](https://paddyspub.example/reviews).',
-    'https://paddyspub.example/vancouver-menu.pdf'
+    'https://paddyspub.example/vancouver-menu.pdf',
+    '+1 604 555 0177',
+    NULL
   );
 
 -- Sections
@@ -273,6 +297,40 @@ INSERT INTO
   Tables (Id, Name, Seats, SectionId)
 VALUES
   (8, 'Table 1', 4, 5);
+
+-- Combinable table groups — physical tables an admin flagged as pushable together, bookable as
+-- one unit for a larger party. CombinedSeats must sit in (largest member seats, sum of members]:
+-- group 1 loses a cover where the corners meet (4+2 tables seating 5), group 2 keeps all four.
+-- Member tables stay individually bookable; grouping only deprioritizes them in auto-assign.
+INSERT INTO
+  TableGroups (Id, Name, RestaurantId, CombinedSeats)
+VALUES
+  (1, 'Window booths', 1, 5);
+
+INSERT INTO
+  TableGroupMemberships (TableGroupId, TableId)
+VALUES
+  (1, 1);
+
+INSERT INTO
+  TableGroupMemberships (TableGroupId, TableId)
+VALUES
+  (1, 2);
+
+INSERT INTO
+  TableGroups (Id, Name, RestaurantId, CombinedSeats)
+VALUES
+  (2, NULL, 2, 4);
+
+INSERT INTO
+  TableGroupMemberships (TableGroupId, TableId)
+VALUES
+  (2, 4);
+
+INSERT INTO
+  TableGroupMemberships (TableGroupId, TableId)
+VALUES
+  (2, 5);
 
 -- Highlights (Link=NULL → static card; set a Link to make the whole card clickable)
 INSERT INTO

--- a/scripts/seed-local.sh
+++ b/scripts/seed-local.sh
@@ -157,13 +157,15 @@ exec 3>"$SQL_FILE"
   echo "DELETE FROM Bookings;"
   echo "DELETE FROM Highlights;"
   echo "DELETE FROM SocialLinks;"
+  echo "DELETE FROM TableGroupMemberships;"
+  echo "DELETE FROM TableGroups;"
   echo "DELETE FROM Tables;"
   echo "DELETE FROM Sections;"
   echo "DELETE FROM Restaurants;"
   echo "DELETE FROM BrandSettings;"
   echo "DELETE FROM EmailSettings;"
   echo "DELETE FROM AdminCredentials;"
-  echo "DELETE FROM sqlite_sequence WHERE name IN ('Bookings','Highlights','SocialLinks','Tables','Sections','Restaurants','BrandSettings','EmailSettings','AdminCredentials','AdminNotifications','EmailFailures');"
+  echo "DELETE FROM sqlite_sequence WHERE name IN ('Bookings','Highlights','SocialLinks','TableGroups','Tables','Sections','Restaurants','BrandSettings','EmailSettings','AdminCredentials','AdminNotifications','EmailFailures');"
 
   # Brand (EmailSettings intentionally left empty — no SMTP creds in source control)
   # HeaderImageFit left NULL → defaults to Cover (today's behaviour).
@@ -197,6 +199,17 @@ exec 3>"$SQL_FILE"
   echo "INSERT INTO Tables(Id,Name,Seats,SectionId) VALUES(6,'Bar Table',2,4);"
   echo "INSERT INTO Tables(Id,Name,Seats,SectionId) VALUES(7,'B3',1,3);"
   echo "INSERT INTO Tables(Id,Name,Seats,SectionId) VALUES(8,'Table 1',4,5);"
+
+  # Combinable table groups — tables an admin flagged as pushable together, bookable as one unit
+  # for a larger party. CombinedSeats must sit in (largest member seats, sum of members]: group 1
+  # loses a cover where the corners meet (T1's 4 + T2's 2 seating 5), group 2 keeps all four.
+  # Members stay individually bookable; grouping only deprioritizes them in auto-assign.
+  echo "INSERT INTO TableGroups(Id,Name,RestaurantId,CombinedSeats) VALUES(1,'Window booths',1,5);"
+  echo "INSERT INTO TableGroupMemberships(TableGroupId,TableId) VALUES(1,1);"
+  echo "INSERT INTO TableGroupMemberships(TableGroupId,TableId) VALUES(1,2);"
+  echo "INSERT INTO TableGroups(Id,Name,RestaurantId,CombinedSeats) VALUES(2,NULL,2,4);"
+  echo "INSERT INTO TableGroupMemberships(TableGroupId,TableId) VALUES(2,4);"
+  echo "INSERT INTO TableGroupMemberships(TableGroupId,TableId) VALUES(2,5);"
 
   # Highlights (Link=NULL → static card; set a Link to make the whole card clickable)
   echo "INSERT INTO Highlights(Id,Title,Body,IconKey,SortOrder,Link) VALUES(1,'Dayman Live Every Friday','Fighter of the Nightman. No cover charge. Cash only. Residency secured after a lengthy legal dispute.','star-outline',0,'https://paddyspub.example/dayman');"
@@ -279,7 +292,7 @@ sqlite3 "$DB" < "$SQL_FILE"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 log "Done. Row counts:"
-for t in Restaurants Sections Tables Highlights SocialLinks BrandSettings Bookings AdminCredentials; do
+for t in Restaurants Sections Tables TableGroups Highlights SocialLinks BrandSettings Bookings AdminCredentials; do
   log "  $t: $(sqlite3 "$DB" "SELECT COUNT(*) FROM $t;")"
 done
 log "Seeded $booking_count bookings."


### PR DESCRIPTION
## Summary

Follow-up to #283. `scripts/config-snapshot.sql` is what `purge-bookings.sh` restores on the VPS every two hours, so it's the file that decides what the demo actually shows — and it was missing both recent features. `seed-local.sh` had the contact fields (added in #283) but no table groups.

## Related issue

Follow-up to #262 / #283. Also backfills #271–#274 into the demo.

## Scope

- [ ] API (OpenRestoApi)
- [ ] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

**`scripts/config-snapshot.sql`** (demo env, restored every 2h)

- **Contact info (#262)** — the `BrandSettings` pair, plus the three per-location states the resolution has to handle: location 1 sets both, 2 sets neither (falls back to the brand values), 3 sets only a phone so its email still falls back. Mirrors what `seed-local.sh` already seeds.
- **Combinable table groups (#271–#274)** — never seeded anywhere, so the whole feature was invisible in the demo *and* in local dev. Adds a named group (T1 + T2 → 5 of a possible 6, a cover lost where the corners meet) and an unnamed one (B1 + B2 → all 4).
- `DELETE FROM TableGroupMemberships` / `TableGroups` before the inserts, and `TableGroups` in the `sqlite_sequence` reset. The snapshot's inserts use explicit `Id`s, so without the deletes the second restore would fail on a UNIQUE violation. `TableGroupMemberships` has a composite PK and no sequence to reset.

**`scripts/seed-local.sh`** (local dev)

- Same two groups, matching deletes + sequence reset, and `TableGroups` added to the summary row counts.

**`scripts/reset-admin.sh`** — no change needed; it only touches `AdminCredentials` and has no schema coupling to the new columns.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally — not run; no application code touched
- [ ] Frontend tests/build pass locally — not run; no application code touched
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

Built a database from the real `dotnet ef migrations script` output and exercised both scripts against it:

- `config-snapshot.sql` applies cleanly; contact values land as intended (`(1, +1 215 555 0123, philly@…)`, `(2, NULL, NULL)`, `(3, +1 604 555 0177, NULL)`; brand `+1 215 555 0100` / `bookings@…`).
- Every seeded group satisfies the invariants `RestaurantManagementService` enforces on write: ≥ 2 members, all members in the group's restaurant, `CombinedSeats` inside `(largest member seats, sum of members]` — asserted programmatically, not eyeballed.
- No orphan or cross-restaurant memberships.
- **Idempotency**: four consecutive restores hold stable row counts (3 restaurants / 5 sections / 8 tables / 2 groups / 4 memberships / 4 highlights / 2 social links / 1 brand). This is the property the new DELETEs exist for — `purge-bookings.sh` replays this file on a schedule.
- `seed-local.sh` run twice against a migrated DB: 617 bookings, groups and contact intact, counts stable. `bash -n` clean on all three scripts.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally

No migration — the columns and tables already shipped in #283 and #271.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

## Note

No **group bookings** are seeded. The member tables are already in the booking rotation, and randomly-placed group bookings would collide with member-table bookings that the mutual-exclusion checks correctly refuse. The group still surfaces as a bookable option at unbooked times, which is the behaviour worth demoing. Happy to add a deterministic, collision-free group booking to `purge-bookings.sh` if you want one visible in the admin bookings list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qwgn1qiDtWBA9Lw4xzNy6U)_