### PR TITLE
fix(deps): patch high-severity brace-expansion DoS (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -2898,9 +2898,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +2915,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2938,9 +2932,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2958,9 +2949,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2978,9 +2966,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2998,9 +2983,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3018,9 +3000,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3038,9 +3017,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4864,9 +4840,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -9079,9 +9055,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9101,9 +9074,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9125,9 +9095,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9147,9 +9114,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -97,7 +97,7 @@
     "react-test-renderer": "19.2.3",
     "uuid": ">=14.0.0",
     "shell-quote": ">=1.8.4",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "js-yaml": ">=5.2.2"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Scheduled dependency audit found one live, high-severity vulnerability: `brace-expansion` (transitive, via `minimatch`) is pinned by an npm `overrides` floor of `>=5.0.8` in `openresto-frontend/package.json`, which resolves to exactly the vulnerable version. [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (CVSS 7.5, CWE-400/770 — unbounded intermediate arrays causing DoS) affects `>=4.0.0 <5.0.9`. The fix is already published upstream at 5.0.9.

This matches GitHub's own Dependabot alert on `main` (1 high) surfaced when pushing this branch: https://github.com/karanshukla/openresto/security/dependabot/42

Everything else was checked and is current or not actionable:
- **Backend (NuGet)**: all package versions match latest stable, and none of the currently-pinned versions fall inside any published vulnerable range (checked against the NuGet vulnerability index). `Microsoft.CodeAnalysis.CSharp.Workspaces`/`.Workspaces.MSBuild` are one minor version behind (5.3.0 vs 5.6.0) but are deliberately pinned per `CLAUDE.md` to unify a Roslyn version split that breaks `dotnet ef migrations add` — left untouched since bumping requires re-verifying the resolved graph with a live `dotnet restore`, which wasn't available in this environment.
- **Frontend (npm)**: `npm audit` is otherwise clean. A number of packages have newer versions available (Expo/RN patch releases, React 19.2.8, TypeScript 7, Jest 30, etc.) but none carry a security advisory — left out of scope for this PR since several are major-version bumps with real breaking-change risk.
- **Root `package.json`**: no vulnerabilities, doesn't pull in `brace-expansion` at all.

## Related issue

N/A — found by scheduled dependency audit, not a filed issue.

## Scope

- [x] Frontend (openresto-frontend)
- [ ] API (OpenRestoApi)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- Bump the `brace-expansion` override floor in `openresto-frontend/package.json` from `>=5.0.8` to `>=5.0.9`.
- Regenerate `openresto-frontend/package-lock.json` accordingly.

## Testing

- [x] `npm audit` — 0 vulnerabilities (was 1 high)
- [x] `npm run check` (prettier + oxlint) passes
- [ ] Frontend Jest suite / full CI — not run locally, deferred to CI
- [x] Manually verified `npm ls brace-expansion` resolves to 5.0.9 everywhere in the tree

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed — N/A, no contract change

---
_Generated by [Claude Code](https://claude.ai/code/session_0119T1FVzxbziQ3A225dPugM)_