### PR TITLE
fix(booking): scope combinable groups to the selected section

### DIFF
--- a/openresto-frontend/components/admin/settings/SectionBlock.tsx
+++ b/openresto-frontend/components/admin/settings/SectionBlock.tsx
@@ -175,8 +175,10 @@ export function SectionBlock({
       const ok = await deleteTableGroup(restaurantId, g.id);
       if (ok) onGroupsChanged(groups.filter((x) => x.id !== g.id));
     } else {
+      // Seats come off the group's own members, not this section's tables — a group rendered here
+      // may still reach into another section, and a missing lookup would silently score it 0 seats.
       const { min, max } = combinedSeatsRange(
-        remaining.map((id) => section.tables.find((t) => t.id === id)?.seats ?? 0)
+        g.members.filter((m) => remaining.includes(m.id)).map((m) => m.seats)
       );
       const updated = await updateTableGroup(restaurantId, g.id, {
         name: g.name ?? null,

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -140,6 +140,15 @@ export default function BookingForm({
   ];
   const isAutoAssign = sectionId === 0;
   const tablesInSection = restaurant.sections.find((s) => s.id === sectionId)?.tables ?? allTables;
+  // Groups belong to the picked section only when *every* member sits in it — booking a group is
+  // booking all its tables, so one member elsewhere means the party would be split across sections.
+  // TableDto carries no sectionId, so membership is resolved through the section's own table ids.
+  const sectionTableIds = new Set(tablesInSection.map((t) => t.id));
+  const groupsInSection = isAutoAssign
+    ? allGroups
+    : allGroups.filter(
+        (g) => g.members.length > 0 && g.members.every((m) => sectionTableIds.has(m.id))
+      );
 
   const timezone = restaurant.timezone || "UTC";
 
@@ -329,11 +338,11 @@ export default function BookingForm({
     })
     .sort((a, b) => a.seats - b.seats);
 
-  // Combinable groups (#274): a group is selectable when its combined capacity fits the party,
-  // respects the optional oversize cap, and (when availability data is present) the group's id is
-  // in the slot's availableGroupIds. Groups use negative Select values (-groupId) so they're
-  // distinguishable from positive table ids.
-  const eligibleGroups = allGroups
+  // Combinable groups (#274): a group is selectable when it sits in the picked section, its combined
+  // capacity fits the party, it respects the optional oversize cap, and (when availability data is
+  // present) the group's id is in the slot's availableGroupIds. Groups use negative Select values
+  // (-groupId) so they're distinguishable from positive table ids.
+  const eligibleGroups = groupsInSection
     .filter(
       (g) =>
         g.combinedSeats >= seats &&

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -672,4 +672,115 @@ describe("BookingForm", () => {
     // No standalone tables (empty availableTableIds) and the group excluded → no dropdown.
     expect(screen.getByText(/No tables available for 6 guests/)).toBeTruthy();
   });
+
+  // ── Groups are scoped to the picked section ───────────────────────────────
+  //
+  // The Select mock always resolves the section field to id 20 ("Patio"), so these two fixtures
+  // differ only in which section owns the group's member tables.
+
+  const groupOfEights = [
+    {
+      id: 1,
+      name: null,
+      combinedSeats: 8,
+      members: [
+        { id: 100, name: "T1", seats: 4 },
+        { id: 101, name: "T2", seats: 4 },
+      ],
+    },
+  ];
+
+  const mockRestaurantGroupInMain = {
+    ...mockRestaurantAllDays,
+    sections: [
+      {
+        id: 10,
+        name: "Main",
+        restaurantId: 1,
+        tables: [
+          { id: 100, name: "T1", seats: 4, sectionId: 10 },
+          { id: 101, name: "T2", seats: 4, sectionId: 10 },
+        ],
+      },
+      {
+        id: 20,
+        name: "Patio",
+        restaurantId: 1,
+        tables: [{ id: 200, name: "P1", seats: 2, sectionId: 20 }],
+      },
+    ],
+    groups: groupOfEights,
+  };
+
+  const mockRestaurantGroupInPatio = {
+    ...mockRestaurantAllDays,
+    sections: [
+      {
+        id: 10,
+        name: "Main",
+        restaurantId: 1,
+        tables: [{ id: 200, name: "P1", seats: 2, sectionId: 10 }],
+      },
+      {
+        id: 20,
+        name: "Patio",
+        restaurantId: 1,
+        tables: [
+          { id: 100, name: "T1", seats: 4, sectionId: 20 },
+          { id: 101, name: "T2", seats: 4, sectionId: 20 },
+        ],
+      },
+    ],
+    groups: groupOfEights,
+  };
+
+  const groupOnlySlot = {
+    slots: [
+      {
+        time: "19:00",
+        isAvailable: true,
+        availableTableIds: [],
+        availableGroupIds: [1],
+        category: "Dinner",
+      },
+    ],
+  };
+
+  it("does not offer a group whose tables live in another section", async () => {
+    mockFetchAvailability.mockResolvedValue(groupOnlySlot);
+    render(
+      <BookingForm restaurant={mockRestaurantGroupInMain} onSubmit={jest.fn()} initialSeats={6} />
+    );
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+    // Select "Patio" — the group's tables are both in "Main".
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select"));
+    });
+    expect(screen.getByText(/No tables available for 6 guests/)).toBeTruthy();
+  });
+
+  it("offers a group whose tables all live in the picked section", async () => {
+    mockFetchAvailability.mockResolvedValue(groupOnlySlot);
+    render(
+      <BookingForm restaurant={mockRestaurantGroupInPatio} onSubmit={jest.fn()} initialSeats={6} />
+    );
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+    // Select "Patio" — this time it owns both of the group's tables.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("section-select"));
+    });
+    await waitFor(() => expect(screen.getByTestId("table-select")).toBeTruthy());
+    expect(screen.queryByText(/No tables available/)).toBeNull();
+  });
+
+  it("still offers every group under 'Any section'", async () => {
+    mockFetchAvailability.mockResolvedValue(groupOnlySlot);
+    render(
+      <BookingForm restaurant={mockRestaurantGroupInMain} onSubmit={jest.fn()} initialSeats={6} />
+    );
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+    // Auto-assign is the default; the group still counts toward capacity, so no large-party notice.
+    expect(screen.queryByText("Large party")).toBeNull();
+    expect(screen.getByText(/best available table/)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

The booking form's Table dropdown filtered **single tables** by the picked section (`tablesInSection`) but built its **combinable-group** options from the restaurant-wide `restaurant.groups` list. Choosing "Patio" still offered a group made entirely of indoor tables. Selecting one submitted `sectionId: null`, and the backend derived the section from the group's members — seating the party in a section they hadn't chosen.

A group now qualifies for a section only when **every** member table sits in it: booking a group books all of its tables, so a single member elsewhere would split the party across sections. `TableDto` carries no `sectionId`, so membership is resolved through the section's own table ids.

"Any section" is unchanged and still considers every group, as does the location-wide large-party capacity check (`maxTableCapacity`) — a party that only a group can seat must not be told to phone the restaurant just because it hasn't picked a section yet.

## Related issue

<!-- none -->

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `components/booking/BookingForm.tsx`: added `groupsInSection`, derived from the selected section's table ids, and switched `eligibleGroups` to build from it instead of `allGroups`.
- `components/admin/settings/SectionBlock.tsx`: `handleUnlink` resolved the remaining members' seats through `section.tables`, which returns `undefined` (scored `0`) for any member outside the section being viewed — a group is rendered in every section it touches. The clamped `combinedSeats` was then computed from a bogus range and rejected by the server. Member seats now come off `g.members`, which already carries them.
- `tests/components/booking/BookingForm.test.tsx`: three cases — a group whose tables live in another section is not offered, a group whose tables all live in the picked section is, and "Any section" still sees every group.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

Frontend suite: 150 suites / 2055 tests pass. `npm run check` (prettier + oxlint) and `tsc --noEmit` clean. The new "another section" case was confirmed to fail against the pre-fix `eligibleGroups = allGroups` and pass after.

Backend tests were not run — this change is frontend-only and touches no API surface. End-to-end verification against a running stack was not done.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed — no API contract change

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBTTgPP1g7LhNeaTE7g9AF)_