### PR TITLE
Cap the VPS build cache, and show the location a deep-linked time belongs to

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,8 +95,11 @@ jobs:
               sleep 5
             done
 
-            echo "==> Pruning unused images..."
+            echo "==> Pruning unused images and capping build cache..."
             docker image prune -f
+            # Age filters are useless here — main is deployed several times a
+            # day, so the whole cache is always "recent". Cap it by size instead.
+            docker builder prune -f --max-used-space 2GB
 
             echo "==> Deployment complete."
 

--- a/docker-compose.vps.yml
+++ b/docker-compose.vps.yml
@@ -65,8 +65,10 @@ services:
       - ${HOST_SSL_KEY_PATH}:/etc/nginx/ssl/server.key:ro
       - media_data:/usr/share/nginx/html/media:ro
     depends_on:
-      backend:
-        condition: service_healthy
-      frontend:
-        condition: service_healthy
+      # Start-order only, deliberately not service_healthy: nginx resolves
+      # backend/frontend at startup and Docker registers their DNS at container
+      # creation, so waiting on healthchecks only lengthens the window where
+      # :8443 is unpublished and the public site 502s.
+      - backend
+      - frontend
     restart: always

--- a/openresto-frontend/app/(user)/_layout.tsx
+++ b/openresto-frontend/app/(user)/_layout.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Platform, View } from "react-native";
 import { Slot, Stack, useRouter, useSegments } from "expo-router";
 import Navbar from "@/components/layout/Navbar";
+import RouteTransition from "@/components/layout/RouteTransition";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { focusTarget } from "@/utils/focusRegistry";
 import KeyboardShortcutsHelp from "@/components/common/KeyboardShortcutsHelp";
@@ -38,7 +39,9 @@ export default function UserLayout() {
     return (
       <View style={{ flex: 1 }}>
         <Navbar onOpenShortcuts={() => setShowShortcutsHelp(true)} />
-        <Slot />
+        <RouteTransition>
+          <Slot />
+        </RouteTransition>
         <KeyboardShortcutsHelp
           visible={showShortcutsHelp}
           scope="user"

--- a/openresto-frontend/components/booking/BookingDrawer.tsx
+++ b/openresto-frontend/components/booking/BookingDrawer.tsx
@@ -17,6 +17,10 @@ export { DRAWER_WIDTH } from "./BookingDrawer.styles";
 
 /** How far the sheet animates before it is considered gone. */
 const SHEET_EXIT_DISTANCE = 800;
+/** How far the side panel travels as it fades in and out. */
+const SIDE_ENTER_DISTANCE = 28;
+const SIDE_ENTER_MS = 200;
+const SIDE_EXIT_MS = 160;
 
 /**
  * Whether a drag on the sheet's handle should dismiss it: either dragged far enough to
@@ -110,9 +114,33 @@ export default function BookingDrawer({
     })
   ).current;
 
+  // The panel owns its exit as well as its entrance: the page drops it from state the
+  // moment onClose fires, so anything that wants an exit animation has to finish it
+  // before handing control back.
+  const enter = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    Animated.timing(enter, {
+      toValue: 1,
+      duration: SIDE_ENTER_MS,
+      useNativeDriver: false,
+    }).start();
+  }, [enter]);
+
   const closeWithHaptic = () => {
     Haptics.selectionAsync();
-    onClose();
+    const exit =
+      variant === "sheet"
+        ? Animated.timing(dragY, {
+            toValue: SHEET_EXIT_DISTANCE,
+            duration: 180,
+            useNativeDriver: false,
+          })
+        : Animated.timing(enter, {
+            toValue: 0,
+            duration: SIDE_EXIT_MS,
+            useNativeDriver: false,
+          });
+    exit.start(() => onCloseRef.current());
   };
 
   const handleSubmit = async (data: BookingFormData) => {
@@ -242,15 +270,26 @@ export default function BookingDrawer({
   }
 
   return (
-    <View
+    <Animated.View
       testID="booking-drawer"
       style={[
         styles.side,
         { backgroundColor: colors.card, borderColor: colors.border },
         theme.shadows.popup,
+        {
+          opacity: enter,
+          transform: [
+            {
+              translateX: enter.interpolate({
+                inputRange: [0, 1],
+                outputRange: [SIDE_ENTER_DISTANCE, 0],
+              }),
+            },
+          ],
+        },
       ]}
     >
       {body()}
-    </View>
+    </Animated.View>
   );
 }

--- a/openresto-frontend/components/layout/RouteTransition.styles.ts
+++ b/openresto-frontend/components/layout/RouteTransition.styles.ts
@@ -1,0 +1,5 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  root: { flex: 1 },
+});

--- a/openresto-frontend/components/layout/RouteTransition.tsx
+++ b/openresto-frontend/components/layout/RouteTransition.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { Animated } from "react-native";
+import { usePathname } from "expo-router";
+import { styles } from "./RouteTransition.styles";
+
+const DURATION_MS = 180;
+/** How far the incoming view rises as it fades in. */
+const RISE = 6;
+
+/**
+ * Fades and lifts route content whenever the path changes. On web the user layout
+ * renders a bare `<Slot />`, so moving between the home page, the locations list and a
+ * booking confirmation is a hard cut with no sense of one view replacing another.
+ *
+ * Keyed off the pathname rather than the rendered children: query-string changes
+ * (`?time=19:30`) land on the same view and should not replay the transition.
+ */
+export default function RouteTransition({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const anim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    anim.setValue(0);
+    Animated.timing(anim, {
+      toValue: 1,
+      duration: DURATION_MS,
+      useNativeDriver: false,
+    }).start();
+  }, [pathname, anim]);
+
+  return (
+    <Animated.View
+      testID="route-transition"
+      style={[
+        styles.root,
+        {
+          opacity: anim,
+          transform: [
+            { translateY: anim.interpolate({ inputRange: [0, 1], outputRange: [RISE, 0] }) },
+          ],
+        },
+      ]}
+    >
+      {children}
+    </Animated.View>
+  );
+}

--- a/openresto-frontend/components/restaurant/LocationsScreen.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsScreen.styles.ts
@@ -10,7 +10,12 @@ export const styles = StyleSheet.create({
     width: "100%",
     // react-native-web needs the explicit min-height:0 for the list column to shrink
     // instead of overflowing once the drawer takes its 460px beside it.
-    ...(Platform.OS === "web" ? ({ minHeight: 0 } as object) : null),
+    // The transition lives on the always-applied style, not on `rowWithDrawer` — a
+    // transition declared only while the drawer is open animates the open and snaps
+    // the close, because the rule disappears with the width it was meant to animate.
+    ...(Platform.OS === "web"
+      ? ({ minHeight: 0, transition: "max-width 220ms ease" } as object)
+      : null),
   },
   rowWithDrawer: {
     alignSelf: "center",

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -40,7 +40,9 @@ export function availabilitySummary(
  * (or as a sheet on phones) instead of expanding the card and pushing the rest away.
  *
  * Deep links via /locations/[id] pass `highlightId` to scroll to and expand a specific
- * location; when they also carry a time, the drawer opens straight onto it.
+ * location; when they also carry a time, the drawer opens straight onto it as well —
+ * arriving from a time press on the home page should still show the location the diner
+ * picked, not just a booking panel detached from it.
  */
 export default function LocationsScreen({
   highlightId,
@@ -203,7 +205,7 @@ export default function LocationsScreen({
                         meal={meal}
                         today={today}
                         compact={isCompact}
-                        defaultExpanded={highlightId === r.id && !initialTime}
+                        defaultExpanded={highlightId === r.id}
                         registerRef={registerRef}
                         onExpand={handleExpand}
                         onBook={handleBook}

--- a/openresto-frontend/e2e/home-slot-deeplink.spec.ts
+++ b/openresto-frontend/e2e/home-slot-deeplink.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { expectVisibleWithReload } from "./helpers";
+
+/**
+ * Pressing a time on a home-page card is a booking intent aimed at one specific
+ * location: it deep-links into /locations/:id?time=…, which must both open the
+ * booking panel on that time *and* expand the location it belongs to. Issue #310
+ * — the panel opened over a list of collapsed cards, leaving no sign of which
+ * location was being booked.
+ */
+test.describe("Home slot deep link", () => {
+  test("opens the booking panel and expands the location it belongs to", async ({ page }) => {
+    await page.goto("/");
+
+    const slot = page.getByLabel(/^Book \d{2}:\d{2} at .+$/).first();
+    await expectVisibleWithReload(page, slot, { timeout: 20_000 });
+    const time = ((await slot.getAttribute("aria-label")) ?? "").slice(5, 10);
+    await slot.click();
+
+    await page.waitForURL(/.*\/locations\/\d+\?time=/, { timeout: 15_000 });
+
+    const drawer = page.getByTestId("booking-drawer");
+    await expect(drawer).toBeVisible({ timeout: 20_000 });
+    await expect(drawer.getByText(time, { exact: false }).first()).toBeVisible();
+
+    // "Seating & tables" only renders inside the expanded details accordion.
+    await expect(page.getByText("Seating & tables").first()).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
@@ -200,11 +200,13 @@ describe("BookingDrawer", () => {
     expect(panel.overflow).toBe("hidden");
   });
 
-  it("closes on the close button", () => {
+  it("closes on the close button", async () => {
     const onClose = jest.fn();
     renderWithProviders(<BookingDrawer {...baseProps} onClose={onClose} />);
     fireEvent.press(screen.getByTestId("booking-drawer-close"));
-    expect(onClose).toHaveBeenCalled();
+    // The panel animates itself out before handing control back — the page drops it from
+    // state as soon as onClose fires, so an immediate call would cut the exit off.
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
   describe("as a bottom sheet", () => {
@@ -233,11 +235,11 @@ describe("BookingDrawer", () => {
       expect(grabber.props.onMoveShouldSetResponder).toBeDefined();
     });
 
-    it("closes when the backdrop is tapped", () => {
+    it("closes when the backdrop is tapped, after the sheet has slid away", async () => {
       const onClose = jest.fn();
       renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" onClose={onClose} />);
       fireEvent.press(screen.getByTestId("booking-drawer-backdrop"));
-      expect(onClose).toHaveBeenCalled();
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
     });
   });
 

--- a/openresto-frontend/tests/components/layout/RouteTransition.test.tsx
+++ b/openresto-frontend/tests/components/layout/RouteTransition.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import { Text } from "react-native";
+import RouteTransition from "@/components/layout/RouteTransition";
+
+const mockUsePathname = jest.fn();
+jest.mock("expo-router", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+function opacityOf(): number {
+  const style = screen.getByTestId("route-transition").props.style;
+  const flat = Array.isArray(style) ? Object.assign({}, ...style) : style;
+  // Animated values render as the node itself in the test renderer; read through it.
+  return typeof flat.opacity === "number" ? flat.opacity : flat.opacity.__getValue();
+}
+
+describe("RouteTransition", () => {
+  beforeEach(() => {
+    mockUsePathname.mockReturnValue("/");
+  });
+
+  it("renders its children", () => {
+    render(
+      <RouteTransition>
+        <Text>Home</Text>
+      </RouteTransition>
+    );
+    expect(screen.getByText("Home")).toBeTruthy();
+  });
+
+  it("fades the view in on mount", async () => {
+    render(
+      <RouteTransition>
+        <Text>Home</Text>
+      </RouteTransition>
+    );
+    expect(opacityOf()).toBe(0);
+    await waitFor(() => expect(opacityOf()).toBe(1), { timeout: 1000 });
+  });
+
+  it("replays the transition when the path changes", async () => {
+    const { rerender } = render(
+      <RouteTransition>
+        <Text>Home</Text>
+      </RouteTransition>
+    );
+    await waitFor(() => expect(opacityOf()).toBe(1), { timeout: 1000 });
+
+    mockUsePathname.mockReturnValue("/locations/2");
+    rerender(
+      <RouteTransition>
+        <Text>Locations</Text>
+      </RouteTransition>
+    );
+    // A new view arriving starts from transparent again rather than snapping in.
+    expect(opacityOf()).toBe(0);
+    await waitFor(() => expect(opacityOf()).toBe(1), { timeout: 1000 });
+  });
+
+  it("does not replay when only the query string changed", async () => {
+    const { rerender } = render(
+      <RouteTransition>
+        <Text>Locations</Text>
+      </RouteTransition>
+    );
+    await waitFor(() => expect(opacityOf()).toBe(1), { timeout: 1000 });
+
+    // usePathname() excludes the query string, so ?time=19:30 leaves it untouched.
+    rerender(
+      <RouteTransition>
+        <Text>Locations</Text>
+      </RouteTransition>
+    );
+    expect(opacityOf()).toBe(1);
+  });
+});

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -362,8 +362,10 @@ describe("LocationsScreen", () => {
       expect(screen.getByTestId("drawer-restaurant").props.children).toBe("Uptown Grill");
       expect(screen.getByTestId("drawer-time").props.children).toBe("18:30");
       expect(screen.getByTestId("drawer-seats").props.children).toBe("4");
-      // With the drawer carrying the booking, the card itself stays collapsed.
-      expect(screen.getByTestId("expanded-2").props.children).toBe("false");
+      // The card expands too (#310): arriving from a time press on the home page should
+      // still show the location that was picked, not a booking panel on its own.
+      expect(screen.getByTestId("expanded-2").props.children).toBe("true");
+      expect(screen.getByTestId("expanded-1").props.children).toBe("false");
     });
 
     it("expands the linked location's details when the link carries no time", async () => {


### PR DESCRIPTION
## Summary

Two unrelated fixes in one branch by request: the VPS deploy changes from #311, and the locations deep-link regression plus transition polish from #310.

**Deploy pruning (#311).** Both changes were already validated live on the VPS but could not be committed from there, so they sat as uncommitted edits to tracked files. That is the real hazard: the deploy runs `git pull origin main` under `set -e`, so the next upstream edit to either file fails the pull and aborts a deploy mid-flight.

`docker image prune -f` does not touch BuildKit cache. It had grown to 5.29 GB with the disk at 86%, on track for a no-space build failure. An age filter frees nothing here, because main deploys several times a day and the whole cache is always recent (oldest entry: 2 days). Capped by size instead. Inert until merged, since Actions runs from the repo, not the VPS checkout.

The proxy's `service_healthy` conditions gate the only container publishing :8443, which the host banner proxy fronts, so every recreate is a public 502 window. nginx resolves its upstreams at startup against DNS that Docker registers at container creation, not at health, so start-order is all it needs. This does not shrink the measured 11s recreation gap (backend was already healthy inside its 20s `start_period`), it removes a stall that would bite whenever the backend is slow to pass. The maintenance page that fixes the user-visible symptom stays in VPS-local, untracked banner-proxy config.

**Locations (#310).** Root cause of the regression: `LocationsScreen` passed `defaultExpanded={highlightId === r.id && !initialTime}`, so a deep link carrying a time deliberately left the card collapsed and let the booking drawer stand in for it. Pressing a time on a home card opened a panel over a list of collapsed cards, with nothing showing which location was being booked. The card now expands whether or not the link carries a time.

## Related issue

Closes #311
Closes #310

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

- `deploy.yml`: cap BuildKit cache with `docker builder prune -f --max-used-space 2GB`.
- `docker-compose.vps.yml`: proxy `depends_on` drops to start-order only.
- `LocationsScreen`: a deep-linked location expands even when the link carries a time.
- `BookingDrawer`: the side panel fades and slides in, and animates itself out before calling `onClose`. The sheet reuses its drag-dismiss animation for backdrop taps and the close button instead of vanishing.
- `LocationsScreen.styles`: the list column transitions its width when the panel opens or closes. The transition lives on the always-applied `row` style, not on `rowWithDrawer`, because a rule declared only while the drawer is open animates the open and snaps the close.
- New `RouteTransition`: route content fades in on web, where the user layout renders a bare `<Slot />` and every navigation was a hard cut.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally (backend untouched)
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

2272 frontend unit tests pass, including a new `RouteTransition` suite. The two drawer close tests now await the exit animation, and the deep-link test asserts the card expands. New E2E spec `home-slot-deeplink.spec.ts` (extensive set, untagged) covers press a time on home to panel open plus details expanded, and fails on main. Verified by hand against the local stack: a home time press lands on `/locations/1?time=14:30` with the card expanded, the drawer on 14:30, and a clean close.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed (n/a)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTZu9fiwa6ofXMroidY5fk
