### PR TITLE
Derive the Expo app version from package.json and guard releases on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,21 @@ permissions:
   packages: write
 
 jobs:
+  verify-version:
+    name: Verify version fields match the tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check package versions and CHANGELOG against the tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: ./scripts/check-release-version.sh "$RELEASE_TAG"
+
   build-backend:
     name: Build backend (multi-arch)
     runs-on: ubuntu-latest
+    needs: [verify-version]
     steps:
       - uses: actions/checkout@v7
 
@@ -49,6 +61,7 @@ jobs:
   build-frontend:
     name: Build frontend (multi-arch)
     runs-on: ubuntu-latest
+    needs: [verify-version]
     steps:
       - uses: actions/checkout@v7
 
@@ -86,6 +99,7 @@ jobs:
   build-nginx:
     name: Build nginx (multi-arch)
     runs-on: ubuntu-latest
+    needs: [verify-version]
     steps:
       - uses: actions/checkout@v7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **One source of truth for the release version** — v1.6.0 shipped with all four `version` fields still reading `1.5.0`, and the Expo app version had been stuck at `1.0.0` since the first commit, because nothing checked. `app.config.ts` now takes its version from `openresto-frontend/package.json` (and the dead duplicate in `app.json`, which `app.config.ts` overrides anyway, is gone), so the frontend can't drift. A new `scripts/check-release-version.sh` asserts both `package.json`s, both lockfiles, and a matching CHANGELOG section all agree with the tag; the release workflow runs it as a `verify-version` job gating all three image builds, so a half-finished bump fails before anything is published to GHCR. Run it yourself before tagging.
+
 ## [1.6.1] - 2026-08-09
 
 A small release on top of 1.6.0: one new option (digits-only booking references) and the fixes that shook out of it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,12 +121,23 @@ extensive set by default (i.e., untagged).
 ### Release (tag-triggered)
 
 ```bash
-# Update CHANGELOG.md with a ## [x.y.z] - YYYY-MM-DD section first, then:
+# 1. Add a ## [x.y.z] - YYYY-MM-DD section to CHANGELOG.md
+# 2. Bump "version" in package.json (root) and openresto-frontend/package.json
+#    to the tag without the v prefix, then regenerate both lockfiles:
+npm install --package-lock-only && npm install --package-lock-only --prefix openresto-frontend
+# 3. Confirm everything agrees before tagging (CI runs this too):
+./scripts/check-release-version.sh v1.0.0
 git tag v1.0.0
 git push origin v1.0.0
 ```
 
-Also bump `"version"` in `package.json` (root) and `openresto-frontend/package.json` to match the tag (without the `v` prefix), then run `npm install --package-lock-only` in each directory (root and `openresto-frontend/`) so the corresponding `package-lock.json`'s top-level `version` field stays in sync — don't hand-edit the lockfiles.
+Never hand-edit the lockfiles; `--package-lock-only` is what keeps their top-level `version` in sync.
+
+**Pick the number by semver, not by habit.** A release containing any new feature is a minor bump, even a small one. Patch is for fixes only.
+
+`scripts/check-release-version.sh` is the guard against a half-finished bump: it asserts the two `package.json`s, the two `package-lock.json`s, and a CHANGELOG section all agree with the tag. The `verify-version` job in `release.yml` gates all three image builds on it, so a mismatch fails the release before anything reaches GHCR. v1.6.0 shipped with all four version fields still reading `1.5.0`, which is what this exists to prevent.
+
+The frontend's Expo config takes its `version` from `openresto-frontend/package.json` (`app.config.ts` imports it), so there is nothing to bump there. `app.json` deliberately carries no `version` key: `app.config.ts` overrides everything it sets, so a value there is silently dead.
 
 This triggers `.github/workflows/release.yml`, which builds `linux/amd64` + `linux/arm64` images for backend, frontend, and nginx; pushes them to GHCR (`ghcr.io/karanshukla/openresto-{backend,frontend,nginx}:<tag>`); and creates a GitHub Release with the per-version CHANGELOG section as notes and a pinned `docker-compose.yml` as a downloadable asset.
 

--- a/openresto-frontend/app.config.ts
+++ b/openresto-frontend/app.config.ts
@@ -1,10 +1,12 @@
 import { ExpoConfig, ConfigContext } from "expo/config";
 
+import { version } from "./package.json";
+
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: process.env.EXPO_PUBLIC_APP_NAME ?? "Open Resto",
   slug: "openresto-frontend",
-  version: "1.0.0",
+  version,
   orientation: "default",
   icon: "./assets/images/icon.png",
   scheme: "openrestofrontend",

--- a/openresto-frontend/app.json
+++ b/openresto-frontend/app.json
@@ -2,7 +2,6 @@
   "expo": {
     "name": "Open Resto",
     "slug": "openresto-frontend",
-    "version": "1.0.0",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "openrestofrontend",

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Asserts every version field in the repo agrees with the release version, and
+# that CHANGELOG.md has a section for it. Run before tagging; the release
+# workflow runs it too, so a mismatch fails before any image is published.
+#
+#   ./scripts/check-release-version.sh 1.6.1
+#   ./scripts/check-release-version.sh v1.6.1
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ $# -ne 1 ]; then
+  echo "usage: $(basename "$0") <version>" >&2
+  exit 2
+fi
+
+VERSION="${1#v}"
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: '$1' is not a semver version (expected x.y.z or vx.y.z)" >&2
+  exit 2
+fi
+
+VERSIONED_FILES=(
+  package.json
+  package-lock.json
+  openresto-frontend/package.json
+  openresto-frontend/package-lock.json
+)
+
+failures=0
+
+for file in "${VERSIONED_FILES[@]}"; do
+  actual="$(jq -r '.version // "<missing>"' "$REPO_ROOT/$file")"
+  if [ "$actual" != "$VERSION" ]; then
+    echo "FAIL $file: version is '$actual', expected '$VERSION'" >&2
+    failures=$((failures + 1))
+  else
+    echo "ok   $file"
+  fi
+done
+
+if grep -q "^## \[$VERSION\]" "$REPO_ROOT/CHANGELOG.md"; then
+  echo "ok   CHANGELOG.md has a [$VERSION] section"
+else
+  echo "FAIL CHANGELOG.md: no '## [$VERSION]' section" >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -gt 0 ]; then
+  cat >&2 <<EOF
+
+$failures check(s) failed. To fix:
+  - bump "version" in package.json and openresto-frontend/package.json to $VERSION
+  - run 'npm install --package-lock-only' in each of those directories
+  - add a '## [$VERSION] - YYYY-MM-DD' section to CHANGELOG.md
+EOF
+  exit 1
+fi
+
+echo
+echo "All version fields agree on $VERSION."


### PR DESCRIPTION
v1.6.0 shipped with every `version` field in the repo still reading `1.5.0`, and the Expo app version in `app.json` had never moved off `1.0.0`. Nothing checked, so nothing complained. This fixes both causes going forward rather than retro-editing the shipped tags.

## Version derivation

`app.config.ts` imports `version` from `openresto-frontend/package.json`, so the frontend version follows the release bump on its own.

`app.json`'s `version` key is removed rather than synced. `app.config.ts` spreads `app.json` and then overrides every key it sets, so a value there is silently dead, and keeping one would just reintroduce the drift this is meant to end. Nothing in the repo reads `app.json` directly.

## Release guard

`scripts/check-release-version.sh <tag>` asserts these all agree:

| Checked | Why |
|---|---|
| `package.json` | root version, feeds nothing but is the canonical number |
| `package-lock.json` | top-level `version`, drifts if `--package-lock-only` is skipped |
| `openresto-frontend/package.json` | now also the Expo app version |
| `openresto-frontend/package-lock.json` | same as above |
| `## [x.y.z]` in `CHANGELOG.md` | `create-release` extracts notes from it, and silently falls back to the entire CHANGELOG when it's missing |

`release.yml` runs it as a `verify-version` job that gates all three image builds, so a half-finished bump fails before anything reaches GHCR. It's also runnable locally before tagging, and `CLAUDE.md`'s release section now walks through it in order.

## Verification

- `npx expo config --type public` reports `1.6.1`
- `npx tsc --noEmit` and `npm run check` clean
- Script passes on the current tree, fails all five checks on a version nothing matches
- Would have failed on the `v1.6.0` tree, which is the point

## Note on semver

1.6.1 carries a new feature (numeric booking references), so it should have been 1.7.0. Not worth re-cutting a published release, but `CLAUDE.md` now says outright that any release containing a feature is a minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQ4Qg3Zjz7MwkpY1nGr17Y