### PR TITLE
chore(frontend): drop dangling nativewind-env.d.ts from tsconfig include

### DIFF
--- a/openresto-frontend/tsconfig.json
+++ b/openresto-frontend/tsconfig.json
@@ -7,5 +7,5 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts", "nativewind-env.d.ts"]
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
 }


### PR DESCRIPTION
## Summary

`openresto-frontend/tsconfig.json` lists `nativewind-env.d.ts` in `include`. NativeWind was never adopted here: no dependency in `package.json`, no `tailwind.config`, and the file has never existed in this repo. Dead config.

Its only practical effect was misleading: while investigating #219 I briefly read it as evidence of a prior styling-library attempt. Karan confirmed it was never used.

`expo-env.d.ts` stays. That one is gitignored but generated by `expo start`, so the entry is live.

## Related issue

Follow-up to #219 (closed). Not required by it.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- Remove `"nativewind-env.d.ts"` from `include` in `openresto-frontend/tsconfig.json`

Full diff is one line.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally (no backend changes)
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

`npx tsc --noEmit` is clean, and `prettier --check tsconfig.json` passes. No behaviour change: a non-matching `include` entry was already a no-op, so this only removes the misleading reference.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed (N/A)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MAN6ZT4AnTtc1GozgCgTLQ)_