### PR TITLE
Float the booking panel instead of welding it to the page edge

### DIFF
--- a/openresto-frontend/components/booking/BookingDrawer.styles.ts
+++ b/openresto-frontend/components/booking/BookingDrawer.styles.ts
@@ -1,14 +1,26 @@
 import { StyleSheet } from "react-native";
 import { theme } from "@/theme/theme";
 
-/** Width of the docked side panel; the sheet layout uses the full width instead. */
+/** Width of the floating side panel; the sheet layout uses the full width instead. */
 export const DRAWER_WIDTH = 460;
 
+/** Gap between the panel and the list, the navbar and the bottom of the viewport. */
+const SIDE_INSET = theme.spacing.lg;
+
 export const styles = StyleSheet.create({
+  // A card floating over the page rather than a column welded to its right edge: every
+  // other surface on this screen (the location rows, the filter bar) is a rounded card,
+  // and a full-bleed square panel is the one thing that reads as chrome instead.
   side: {
     width: DRAWER_WIDTH,
     flexShrink: 0,
-    borderLeftWidth: 1,
+    marginTop: SIDE_INSET,
+    marginBottom: SIDE_INSET,
+    marginLeft: SIDE_INSET,
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.card,
+    // Without this the header's fill and the scroll body square off the rounded corners.
+    overflow: "hidden",
   },
   sheetRoot: {
     flex: 1,

--- a/openresto-frontend/components/booking/BookingDrawer.tsx
+++ b/openresto-frontend/components/booking/BookingDrawer.tsx
@@ -246,7 +246,7 @@ export default function BookingDrawer({
       testID="booking-drawer"
       style={[
         styles.side,
-        { backgroundColor: colors.card, borderLeftColor: colors.border },
+        { backgroundColor: colors.card, borderColor: colors.border },
         theme.shadows.popup,
       ]}
     >

--- a/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
@@ -5,6 +5,10 @@ export const styles = StyleSheet.create({
   bar: {
     flexDirection: "row",
     alignItems: "center",
+    // The three controls hold a fixed minimum width, so once the booking panel takes 460px
+    // off the list column there is nothing left for the summary and it spills out of the
+    // bar. Wrapping drops it onto its own line instead, still right-aligned.
+    flexWrap: "wrap",
     gap: theme.spacing.xsm,
     borderWidth: 1,
     borderRadius: theme.borderRadius.card,

--- a/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
@@ -6,6 +6,7 @@
  */
 import React from "react";
 import { screen, waitFor, fireEvent } from "@testing-library/react-native";
+import { StyleSheet } from "react-native";
 import BookingDrawer, { shouldDismissSheet } from "@/components/booking/BookingDrawer";
 import { createBooking } from "@/api/bookings";
 import { renderWithProviders } from "@/tests/helpers/renderWithProviders";
@@ -178,6 +179,20 @@ describe("BookingDrawer", () => {
     expect(onDateChange).toHaveBeenCalledWith("2026-04-18");
   });
 
+  it("floats as a rounded card rather than a column welded to the page edge", () => {
+    renderWithProviders(<BookingDrawer {...baseProps} />);
+    const panel = StyleSheet.flatten(screen.getByTestId("booking-drawer").props.style);
+    expect(panel.borderRadius).toBeGreaterThan(0);
+    // All four sides, not the single left edge a docked column would carry.
+    expect(panel.borderWidth).toBe(1);
+    expect(panel.borderLeftWidth).toBeUndefined();
+    expect(panel.marginTop).toBeGreaterThan(0);
+    expect(panel.marginBottom).toBeGreaterThan(0);
+    expect(panel.marginLeft).toBeGreaterThan(0);
+    // Corners are only round if the header fill and the scroll body are clipped to them.
+    expect(panel.overflow).toBe("hidden");
+  });
+
   it("closes on the close button", () => {
     const onClose = jest.fn();
     renderWithProviders(<BookingDrawer {...baseProps} onClose={onClose} />);
@@ -190,6 +205,16 @@ describe("BookingDrawer", () => {
       renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" />);
       expect(screen.getByTestId("booking-drawer")).toBeTruthy();
       expect(screen.getByText("Toronto Resto")).toBeTruthy();
+    });
+
+    it("keeps the sheet flush to the bottom edge, rounded only at the top", () => {
+      renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" />);
+      const sheet = StyleSheet.flatten(screen.getByTestId("booking-drawer").props.style);
+      // The side panel's float treatment must not leak here: a sheet that floats above
+      // the bottom edge of a phone leaves a strip of page under it.
+      expect(sheet.borderTopLeftRadius).toBeGreaterThan(0);
+      expect(sheet.borderRadius).toBeUndefined();
+      expect(sheet.marginBottom).toBeUndefined();
     });
 
     it("offers a drag handle wired to the pan responder", () => {

--- a/openresto-frontend/tests/components/restaurant/LocationsFilterBar.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsFilterBar.test.tsx
@@ -3,6 +3,7 @@
  */
 import React from "react";
 import { screen, fireEvent } from "@testing-library/react-native";
+import { StyleSheet } from "react-native";
 import LocationsFilterBar, { formatBarDate } from "@/components/restaurant/LocationsFilterBar";
 import { renderWithProviders } from "@/tests/helpers/renderWithProviders";
 
@@ -88,6 +89,16 @@ describe("LocationsFilterBar", () => {
       <LocationsFilterBar {...baseProps} summary="2 of 3 locations have tables" />
     );
     expect(screen.getByText("2 of 3 locations have tables")).toBeTruthy();
+  });
+
+  it("lets the summary wrap rather than spill out of the bar", () => {
+    renderWithProviders(
+      <LocationsFilterBar {...baseProps} summary="2 of 6 locations have tables" />
+    );
+    // The three controls hold a fixed minimum width, so on a list column narrowed by the
+    // booking panel the summary has to be able to drop onto its own line.
+    const bar = StyleSheet.flatten(screen.getByTestId("locations-filter-bar").props.style);
+    expect(bar.flexWrap).toBe("wrap");
   });
 
   it("omits the summary when there is nothing to say", () => {


### PR DESCRIPTION
## Summary

The booking panel was the only square surface on the Locations page. Every other surface there (the location rows, the filter bar, the cards inside them) is a rounded card, while the panel was a full-height column with a single left border running from the navbar to the bottom of the viewport. That reads as chrome bolted to the window rather than as part of the page.

It floats now: rounded on all four corners, bordered on all four sides, inset from the list column, the navbar and the bottom edge, keeping the popup shadow it already had. `overflow: hidden` goes on with the radius, otherwise the header's fill and the scroll body square the corners back off.

Measured at 1440x1000 the panel sits at y 80 to 984 with 88px clear to the right, and at 1100px wide it keeps a 28px gap, because the row is already capped at the app's content width and centred.

Second commit fixes a bug I hit while shooting screenshots for the first one. The three filter controls hold a fixed minimum width totalling 452px, so once the booking panel takes 460px off the list column, a viewport around 1100px leaves the availability summary nothing to sit in and its text renders outside the bar, over the page behind it. The bar wraps now: the summary drops onto its own line, still right-aligned. The compact bar can't reach a wrap, its controls are flex-sized rather than minimum-width, so they shrink onto one line.

Rebased onto `main` after #307 merged.

## Related issue

Closes #

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

| File | Change |
| --- | --- |
| `components/booking/BookingDrawer.styles.ts` | `side` gains a border on all four sides, `borderRadius.card`, `overflow: hidden` and a `SIDE_INSET` margin on three edges, replacing the lone `borderLeftWidth`. |
| `components/booking/BookingDrawer.tsx` | `borderLeftColor` becomes `borderColor` now that all four sides are drawn. |
| `components/restaurant/LocationsFilterBar.styles.ts` | `bar` gains `flexWrap: "wrap"` so the availability summary wraps instead of overflowing. |

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

Three new tests. Two on the drawer, one on each variant. The side panel asserts the rounded, four-sided, inset, clipped treatment. The sheet asserts the opposite: top-only radius, no `borderRadius`, no bottom margin. **Mobile is the thing this change could plausibly break** (a sheet floating above the bottom of a phone leaves a strip of page under it), so it gets an explicit guard rather than being left to a screenshot.

The third asserts the filter bar can wrap.

`tsc --noEmit` clean, `npm run check` clean. The two failing tests (`BookingDrawer`, `LocationsFilterBar`) are the pre-existing locale formatting assertions ("Fri 17 Apr" vs the expected "Fri, Apr 17") that also fail on a clean tree here and pass in CI.

Verified against the Docker stack at :5062 with a rebuilt frontend image: 1440px, 1100px with and without the panel open, and a 390px phone viewport where both the sheet and the compact bar are unchanged (the compact bar still measures a single 66px row).

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed

## Notes for review

- Inset is `theme.spacing.lg` (16) on three edges. The right edge gets its gap from the row's existing content-width cap, so it is not set here.
- Separately and still not fixed here: on a phone the compact bar squeezes the guests trigger to 64px, and its label is ellipsised down to a 1px-wide "2" that reads as a stray dot next to the icon. Pre-existing on `main`, unrelated to the wrap, and it wants its own look at the compact bar's proportions.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01BkxKQ7cTyubcYKYfMi3NNj
