### PR TITLE
Fix booking confirmation page for numeric booking references

### DIFF
--- a/openresto-frontend/app/(user)/_layout.tsx
+++ b/openresto-frontend/app/(user)/_layout.tsx
@@ -56,7 +56,7 @@ export default function UserLayout() {
       <Stack.Screen name="restaurant/[id]" options={{ title: "Restaurant" }} />
       <Stack.Screen name="book" options={{ title: "Book a Table" }} />
       <Stack.Screen
-        name="booking-confirmation/[bookingId]"
+        name="booking-confirmation/[bookingRef]"
         options={{ title: "Booking Confirmed", headerBackVisible: false }}
       />
       <Stack.Screen name="lookup" options={{ title: "Find My Booking" }} />

--- a/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
+++ b/openresto-frontend/app/(user)/booking-confirmation/[bookingRef].tsx
@@ -51,10 +51,14 @@ export default function BookingConfirmationScreen() {
     if (!bookingRef) return;
     let cancelled = false;
     async function load() {
-      const numericId = /^\d+$/.test(bookingRef) ? parseInt(bookingRef, 10) : NaN;
-      const data = isNaN(numericId)
-        ? await getBookingByRef(bookingRef, email ?? "")
-        : await getBookingById(numericId);
+      // The path segment is a booking reference. Since references can be all-digits (#179),
+      // its shape no longer distinguishes a reference from a database id, so the reference
+      // lookup — the public, email-gated path every confirmation link and email uses — always
+      // runs first. The id lookup survives only as a fallback for legacy
+      // /booking-confirmation/<id> links, and is admin-only server-side.
+      const data =
+        (await getBookingByRef(bookingRef, email ?? "")) ??
+        (/^\d+$/.test(bookingRef) ? await getBookingById(parseInt(bookingRef, 10)) : null);
       if (cancelled) return;
       setBooking(data);
       if (data?.restaurantId) {

--- a/openresto-frontend/tests/app/(user)/booking-confirmation.test.tsx
+++ b/openresto-frontend/tests/app/(user)/booking-confirmation.test.tsx
@@ -83,14 +83,42 @@ describe("BookingConfirmationScreen", () => {
     expect(screen.getAllByText(/Toronto Resto/).length).toBeGreaterThan(0);
   });
 
-  it("renders success state for numeric id", async () => {
+  it("resolves an all-digit segment as a booking reference, not a database id", async () => {
+    // Regression test for #179: numeric booking references are indistinguishable from a
+    // database id by shape. Treating them as an id sent every confirmation link (and every
+    // confirmation email) to the admin-only by-id endpoint, which 401s for the diner who
+    // owns the booking and rendered as "no booking found".
+    const { useLocalSearchParams } = require("expo-router");
+    useLocalSearchParams.mockReturnValue({ bookingRef: "97977036", email: "test@test.com" });
+
+    renderWithProviders(<BookingConfirmationScreen />);
+    await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
+
+    expect(getBookingByRef).toHaveBeenCalledWith("97977036", "test@test.com");
+    expect(getBookingById).not.toHaveBeenCalled();
+    expect(screen.getByText("Booking Confirmed")).toBeTruthy();
+  });
+
+  it("falls back to the id lookup for a legacy numeric link with no matching reference", async () => {
     const { useLocalSearchParams } = require("expo-router");
     useLocalSearchParams.mockReturnValue({ bookingRef: "50" });
+    (getBookingByRef as jest.Mock).mockResolvedValue(null);
 
     renderWithProviders(<BookingConfirmationScreen />);
     await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
 
     expect(getBookingById).toHaveBeenCalledWith(50);
+  });
+
+  it("does not attempt an id lookup for a word reference that is not found", async () => {
+    const { useLocalSearchParams } = require("expo-router");
+    useLocalSearchParams.mockReturnValue({ bookingRef: "no-such-ref", email: "test@test.com" });
+    (getBookingByRef as jest.Mock).mockResolvedValue(null);
+
+    renderWithProviders(<BookingConfirmationScreen />);
+    await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
+
+    expect(getBookingById).not.toHaveBeenCalled();
   });
 
   it("shows cancel button for an active booking", async () => {

--- a/openresto-frontend/tests/app/(user)/user-layout.test.tsx
+++ b/openresto-frontend/tests/app/(user)/user-layout.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import fs from "fs";
+import path from "path";
+import { render } from "@testing-library/react-native";
+import { Platform } from "react-native";
+import UserLayout from "@/app/(user)/_layout";
+
+// Populated by the Stack.Screen mock below. Named with the `mock` prefix so the
+// jest.mock factory is allowed to close over it.
+const mockRegisteredRoutes: string[] = [];
+
+jest.mock("expo-router", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  const Stack = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(View, { testID: "stack" }, children);
+  Stack.Screen = ({ name }: { name: string }) => {
+    mockRegisteredRoutes.push(name);
+    return null;
+  };
+  return {
+    Stack,
+    Slot: () => React.createElement(View, { testID: "slot" }),
+    useRouter: () => ({ push: jest.fn() }),
+    useSegments: () => ["(user)"],
+  };
+});
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: () => ({ appName: "Open Resto", primaryColor: "#0a7ea4" }),
+}));
+
+jest.mock("@/components/layout/Navbar", () => () => null);
+jest.mock("@/components/common/KeyboardShortcutsHelp", () => () => null);
+jest.mock("@/hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: jest.fn() }));
+
+describe("(user)/_layout route registration", () => {
+  it("registers only routes that exist on disk", () => {
+    // Expo Router matches a <Stack.Screen name> against the route filename. A name that
+    // matches nothing silently drops that screen's options — which is how
+    // "booking-confirmation/[bookingId]" sat here while the route file was always
+    // [bookingRef].tsx, leaving the confirmation screen without its title or its
+    // suppressed back button. Renaming a route file is the moment this breaks, and
+    // nothing else in the suite notices, so the check is against the filesystem
+    // rather than a hardcoded list.
+    const originalOS = Platform.OS;
+    // The <Stack> is the native branch; on web the layout returns a <Slot> instead.
+    Object.defineProperty(Platform, "OS", { value: "ios", configurable: true });
+    mockRegisteredRoutes.length = 0;
+
+    try {
+      render(<UserLayout />);
+    } finally {
+      Object.defineProperty(Platform, "OS", { value: originalOS, configurable: true });
+    }
+
+    expect(mockRegisteredRoutes.length).toBeGreaterThan(0);
+
+    const routesDir = path.join(process.cwd(), "app", "(user)");
+    const missing = mockRegisteredRoutes.filter((name) => {
+      const base = path.join(routesDir, name);
+      return !fs.existsSync(`${base}.tsx`) && !fs.existsSync(path.join(base, "index.tsx"));
+    });
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #296 — the numeric booking reference format shipped with a broken confirmation page.

`/booking-confirmation/[bookingRef]` disambiguated its path segment **by shape**: all-digits meant a database id (looked up via `getBookingById`), anything else meant a booking reference (`getBookingByRef`). Numeric references are all-digits, so every one of them took the id branch — which hits the `[Authorize]` by-id endpoint, 401s for the diner who owns the booking, and renders as "no booking found".

Reported against `https://openres.to/booking-confirmation/97977036?email=…`.

## Related issue

Follow-up to #179 / #296

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

### 1. Numeric references resolve on the confirmation page (`1ae5956`)

One root cause, two user-visible breakages:

1. The redirect straight after booking (`LocationListItem` pushes the new booking's reference into that segment).
2. The **"view booking" link in every confirmation email** — `EmailTemplateService` builds `/booking-confirmation/{BookingRef}?email={email}`. For a Numeric-format location, every confirmation email sent since #296 merged has pointed at a dead page. Worth noting for anything already in customers' inboxes: those links start working the moment this deploys, since nothing about the stored reference changes.

Shape can no longer tell a reference from an id, so the fix stops guessing: the **reference lookup always runs first** — it's the public, email-gated path that every confirmation link uses. The id lookup remains as a fallback for legacy `/booking-confirmation/<id>` links, so those keep working for the admins who can actually authorize them.

```js
const data =
  (await getBookingByRef(bookingRef, email ?? "")) ??
  (/^\d+$/.test(bookingRef) ? await getBookingById(parseInt(bookingRef, 10)) : null);
```

No extra request in the common path — a numeric reference resolves on the first call.

**Sweep for anything else numeric references touch:** `/lookup` passes the reference straight through (never broken). The backend never parses a reference as an int, and after this change the only shape-based reference logic left in the codebase is the fallback line above. The cancel flow, the recent-bookings cookie, calendar export, and the admin reference search all treat it as an opaque string.

### 2. The confirmation screen's route registration (`be942a0`)

`app/(user)/_layout.tsx` registered `booking-confirmation/[bookingId]`, but the route file has always been `[bookingRef].tsx`. Expo Router matches a `Stack.Screen` name against the route filename, so the entry matched nothing and the screen silently lost its options — the "Booking Confirmed" title and the suppressed back button never applied on native. The tab title comes from the root layout, which is why the web build looked fine.

Predates #179 and is unrelated to numeric references; included here on request.

The accompanying test walks the `Stack.Screen` names the layout registers and asserts each resolves to a file on disk, rather than checking a hardcoded list — a route rename is exactly when this breaks, and nothing else in the suite notices. Verified it fails on the old name before restoring the fix.

## Testing

- [x] Frontend tests/build pass locally — 2163/2163 across 160 suites, `npm run check` and `tsc --noEmit` clean.
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

Test changes: the old `renders success state for numeric id` case asserted the exact behaviour that caused this bug, so it's replaced by three that pin the new precedence — an all-digit segment resolves as a reference and never calls the id lookup; a legacy numeric link with no matching reference still falls back to the id lookup; and a word reference that isn't found never attempts an id lookup.

One caveat worth stating plainly: a single test failed once, in the run launched immediately after the layout edit, and I could not reproduce it in three subsequent full runs. I don't know which test it was — most likely Jest reading the file mid-write — so I'm flagging it rather than calling it explained. CI is the tiebreaker.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

None — client-side routing only. Stored references are untouched.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed — no contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJKFDfyjwa9Sqvur8g2r42
