### PR TITLE
Untangle the useBookingSeating/useTableHold circular dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Untangled the circular dependency between `useBookingSeating` and `useTableHold`** (#316) — the split in #315 left one seam: the hold hook needs the seating pick, and the seating hook was calling back into the hold hook to drop a hold its own change had invalidated. `BookingForm` bridged that with a ref assigned during render, which only worked because of the order the two hooks happened to be called in. The explicit release turned out to be redundant: every param that identifies the held unit is already a dependency of the hold effect, so a seating change either stops being holdable (released outright) or resolves to a different unit (replaced atomically, forwarding the old hold id so the server frees it in the same call). The ref, the `releaseCurrentHold` argument and the party-size release effect are all gone, and `releaseCurrentHold` is no longer exported so the cycle can't come back. Data now flows one way, which means swapping the two hook calls fails to compile rather than silently changing behaviour. Four `useTableHold` tests cover the contract the ref was standing in for: pick cleared, pick moved to another table, table swapped for a combinable group, and a param outside the held unit (the email) changing without churning a valid hold.
+
 ## [1.7.0] - 2026-08-12
 
 This is a frontend focused release. I wanted to move away from responsive design towards interfaces that felt familiar on mobile and web. I also wanted to give the code some love, so a ton of refactoring and accessibility passes have been included.

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -1,5 +1,5 @@
 import { RestaurantDto } from "@/api/restaurants";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "../common/Button";
 import { ThemedText } from "../themed-text";
 import { Platform, View, ActivityIndicator, useWindowDimensions } from "react-native";
@@ -128,12 +128,6 @@ export default function BookingForm({
 
   const currentSlot = availabilitySlots.find((s) => s.time === time);
 
-  // useTableHold and useBookingSeating each need something the other produces: the hold needs
-  // the current seating pick, and a seating change has to drop the hold that pick invalidated.
-  // A ref breaks the cycle — it is filled in below, during the same render, so the seating
-  // hook's effects always see the live releaser by the time they run.
-  const releaseHoldRef = useRef<() => void>(() => {});
-
   const {
     allTables,
     sectionId,
@@ -146,38 +140,25 @@ export default function BookingForm({
     tableOptions,
     maxTableCapacity,
     partyTooLarge,
-  } = useBookingSeating({
-    restaurant,
-    seats,
-    currentSlot,
-    releaseCurrentHold: () => releaseHoldRef.current(),
-  });
+  } = useBookingSeating({ restaurant, seats, currentSlot });
 
-  const {
-    holdStatus,
-    holdMessage,
-    secondsLeft,
-    holdId,
-    resolvedTableId,
-    setHoldStatus,
-    releaseCurrentHold,
-  } = useTableHold({
-    restaurantId: restaurant.id,
-    sections: restaurant.sections,
-    tableId,
-    date,
-    time,
-    email: customerEmail,
-    autoAssign: isAutoAssign,
-    seats,
-    tableGroupId,
-  });
-  releaseHoldRef.current = releaseCurrentHold;
-
-  useEffect(() => {
-    releaseCurrentHold();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [seats]);
+  // The seating pick is the only thing that flows between these two hooks, and it flows one way:
+  // useTableHold releases or replaces its hold whenever these params change, so nothing has to
+  // reach back into it. The call order is therefore pinned by the tableId/isAutoAssign reads
+  // below rather than by effect timing — swapping the hooks fails to compile instead of silently
+  // changing behaviour.
+  const { holdStatus, holdMessage, secondsLeft, holdId, resolvedTableId, setHoldStatus } =
+    useTableHold({
+      restaurantId: restaurant.id,
+      sections: restaurant.sections,
+      tableId,
+      date,
+      time,
+      email: customerEmail,
+      autoAssign: isAutoAssign,
+      seats,
+      tableGroupId,
+    });
 
   // When the party size exceeds the largest table, surface the contact-restaurant
   // notice so the user knows why booking is blocked. Re-opens on each over-capacity

--- a/openresto-frontend/components/booking/useBookingSeating.ts
+++ b/openresto-frontend/components/booking/useBookingSeating.ts
@@ -18,8 +18,6 @@ export interface UseBookingSeatingArgs {
   seats: number;
   /** The slot the diner has picked, if availability has loaded for it. */
   currentSlot: TimeSlotDto | undefined;
-  /** Drops any live hold when the seating choice changes out from under it. */
-  releaseCurrentHold: () => void;
 }
 
 /**
@@ -28,13 +26,11 @@ export interface UseBookingSeatingArgs {
  * "Any section" (id 0) is the default: the form hides the table dropdown and the server picks.
  * Otherwise the hook keeps a concrete table selected, re-picking whenever availability, party
  * size or section changes so the form never sits on a table the API would reject.
+ *
+ * Selection is all it owns. A live hold on the previous pick is invalidated by the new pick
+ * flowing into `useTableHold`, which releases or replaces it — never by this hook reaching back.
  */
-export function useBookingSeating({
-  restaurant,
-  seats,
-  currentSlot,
-  releaseCurrentHold,
-}: UseBookingSeatingArgs) {
+export function useBookingSeating({ restaurant, seats, currentSlot }: UseBookingSeatingArgs) {
   const [sectionId, setSectionId] = useState<number>(ANY_SECTION_ID);
   const [tableId, setTableId] = useState<number | undefined>();
   // Combinable-group selection (#274): when set, the diner picked a combined-table group from the
@@ -121,7 +117,6 @@ export function useBookingSeating({
   }, [availableTableIds, seats, isAutoAssign]);
 
   useEffect(() => {
-    releaseCurrentHold();
     if (isAutoAssign) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setTableId(undefined);

--- a/openresto-frontend/components/booking/useTableHold.ts
+++ b/openresto-frontend/components/booking/useTableHold.ts
@@ -38,9 +38,17 @@ export interface UseTableHoldResult {
   /** Combinable-table group the server resolved for a group hold (null otherwise). */
   resolvedGroupId: number | null;
   setHoldStatus: (status: HoldStatus) => void;
-  releaseCurrentHold: () => void;
 }
 
+/**
+ * Owns the whole hold lifecycle for one booking form.
+ *
+ * Every param that identifies the held unit is a dependency of the effect below, so a hold never
+ * outlives the selection that produced it: the params either stop being holdable (released
+ * outright) or resolve to a different unit (replaced atomically, passing the old hold id so the
+ * server frees it in the same call). Callers therefore never release a hold themselves — changing
+ * what they pass in is the whole protocol.
+ */
 export function useTableHold({
   restaurantId,
   sections,
@@ -214,6 +222,5 @@ export function useTableHold({
     resolvedSectionId,
     resolvedGroupId,
     setHoldStatus,
-    releaseCurrentHold,
   };
 }

--- a/openresto-frontend/tests/components/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/BookingForm.test.tsx
@@ -9,7 +9,6 @@ import { renderWithProviders } from "@/tests/helpers/renderWithProviders";
 
 // Mock useTableHold
 jest.mock("@/components/booking/useTableHold");
-const mockReleaseCurrentHold = jest.fn();
 const mockSetHoldStatus = jest.fn();
 
 jest.mock("@/api/availability", () => ({
@@ -67,7 +66,6 @@ describe("BookingForm", () => {
       resolvedTableId: null,
       resolvedSectionId: null,
       setHoldStatus: mockSetHoldStatus,
-      releaseCurrentHold: mockReleaseCurrentHold,
     });
     // Mock window.confirm
     delete (window as any).confirm;
@@ -239,7 +237,6 @@ describe("BookingForm", () => {
       secondsLeft: 0,
       holdId: null,
       setHoldStatus: mockSetHoldStatus,
-      releaseCurrentHold: mockReleaseCurrentHold,
     });
     const onSubmit = jest.fn();
     renderWithProviders(<BookingForm restaurant={mockRestaurant} onSubmit={onSubmit} />);

--- a/openresto-frontend/tests/components/booking/BookingForm.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingForm.test.tsx
@@ -40,7 +40,6 @@ jest.mock("@/context/BrandContext", () => ({
 
 // Controllable hold status
 const mockSetHoldStatus = jest.fn();
-const mockReleaseCurrentHold = jest.fn();
 let mockHoldStatus = "idle";
 
 jest.mock("@/components/booking/useTableHold", () => ({
@@ -52,7 +51,6 @@ jest.mock("@/components/booking/useTableHold", () => ({
     resolvedTableId: null,
     resolvedSectionId: null,
     setHoldStatus: mockSetHoldStatus,
-    releaseCurrentHold: mockReleaseCurrentHold,
   }),
 }));
 

--- a/openresto-frontend/tests/hooks/useTableHold.test.ts
+++ b/openresto-frontend/tests/hooks/useTableHold.test.ts
@@ -156,7 +156,13 @@ describe("useTableHold", () => {
     expect(mockReleaseHold).toHaveBeenCalledWith("hold-cleanup");
   });
 
-  it("releaseCurrentHold resets state and calls releaseHold", async () => {
+  // ── Seating changes drop the hold they invalidated (#316) ──────────────────
+  //
+  // The seating pick reaches this hook only as params, so these cover the whole contract that
+  // BookingForm used to enforce with an explicit releaseCurrentHold() call: a pick that stops
+  // being holdable releases outright, and a pick that resolves elsewhere is replaced atomically.
+
+  it("releases the hold when the seating pick is cleared", async () => {
     mockCreateHold.mockResolvedValueOnce({
       ok: true,
       hold: {
@@ -166,8 +172,9 @@ describe("useTableHold", () => {
       },
     });
 
-    const params = { ...defaultParams, tableId: 100 };
-    const { result } = renderHook(() => useTableHold(params));
+    const { result, rerender } = renderHook((props: UseTableHoldParams) => useTableHold(props), {
+      initialProps: { ...defaultParams, tableId: 100 },
+    });
 
     await act(async () => {
       jest.advanceTimersByTime(2000);
@@ -175,13 +182,146 @@ describe("useTableHold", () => {
 
     expect(result.current.holdStatus).toBe("held");
 
-    act(() => {
-      result.current.releaseCurrentHold();
-    });
+    // Switching to a section with no fitting table leaves the form with no pick at all.
+    rerender({ ...defaultParams, tableId: undefined });
 
     expect(mockReleaseHold).toHaveBeenCalledWith("hold-manual");
     expect(result.current.holdStatus).toBe("idle");
     expect(result.current.hold).toBeNull();
+    expect(result.current.holdId).toBeNull();
+  });
+
+  it("keeps the hold when a param outside the held unit changes", async () => {
+    mockCreateHold.mockResolvedValueOnce({
+      ok: true,
+      hold: {
+        holdId: "hold-kept",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
+    });
+
+    const { result, rerender } = renderHook((props: UseTableHoldParams) => useTableHold(props), {
+      initialProps: { ...defaultParams, tableId: 100 },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.holdStatus).toBe("held");
+
+    // The email is a trigger for the effect but not part of the held unit, so correcting a typo
+    // must not churn a hold that is still valid.
+    rerender({ ...defaultParams, tableId: 100, email: "corrected@example.com" });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.holdStatus).toBe("held");
+    expect(result.current.hold?.holdId).toBe("hold-kept");
+    expect(mockCreateHold).toHaveBeenCalledTimes(1);
+    expect(mockReleaseHold).not.toHaveBeenCalled();
+  });
+
+  it("replaces the hold when the seating pick moves to another table", async () => {
+    mockCreateHold.mockResolvedValueOnce({
+      ok: true,
+      hold: {
+        holdId: "hold-table-100",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
+    });
+
+    const sections = [
+      { id: 10, tables: [{ id: 100 }] },
+      { id: 20, tables: [{ id: 200 }] },
+    ];
+    const { result, rerender } = renderHook((props: UseTableHoldParams) => useTableHold(props), {
+      initialProps: { ...defaultParams, sections, tableId: 100 },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.holdStatus).toBe("held");
+
+    mockCreateHold.mockResolvedValueOnce({
+      ok: true,
+      hold: {
+        holdId: "hold-table-200",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
+    });
+
+    // Picking a table in another section: the old hold stops standing the moment the pick changes.
+    rerender({ ...defaultParams, sections, tableId: 200 });
+    expect(result.current.holdStatus).toBe("pending");
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(mockCreateHold).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ tableId: 200, sectionId: 20, currentHoldId: "hold-table-100" })
+    );
+    expect(result.current.hold?.holdId).toBe("hold-table-200");
+  });
+
+  it("replaces a table hold when the pick switches to a combinable group", async () => {
+    mockCreateHold.mockResolvedValueOnce({
+      ok: true,
+      hold: {
+        holdId: "hold-table",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+      },
+    });
+
+    const { result, rerender } = renderHook((props: UseTableHoldParams) => useTableHold(props), {
+      initialProps: { ...defaultParams, tableId: 100, seats: 4 },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.holdStatus).toBe("held");
+
+    mockCreateHold.mockResolvedValueOnce({
+      ok: true,
+      hold: {
+        holdId: "hold-group",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+        secondsRemaining: 120,
+        tableGroupId: 5,
+      },
+    });
+
+    // tableId and tableGroupId are mutually exclusive in the dropdown, so the group pick arrives
+    // with the table cleared.
+    rerender({ ...defaultParams, tableId: undefined, tableGroupId: 5, seats: 4 });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(mockCreateHold).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        tableId: null,
+        sectionId: null,
+        tableGroupId: 5,
+        seats: 4,
+        currentHoldId: "hold-table",
+      })
+    );
+    expect(result.current.resolvedGroupId).toBe(5);
   });
 
   it("re-triggers hold when date changes, passing currentHoldId for atomic replace", async () => {


### PR DESCRIPTION
## Summary

`useTableHold` needs the seating pick, and `useBookingSeating` was calling back into it to drop a hold its own change had invalidated. `BookingForm` bridged that with a ref assigned during render, which only held up because of the order the two hooks happened to be called in.

Option 1 from the issue turned out to be right, and it was a delete rather than a rewrite. The explicit release was redundant. Every param that identifies the held unit (`tableId`, `tableGroupId`, `autoAssign`, `seats`, `date`, `time`) is already a dependency of the hold effect, so a seating change lands in one of two paths that both already work:

- the pick stops being holdable (no table, no group, not auto-assign), and the effect releases outright at `useTableHold.ts:127`
- the pick resolves to a different unit, the params key changes, and the debounced `createHold` replaces it atomically, forwarding the old hold id so the server frees it in the same call

The one case the old code released and the new one doesn't is a section switch that resolves to the same table id, which can't happen (tables belong to one section) except when the pick is empty on both sides, and an empty pick was already covered by the first path.

Data now flows one way, so the acceptance criterion holds structurally: swapping the two hook calls fails to compile (`tableId` / `isAutoAssign` are read before they'd be defined) rather than silently changing behaviour.

## Related issue

Closes #316

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

- `BookingForm.tsx`: dropped `releaseHoldRef`, the `releaseCurrentHold` destructure, and the `[seats]` release effect (party size is already a hold param, so that effect was redundant for the same reason).
- `useBookingSeating.ts`: dropped the `releaseCurrentHold` arg and its call in the `[sectionId]` effect. The hook now owns selection and nothing else.
- `useTableHold.ts`: `releaseCurrentHold` is no longer part of `UseTableHoldResult`, so the cycle can't be reintroduced without a deliberate API change. It's still the internal release path. Added a doc block stating the protocol: callers change what they pass in, they never release a hold themselves.
- Tests: the direct `releaseCurrentHold()` test is retargeted at the params-become-unholdable path, which exercises the same code with a live hold instead of a synthetic call, plus three new cases (see Testing). Removed the now-unused `releaseCurrentHold` from both `BookingForm` test mocks.
- CHANGELOG entry under Unreleased.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally (untouched, frontend-only change)
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

`npm test`: 160 suites, 2277 tests, all passing. `npm run check` and `npx tsc --noEmit` clean.

Four `useTableHold` cases now cover the contract the ref was standing in for:

| Case | Asserts |
|---|---|
| Seating pick cleared | `releaseHold` called with the live id, status back to `idle` |
| Pick moves to another table | new `createHold` carries `tableId: 200`, `sectionId: 20`, `currentHoldId: "hold-table-100"` |
| Table swapped for a combinable group | new `createHold` carries `tableGroupId: 5`, null table/section, `currentHoldId` of the table hold |
| Email edited while held | no second `createHold`, no `releaseHold`, hold id unchanged |

That last one is the converse, and it covers the params-key short-circuit that was previously untested. `useTableHold.ts` goes from 97.77% to 100% line coverage and 89.39% to 96.96% branch; the three files together go 96.41% to 96.70% statements.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

## One behavioural note

On a section change the old hold used to be freed server-side immediately, and now it survives until the atomic swap 2s later (or until the release path fires). That matches what date and time changes have always done, and it means a fast toggle away and back no longer risks losing your table to someone else in the gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6sov69xs1psWXd6sKXb5k)_