### PR TITLE
Override nanoid to ^3.3.17 to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -6454,6 +6454,24 @@
         }
       }
     },
+    "node_modules/expo-router/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/expo-server": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-57.0.1.tgz",
@@ -9930,24 +9948,6 @@
       "integrity": "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==",
       "license": "MIT"
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -10687,6 +10687,24 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -100,7 +100,8 @@
     "uuid": ">=14.0.0",
     "shell-quote": ">=1.8.4",
     "brace-expansion": ">=5.0.9",
-    "js-yaml": ">=5.2.2"
+    "js-yaml": ">=5.2.2",
+    "nanoid": "^3.3.17"
   },
   "engines": {
     "node": ">=24.15.0"


### PR DESCRIPTION
## Summary

Clears one of the three open high-severity Dependabot alerts by overriding `nanoid` to `^3.3.17`. The other two have no upstream fix and are documented below rather than papered over.

## Related issue

Dependabot alerts [#43](https://github.com/karanshukla/openresto/security/dependabot/43), [#44](https://github.com/karanshukla/openresto/security/dependabot/44), [#45](https://github.com/karanshukla/openresto/security/dependabot/45)

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Alert status

| Alert | Package | Severity | Vulnerable | Patched | Action |
|---|---|---|---|---|---|
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | nanoid | high (CVSS 5.9) | `< 3.3.17` | 3.3.17 | Fixed here, override to `^3.3.17` (resolves 3.3.18) |
| [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) | image-size | high (CVSS 7.5) | `<= 2.0.2` | none | No fix exists |
| [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) | image-size | high (CVSS 7.5) | `<= 2.0.2` | none | No fix exists |

## Changes

- Added `"nanoid": "^3.3.17"` to the existing `overrides` block in `openresto-frontend/package.json`, alongside how `uuid`, `shell-quote`, `brace-expansion` and `js-yaml` are already pinned.
- Regenerated `openresto-frontend/package-lock.json` via `npm install --package-lock-only`. The lockfile diff is nanoid-only: the hoisted `nanoid@3.3.16` entry is replaced by `3.3.18` under `expo-router` and under `postcss`.

## Why a caret and not `>=`

The neighbouring overrides all use `>=`. That is wrong for this one. `nanoid` reaches us transitively at 3.3.16 through two paths:

```
expo-router@57 -> nanoid@^3.3.8
expo@57 -> @expo/metro-config -> postcss@8.5.21 -> nanoid@^3.3.16
```

An unbounded `>=3.3.17` resolves to nanoid 6.0.1, which I confirmed drops the `require` export condition entirely (v3 ships `index.cjs`, v6 does not). `postcss` is CommonJS and does `require("nanoid/non-secure")`, so `>=` would have traded a denial-of-service advisory for a hard module resolution failure at build time. 3.3.18 is a patch bump inside the `^3.3.x` range both consumers already declare, so it is a drop-in.

## On the two image-size alerts

Not fixable right now, so this PR deliberately leaves them. `image-size` latest published is 2.0.2 and the advisory range is `<= 2.0.2`, meaning the newest release is itself vulnerable. It arrives via `expo -> @expo/metro -> metro@0.84.4 -> image-size@1.2.1`, so it is Metro build tooling and is not in anything we ship to a browser. Both advisories are infinite-loop denial of service in the ICNS/JXL/HEIF parsers, reachable only by feeding attacker-controlled images to the bundler.

Options, in the order I would take them: leave them open until upstream ships a fix (they will resolve on a future Expo/Metro bump), or dismiss them in the Dependabot UI as "no bandwidth to fix"/tolerable risk so the alert count stops masking new ones. I would not add a speculative override here, since there is no version to point at.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

Notes on the above: this is a lockfile-only change, and I regenerated with `--package-lock-only`, so local `node_modules` still has the old nanoid and a local test run would not actually exercise the new resolution. CI installs from the lockfile, so that is the run that matters. I validated the lockfile resolves cleanly with `npm ci --dry-run` and confirmed no `nanoid` entry below 3.3.17 remains.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xsHaVWMviiF2NFVnKYzaP
