### PR TITLE
Put a guests picker back in the booking drawer

### DIFF
--- a/openresto-frontend/components/booking/BookingDrawer.tsx
+++ b/openresto-frontend/components/booking/BookingDrawer.tsx
@@ -44,15 +44,15 @@ function summaryLine(seats: number, date: string, time: string, today: string): 
  * the comparison stays put while the booking happens beside it.
  *
  * Party size, date and the tapped time arrive already decided, so the panel opens with a
- * hold in flight and asks only for a name and an email. Party size stays adjustable here
- * because it is the one of the three a diner revises while booking rather than while
- * browsing; the page-level bar is the first pass at it.
+ * hold in flight. Party size and date stay adjustable here, and a change is handed back to
+ * the page: the bar is the first pass at them, the booking is where they get settled.
  */
 export default function BookingDrawer({
   restaurant,
   seats,
   onSeatsChange,
   date,
+  onDateChange,
   time,
   today,
   variant,
@@ -60,9 +60,10 @@ export default function BookingDrawer({
 }: {
   restaurant: RestaurantDto;
   seats: number;
-  /** Party size is the page's, so changing it in here re-filters the list behind the drawer. */
+  /** Party size and date are the page's, so changing either in here re-filters the list. */
   onSeatsChange: (seats: number) => void;
   date: string;
+  onDateChange: (date: string) => void;
   time: string;
   /** Today's date in the brand's timezone, for the "Today · 19:30" summary. */
   today: string;
@@ -183,17 +184,18 @@ export default function BookingDrawer({
           </ThemedView>
         )}
         <BookingForm
-          // Remounting on a new (location, date, time) resets the hold and the suggested
-          // table for the new criteria rather than carrying the old ones over. Party size
-          // is deliberately not part of the key — it is changed from inside the form, which
-          // already releases the hold and re-asks for availability, and remounting on it
-          // would throw away a name and email the diner has just typed.
-          key={`${restaurant.id}-${date}-${time}`}
+          // Remounting on a new (location, time) resets the hold and the suggested table
+          // rather than carrying the old ones over. Party size and date are deliberately not
+          // part of the key — both are changed from inside the form, which already releases
+          // the hold and re-asks for availability, and remounting on them would throw away a
+          // name and email the diner has just typed.
+          key={`${restaurant.id}-${time}`}
           layout="drawer"
           restaurant={restaurant}
           seats={seats}
           onSeatsChange={onSeatsChange}
           date={date}
+          onDateChange={onDateChange}
           initialTime={time}
           onSubmit={handleSubmit}
         />

--- a/openresto-frontend/components/booking/BookingDrawer.tsx
+++ b/openresto-frontend/components/booking/BookingDrawer.tsx
@@ -43,12 +43,15 @@ function summaryLine(seats: number, date: string, time: string, today: string): 
  * phones. It exists so choosing a time doesn't push the list of locations off-screen —
  * the comparison stays put while the booking happens beside it.
  *
- * Party size, date and the tapped time arrive already decided, so the panel opens with
- * a hold in flight and asks only for a name and an email.
+ * Party size, date and the tapped time arrive already decided, so the panel opens with a
+ * hold in flight and asks only for a name and an email. Party size stays adjustable here
+ * because it is the one of the three a diner revises while booking rather than while
+ * browsing; the page-level bar is the first pass at it.
  */
 export default function BookingDrawer({
   restaurant,
   seats,
+  onSeatsChange,
   date,
   time,
   today,
@@ -57,6 +60,8 @@ export default function BookingDrawer({
 }: {
   restaurant: RestaurantDto;
   seats: number;
+  /** Party size is the page's, so changing it in here re-filters the list behind the drawer. */
+  onSeatsChange: (seats: number) => void;
   date: string;
   time: string;
   /** Today's date in the brand's timezone, for the "Today · 19:30" summary. */
@@ -178,12 +183,16 @@ export default function BookingDrawer({
           </ThemedView>
         )}
         <BookingForm
-          // Remounting on a new (location, party, date, time) resets the hold and the
-          // suggested table for the new criteria rather than carrying the old ones over.
-          key={`${restaurant.id}-${seats}-${date}-${time}`}
+          // Remounting on a new (location, date, time) resets the hold and the suggested
+          // table for the new criteria rather than carrying the old ones over. Party size
+          // is deliberately not part of the key — it is changed from inside the form, which
+          // already releases the hold and re-asks for availability, and remounting on it
+          // would throw away a name and email the diner has just typed.
+          key={`${restaurant.id}-${date}-${time}`}
           layout="drawer"
           restaurant={restaurant}
           seats={seats}
+          onSeatsChange={onSeatsChange}
           date={date}
           initialTime={time}
           onSubmit={handleSubmit}

--- a/openresto-frontend/components/booking/BookingForm.styles.ts
+++ b/openresto-frontend/components/booking/BookingForm.styles.ts
@@ -42,29 +42,28 @@ export const styles = StyleSheet.create({
     textTransform: "uppercase",
     letterSpacing: 0.8,
   },
-  // One bordered card: the toggle is its header and the fields live inside it, so an
-  // open disclosure stays a single object instead of a box floating under a button.
-  disclosureCard: {
-    borderWidth: 1,
-    borderRadius: 8,
-    overflow: "hidden",
+  drawerRow: {
+    flexDirection: "row",
+    gap: 12,
   },
+  // Halves rather than content-sized: the guests and date controls carry different label
+  // lengths, and a split row is the only thing keeping them off one column each.
+  drawerRowHalf: {
+    flex: 1,
+    minWidth: 0,
+  },
+  // No border and no fill: the toggle is a row of the form, not a control wrapped around
+  // the fields it reveals, which read as plain fields like every other one.
   disclosureToggle: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
-    minHeight: 44,
-    paddingHorizontal: 12,
+    gap: 8,
+    minHeight: 28,
   },
   disclosureText: {
     flex: 1,
     fontSize: 14,
     fontWeight: "500",
-  },
-  disclosureBody: {
-    gap: 16,
-    padding: 14,
-    borderTopWidth: 1,
   },
   fieldRow: {
     flexDirection: "row",

--- a/openresto-frontend/components/booking/BookingForm.styles.ts
+++ b/openresto-frontend/components/booking/BookingForm.styles.ts
@@ -42,14 +42,19 @@ export const styles = StyleSheet.create({
     textTransform: "uppercase",
     letterSpacing: 0.8,
   },
+  // One bordered card: the toggle is its header and the fields live inside it, so an
+  // open disclosure stays a single object instead of a box floating under a button.
+  disclosureCard: {
+    borderWidth: 1,
+    borderRadius: 8,
+    overflow: "hidden",
+  },
   disclosureToggle: {
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
     minHeight: 44,
     paddingHorizontal: 12,
-    borderWidth: 1,
-    borderRadius: 8,
   },
   disclosureText: {
     flex: 1,
@@ -59,8 +64,7 @@ export const styles = StyleSheet.create({
   disclosureBody: {
     gap: 16,
     padding: 14,
-    borderWidth: 1,
-    borderRadius: 8,
+    borderTopWidth: 1,
   },
   fieldRow: {
     flexDirection: "row",

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -90,9 +90,10 @@ function suggestTime(restaurant: HoursSource, timezone: string): string {
 
 /**
  * `inline` is the full form: it owns party size and date and lays fields out in pairs.
- * `drawer` is the booking-drawer variant, where party size and date have already been
- * chosen on the page-level filter bar and are passed in — leaving the drawer to ask
- * only what the list can't: which time, who, and how to reach them.
+ * `drawer` is the booking-drawer variant, where party size and date arrive already chosen
+ * from the page-level filter bar. The date stays the page's; party size is offered again
+ * here — the bar is a first pass at it and the booking is where it gets settled — and a
+ * change is handed back to the page rather than kept private to the form.
  */
 export type BookingFormLayout = "inline" | "drawer";
 
@@ -104,6 +105,7 @@ export default function BookingForm({
   initialSeats,
   layout = "inline",
   seats: controlledSeats,
+  onSeatsChange,
   date: controlledDate,
 }: {
   restaurant: RestaurantDto;
@@ -112,8 +114,9 @@ export default function BookingForm({
   initialTime?: string;
   initialSeats?: number;
   layout?: BookingFormLayout;
-  /** When set, party size is owned by the caller and its picker is not rendered. */
+  /** When set, party size is owned by the caller — changing it here reports back up. */
   seats?: number;
+  onSeatsChange?: (seats: number) => void;
   /** When set, the date is owned by the caller and its picker is not rendered. */
   date?: string;
 }) {
@@ -126,6 +129,9 @@ export default function BookingForm({
   const [specialRequests, setSpecialRequests] = useState("");
   const [seatsState, setSeats] = useState(initialSeats ?? 2);
   const seats = controlledSeats ?? seatsState;
+  // Party size can be owned by the page (the Locations filter bar) so the list behind the
+  // drawer re-filters with it; without a caller it stays local to the form.
+  const changeSeats = (value: number) => (onSeatsChange ? onSeatsChange(value) : setSeats(value));
   const [submitting, setSubmitting] = useState(false);
   const [seatingOpen, setSeatingOpen] = useState(false);
   const [sectionId, setSectionId] = useState<number>(0); // 0 = "Any section" (server auto-assigns)
@@ -330,8 +336,13 @@ export default function BookingForm({
 
   // ── Options ──────────────────────────────────────────────────────────────────
 
+  // The drawer sits under a header reading "2 guests · Today · 19:00" and beside the
+  // Locations bar, so its options speak guests; the inline form's field is already
+  // labelled "Number of Guests" and names the seats instead.
   const seatOptions = [...Array(10).keys()].map((i) => ({
-    label: `${i + 1} seat${i > 0 ? "s" : ""}`,
+    label: isDrawer
+      ? `${i + 1} ${i === 0 ? "guest" : "guests"}`
+      : `${i + 1} seat${i > 0 ? "s" : ""}`,
     value: i + 1,
   }));
 
@@ -457,6 +468,19 @@ export default function BookingForm({
         All times are in {timezone.replace(/_/g, " ")} (currently {restaurantCurrentTime} there)
       </ThemedText>
     ) : null;
+
+  const guestsField = (
+    <View style={styles.field}>
+      <ThemedText style={styles.label}>Guests</ThemedText>
+      <Select
+        icon="people-outline"
+        accessibilityLabel="Number of guests"
+        selectedValue={seats}
+        onSelect={(v) => changeSeats(v as number)}
+        options={seatOptions}
+      />
+    </View>
+  );
 
   const timePickerField = (label = "Time") => (
     <View style={styles.field}>
@@ -645,7 +669,10 @@ export default function BookingForm({
         <WalkInDaysBanner restaurant={restaurant} />
 
         <View style={styles.drawerSection}>
-          {sectionHeading("Time", loadingAvailability)}
+          {sectionHeading("Party & time", loadingAvailability)}
+          {/* Directly above the chips it filters: changing it re-asks for times, and the
+              list behind the drawer re-filters with it. */}
+          {guestsField}
           {timesContent}
           {/* Right under the times it qualifies, not buried in the footer. */}
           {timezoneHint}
@@ -670,8 +697,10 @@ export default function BookingForm({
         {divider}
 
         {/* Seating is the one optional step, so it reads as a single closed control rather
-            than a bare text link floating between the fields above and the footer below. */}
-        <View style={styles.drawerSection}>
+            than a bare text link floating between the fields above and the footer below.
+            Open, the fields stay inside that same control — a separate bordered box below
+            the toggle reads as two unrelated things stacked. */}
+        <View style={[styles.disclosureCard, { borderColor: colors.border }]}>
           <Pressable
             testID="seating-disclosure-toggle"
             onPress={() => {
@@ -680,24 +709,29 @@ export default function BookingForm({
             }}
             accessibilityRole="button"
             accessibilityState={{ expanded: seatingOpen }}
-            style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
-              styles.disclosureToggle,
-              {
-                backgroundColor: colors.input,
-                borderColor: hovered || pressed ? PRIMARY : colors.border,
-              },
-            ]}
+            style={[styles.disclosureToggle, { backgroundColor: colors.input }]}
           >
-            <Ionicons name="options-outline" size={16} color={colors.muted} />
-            <ThemedText style={styles.disclosureText}>Choose a section or table</ThemedText>
-            <Ionicons
-              name={seatingOpen ? "chevron-up" : "chevron-down"}
-              size={16}
-              color={colors.muted}
-            />
+            {({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => {
+              const accent = hovered || pressed ? PRIMARY : colors.muted;
+              return (
+                <>
+                  <Ionicons name="options-outline" size={16} color={accent} />
+                  <ThemedText
+                    style={[styles.disclosureText, (hovered || pressed) && { color: PRIMARY }]}
+                  >
+                    Choose a section or table
+                  </ThemedText>
+                  <Ionicons
+                    name={seatingOpen ? "chevron-up" : "chevron-down"}
+                    size={16}
+                    color={accent}
+                  />
+                </>
+              );
+            }}
           </Pressable>
           {seatingOpen && (
-            <View style={[styles.disclosureBody, { borderColor: colors.border }]}>
+            <View style={[styles.disclosureBody, { borderTopColor: colors.border }]}>
               {/* Labelled "Exact time" because the chips above are already "Time" — this one
                   reaches times the availability list doesn't offer. */}
               {timePickerField("Exact time")}

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -107,6 +107,7 @@ export default function BookingForm({
   seats: controlledSeats,
   onSeatsChange,
   date: controlledDate,
+  onDateChange,
 }: {
   restaurant: RestaurantDto;
   onSubmit: (data: BookingFormData) => Promise<void> | void;
@@ -117,8 +118,9 @@ export default function BookingForm({
   /** When set, party size is owned by the caller — changing it here reports back up. */
   seats?: number;
   onSeatsChange?: (seats: number) => void;
-  /** When set, the date is owned by the caller and its picker is not rendered. */
+  /** When set, the date is owned by the caller — changing it here reports back up. */
   date?: string;
+  onDateChange?: (date: string) => void;
 }) {
   const { colors, primaryColor: PRIMARY } = useAppTheme();
   const { width } = useWindowDimensions();
@@ -176,6 +178,7 @@ export default function BookingForm({
   const [tableGroupId, setTableGroupId] = useState<number | undefined>();
   const [dateState, setDate] = useState<string>(() => suggestDate(restaurant, timezone));
   const date = controlledDate ?? dateState;
+  const changeDate = (value: string) => (onDateChange ? onDateChange(value) : setDate(value));
   const [time, setTime] = useState<string>(() => initialTime ?? suggestTime(restaurant, timezone));
 
   const [availabilitySlots, setAvailabilitySlots] = useState<TimeSlotDto[]>([]);
@@ -469,15 +472,28 @@ export default function BookingForm({
       </ThemedText>
     ) : null;
 
-  const guestsField = (
+  const guestsField = (label = "Guests") => (
     <View style={styles.field}>
-      <ThemedText style={styles.label}>Guests</ThemedText>
+      <ThemedText style={styles.label}>{label}</ThemedText>
       <Select
         icon="people-outline"
         accessibilityLabel="Number of guests"
         selectedValue={seats}
         onSelect={(v) => changeSeats(v as number)}
         options={seatOptions}
+      />
+    </View>
+  );
+
+  const dateField = (
+    <View style={styles.field}>
+      <ThemedText style={styles.label}>Date</ThemedText>
+      {/* Customer flow: future-dates-only is intentional. Do NOT pass allowPast
+          here — only the admin New Booking modal opts in to back-dating (#160). */}
+      <DatePicker
+        selectedDate={date}
+        onSelect={changeDate}
+        openDays={restaurant.openDays?.split(",").map(Number)}
       />
     </View>
   );
@@ -661,21 +677,28 @@ export default function BookingForm({
   const divider = <View style={[styles.divider, { backgroundColor: colors.border }]} />;
 
   // ── Drawer layout ──
-  // Party size and date are already settled by the page-level bar, so the drawer asks
-  // only for the time, the diner, and (behind a disclosure) a specific seat.
+  // Every field the drawer owns is a plain field in one column, separated into sections by
+  // the same headings and rules. Party size and date arrive chosen from the page-level bar
+  // and are asked again here, because the booking is where they get settled.
   if (isDrawer) {
     return (
       <View style={styles.drawerForm}>
         <WalkInDaysBanner restaurant={restaurant} />
 
         <View style={styles.drawerSection}>
-          {sectionHeading("Party & time", loadingAvailability)}
-          {/* Directly above the chips it filters: changing it re-asks for times, and the
-              list behind the drawer re-filters with it. */}
-          {guestsField}
+          {sectionHeading("Party & date", loadingAvailability)}
+          {/* Above the chips they filter: changing either re-asks for times, and the list
+              behind the drawer re-filters with them. */}
+          <View style={styles.drawerRow}>
+            <View style={styles.drawerRowHalf}>{guestsField()}</View>
+            <View style={styles.drawerRowHalf}>{dateField}</View>
+          </View>
           {timesContent}
           {/* Right under the times it qualifies, not buried in the footer. */}
           {timezoneHint}
+          {/* Labelled "Exact time" because the chips above are the times on offer — this one
+              reaches the ones the availability list doesn't show. */}
+          {timePickerField("Exact time")}
           {holdBanner}
           {partyTooLarge && (
             <LargePartyNotice
@@ -696,11 +719,11 @@ export default function BookingForm({
 
         {divider}
 
-        {/* Seating is the one optional step, so it reads as a single closed control rather
-            than a bare text link floating between the fields above and the footer below.
-            Open, the fields stay inside that same control — a separate bordered box below
-            the toggle reads as two unrelated things stacked. */}
-        <View style={[styles.disclosureCard, { borderColor: colors.border }]}>
+        {/* Seating is optional, so it opens on request rather than sitting there asking a
+            question most diners don't have an answer to. The toggle is a plain row and the
+            fields it reveals are plain fields: boxing them made the one part of the form
+            that is genuinely about sections read as a section of its own. */}
+        <View style={styles.drawerSection}>
           <Pressable
             testID="seating-disclosure-toggle"
             onPress={() => {
@@ -709,16 +732,14 @@ export default function BookingForm({
             }}
             accessibilityRole="button"
             accessibilityState={{ expanded: seatingOpen }}
-            style={[styles.disclosureToggle, { backgroundColor: colors.input }]}
+            style={styles.disclosureToggle}
           >
             {({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => {
               const accent = hovered || pressed ? PRIMARY : colors.muted;
               return (
                 <>
                   <Ionicons name="options-outline" size={16} color={accent} />
-                  <ThemedText
-                    style={[styles.disclosureText, (hovered || pressed) && { color: PRIMARY }]}
-                  >
+                  <ThemedText style={[styles.disclosureText, { color: accent }]}>
                     Choose a section or table
                   </ThemedText>
                   <Ionicons
@@ -731,13 +752,10 @@ export default function BookingForm({
             }}
           </Pressable>
           {seatingOpen && (
-            <View style={[styles.disclosureBody, { borderTopColor: colors.border }]}>
-              {/* Labelled "Exact time" because the chips above are already "Time" — this one
-                  reaches times the availability list doesn't offer. */}
-              {timePickerField("Exact time")}
+            <>
               {sectionField}
               {tableField}
-            </View>
+            </>
           )}
         </View>
 
@@ -765,24 +783,8 @@ export default function BookingForm({
         testID="booking-field-row"
         style={isTwoColumn ? styles.fieldRow : styles.fieldRowStacked}
       >
-        <View style={[styles.field, half]}>
-          <ThemedText style={styles.label}>Number of Guests</ThemedText>
-          <Select
-            selectedValue={seats}
-            onSelect={(v) => setSeats(v as number)}
-            options={seatOptions}
-          />
-        </View>
-        <View style={[styles.field, half]}>
-          <ThemedText style={styles.label}>Date</ThemedText>
-          {/* Customer flow: future-dates-only is intentional. Do NOT pass allowPast
-              here — only the admin New Booking modal opts in to back-dating (#160). */}
-          <DatePicker
-            selectedDate={date}
-            onSelect={setDate}
-            openDays={restaurant.openDays?.split(",").map(Number)}
-          />
-        </View>
+        <View style={half}>{guestsField("Number of Guests")}</View>
+        <View style={half}>{dateField}</View>
       </View>
 
       {partyTooLarge && (

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -229,6 +229,7 @@ export default function LocationsScreen({
             time={drawer.time}
             today={today}
             variant="side"
+            onSeatsChange={setSeats}
             onClose={closeDrawer}
           />
         )}
@@ -242,6 +243,7 @@ export default function LocationsScreen({
           time={drawer.time}
           today={today}
           variant="sheet"
+          onSeatsChange={setSeats}
           onClose={closeDrawer}
         />
       )}

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -230,6 +230,7 @@ export default function LocationsScreen({
             today={today}
             variant="side"
             onSeatsChange={setSeats}
+            onDateChange={setDate}
             onClose={closeDrawer}
           />
         )}
@@ -244,6 +245,7 @@ export default function LocationsScreen({
           today={today}
           variant="sheet"
           onSeatsChange={setSeats}
+          onDateChange={setDate}
           onClose={closeDrawer}
         />
       )}

--- a/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
@@ -37,6 +37,7 @@ jest.mock("@/components/booking/BookingForm", () => {
     default: function MockBookingForm({
       onSubmit,
       onSeatsChange,
+      onDateChange,
       layout,
       seats,
       date,
@@ -58,6 +59,7 @@ jest.mock("@/components/booking/BookingForm", () => {
           <Text testID="form-date">{String(date)}</Text>
           <Text testID="form-initial-time">{String(initialTime)}</Text>
           <Pressable testID="form-seats-change" onPress={() => onSeatsChange(6)} />
+          <Pressable testID="form-date-change" onPress={() => onDateChange("2026-04-18")} />
           <Pressable
             testID="submit-trigger"
             onPress={() =>
@@ -129,6 +131,7 @@ const baseProps = {
   variant: "side" as const,
   onClose: jest.fn(),
   onSeatsChange: jest.fn(),
+  onDateChange: jest.fn(),
 };
 
 describe("BookingDrawer", () => {
@@ -166,6 +169,13 @@ describe("BookingDrawer", () => {
     renderWithProviders(<BookingDrawer {...baseProps} onSeatsChange={onSeatsChange} />);
     fireEvent.press(screen.getByTestId("form-seats-change"));
     expect(onSeatsChange).toHaveBeenCalledWith(6);
+  });
+
+  it("passes a date change up to the page the same way", () => {
+    const onDateChange = jest.fn();
+    renderWithProviders(<BookingDrawer {...baseProps} onDateChange={onDateChange} />);
+    fireEvent.press(screen.getByTestId("form-date-change"));
+    expect(onDateChange).toHaveBeenCalledWith("2026-04-18");
   });
 
   it("closes on the close button", () => {

--- a/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
@@ -34,7 +34,14 @@ jest.mock("@/components/booking/BookingForm", () => {
   const { Pressable, Text } = require("react-native");
   return {
     __esModule: true,
-    default: function MockBookingForm({ onSubmit, layout, seats, date, initialTime }: any) {
+    default: function MockBookingForm({
+      onSubmit,
+      onSeatsChange,
+      layout,
+      seats,
+      date,
+      initialTime,
+    }: any) {
       const baseData = {
         customerEmail: "test@example.com",
         customerName: "Test Guest",
@@ -50,6 +57,7 @@ jest.mock("@/components/booking/BookingForm", () => {
           <Text testID="form-seats">{String(seats)}</Text>
           <Text testID="form-date">{String(date)}</Text>
           <Text testID="form-initial-time">{String(initialTime)}</Text>
+          <Pressable testID="form-seats-change" onPress={() => onSeatsChange(6)} />
           <Pressable
             testID="submit-trigger"
             onPress={() =>
@@ -120,6 +128,7 @@ const baseProps = {
   today: TODAY,
   variant: "side" as const,
   onClose: jest.fn(),
+  onSeatsChange: jest.fn(),
 };
 
 describe("BookingDrawer", () => {
@@ -150,6 +159,13 @@ describe("BookingDrawer", () => {
     expect(screen.getByTestId("form-seats").props.children).toBe("5");
     expect(screen.getByTestId("form-date").props.children).toBe(TODAY);
     expect(screen.getByTestId("form-initial-time").props.children).toBe("19:30");
+  });
+
+  it("passes a party-size change up to the page so the list behind it follows", () => {
+    const onSeatsChange = jest.fn();
+    renderWithProviders(<BookingDrawer {...baseProps} onSeatsChange={onSeatsChange} />);
+    fireEvent.press(screen.getByTestId("form-seats-change"));
+    expect(onSeatsChange).toHaveBeenCalledWith(6);
   });
 
   it("closes on the close button", () => {

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -162,8 +162,15 @@ jest.mock("@/utils/date", () => ({
 
 jest.mock("@/components/common/Select", () => ({
   __esModule: true,
-  default: ({ onSelect, placeholder, selectedValue, options }: any) => {
+  default: ({ onSelect, placeholder, selectedValue, options, accessibilityLabel }: any) => {
     const { Pressable, Text } = require("react-native");
+    if (accessibilityLabel === "Number of guests") {
+      return (
+        <Pressable testID="guests-select" onPress={() => onSelect(selectedValue + 1)}>
+          <Text>GuestsSelect:{selectedValue}</Text>
+        </Pressable>
+      );
+    }
     if (placeholder === "Select a section") {
       return (
         <Pressable testID="section-select" onPress={() => onSelect(20)}>
@@ -873,12 +880,49 @@ describe("BookingForm drawer layout", () => {
     );
   }
 
-  it("drops the guests and date pickers — the page bar owns them", async () => {
+  it("drops the date picker — the page bar owns the date", async () => {
     renderDrawer();
     await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
-    expect(screen.queryByText("Number of Guests")).toBeNull();
     expect(screen.queryByText("Date")).toBeNull();
     expect(screen.queryAllByTestId("booking-field-row")).toHaveLength(0);
+  });
+
+  it("keeps party size adjustable, seeded from the page bar", async () => {
+    renderDrawer();
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+    expect(screen.getByText("Guests")).toBeTruthy();
+    expect(screen.getByText("GuestsSelect:4")).toBeTruthy();
+  });
+
+  it("reports a party-size change back to the caller instead of diverging from it", async () => {
+    const onSeatsChange = jest.fn();
+    renderDrawer({ onSeatsChange });
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+
+    fireEvent.press(screen.getByTestId("guests-select"));
+
+    expect(onSeatsChange).toHaveBeenCalledWith(5);
+    // Still showing the caller's number: the page owns it, so the form waits to be told.
+    expect(screen.getByText("GuestsSelect:4")).toBeTruthy();
+  });
+
+  it("re-asks for availability when the caller raises the party size", async () => {
+    const { rerender } = renderDrawer();
+    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+
+    rerender(
+      <BookingForm
+        layout="drawer"
+        restaurant={mockRestaurantAllDays as any}
+        seats={6}
+        date="2026-06-24"
+        onSubmit={jest.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(mockFetchAvailability).toHaveBeenCalledWith(expect.anything(), "2026-06-24", 6)
+    );
   });
 
   it("fetches availability for the caller's party size and date", async () => {
@@ -919,14 +963,14 @@ describe("BookingForm drawer layout", () => {
     renderDrawer();
     await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
 
-    expect(screen.getByText("Time")).toBeTruthy();
+    expect(screen.getByText("Party & time")).toBeTruthy();
     expect(screen.getByText("Your details")).toBeTruthy();
 
-    // Opening seating adds an exact-time picker, which must not collide with the
-    // "Time" section heading above it.
+    // Opening seating adds an exact-time picker, which must not collide with a
+    // "Time" label above it.
     fireEvent.press(screen.getByTestId("seating-disclosure-toggle"));
     expect(screen.getByText("Exact time")).toBeTruthy();
-    expect(screen.getAllByText("Time")).toHaveLength(1);
+    expect(screen.queryAllByText("Time")).toHaveLength(0);
   });
 
   it("shows the same privacy note as the inline form, in full and without a toggle", async () => {

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -880,18 +880,14 @@ describe("BookingForm drawer layout", () => {
     );
   }
 
-  it("drops the date picker — the page bar owns the date", async () => {
-    renderDrawer();
-    await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
-    expect(screen.queryByText("Date")).toBeNull();
-    expect(screen.queryAllByTestId("booking-field-row")).toHaveLength(0);
-  });
-
-  it("keeps party size adjustable, seeded from the page bar", async () => {
+  it("keeps party size and date adjustable, seeded from the page bar", async () => {
     renderDrawer();
     await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
     expect(screen.getByText("Guests")).toBeTruthy();
     expect(screen.getByText("GuestsSelect:4")).toBeTruthy();
+    expect(screen.getByText("Date")).toBeTruthy();
+    // The drawer lays fields out in its own single column, never the inline pair rows.
+    expect(screen.queryAllByTestId("booking-field-row")).toHaveLength(0);
   });
 
   it("reports a party-size change back to the caller instead of diverging from it", async () => {
@@ -906,22 +902,17 @@ describe("BookingForm drawer layout", () => {
     expect(screen.getByText("GuestsSelect:4")).toBeTruthy();
   });
 
-  it("re-asks for availability when the caller raises the party size", async () => {
-    const { rerender } = renderDrawer();
+  it("reports a date change back to the caller instead of diverging from it", async () => {
+    const onDateChange = jest.fn();
+    renderDrawer({ onDateChange });
     await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
 
-    rerender(
-      <BookingForm
-        layout="drawer"
-        restaurant={mockRestaurantAllDays as any}
-        seats={6}
-        date="2026-06-24"
-        onSubmit={jest.fn()}
-      />
-    );
+    fireEvent.press(screen.getByTestId("date-picker-sun"));
 
+    expect(onDateChange).toHaveBeenCalledWith("2026-06-21");
+    // The page owns the date, so the form keeps showing the one it was given.
     await waitFor(() =>
-      expect(mockFetchAvailability).toHaveBeenCalledWith(expect.anything(), "2026-06-24", 6)
+      expect(mockFetchAvailability).toHaveBeenLastCalledWith(expect.anything(), "2026-06-24", 4)
     );
   });
 
@@ -943,14 +934,16 @@ describe("BookingForm drawer layout", () => {
     expect(screen.queryByText("Table")).toBeNull();
   });
 
-  it("reveals the time, section and table controls from the seating disclosure", async () => {
+  it("reveals the section and table controls from the seating disclosure", async () => {
     renderDrawer();
     await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
+
+    // The exact-time picker is about time, not seating, so it stays out in the form.
+    expect(screen.getByTestId("time-picker")).toBeTruthy();
 
     fireEvent.press(screen.getByTestId("seating-disclosure-toggle"));
     expect(screen.getByText("Section")).toBeTruthy();
     expect(screen.getByText("Table")).toBeTruthy();
-    expect(screen.getByTestId("time-picker")).toBeTruthy();
 
     fireEvent.press(screen.getByTestId("seating-disclosure-toggle"));
     expect(screen.queryByText("Section")).toBeNull();
@@ -963,12 +956,11 @@ describe("BookingForm drawer layout", () => {
     renderDrawer();
     await waitFor(() => expect(mockFetchAvailability).toHaveBeenCalled());
 
-    expect(screen.getByText("Party & time")).toBeTruthy();
+    expect(screen.getByText("Party & date")).toBeTruthy();
     expect(screen.getByText("Your details")).toBeTruthy();
 
-    // Opening seating adds an exact-time picker, which must not collide with a
-    // "Time" label above it.
-    fireEvent.press(screen.getByTestId("seating-disclosure-toggle"));
+    // The exact-time picker sits under the chips that are already the times on offer,
+    // so it must not be labelled "Time" as well.
     expect(screen.getByText("Exact time")).toBeTruthy();
     expect(screen.queryAllByText("Time")).toHaveLength(0);
   });

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -38,6 +38,7 @@ jest.mock("@/components/booking/BookingDrawer", () => {
       variant,
       onClose,
       onSeatsChange,
+      onDateChange,
     }: any) {
       return (
         <View testID="mock-drawer">
@@ -48,6 +49,7 @@ jest.mock("@/components/booking/BookingDrawer", () => {
           <Text testID="drawer-variant">{variant}</Text>
           <Pressable testID="drawer-close" onPress={onClose} />
           <Pressable testID="drawer-seats-change" onPress={() => onSeatsChange(6)} />
+          <Pressable testID="drawer-date-change" onPress={() => onDateChange("2026-09-09")} />
         </View>
       );
     },
@@ -266,6 +268,20 @@ describe("LocationsScreen", () => {
       expect(screen.getByTestId("drawer-seats").props.children).toBe("6");
       expect(screen.getByTestId("seats-1").props.children).toBe("6");
       expect(screen.getByTestId("seats-2").props.children).toBe("6");
+    });
+
+    it("adopts a date chosen inside the drawer, list included", async () => {
+      (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+      renderWithProviders(<LocationsScreen />);
+      await waitFor(() => expect(screen.getByTestId("book-2")).toBeTruthy());
+      fireEvent.press(screen.getByTestId("book-2"));
+      await waitFor(() => expect(screen.getByTestId("mock-drawer")).toBeTruthy());
+
+      fireEvent.press(screen.getByTestId("drawer-date-change"));
+
+      expect(screen.getByTestId("drawer-date").props.children).toBe("2026-09-09");
+      expect(screen.getByTestId("date-1").props.children).toBe("2026-09-09");
+      expect(screen.getByTestId("date-2").props.children).toBe("2026-09-09");
     });
 
     it("opens as a bottom sheet at phone width", async () => {

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -30,7 +30,15 @@ jest.mock("@/components/booking/BookingDrawer", () => {
   const { View, Text, Pressable } = require("react-native");
   return {
     __esModule: true,
-    default: function MockBookingDrawer({ restaurant, seats, date, time, variant, onClose }: any) {
+    default: function MockBookingDrawer({
+      restaurant,
+      seats,
+      date,
+      time,
+      variant,
+      onClose,
+      onSeatsChange,
+    }: any) {
       return (
         <View testID="mock-drawer">
           <Text testID="drawer-restaurant">{restaurant.name}</Text>
@@ -39,6 +47,7 @@ jest.mock("@/components/booking/BookingDrawer", () => {
           <Text testID="drawer-time">{String(time)}</Text>
           <Text testID="drawer-variant">{variant}</Text>
           <Pressable testID="drawer-close" onPress={onClose} />
+          <Pressable testID="drawer-seats-change" onPress={() => onSeatsChange(6)} />
         </View>
       );
     },
@@ -241,6 +250,22 @@ describe("LocationsScreen", () => {
       expect(screen.getByTestId("drawer-time").props.children).toBe("19:30");
       expect(screen.getByTestId("drawer-seats").props.children).toBe("3");
       expect(screen.getByTestId("drawer-variant").props.children).toBe("side");
+    });
+
+    it("adopts a party size chosen inside the drawer, list included", async () => {
+      (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+      renderWithProviders(<LocationsScreen initialSeats={3} />);
+      await waitFor(() => expect(screen.getByTestId("book-2")).toBeTruthy());
+      fireEvent.press(screen.getByTestId("book-2"));
+      await waitFor(() => expect(screen.getByTestId("mock-drawer")).toBeTruthy());
+
+      fireEvent.press(screen.getByTestId("drawer-seats-change"));
+
+      // The bar is the first pass at party size; whatever the booking panel settles on wins,
+      // so the cards behind it can't go on advertising times for a different party.
+      expect(screen.getByTestId("drawer-seats").props.children).toBe("6");
+      expect(screen.getByTestId("seats-1").props.children).toBe("6");
+      expect(screen.getByTestId("seats-2").props.children).toBe("6");
     });
 
     it("opens as a bottom sheet at phone width", async () => {


### PR DESCRIPTION
## Summary

The Locations redesign (#302) hoisted party size and date into the page-level filter bar and dropped both from the booking panel. Once the drawer is open neither can be changed, and on a phone the sheet covers the bar entirely, so the only way to book for a different party or day is to close the panel, change the bar and re-pick a time.

The filter bar is the first pass. The booking is where these get settled, so both pickers are back in the drawer, and the one in the booker is the one that wins. Each reports its value up to `LocationsScreen`, which owns it, so the bar, the cards and the availability summary follow the panel instead of sitting next to it advertising times for a booking you're no longer making. Verified live: picking 6 guests flips the header, the bar and every card, and fires the large-party notice when the party outgrows the biggest table; picking a new date moves the whole page onto that day.

Both also come out of `BookingDrawer`'s remount key. Changing either used to rebuild the form and throw away a half-typed name and email. The form already releases the hold, re-fetches availability and re-picks a table on a change of either, so the key was duplicating what the effects do.

The second half of this PR is the drawer's layout. Seating was boxed off in its own bordered card, which made the one part of the form genuinely about sections read as a section of its own, floating between the fields above it and the footer below. The toggle is a plain row now and the fields it reveals are plain fields, identical to Full Name and Email. The exact-time picker came out of that box with them: it is about time, not seating, so it sits under the chips it supplements.

The drawer reads as one column of fields in three headed groups: "Party & date" (guests, date, the meal chips, exact time), "Your details", and the optional seating row.

## Related issue

Closes #

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

| File | Change |
| --- | --- |
| `components/booking/BookingForm.tsx` | New `onSeatsChange` / `onDateChange` props: controlled party size and date report changes back instead of being read-only. Drawer layout gains a Guests + Date row above the chips, the exact-time picker moves out of the seating disclosure, and the disclosure loses its card. Both layouts now share one guests field and one date field. |
| `components/booking/BookingForm.styles.ts` | `drawerRow` / `drawerRowHalf` for the split row; `disclosureToggle` drops its border and fill; `disclosureCard` and `disclosureBody` are gone. |
| `components/booking/BookingDrawer.tsx` | Threads both callbacks through, drops `seats` and `date` from the `BookingForm` remount key. |
| `components/restaurant/LocationsScreen.tsx` | Passes `setSeats` and `setDate` to both drawer variants. |

Drawer seat options read "2 guests" rather than the inline form's "2 seats", matching the drawer header and the filter bar. The inline form's own field is already labelled "Number of Guests".

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

New tests: both pickers render seeded from the caller, both report changes up rather than diverging locally, `BookingDrawer` passes both callbacks through, `LocationsScreen` adopts the drawer's party size and date across its cards, and the disclosure reveals section and table while the exact-time picker stays out in the form. Updated the drawer-layout tests that asserted the pickers were absent and that the first section heading read "Time".

`tsc --noEmit` clean, `npm run check` clean, 2263 Jest tests with 3 failures. All three are pre-existing locale formatting assertions on my machine ("Fri 17 Apr" vs the expected "Fri, Apr 17") in `LocationsFilterBar`, `DatePickerWeb` and `BookingDrawer`. Confirmed by stashing and re-running on a clean tree. They pass in CI, which runs en-US. Worth pinning the locale in those assertions at some point, but not in this PR.

Verified end-to-end against the Docker stack at :5062 (rebuilt frontend image), desktop drawer and phone sheet.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed

## Notes for review

- Drawer changes propagate up rather than staying local on purpose. On desktop both sets of controls are on screen at once, so a private drawer value would visibly contradict the bar and the summary line next to it.
- The meal window (Lunch / Dinner / All) stays page-only. It is a browsing filter, not a property of the booking, so there is nothing for the drawer to settle.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01BkxKQ7cTyubcYKYfMi3NNj
