### PR TITLE
feat(booking): show combinable table groups in the diner seating minimap

### DIFF
--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -16,6 +16,7 @@ import { getNowInTimezone, formatCurrentTimeInTimezone, isViewerInTimezone } fro
 import { isValidEmail } from "@/utils/validation";
 import { getHoursForDate, HoursSource } from "@/utils/openingHours";
 import { isWalkInOnlyOnDate, walkInDaysLabel } from "@/utils/walkIn";
+import { groupDropdownLabel, groupedTableIds } from "@/utils/tableGroups";
 import WalkInNotice from "./WalkInNotice";
 import WalkInDaysBanner from "./WalkInDaysBanner";
 import LargePartyNotice from "./LargePartyNotice";
@@ -83,20 +84,6 @@ function suggestTime(restaurant: HoursSource, timezone: string): string {
 
 // ── Component ────────────────────────────────────────────────────────────────
 
-/**
- * Dropdown label for a combinable-table group (#274): uses the admin-assigned name when present,
- * else falls back to the member table names joined with " + ". Mirrors the issue's L1/L2 decision.
- */
-function groupLabel(g: {
-  name?: string | null;
-  combinedSeats: number;
-  members: { id: number; name?: string | null }[];
-}): string {
-  return g.name
-    ? `${g.name} (${g.combinedSeats} seats)`
-    : `Tables ${g.members.map((m) => m.name ?? m.id).join(" + ")} (${g.combinedSeats} seats combined)`;
-}
-
 export default function BookingForm({
   restaurant,
   onSubmit,
@@ -122,7 +109,7 @@ export default function BookingForm({
   const allGroups = restaurant.groups ?? [];
   // Tables flagged combinable. They stay individually bookable (#242) — this only deprioritizes
   // them in the suggested-table pick below.
-  const groupedTableIds = new Set(allGroups.flatMap((g) => g.members.map((m) => m.id)));
+  const groupedTableIdSet = groupedTableIds(allGroups);
   // Largest capacity at this location — the best single table OR the best combinable group (#274).
   // Parties above this can't be seated even with pushed-together tables and must contact the
   // restaurant directly. Computed client-side from the nested restaurant payload — no extra fetch.
@@ -192,7 +179,7 @@ export default function BookingForm({
     // leaves the mergeable tables free for the parties that need them pushed together.
     eligible.sort((a, b) => {
       if (a.seats !== b.seats) return a.seats - b.seats;
-      return Number(groupedTableIds.has(a.id)) - Number(groupedTableIds.has(b.id));
+      return Number(groupedTableIdSet.has(a.id)) - Number(groupedTableIdSet.has(b.id));
     });
     return eligible[0]?.id ?? pool[0]?.id;
   }
@@ -348,7 +335,7 @@ export default function BookingForm({
       label: `${table.name ?? `Table ${table.id}`} (${table.seats} seats)`,
       value: table.id,
     })),
-    ...eligibleGroups.map((g) => ({ label: groupLabel(g), value: -g.id })),
+    ...eligibleGroups.map((g) => ({ label: groupDropdownLabel(g), value: -g.id })),
   ];
 
   // ── Submit ───────────────────────────────────────────────────────────────────

--- a/openresto-frontend/components/restaurant/LocationListItem.tsx
+++ b/openresto-frontend/components/restaurant/LocationListItem.tsx
@@ -11,6 +11,7 @@ import { RestaurantDto } from "@/api/restaurants";
 import { fetchAvailability, TimeSlotDto } from "@/api/availability";
 import { getHoursForDay, hasCustomHours } from "@/utils/openingHours";
 import { isWalkInOnlyOnDay, walkInBadgeLabel } from "@/utils/walkIn";
+import { groupDisplayName, groupedTableIds } from "@/utils/tableGroups";
 import { getOpenDaysList, getRestaurantDate, getRestaurantNow } from "@/utils/restaurantTime";
 import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
 import { LinkedText } from "@/components/common/LinkedText";
@@ -58,6 +59,16 @@ export default function LocationListItem({
   const { colors, isDark, primaryColor } = useAppTheme();
   const mutedColor = colors.muted;
   const borderColor = colors.border;
+
+  // Combinable-table groups (#271-#274). Members stay individually bookable, so the seating
+  // minimap marks them rather than hiding them, and lists each group as its own bookable unit.
+  const tableGroups = restaurant.groups ?? [];
+  // Keyed off restaurant.groups, not tableGroups — the `?? []` fallback is a fresh array each
+  // render, which would defeat the memo on locations that have no groups.
+  const groupMemberIds = useMemo(
+    () => groupedTableIds(restaurant.groups ?? []),
+    [restaurant.groups]
+  );
 
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [slots, setSlots] = useState<TimeSlotDto[]>([]);
@@ -594,9 +605,14 @@ export default function LocationListItem({
                             },
                           ]}
                         >
-                          <ThemedText style={styles.tableName}>
-                            {table.name ?? `Table ${table.id}`}
-                          </ThemedText>
+                          <View style={styles.tableNameRow}>
+                            <ThemedText style={styles.tableName}>
+                              {table.name ?? `Table ${table.id}`}
+                            </ThemedText>
+                            {groupMemberIds.has(table.id) && (
+                              <Ionicons name="link" size={11} color={primaryColor} />
+                            )}
+                          </View>
                           <ThemedText style={[styles.tableSeats, { color: mutedColor }]}>
                             {table.seats} seats
                           </ThemedText>
@@ -606,6 +622,31 @@ export default function LocationListItem({
                   </ThemedView>
                 ))}
               </View>
+
+              {tableGroups.length > 0 && (
+                <View style={styles.groupBlock}>
+                  <ThemedText style={[styles.groupBlockHeading, { color: mutedColor }]}>
+                    Tables we can combine
+                  </ThemedText>
+                  {tableGroups.map((group) => (
+                    <View
+                      key={group.id}
+                      style={[
+                        styles.groupRow,
+                        { borderColor: `${primaryColor}55`, backgroundColor: `${primaryColor}12` },
+                      ]}
+                    >
+                      <Ionicons name="link" size={15} color={primaryColor} />
+                      <View style={styles.groupTextCol}>
+                        <ThemedText style={styles.groupName}>{groupDisplayName(group)}</ThemedText>
+                        <ThemedText style={[styles.groupSeats, { color: mutedColor }]}>
+                          Seats up to {group.combinedSeats} pushed together
+                        </ThemedText>
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              )}
             </View>
           )}
         </View>
@@ -907,6 +948,39 @@ const styles = StyleSheet.create({
     fontWeight: "500",
   },
   tableSeats: {
+    fontSize: 11.5,
+  },
+  tableNameRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  groupBlock: {
+    gap: 8,
+  },
+  groupBlockHeading: {
+    fontSize: 11.5,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  groupRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.md,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  groupTextCol: {
+    flex: 1,
+    gap: 2,
+  },
+  groupName: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  groupSeats: {
     fontSize: 11.5,
   },
 });

--- a/openresto-frontend/tests/components/restaurant/LocationListItem.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationListItem.test.tsx
@@ -774,4 +774,99 @@ describe("LocationListItem", () => {
     );
     await waitFor(() => expect(screen.getByText("Table 202")).toBeTruthy());
   });
+  // ── Combinable table groups in the seating minimap (#271-#274) ──────────
+
+  const restaurantWithGroups = {
+    ...mockRestaurant,
+    sections: [
+      {
+        id: 1,
+        name: "Main",
+        restaurantId: 1,
+        tables: [
+          { id: 101, name: "T1", seats: 4, sectionId: 1 },
+          { id: 102, name: "T2", seats: 2, sectionId: 1 },
+          { id: 103, name: "T3", seats: 2, sectionId: 1 },
+        ],
+      },
+    ],
+    groups: [
+      {
+        id: 1,
+        name: "Window booths",
+        combinedSeats: 5,
+        members: [
+          { id: 101, name: "T1", seats: 4 },
+          { id: 102, name: "T2", seats: 2 },
+        ],
+      },
+    ],
+  };
+
+  it("lists combinable groups with their combined capacity in the seating block", async () => {
+    renderWithProviders(
+      <LocationListItem
+        restaurant={restaurantWithGroups as any}
+        defaultExpanded
+        registerRef={registerRef}
+        onExpand={onExpand}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("Tables we can combine")).toBeTruthy());
+    expect(screen.getByText("Window booths")).toBeTruthy();
+    expect(screen.getByText("Seats up to 5 pushed together")).toBeTruthy();
+  });
+
+  it("still lists member tables individually — grouping does not hide them (#242)", async () => {
+    renderWithProviders(
+      <LocationListItem
+        restaurant={restaurantWithGroups as any}
+        defaultExpanded
+        registerRef={registerRef}
+        onExpand={onExpand}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("T1")).toBeTruthy());
+    expect(screen.getByText("T2")).toBeTruthy();
+    expect(screen.getByText("T3")).toBeTruthy();
+  });
+
+  it("names an unnamed group after its member tables", async () => {
+    const unnamedGroup = {
+      ...restaurantWithGroups,
+      groups: [
+        {
+          id: 2,
+          name: null,
+          combinedSeats: 4,
+          members: [
+            { id: 102, name: "T2", seats: 2 },
+            { id: 103, name: "T3", seats: 2 },
+          ],
+        },
+      ],
+    };
+    renderWithProviders(
+      <LocationListItem
+        restaurant={unnamedGroup as any}
+        defaultExpanded
+        registerRef={registerRef}
+        onExpand={onExpand}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("Tables T2 + T3")).toBeTruthy());
+  });
+
+  it("omits the combinable block entirely for a location with no groups", async () => {
+    renderWithProviders(
+      <LocationListItem
+        restaurant={mockRestaurant as any}
+        defaultExpanded
+        registerRef={registerRef}
+        onExpand={onExpand}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("Seating & tables")).toBeTruthy());
+    expect(screen.queryByText("Tables we can combine")).toBeNull();
+  });
 });

--- a/openresto-frontend/tests/utils/tableGroups.test.ts
+++ b/openresto-frontend/tests/utils/tableGroups.test.ts
@@ -1,0 +1,63 @@
+import {
+  groupDisplayName,
+  groupDropdownLabel,
+  groupedTableIds,
+  TableGroupLike,
+} from "@/utils/tableGroups";
+
+const named: TableGroupLike = {
+  name: "Window booths",
+  combinedSeats: 5,
+  members: [
+    { id: 1, name: "T1" },
+    { id: 2, name: "T2" },
+  ],
+};
+
+const unnamed: TableGroupLike = {
+  combinedSeats: 4,
+  members: [
+    { id: 4, name: "B1" },
+    { id: 5, name: "B2" },
+  ],
+};
+
+describe("groupDisplayName", () => {
+  it("uses the admin-assigned name when present, with no capacity suffix", () => {
+    expect(groupDisplayName(named)).toBe("Window booths");
+  });
+
+  it("falls back to the member table names", () => {
+    expect(groupDisplayName(unnamed)).toBe("Tables B1 + B2");
+  });
+
+  it("falls back to the table id for an unnamed member table", () => {
+    expect(
+      groupDisplayName({ combinedSeats: 4, members: [{ id: 7 }, { id: 8, name: "B2" }] })
+    ).toBe("Tables 7 + B2");
+  });
+});
+
+describe("groupDropdownLabel", () => {
+  it("appends the capacity to a named group", () => {
+    expect(groupDropdownLabel(named)).toBe("Window booths (5 seats)");
+  });
+
+  it("spells out the members for an unnamed group", () => {
+    expect(groupDropdownLabel(unnamed)).toBe("Tables B1 + B2 (4 seats combined)");
+  });
+});
+
+describe("groupedTableIds", () => {
+  it("collects every member id across groups", () => {
+    expect(groupedTableIds([named, unnamed])).toEqual(new Set([1, 2, 4, 5]));
+  });
+
+  it("returns an empty set when there are no groups", () => {
+    expect(groupedTableIds([])).toEqual(new Set());
+  });
+
+  it("de-duplicates ids", () => {
+    expect(groupedTableIds([named, named])).toEqual(new Set([1, 2]));
+  });
+});

--- a/openresto-frontend/utils/tableGroups.ts
+++ b/openresto-frontend/utils/tableGroups.ts
@@ -1,0 +1,44 @@
+/**
+ * Naming + membership helpers for combinable table groups (#271–#274), shared by the diner
+ * booking dropdown and the seating minimap so the two can't drift apart on what a group is
+ * called. A group is named by the admin or, when unnamed, by its member tables.
+ */
+
+export interface TableGroupLike {
+  name?: string | null;
+  combinedSeats: number;
+  members: { id: number; name?: string | null }[];
+}
+
+/** Member table names joined for display, e.g. "T1 + T2". Falls back to the id for unnamed tables. */
+function memberNames(group: TableGroupLike): string {
+  return group.members.map((m) => m.name ?? m.id).join(" + ");
+}
+
+/**
+ * The group's display name on its own, with no capacity suffix — for surfaces that show the
+ * seat count separately (the seating minimap renders it on its own line).
+ */
+export function groupDisplayName(group: TableGroupLike): string {
+  return group.name ?? `Tables ${memberNames(group)}`;
+}
+
+/**
+ * Single-line label for the booking form's table dropdown, where the capacity has to ride along
+ * in the same string. Named groups read "Window booths (5 seats)"; unnamed ones spell out the
+ * members so the diner knows which tables get pushed together.
+ */
+export function groupDropdownLabel(group: TableGroupLike): string {
+  return group.name
+    ? `${group.name} (${group.combinedSeats} seats)`
+    : `Tables ${memberNames(group)} (${group.combinedSeats} seats combined)`;
+}
+
+/**
+ * Ids of every table that belongs to some group. Used to deprioritize combinable tables in
+ * auto-assign ordering and to mark them in the seating minimap — a member table stays
+ * individually bookable, so this is a display/ordering hint, never a filter (#242).
+ */
+export function groupedTableIds(groups: TableGroupLike[]): Set<number> {
+  return new Set(groups.flatMap((g) => g.members.map((m) => m.id)));
+}


### PR DESCRIPTION
## Summary

The "Seating & tables" block under the inline booking form listed every table individually with no hint that some can be pushed together. The only place a diner could discover a combinable group was the table dropdown — and only *after* picking a party size large enough to need one. This surfaces groups in the minimap, where someone browsing the location can see them.

## Related issue

Follow-up to #271–#274 (combinable table groups). No issue number of its own.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

**`components/restaurant/LocationListItem.tsx`** — the seating block now:

- marks member table chips with a small link icon in the brand colour, so it's visible *which* physical tables participate; and
- lists each group as its own tinted row below the section grid — `⛓ Window booths` / `Seats up to 5 pushed together`, or `Tables T2 + T3` when the group is unnamed.

Member tables are still listed individually. That's deliberate and matches #242: grouping only deprioritizes a table in auto-assign, it never makes it unbookable, so hiding members from the minimap would misrepresent what's available.

**`utils/tableGroups.ts`** (new) — group naming moves out of `BookingForm` so the minimap and the dropdown can't drift on what a group is called:

- `groupDisplayName` — name only, for surfaces that render capacity separately (the minimap puts it on its own line).
- `groupDropdownLabel` — the single-line `"Window booths (5 seats)"` form, moved verbatim from `BookingForm`'s private `groupLabel`.
- `groupedTableIds` — the member-id Set, replacing the inline `flatMap` in `BookingForm`.

`BookingForm` behaviour is unchanged — this is a pure extract.

## Testing

- [x] `OpenRestoApi.Tests` pass locally — not re-run; no backend code touched
- [x] Frontend tests/build pass locally — 2064 passed across 151 suites; `npm run check` and `tsc --noEmit` clean
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

New coverage: a `utils/tableGroups` suite (naming, id-fallback for unnamed member tables, de-duplication), and four `LocationListItem` cases — the group row renders with its combined capacity, member tables are *still* listed individually (the #242 regression guard), an unnamed group falls back to member names, and the block is absent entirely for a location with no groups.

**I could not verify this visually.** The Docker daemon isn't available in this environment, so the layout and the icon/tint choices are unrendered — assertions are on text content only. Worth a look in a running stack before merge; the demo seed from #284 has both a named group (`Window booths`, T1 + T2) and an unnamed one (B1 + B2) ready to look at.

## Migrations

- [ ] This PR includes a database migration

None — `groups` is already on `RestaurantDto` and the payload is already fetched.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

## Open design question

I put the group list *below* the section grid rather than inside a section card, because a group is restaurant-scoped — `AddTableGroupAsync` validates members belong to the same restaurant, not the same section — so members can legitimately span two sections and a chip inside one card would be wrong. If you'd rather it sat elsewhere (above the sections, or inline in the card when all members happen to share a section), easy to move.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qwgn1qiDtWBA9Lw4xzNy6U)_