### PR TITLE
Stop home-slot-deeplink depending on the time of day

### DIFF
--- a/openresto-frontend/e2e/home-slot-deeplink.spec.ts
+++ b/openresto-frontend/e2e/home-slot-deeplink.spec.ts
@@ -1,5 +1,14 @@
-import { test, expect } from "@playwright/test";
-import { expectVisibleWithReload } from "./helpers";
+import { test, expect, type Browser } from "@playwright/test";
+import { buildUpdateRestaurantBody, expectVisibleWithReload } from "./helpers";
+import { ADMIN_STATE_FILE } from "./global-setup";
+
+const PASTA_PLACE_ID = 1;
+
+/** Minutes past midnight, in UTC — the timezone the seeded locations run on. */
+function utcMinutesNow(): number {
+  const now = new Date();
+  return now.getUTCHours() * 60 + now.getUTCMinutes();
+}
 
 /**
  * Pressing a time on a home-page card is a booking intent aimed at one specific
@@ -7,9 +16,70 @@ import { expectVisibleWithReload } from "./helpers";
  * booking panel on that time *and* expand the location it belongs to. Issue #310
  * — the panel opened over a list of collapsed cards, leaving no sign of which
  * location was being booked.
+ *
+ * The home card offers *today's* remaining slots and nothing else, so with the
+ * seeded 09:00–22:00 hours and a 30-minute interval the last chip of the day is
+ * 21:30 and this spec had nothing to click after that — it timed out for two and
+ * a half hours out of every twenty-four, which is how it failed a run that had
+ * nothing to do with it. It now opens the location around the clock on a 15-minute
+ * interval for the duration of the spec, and restores the seeded hours afterwards.
  */
 test.describe("Home slot deep link", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let original: Record<string, unknown> | undefined;
+
+  async function putRestaurant(browser: Browser, body: Record<string, unknown>) {
+    const ctx = await browser.newContext({ storageState: ADMIN_STATE_FILE });
+    const page = await ctx.newPage();
+    const res = await page.request.put(`/api/restaurants/${PASTA_PLACE_ID}`, { data: body });
+    expect(res.ok()).toBeTruthy();
+    await ctx.close();
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    original = (await page.request
+      .get(`/api/restaurants/${PASTA_PLACE_ID}`)
+      .then((r) => r.json())) as Record<string, unknown>;
+    await ctx.close();
+
+    await putRestaurant(
+      browser,
+      buildUpdateRestaurantBody(original, {
+        openTime: "00:00",
+        closeTime: "23:59",
+        openDays: "1,2,3,4,5,6,7",
+        openHours: null,
+        bookingSlotIntervalMinutes: 15,
+        walkInOnly: false,
+        walkInDays: "",
+      })
+    );
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (!original) return;
+    await putRestaurant(
+      browser,
+      buildUpdateRestaurantBody(original, {
+        openTime: original.openTime,
+        closeTime: original.closeTime,
+        bookingSlotIntervalMinutes: original.bookingSlotIntervalMinutes ?? 30,
+      })
+    );
+  });
+
   test("opens the booking panel and expands the location it belongs to", async ({ page }) => {
+    // The last 15-minute slot of the day starts at 23:45. Past that there is
+    // genuinely nothing left to book today and no chip to press — the product is
+    // right and the spec has no subject, so say so rather than time out.
+    test.skip(
+      utcMinutesNow() >= 23 * 60 + 45,
+      "no slot remains today; the home card only offers today's times"
+    );
+
     await page.goto("/");
 
     const slot = page.getByLabel(/^Book \d{2}:\d{2} at .+$/).first();


### PR DESCRIPTION
## Summary

`Playwright E2E (Extensive)` went red on the merge of #332. It is **not** that change: #332's diff touches only `compactFoot`, a compact-layout style that Playwright's 1280px desktop viewport never renders. The failing spec is a pre-existing clock dependency that the merge happened to land in.

`RestaurantCard` fetches availability for **today** and keeps only slots strictly in the future. Seeded venues are 09:00–22:00 UTC on a 30-minute interval, so the last chip of the day starts at **21:30**. The extensive job started at **21:44 UTC**, the home page had no `Book HH:MM at …` chip at all, and the spec had nothing to click — 60s timeout, all three attempts. The previous extensive run passed at 20:26, when 21:00 and 21:30 were still ahead.

That is roughly two and a half hours out of every twenty-four in which this spec cannot pass.

## Related issue

Guards #310. Broke the extensive run on the merge of #332.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- The spec now owns its fixture, the same way `walk-in-days.spec.ts` and `restaurant-detail.spec.ts` do: `beforeAll` opens Pasta Place 00:00–23:59 on a 15-minute interval via the admin API, `afterAll` restores the seeded hours and interval. It reads the location first and echoes the full body back through `buildUpdateRestaurantBody`, so nothing else is clobbered.
- `openHours: null` in the override matters: the GET response always carries a resolved 7-entry `openHours`, and echoing that back would override the `openTime`/`closeTime` the fixture is setting.
- Past 23:45 UTC there is genuinely no slot left today and the product is right to offer none, so the spec skips with that reason rather than timing out. The dead window goes from ~2h30m a day to 15 minutes.

## Testing

- [x] `OpenRestoApi.Tests` pass locally (untouched)
- [x] Frontend tests/build pass locally (`npm run check` clean)
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

Ran the real Playwright suite locally, which needed no Docker: backend on :8080 in `ASPNETCORE_ENVIRONMENT=Testing`, Expo web on :8081 with `EXPO_PUBLIC_API_URL=/api`, and a small node reverse proxy on :5062 standing in for nginx, so `playwright.config.ts` worked unchanged.

- **22:04 UTC, committed spec** → fails, identical 60s timeout to CI. Exact reproduction.
- **22:05 UTC, this spec** → passes in 4.3s.
- Restaurant 1 confirmed back at 09:00–22:00 / interval 30 / `walkInDays ""` afterwards, so the fixture does not leak.
- `home-slot-deeplink`, `home`, `restaurant-detail` and `locations-card` run together: **9 passed**. That is also the first real run of the three `locations-card.spec.ts` tests added in #330, which I had shipped unverified — they pass.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01St5GbnWsKWm78dhpJQ4Df8)_