### PR TITLE
Bump ASP.NET Core/EF Core to 10.0.11 to fix two high-severity NuGet advisories

### DIFF
--- a/OpenRestoApi.Tests/OpenRestoApi.Tests.csproj
+++ b/OpenRestoApi.Tests/OpenRestoApi.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/OpenRestoApi/OpenRestoApi.csproj
+++ b/OpenRestoApi/OpenRestoApi.csproj
@@ -16,13 +16,13 @@
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.16.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
 <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" PrivateAssets="all" />
-    <!-- Microsoft.EntityFrameworkCore.Design 10.0.10 depends on these at 5.0.0, which pins
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" PrivateAssets="all" />
+    <!-- Microsoft.EntityFrameworkCore.Design 10.0.11 depends on these at 5.0.0, which pins
          Microsoft.CodeAnalysis.Workspaces.Common to an exact [5.0.0], while
          Microsoft.CodeAnalysis.CSharp/.Common resolve to 5.3.0 elsewhere in the graph. That
          split-version Roslyn install crashes `dotnet ef migrations add` at design-time with


### PR DESCRIPTION
## Summary

Routine dependency/security scan flagged two high-severity NuGet advisories via `dotnet list package --vulnerable --include-transitive`. Both are fixed by patch-bumping the ASP.NET Core / EF Core package family from `10.0.10` → `10.0.11`, with no other transitive changes.

| Package | Advisory | Current | Fixed by |
|---|---|---|---|
| `Microsoft.OpenApi` (transitive via `Microsoft.AspNetCore.OpenApi`) | [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (high) | 2.0.0 | `Microsoft.AspNetCore.OpenApi` 10.0.11 → `Microsoft.OpenApi` ≥2.7.5 |
| `SQLitePCLRaw.lib.e_sqlite3` (transitive via `Microsoft.EntityFrameworkCore.Sqlite`) | [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (high) | 2.1.11 | `Microsoft.EntityFrameworkCore.Sqlite` 10.0.11 → `SQLitePCLRaw` 2.1.12 |

## Related issue

N/A — found via a scheduled dependency/security scan, no tracking issue.

## Scope

- [x] API (OpenRestoApi)
- [ ] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `OpenRestoApi/OpenRestoApi.csproj`: bump `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.OpenApi`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.Sqlite`, `Microsoft.EntityFrameworkCore.Design` from `10.0.10` → `10.0.11`; updated the adjacent Roslyn-pin comment's stale version reference to match.
- `OpenRestoApi.Tests/OpenRestoApi.Tests.csproj`: matching bump for `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.EntityFrameworkCore.InMemory`, `Microsoft.EntityFrameworkCore.Sqlite` (EF Core requires matching versions across its packages within a project graph — the test project pins its own copies, and leaving them at 10.0.10 produces an `NU1605` package-downgrade error against the bumped main project).

## Testing

- [x] `OpenRestoApi.Tests` pass locally (1497/1497, 99.08% line coverage)
- [ ] Frontend tests/build pass locally — no frontend changes in this PR
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — confirmed via `dotnet list package --vulnerable --include-transitive` that both advisories are gone post-bump, `dotnet build` is clean (0 errors, same pre-existing warnings only), and the CLAUDE.md-documented Roslyn `CodeAnalysis.CSharp`/`.Common` version stays unified at `5.3.0` post-bump (checked `obj/project.assets.json`) so the `dotnet ef migrations add` `TypeLoadException` failure mode this repo has hit before does not regress.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed — n/a, dependency-only change

---

### Other dependency scan findings (not included in this PR)

**Backend — non-security, in-range/minor updates available** (not bumped, no vuln attached):
- `Microsoft.CodeAnalysis.CSharp.Workspaces` / `Microsoft.CodeAnalysis.Workspaces.MSBuild` 5.3.0 → 5.6.0
- `Roslynator.Analyzers` / `Roslynator.Formatting.Analyzers` 4.12.9 → 4.16.0 (analyzer-only, no runtime impact)

**Frontend — one high-severity advisory with no fix currently available upstream:**
- `image-size` (pulled in transitively via `metro` ← `@expo/metro` ← `expo`) has two open high-severity DoS advisories ([GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr), [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq): infinite loops parsing malformed ICNS/JXL/HEIF images). The advisories cover `<=2.0.2`, and **2.0.2 is currently the latest published version on npm** — there is no patched release to bump to yet. I tried a `package.json` `overrides` pin to force the newest available version; it resolves to the same still-vulnerable 2.0.2, so it was reverted as a no-op. `npm audit fix --force` "fixes" this only by downgrading `expo` to `53.0.27`, a major regression not worth taking for an unpatched issue. Risk is low in practice: `image-size` is invoked by Metro's bundler at dev/build time only, not by anything running in the production containers, so it isn't reachable by an external attacker against a deployed instance. Recommend re-running `npm audit` periodically until upstream ships a fix.
- Frontend also has a number of routine outdated packages with available in-range or major updates (`react`/`react-dom` 19.2.3→19.2.8, `react-native` 0.86.0→0.87.0, `react-native-gesture-handler` 2.x→3.x major, `jest` 29→30 major, `typescript` 6→7 major, `@testing-library/react-native` 13→14 major, etc.) — none carry a security advisory, so left out of this PR to keep it scoped to the vulnerability fix; happy to open a separate freshness-only PR if wanted.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_011SrakBhNEDfWLwsgafYQY2

---
_Generated by [Claude Code](https://claude.ai/code/session_011SrakBhNEDfWLwsgafYQY2)_