### PR TITLE
Stack the booking form's field pairs below 768px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **One source of truth for the release version** — v1.6.0 shipped with all four `version` fields still reading `1.5.0`, and the Expo app version had been stuck at `1.0.0` since the first commit, because nothing checked. `app.config.ts` now takes its version from `openresto-frontend/package.json` (and the dead duplicate in `app.json`, which `app.config.ts` overrides anyway, is gone), so the frontend can't drift. A new `scripts/check-release-version.sh` asserts both `package.json`s, both lockfiles, and a matching CHANGELOG section all agree with the tag; the release workflow runs it as a `verify-version` job gating all three image builds, so a half-finished bump fails before anything is published to GHCR. Run it yourself before tagging.
 
+### Fixed
+
+- **Booking form rendered its desktop two-column grid on phones**: the side-by-side field pairs were gated on `Platform.OS === "web"`, and a phone browser is `web`, so a 390px screen got the same two columns as a 1280px desktop. Each column came out around 180px wide: the email address truncated mid-string, the special-requests placeholder wrapped to three lines, and the "we'll seat you at the best available table" hint ran two lines deep next to Full Name. The pairs now collapse below 768px (the width `PageContainer` already switches its padding at, so the form and its container agree), giving Email and Special Requests a full-width row each, and the table-hold countdown moves out of the email column to sit directly above Confirm Booking where it is actually read. Native already stacked, and desktop web is unchanged.
+
 ## [1.6.1] - 2026-08-09
 
 A small release on top of 1.6.0: one new option (digits-only booking references) and the fixes that shook out of it.

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -6,7 +6,7 @@ import Select from "../common/Select";
 import DatePicker from "../common/DatePicker";
 import TimePicker from "../common/TimePicker";
 import { ThemedText } from "../themed-text";
-import { Platform, StyleSheet, View, ActivityIndicator } from "react-native";
+import { Platform, StyleSheet, View, ActivityIndicator, useWindowDimensions } from "react-native";
 import { useTableHold } from "./useTableHold";
 import HoldStatusBanner from "./HoldStatusBanner";
 import PopularTimesPicker from "./PopularTimesPicker";
@@ -23,6 +23,12 @@ import LargePartyNotice from "./LargePartyNotice";
 import LargePartyNoticeModal from "./LargePartyNoticeModal";
 
 const isWeb = Platform.OS === "web";
+/**
+ * Below this the paired fields stack — a phone browser is still `Platform.OS === "web"`,
+ * so width rather than platform decides the column count. Matches the breakpoint
+ * PageContainer switches its padding at, so the form and its container agree.
+ */
+const TWO_COLUMN_MIN_WIDTH = 768;
 
 export interface BookingFormData {
   customerEmail: string;
@@ -98,6 +104,8 @@ export default function BookingForm({
   initialSeats?: number;
 }) {
   const { colors, primaryColor: PRIMARY } = useAppTheme();
+  const { width } = useWindowDimensions();
+  const isTwoColumn = isWeb && width >= TWO_COLUMN_MIN_WIDTH;
   const [customerEmail, setCustomerEmail] = useState("");
   const [customerName, setCustomerName] = useState("");
   const [specialRequests, setSpecialRequests] = useState("");
@@ -409,6 +417,16 @@ export default function BookingForm({
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
+  const holdBanner = (
+    <HoldStatusBanner
+      holdStatus={holdStatus}
+      secondsLeft={secondsLeft}
+      hasSelection={(isAutoAssign || !!tableId) && !!date && !!time}
+      holdMessage={holdMessage}
+      onRefresh={onRefresh}
+    />
+  );
+
   return (
     <View style={styles.form}>
       <WalkInDaysBanner restaurant={restaurant} />
@@ -435,8 +453,11 @@ export default function BookingForm({
       </View>
 
       {/* Row 1: Guests + Date */}
-      <View style={isWeb ? styles.fieldRow : undefined}>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+      <View
+        testID="booking-field-row"
+        style={isTwoColumn ? styles.fieldRow : styles.fieldRowStacked}
+      >
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Number of Guests</ThemedText>
           <Select
             selectedValue={seats}
@@ -444,7 +465,7 @@ export default function BookingForm({
             options={seatOptions}
           />
         </View>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Date</ThemedText>
           {/* Customer flow: future-dates-only is intentional. Do NOT pass allowPast
               here — only the admin New Booking modal opts in to back-dating (#160). */}
@@ -464,8 +485,11 @@ export default function BookingForm({
       )}
 
       {/* Row 2: Time + Section */}
-      <View style={isWeb ? styles.fieldRow : undefined}>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+      <View
+        testID="booking-field-row"
+        style={isTwoColumn ? styles.fieldRow : styles.fieldRowStacked}
+      >
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Time</ThemedText>
           <TimePicker
             selectedTime={time}
@@ -474,7 +498,7 @@ export default function BookingForm({
             maxTime={maxPickerTime}
           />
         </View>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Section</ThemedText>
           <Select
             selectedValue={sectionId}
@@ -497,8 +521,11 @@ export default function BookingForm({
       )}
 
       {/* Row 3: Table + Full Name */}
-      <View style={isWeb ? styles.fieldRow : undefined}>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+      <View
+        testID="booking-field-row"
+        style={isTwoColumn ? styles.fieldRow : styles.fieldRowStacked}
+      >
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Table</ThemedText>
           {isAutoAssign ? (
             <ThemedText style={[styles.autoAssignHint, { color: colors.muted }]}>
@@ -533,7 +560,7 @@ export default function BookingForm({
             />
           )}
         </View>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Full Name</ThemedText>
           <Input
             placeholder="Your full name"
@@ -546,9 +573,13 @@ export default function BookingForm({
         </View>
       </View>
 
-      {/* Row 4: Email + Special Requests */}
-      <View style={isWeb ? [styles.fieldRow, styles.fieldRowStretch] : undefined}>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+      {/* Row 4: Email + Special Requests. Stacked, each gets its own full-width row and the
+          hold banner moves out to sit directly above the confirm button. */}
+      <View
+        testID="booking-field-row"
+        style={isTwoColumn ? [styles.fieldRow, styles.fieldRowStretch] : styles.fieldRowStacked}
+      >
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Email</ThemedText>
           <Input
             placeholder="your@email.com"
@@ -559,17 +590,9 @@ export default function BookingForm({
             returnKeyType="next"
             blurOnSubmit={false}
           />
-          <View style={isWeb ? styles.holdPush : undefined}>
-            <HoldStatusBanner
-              holdStatus={holdStatus}
-              secondsLeft={secondsLeft}
-              hasSelection={(isAutoAssign || !!tableId) && !!date && !!time}
-              holdMessage={holdMessage}
-              onRefresh={onRefresh}
-            />
-          </View>
+          {isTwoColumn && <View style={styles.holdPush}>{holdBanner}</View>}
         </View>
-        <View style={[styles.field, isWeb && styles.fieldHalf]}>
+        <View style={[styles.field, isTwoColumn && styles.fieldHalf]}>
           <ThemedText style={styles.label}>Special Requests / Allergies</ThemedText>
           <Input
             placeholder="e.g. nut allergy, high chair needed… (optional)"
@@ -581,6 +604,8 @@ export default function BookingForm({
           />
         </View>
       </View>
+
+      {!isTwoColumn && holdBanner}
 
       <ThemedText style={styles.gdpr}>
         By confirming, you agree that your email and booking details will be stored to manage your
@@ -628,6 +653,11 @@ const styles = StyleSheet.create({
   },
   fieldRowStretch: {
     alignItems: "stretch",
+  },
+  // Stacked, the pair's two fields are plain siblings with no gap of their own,
+  // so without this they'd sit tighter together than consecutive rows do.
+  fieldRowStacked: {
+    gap: 20,
   },
   holdPush: {
     marginTop: "auto",

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -3,6 +3,7 @@
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { StyleSheet } from "react-native";
 import BookingForm from "@/components/booking/BookingForm";
 import { getNowInTimezone } from "@/utils/date";
 
@@ -10,14 +11,22 @@ jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
 }));
 
-// This whole file renders under Platform.OS === "web" so the isWeb-only
-// layout branches (fieldRow/fieldHalf/holdPush styles) get exercised. The
-// native (non-web) branches are already covered by
+// This whole file renders under Platform.OS === "web" at a desktop width, so the
+// two-column layout branches (fieldRow/fieldHalf/holdPush styles) get exercised.
+// The native (non-web) branches are already covered by
 // tests/components/BookingForm.test.tsx, which uses the jest-expo default
 // (Platform.OS === "ios").
+//
+// A phone browser is also Platform.OS === "web", so width — not platform — is
+// what decides the column count. useWindowDimensions reads Dimensions.get, so
+// patching that is how the responsive-layout tests below shrink the viewport.
+let mockViewportWidth = 1024;
 jest.mock("react-native", () => {
   const rn = jest.requireActual("react-native");
   rn.Platform.OS = "web";
+  const actualGet = rn.Dimensions.get.bind(rn.Dimensions);
+  rn.Dimensions.get = (dim: string) =>
+    dim === "window" ? { ...actualGet("window"), width: mockViewportWidth } : actualGet(dim);
   return rn;
 });
 
@@ -54,7 +63,10 @@ jest.mock("@/api/availability", () => ({
 
 jest.mock("@/components/booking/HoldStatusBanner", () => ({
   __esModule: true,
-  default: () => null,
+  default: () => {
+    const { View } = require("react-native");
+    return <View testID="hold-banner" />;
+  },
 }));
 
 jest.mock("@/components/booking/LargePartyNoticeModal", () => ({
@@ -782,5 +794,59 @@ describe("BookingForm", () => {
     // Auto-assign is the default; the group still counts toward capacity, so no large-party notice.
     expect(screen.queryByText("Large party")).toBeNull();
     expect(screen.getByText(/best available table/)).toBeTruthy();
+  });
+});
+
+// Platform.OS === "web" covers a phone browser too, so these assert that the
+// side-by-side field pairs collapse on width rather than on platform.
+describe("BookingForm responsive layout", () => {
+  const DESKTOP_WIDTH = 1024;
+  const PHONE_WIDTH = 390;
+
+  afterEach(() => {
+    mockViewportWidth = DESKTOP_WIDTH;
+  });
+
+  function rowFlexDirections() {
+    return screen
+      .getAllByTestId("booking-field-row")
+      .map((row) => StyleSheet.flatten(row.props.style)?.flexDirection);
+  }
+
+  it("lays the field pairs out side by side at desktop width", async () => {
+    mockViewportWidth = DESKTOP_WIDTH;
+    render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+
+    const directions = rowFlexDirections();
+    expect(directions).toHaveLength(4);
+    expect(directions.every((d) => d === "row")).toBe(true);
+  });
+
+  it("stacks every field pair onto its own row at phone width", async () => {
+    mockViewportWidth = PHONE_WIDTH;
+    render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+
+    const directions = rowFlexDirections();
+    expect(directions).toHaveLength(4);
+    // No row lays out horizontally, so Email and Special Requests each get the
+    // full width instead of sharing a ~180px column.
+    expect(directions.every((d) => d === undefined)).toBe(true);
+  });
+
+  it("renders the hold banner exactly once in either layout", async () => {
+    mockViewportWidth = PHONE_WIDTH;
+    const { unmount } = render(
+      <BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />
+    );
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+    expect(screen.getAllByTestId("hold-banner")).toHaveLength(1);
+    unmount();
+
+    mockViewportWidth = DESKTOP_WIDTH;
+    render(<BookingForm restaurant={mockRestaurantAllDays} onSubmit={jest.fn()} />);
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+    expect(screen.getAllByTestId("hold-banner")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

The booking form gated its side-by-side field pairs on `Platform.OS === "web"`. A phone browser is `web`, so a 390px screen rendered the same two-column grid as a 1280px desktop, with each column landing around 180px wide. Width now decides the column count instead of platform.

Symptoms on a phone, all visible in the same screenshot: the email address truncated mid-string (`djsisnggy@gmail.c`), the special-requests placeholder wrapped to three lines inside a box sized for two, and the auto-assign hint ("We'll seat you at the best available table.") ran two lines deep beside Full Name, knocking the two columns out of alignment.

Threshold is 768px, matching the width `PageContainer` already switches its padding at, so the form and its container agree rather than leaving a band where the container is in mobile mode and the form is not. The rest of the customer-facing app (`lookup.tsx`, `BookingConfirmationSkeleton`, `Navbar`) already used the `web && width >= N` idiom, so this brings the form in line with the existing convention rather than inventing one.

## Related issue

No tracking issue, reported directly with a screenshot.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra (CHANGELOG only)

## Changes

- `BookingForm` swaps the module-level `isWeb` layout gate for `isTwoColumn = isWeb && width >= 768` from `useWindowDimensions`. All four field pairs (Guests/Date, Time/Section, Table/Full Name, Email/Special Requests) collapse to full-width rows below it.
- The table-hold countdown moves out of the email column when stacked. In two columns it is bottom-aligned against the taller textarea, which reads fine; stacked, it would land between Email and Special Requests, so it now renders as its own block directly above Confirm Booking where it is actually read.
- Added `fieldRowStacked` (`gap: 20`). A pair's two fields are plain siblings with no gap of their own, so without it they sat tighter together than consecutive rows did and the form's vertical rhythm alternated tight/loose. This also stops the italic table hint from reading as a caption on Full Name.
- Three tests in `tests/components/booking/BookingForm.test.tsx` assert the collapse by driving `Dimensions.get`, since `Platform.OS` alone can no longer distinguish the two layouts. The existing 35 specs in that file pin the viewport to 1024px so they keep covering the two-column branch.

Native already stacked (`Platform.OS !== "web"`), so nothing changes there. Admin's two-column forms are unaffected: `app/admin/_layout.tsx` puts up a min-width wall below 600px, so they are never reachable at phone width.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally (untouched, no backend changes)
- [x] Frontend tests/build pass locally: 2166 tests / 160 suites green, `npm run check` clean. `BookingForm.tsx` branch coverage 95.15% vs 95.06% before, same three pre-existing uncovered spots.
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

Manual verification ran the backend on `:8080` with `seed-local.sh` and Expo web on `:8081`, then drove `/locations/1` with Playwright at several widths:

| Viewport | Result |
|---|---|
| 390px | Stacked. Full email visible, placeholder fits, uniform 20px spacing, hold banner above the button |
| 760px | Stacked (just under the breakpoint) |
| 800px | Two columns |
| 1280px | Two columns, unchanged from `main` |

E2E is untouched by this: Playwright runs `devices["Desktop Chrome"]` at 1280px, so every spec stays on the two-column path. Could not run the suite here, no Docker in this environment.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed (CHANGELOG entry under Unreleased; no API contract change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dugGgPj1LmCHSc34cJmfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015dugGgPj1LmCHSc34cJmfQ)_