### PR TITLE
Stop the compact footer pushing Book now off the card

### DIFF
--- a/openresto-frontend/components/restaurant/LocationListItem.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationListItem.styles.ts
@@ -46,9 +46,19 @@ export const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+    gap: theme.spacing.sm,
     paddingTop: theme.spacing.xs,
     borderTopWidth: 1,
     borderStyle: "dashed",
+  },
+  /**
+   * The status line shares this row with Details and Book now, and it is the only one of the
+   * three that can give ground. Without a shrinking box around it the walk-in sentence takes
+   * its full intrinsic width and pushes the buttons clean off the card.
+   */
+  compactFootLead: {
+    flex: 1,
+    minWidth: 0,
   },
 
   thumb: {
@@ -177,6 +187,7 @@ export const styles = StyleSheet.create({
     paddingVertical: 9,
   },
   walkInText: {
+    flexShrink: 1,
     fontSize: 12.5,
     fontStyle: "italic",
   },

--- a/openresto-frontend/components/restaurant/LocationListItem.tsx
+++ b/openresto-frontend/components/restaurant/LocationListItem.tsx
@@ -292,7 +292,9 @@ export default function LocationListItem({
           {bookable ? slotRow : null}
 
           <View style={[styles.compactFoot, { borderTopColor: borderColor }]}>
-            {walkInLine ?? hoursMeta}
+            <View testID={`location-foot-lead-${restaurant.id}`} style={styles.compactFootLead}>
+              {walkInLine ?? hoursMeta}
+            </View>
             {headerActions}
           </View>
         </View>

--- a/openresto-frontend/tests/components/restaurant/LocationListItem.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationListItem.test.tsx
@@ -8,7 +8,7 @@
  */
 import React from "react";
 import { screen, waitFor, fireEvent } from "@testing-library/react-native";
-import { Platform } from "react-native";
+import { Platform, StyleSheet } from "react-native";
 import LocationListItem from "@/components/restaurant/LocationListItem";
 import { fetchAvailability } from "@/api/availability";
 import { renderWithProviders } from "@/tests/helpers/renderWithProviders";
@@ -449,6 +449,26 @@ describe("LocationListItem", () => {
       expect(screen.getAllByText("No reservations required, first come first served")).toHaveLength(
         1
       );
+    });
+
+    it("lets the footer's status line shrink so the actions stay on the card", async () => {
+      // The compact footer holds three things on one row and only the status line can give
+      // ground. Without this the walk-in sentence took its full intrinsic width and pushed
+      // Details and Book now clean off the right edge of the card.
+      renderWithProviders(
+        <LocationListItem
+          {...baseProps}
+          compact
+          restaurant={{ ...utcRestaurant, walkInDays: String(THURSDAY) } as any}
+        />
+      );
+      await waitFor(() => expect(screen.getByTestId("location-foot-lead-1")).toBeTruthy());
+
+      const lead = StyleSheet.flatten(screen.getByTestId("location-foot-lead-1").props.style);
+      expect(lead.flex).toBe(1);
+      expect(lead.minWidth).toBe(0);
+      // Its neighbour must not give ground in turn, or the buttons would squash instead.
+      expect(screen.getByTestId("location-book-now-1")).toBeTruthy();
     });
 
     it("falls back to the hours line in the footer for a bookable location", async () => {


### PR DESCRIPTION
## Summary

On a phone the compact card footer holds three things on one row: the status line, Details, and the Book now button added in #330. The status line had no `flex`, so it took its full intrinsic width and pushed the action cluster past the card's right edge.

Reproduced against the real stack (backend + Expo web, 390px viewport, a location set walk-in for today):

| | Book now left | Book now right | Card right | Overflow |
|---|---|---|---|---|
| Before | 396 | 486 | 374 | **+112px** |
| After | 271 | 361 | 374 | −13px (inside the padding) |

Worst on a walk-in day, where the lead text is the long "No reservations required, first come first served" — which is exactly the case the button matters most for now that it survives a walk-in day.

## Related issue

Follows up #328 (Book now, added in #330).

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- The footer's status line sits in a `flex: 1` / `minWidth: 0` box, so it is the one of the three that gives ground, and wraps instead of overflowing. `walkInText` gets `flexShrink: 1` so the sentence actually wraps rather than pushing its row wide.
- `compactFoot` gains a gap, so the text never butts against Details.
- The action cluster keeps `flexShrink: 0` — squashing the buttons instead would just move the problem.

A bookable location's footer is unchanged in practice: "09:00 – 22:00 today" is short enough to stay on one line, so no card gets taller.

## Testing

- [x] `OpenRestoApi.Tests` pass locally (untouched)
- [x] Frontend tests/build pass locally (2448 passed, `npm run check` clean)
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

Verified visually this time rather than by inference: ran the .NET backend and the Expo web dev server locally, drove Chromium at 390px, and measured the button's rect against the card's before and after. Both the walk-in card and a bookable card were checked, and the bookable card's footer stayed a single line.

Regression test asserts the lead box keeps `flex: 1` / `minWidth: 0` alongside a rendered Book now, since RNTL has no layout engine to catch the overflow itself.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01St5GbnWsKWm78dhpJQ4Df8)_