### PR TITLE
Stop the compact filter bar squeezing the guest count into a dot

### DIFF
--- a/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
@@ -7,7 +7,8 @@ export const styles = StyleSheet.create({
     alignItems: "center",
     // The three controls hold a fixed minimum width, so once the booking panel takes 460px
     // off the list column there is nothing left for the summary and it spills out of the
-    // bar. Wrapping drops it onto its own line instead, still right-aligned.
+    // bar. Wrapping drops it onto its own line instead, still right-aligned, and does the
+    // same for a control itself on a phone too narrow to hold all three.
     flexWrap: "wrap",
     gap: theme.spacing.xsm,
     borderWidth: 1,
@@ -27,11 +28,17 @@ export const styles = StyleSheet.create({
   controlMeal: {
     minWidth: 150,
   },
+  // A share of the row is not a promise of enough room: at a 1:2:2 split a 390px phone
+  // leaves the seat trigger 64px, which is less than its own icon, digits and chevron, so
+  // the count ellipsised down to a stray dot. The floors are what each trigger actually
+  // needs, and the bar wraps when they no longer fit rather than squeezing one of them.
   controlCompactSeats: {
     flex: 1,
+    minWidth: 80,
   },
   controlCompactWide: {
     flex: 2,
+    minWidth: 116,
   },
   summary: {
     marginLeft: "auto",

--- a/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
@@ -19,6 +19,11 @@ const MEAL_OPTIONS = [
   { label: "All times", value: "All" },
 ];
 
+/** "All times" is two words the compact bar can't spare the room for. */
+const MEAL_OPTIONS_COMPACT = MEAL_OPTIONS.map((o) =>
+  o.value === "All" ? { ...o, label: "All" } : o
+);
+
 const SEAT_OPTIONS = [...Array(10).keys()].map((i) => ({
   label: `${i + 1} ${i === 0 ? "guest" : "guests"}`,
   value: i + 1,
@@ -82,7 +87,10 @@ export default function LocationsFilterBar({
         theme.shadows.sm,
       ]}
     >
-      <View style={compact ? styles.controlCompactSeats : styles.controlSeats}>
+      <View
+        testID="filter-control-seats"
+        style={compact ? styles.controlCompactSeats : styles.controlSeats}
+      >
         <Select
           icon="people-outline"
           accessibilityLabel="Number of guests"
@@ -94,7 +102,7 @@ export default function LocationsFilterBar({
 
       <View style={compact ? styles.controlCompactWide : styles.controlDate}>
         <DatePicker
-          icon="calendar-outline"
+          icon={compact ? undefined : "calendar-outline"}
           triggerLabel={formatBarDate(date, today, !!compact)}
           selectedDate={date}
           onSelect={onDateChange}
@@ -103,9 +111,9 @@ export default function LocationsFilterBar({
 
       <View style={compact ? styles.controlCompactWide : styles.controlMeal}>
         <Select
-          icon="time-outline"
+          icon={compact ? undefined : "time-outline"}
           accessibilityLabel="Time of day"
-          options={MEAL_OPTIONS}
+          options={compact ? MEAL_OPTIONS_COMPACT : MEAL_OPTIONS}
           selectedValue={meal}
           onSelect={(v) => onMealChange(v as MealWindow)}
         />

--- a/openresto-frontend/tests/components/restaurant/LocationsFilterBar.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsFilterBar.test.tsx
@@ -118,6 +118,20 @@ describe("LocationsFilterBar", () => {
       expect(screen.getByText("Today")).toBeTruthy();
     });
 
+    it("gives the seat trigger room for its own icon, digits and chevron", () => {
+      renderWithProviders(<LocationsFilterBar {...baseProps} compact />);
+      // A 1:2:2 share of a 390px phone is 64px, less than the trigger's contents, and the
+      // count ellipsised down to a stray dot beside the icon. The floor is what it needs.
+      const seats = StyleSheet.flatten(screen.getByTestId("filter-control-seats").props.style);
+      expect(seats.minWidth).toBeGreaterThanOrEqual(80);
+    });
+
+    it("shortens the meal window to a single word", () => {
+      renderWithProviders(<LocationsFilterBar {...baseProps} compact meal="All" />);
+      expect(screen.getByText("All")).toBeTruthy();
+      expect(screen.queryByText("All times")).toBeNull();
+    });
+
     it("still reports changes upward", () => {
       const onSeatsChange = jest.fn();
       renderWithProviders(


### PR DESCRIPTION
## Summary

On a 390px phone the compact filter bar's 1:2:2 split gives the guests control 64px. Its trigger needs about 79: 12px of padding either side, a 15px icon, room for two digits, and the chevron. The count lost that fight and ellipsised down to a single pixel, so the control rendered as an icon beside a stray dot with no readable party size at all.

Three icon'd dropdowns do not fit a phone, so the two whose labels already say what they are lose their glyph. "Today" and "All" are self-describing; a bare "2" is not, so it keeps its icon. The meal window also shortens to one word on the compact bar, the way the seat labels already do there.

Each compact control now carries the width its own contents need, and the bar wraps when they no longer fit, so a narrow phone drops a control onto a second line rather than squeezing one of the three below legibility. The wide bar is untouched.

Measured on the built stack:

| Viewport | Bar | Guests trigger | Result |
| --- | --- | --- | --- |
| 430px | 66px, one row | 80px | icon, count and chevron all legible |
| 390px | 66px, one row | 80px | same, this is the width that was broken |
| 320px | 118px, two rows | 86px | guests + date on the first row, meal window on the second |
| 1440px | unchanged | unchanged | all three icons, "All times", summary on the same line |

## Related issue

Closes #

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

| File | Change |
| --- | --- |
| `components/restaurant/LocationsFilterBar.styles.ts` | `controlCompactSeats` and `controlCompactWide` gain `minWidth` floors of 80 and 116. The `flexWrap` comment now covers the phone case too. |
| `components/restaurant/LocationsFilterBar.tsx` | Date and meal drop their icon on the compact bar; the compact meal options shorten "All times" to "All". `testID` on the seats control so the floor can be asserted. |

The wrap this leans on is already there from #308, where it stopped the availability summary spilling out of the bar. This change is the second thing it buys.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

Two new tests on the compact bar: the seats control holds its floor, and the meal window renders as one word. `tsc --noEmit` clean, `npm run check` clean, 1262 tests in `tests/components` with 3 failures, all the pre-existing locale date-format assertions that also fail on a clean tree here and pass in CI.

No E2E impact: `selectMealWindow` accepts "All times" but every spec passes "Lunch", and all Playwright projects run Desktop Chrome, which keeps the wide bar.

Verified against the Docker stack at :5062 with a rebuilt frontend image at all four widths in the table above.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed

## Notes for review

- The floors are content-derived, not round numbers: 80 is the seat trigger's padding, icon, two digits and chevron; 116 covers the longest date label the compact bar renders before it would rather wrap.
- Dropping two of the three glyphs is the judgement call here. The alternative was keeping them and letting the date ellipsise instead, which trades a readable count for an unreadable date.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01BkxKQ7cTyubcYKYfMi3NNj
