### PR TITLE
Tighten locations card spacing

### DIFF
--- a/openresto-frontend/components/restaurant/LocationListItem.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationListItem.styles.ts
@@ -26,7 +26,7 @@ export const styles = StyleSheet.create({
   wideIdentity: {
     flex: 1,
     minWidth: 0,
-    gap: 3,
+    gap: theme.spacing.xxs,
   },
 
   compactHeader: {
@@ -91,10 +91,16 @@ export const styles = StyleSheet.create({
     flexWrap: "wrap",
   },
 
+  /**
+   * Column and row gaps are deliberately different. Address, hours and menu wrap against the
+   * card's width, and at the column gap a wrapped line reads as a new block rather than as a
+   * continuation of the one above it.
+   */
   metaRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 14,
+    columnGap: 14,
+    rowGap: theme.spacing.xs,
     flexWrap: "wrap",
   },
   metaItem: {
@@ -105,6 +111,7 @@ export const styles = StyleSheet.create({
   },
   metaText: {
     fontSize: 13,
+    lineHeight: 18,
   },
   metaLink: {
     fontWeight: "500",
@@ -161,15 +168,18 @@ export const styles = StyleSheet.create({
   },
   slotText: {
     fontSize: 13,
+    lineHeight: 16,
     fontWeight: "500",
     textAlign: "center",
   },
   slotMoreText: {
     fontSize: 13,
+    lineHeight: 16,
     fontWeight: "600",
   },
   slotMoreInline: {
     fontSize: 12.5,
+    lineHeight: 17,
     marginLeft: theme.spacing.xs,
   },
   slotsLoading: {
@@ -178,6 +188,7 @@ export const styles = StyleSheet.create({
   },
   noSlotsText: {
     fontSize: 12.5,
+    lineHeight: 17,
     fontStyle: "italic",
   },
   walkInRow: {
@@ -189,11 +200,17 @@ export const styles = StyleSheet.create({
   walkInText: {
     flexShrink: 1,
     fontSize: 12.5,
+    lineHeight: 17,
     fontStyle: "italic",
   },
 
+  /**
+   * Horizontal padding matches the header's, so the panel's text starts on the same line as
+   * the thumbnail above it rather than 4px inside it.
+   */
   expandedBody: {
-    padding: theme.spacing.lg,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.lg,
     gap: theme.spacing.xxl,
     borderTopWidth: 1,
   },
@@ -202,7 +219,7 @@ export const styles = StyleSheet.create({
     lineHeight: 22,
   },
   tagRow: {
-    marginTop: theme.spacing.xs,
+    marginTop: theme.spacing.sm,
   },
   mapLinks: {
     flexDirection: "row",

--- a/openresto-frontend/components/restaurant/RestaurantTags.styles.ts
+++ b/openresto-frontend/components/restaurant/RestaurantTags.styles.ts
@@ -14,6 +14,7 @@ export const styles = StyleSheet.create({
   },
   tagText: {
     fontSize: 12,
+    lineHeight: 16,
     fontWeight: "500",
   },
 });


### PR DESCRIPTION
Every small-text style in the locations card set `fontSize` without `lineHeight`, so each one inherited `lineHeight: 24` from `ThemedText`'s `default` type. 13px meta text rendered in a 24px box and 12px tag text rendered in a 24px box, which is what made the tag pills read as fat capsules and the meta lines drift apart.

`metaRow` compounded it with a single `gap: 14` applying to both axes, so a wrapped meta line cost 24 + 14 = 38px against 3px of gap between the name and the address above it. Address, hours and menu wrap against the card width routinely, so a wrapped line read as a new block rather than a continuation of the one above it.

## Changes

| Style | Before | After |
|---|---|---|
| `metaText`, `slotText`, `walkInText`, `noSlotsText`, `slotMore*`, `tagText` | inherited `lineHeight: 24` | explicit 16 to 18 |
| `metaRow` | `gap: 14` (both axes) | `columnGap: 14`, `rowGap: 4` |
| `wideIdentity` | `gap: 3` | `gap: 6` |
| `tagRow` | `marginTop: 4` | `marginTop: 8` |
| `expandedBody` | `padding: 16` | `paddingHorizontal: 12`, `paddingVertical: 16` |

The last one aligns the accordion panel's left edge with the header's, so the panel text starts on the thumbnail's left edge rather than 4px inside it.

`wideIdentity` and `tagRow` only read as spaced because of the oversized line boxes, so they needed raising once those tightened.

## Verification

Measured in Chrome against `npm run dev`: tag pill 32px to 24px, meta line 24px to 18px, `metaRow` row-gap 14px to 4px, and the expanded panel's children now sit at the same 12.7px left offset as the thumbnail. `npm run check` clean, 2453 frontend tests pass.

The local dev dataset has short addresses that don't wrap at any desktop width, so the row-gap change is confirmed by computed style rather than visually. The wrap is reproducible against the demo dataset.

## Follow-up

The same inherited-`lineHeight` bug is still present in the expanded panel's own styles (`subHeading`, `mapLinkText`, `tableName`, `tableSeats`, `groupName`, `groupSeats`, `menuButtonText`) and in `cardStyles.viewBtnText`. Left out to keep this diff to what shows on the card face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)