### PR TITLE
Float the pinned locations filter as a pill

### DIFF
--- a/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
@@ -18,11 +18,11 @@ export const styles = StyleSheet.create({
     gap: theme.spacing.sm,
     padding: theme.spacing.xsm,
   },
-  // Pinned: the band behind the bar is the header surface, so the bar itself contributes
-  // nothing but the controls and the padding holding them off the band's edges.
-  barFlat: {
-    backgroundColor: "transparent",
-    borderRadius: 0,
+  // Pinned, the bar is the only thing between the diner and the list scrolling under it, so
+  // it lifts off the page rather than resting in it. The shadow is the whole cue: without it
+  // a pill sitting over cards reads as one that failed to scroll away.
+  barRaised: {
+    ...theme.shadows.lg,
   },
   controlSeats: {
     minWidth: 132,

--- a/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
@@ -18,6 +18,12 @@ export const styles = StyleSheet.create({
     gap: theme.spacing.sm,
     padding: theme.spacing.xsm,
   },
+  // Pinned: the band behind the bar is the header surface, so the bar itself contributes
+  // nothing but the controls and the padding holding them off the band's edges.
+  barFlat: {
+    backgroundColor: "transparent",
+    borderRadius: 0,
+  },
   controlSeats: {
     minWidth: 132,
   },

--- a/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
@@ -56,6 +56,7 @@ export default function LocationsFilterBar({
   onMealChange,
   summary,
   compact,
+  flat,
 }: {
   seats: number;
   onSeatsChange: (seats: number) => void;
@@ -68,13 +69,23 @@ export default function LocationsFilterBar({
   /** e.g. "2 of 3 locations have tables". Hidden on the compact bar. */
   summary?: string | null;
   compact?: boolean;
+  /**
+   * Set while the bar is pinned to the top of the page. The band behind it becomes the
+   * surface at that point, so the bar drops its own card treatment rather than sitting on
+   * the band as a second, rounded shape inside a square one.
+   */
+  flat?: boolean;
 }) {
   const { colors } = useAppTheme();
 
   return (
     <View
       testID="locations-filter-bar"
-      style={[styles.bar, compact && styles.barCompact, { backgroundColor: colors.card }]}
+      style={[
+        styles.bar,
+        compact && styles.barCompact,
+        flat ? styles.barFlat : { backgroundColor: colors.card },
+      ]}
     >
       <View
         testID="filter-control-seats"

--- a/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
@@ -56,7 +56,7 @@ export default function LocationsFilterBar({
   onMealChange,
   summary,
   compact,
-  flat,
+  raised,
 }: {
   seats: number;
   onSeatsChange: (seats: number) => void;
@@ -69,12 +69,8 @@ export default function LocationsFilterBar({
   /** e.g. "2 of 3 locations have tables". Hidden on the compact bar. */
   summary?: string | null;
   compact?: boolean;
-  /**
-   * Set while the bar is pinned to the top of the page. The band behind it becomes the
-   * surface at that point, so the bar drops its own card treatment rather than sitting on
-   * the band as a second, rounded shape inside a square one.
-   */
-  flat?: boolean;
+  /** Set while the bar is pinned, where it floats over the list rather than sitting in it. */
+  raised?: boolean;
 }) {
   const { colors } = useAppTheme();
 
@@ -84,7 +80,8 @@ export default function LocationsFilterBar({
       style={[
         styles.bar,
         compact && styles.barCompact,
-        flat ? styles.barFlat : { backgroundColor: colors.card },
+        { backgroundColor: colors.card },
+        raised && styles.barRaised,
       ]}
     >
       <View

--- a/openresto-frontend/components/restaurant/LocationsScreen.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsScreen.styles.ts
@@ -1,12 +1,22 @@
 import { StyleSheet, Platform } from "react-native";
 import { theme } from "@/theme/theme";
+import type { RgbColor } from "@/utils/colors";
 
 /**
- * The list's own column, narrower than PageContainer's default. The sticky band mirrors it
- * from outside the column, so the two have to read from one value or the pinned controls
- * drift off the cards below them.
+ * The mask behind the pinned filter pill: the page colour under the pill, fading out over the
+ * band's bottom padding. Solid to the pill's lower edge is what stops cards appearing in the
+ * gap above it, and fading rather than stopping is what keeps the band from reading as a
+ * square header around a rounded pill — the shape this page had before.
+ *
+ * The last stop is the page colour at zero alpha, not `transparent`: Safari resolves the
+ * keyword to transparent *black*, which greys the fade on a light page.
  */
-export const PAGE_MAX_WIDTH = 820;
+export function pinnedMask({ r, g, b }: RgbColor): object {
+  const page = `rgba(${r},${g},${b},1)`;
+  return {
+    backgroundImage: `linear-gradient(to bottom, ${page} 0, ${page} calc(100% - ${theme.spacing.md}px), rgba(${r},${g},${b},0) 100%)`,
+  };
+}
 
 export const styles = StyleSheet.create({
   root: { flex: 1 },
@@ -38,7 +48,7 @@ export const styles = StyleSheet.create({
   scroll: { flex: 1 },
   scrollContent: { flexGrow: 1 },
   page: {
-    maxWidth: PAGE_MAX_WIDTH,
+    maxWidth: 820,
     gap: theme.spacing.lg,
   },
   header: {
@@ -58,44 +68,12 @@ export const styles = StyleSheet.create({
     // Both paddings are cancelled by matching negative margins: the band only exists once
     // the bar is pinned, and at rest the list should sit exactly where it did before. The
     // top half is what keeps the pinned bar off the navbar's underside instead of welded
-    // to it, and it hides the cards passing through that gap.
+    // to it; the bottom half is the run the mask needs to fade out over.
     paddingTop: theme.spacing.md,
     marginTop: -theme.spacing.md,
-    paddingBottom: theme.spacing.sm,
-    marginBottom: -(theme.spacing.sm + 1),
-    // Always present and transparent so pinning only changes the colour: a border that
-    // appeared with the pin would push the whole list down a pixel as it landed.
-    borderBottomWidth: 1,
-    borderBottomColor: "transparent",
+    paddingBottom: theme.spacing.md,
+    marginBottom: -theme.spacing.md,
     ...(Platform.OS === "web" ? ({ position: "sticky", top: 0 } as object) : null),
-  },
-  /**
-   * Pinned, the band is page chrome and runs the full width of the viewport, matching the
-   * navbar directly above it. It lives inside the page's content column, so it has to break
-   * out of one: `100vw` plus the centring margin is the standard full-bleed escape.
-   *
-   * Applied together with `filterBandInner`, and only when `LocationsScreen` decides the band
-   * may bleed. Never on native, where `position: sticky` doesn't apply either, and never
-   * while the booking drawer is open, since the list column is then narrower than the
-   * viewport and a viewport-wide band would run on underneath the drawer.
-   */
-  filterBleed: {
-    width: "100vw",
-    marginLeft: "calc(50% - 50vw)",
-    marginRight: "calc(50% - 50vw)",
-  } as object,
-  /**
-   * Puts the content column back inside a bled band so the controls stay over the cards.
-   * The padding mirrors PageContainer's, which is what the cards below are inset by.
-   */
-  filterBandInner: {
-    width: "100%",
-    maxWidth: PAGE_MAX_WIDTH,
-    alignSelf: "center",
-    paddingHorizontal: theme.spacing.xxl,
-  },
-  filterBandInnerCompact: {
-    paddingHorizontal: theme.spacing.lg,
   },
   list: {
     gap: theme.spacing.md,

--- a/openresto-frontend/components/restaurant/LocationsScreen.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsScreen.styles.ts
@@ -1,6 +1,13 @@
 import { StyleSheet, Platform } from "react-native";
 import { theme } from "@/theme/theme";
 
+/**
+ * The list's own column, narrower than PageContainer's default. The sticky band mirrors it
+ * from outside the column, so the two have to read from one value or the pinned controls
+ * drift off the cards below them.
+ */
+export const PAGE_MAX_WIDTH = 820;
+
 export const styles = StyleSheet.create({
   root: { flex: 1 },
   loadingRoot: {
@@ -31,7 +38,7 @@ export const styles = StyleSheet.create({
   scroll: { flex: 1 },
   scrollContent: { flexGrow: 1 },
   page: {
-    maxWidth: 820,
+    maxWidth: PAGE_MAX_WIDTH,
     gap: theme.spacing.lg,
   },
   header: {
@@ -45,9 +52,7 @@ export const styles = StyleSheet.create({
     ...theme.typography.body,
   },
   // The explicit zIndex is required: react-native-web stamps `zIndex: 0` on every View
-  // and a later sibling would otherwise paint straight over the pinned bar. The
-  // page-coloured band (set at the call site, where the theme is) fills the bar's
-  // rounded corners so cards don't show through them on the way past.
+  // and a later sibling would otherwise paint straight over the pinned bar.
   filterSticky: {
     zIndex: 5,
     // Both paddings are cancelled by matching negative margins: the band only exists once
@@ -63,6 +68,34 @@ export const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: "transparent",
     ...(Platform.OS === "web" ? ({ position: "sticky", top: 0 } as object) : null),
+  },
+  /**
+   * Pinned, the band is page chrome and runs the full width of the viewport, matching the
+   * navbar directly above it. It lives inside the page's content column, so it has to break
+   * out of one: `100vw` plus the centring margin is the standard full-bleed escape.
+   *
+   * Applied together with `filterBandInner`, and only when `LocationsScreen` decides the band
+   * may bleed. Never on native, where `position: sticky` doesn't apply either, and never
+   * while the booking drawer is open, since the list column is then narrower than the
+   * viewport and a viewport-wide band would run on underneath the drawer.
+   */
+  filterBleed: {
+    width: "100vw",
+    marginLeft: "calc(50% - 50vw)",
+    marginRight: "calc(50% - 50vw)",
+  } as object,
+  /**
+   * Puts the content column back inside a bled band so the controls stay over the cards.
+   * The padding mirrors PageContainer's, which is what the cards below are inset by.
+   */
+  filterBandInner: {
+    width: "100%",
+    maxWidth: PAGE_MAX_WIDTH,
+    alignSelf: "center",
+    paddingHorizontal: theme.spacing.xxl,
+  },
+  filterBandInnerCompact: {
+    paddingHorizontal: theme.spacing.lg,
   },
   list: {
     gap: theme.spacing.md,

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
-  Platform,
   ScrollView,
   View,
   useWindowDimensions,
@@ -22,7 +21,8 @@ import LocationListItem from "@/components/restaurant/LocationListItem";
 import LocationsFilterBar, { type MealWindow } from "@/components/restaurant/LocationsFilterBar";
 import BookingDrawer from "@/components/booking/BookingDrawer";
 import Button from "@/components/common/Button";
-import { styles } from "./LocationsScreen.styles";
+import { hexToRgb } from "@/utils/colors";
+import { styles, pinnedMask } from "./LocationsScreen.styles";
 
 /** What the user is currently booking: a location plus the time they tapped. */
 interface DrawerTarget {
@@ -67,6 +67,7 @@ export default function LocationsScreen({
   const { colors } = useAppTheme();
   const { width } = useWindowDimensions();
   const isCompact = isMobileWidth(width);
+  const pageRgb = useMemo(() => hexToRgb(colors.page), [colors.page]);
 
   const [seats, setSeats] = useState(initialSeats ?? 2);
   const [dateOverride, setDateOverride] = useState<string | null>(null);
@@ -190,8 +191,6 @@ export default function LocationsScreen({
 
   const summary = availabilitySummary(availability, restaurants.length);
   const sideDrawer = drawer && !isCompact;
-  // Whether the sticky filter band may run the full width of the viewport. See `filterBleed`.
-  const bleedBand = Platform.OS === "web" && !sideDrawer;
   // Where the navbar's own content ends: its column is capped at CONTENT_MAX_WIDTH but
   // tracks the viewport below that, and it insets its contents by CONTENT_PADDING_H
   // either side. Matching it is what puts the drawer's edge under the overflow menu.
@@ -233,36 +232,20 @@ export default function LocationsScreen({
                     onLayout={(e) => {
                       filterTop.current = e.nativeEvent.layout.y;
                     }}
-                    style={[
-                      styles.filterSticky,
-                      bleedBand && styles.filterBleed,
-                      filterPinned && {
-                        backgroundColor: colors.card,
-                        borderBottomColor: colors.border,
-                      },
-                    ]}
+                    style={[styles.filterSticky, filterPinned && pinnedMask(pageRgb)]}
                   >
-                    <View
-                      style={
-                        bleedBand && [
-                          styles.filterBandInner,
-                          isCompact && styles.filterBandInnerCompact,
-                        ]
-                      }
-                    >
-                      <LocationsFilterBar
-                        seats={seats}
-                        onSeatsChange={setSeats}
-                        date={date}
-                        onDateChange={setDateOverride}
-                        today={today}
-                        meal={meal}
-                        onMealChange={setMeal}
-                        summary={summary}
-                        compact={isCompact}
-                        flat={filterPinned}
-                      />
-                    </View>
+                    <LocationsFilterBar
+                      seats={seats}
+                      onSeatsChange={setSeats}
+                      date={date}
+                      onDateChange={setDateOverride}
+                      today={today}
+                      meal={meal}
+                      onMealChange={setMeal}
+                      summary={summary}
+                      compact={isCompact}
+                      raised={filterPinned}
+                    />
                   </View>
 
                   <View style={styles.list}>

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
+  Platform,
   ScrollView,
   View,
   useWindowDimensions,
@@ -189,6 +190,8 @@ export default function LocationsScreen({
 
   const summary = availabilitySummary(availability, restaurants.length);
   const sideDrawer = drawer && !isCompact;
+  // Whether the sticky filter band may run the full width of the viewport. See `filterBleed`.
+  const bleedBand = Platform.OS === "web" && !sideDrawer;
   // Where the navbar's own content ends: its column is capped at CONTENT_MAX_WIDTH but
   // tracks the viewport below that, and it insets its contents by CONTENT_PADDING_H
   // either side. Matching it is what puts the drawer's edge under the overflow menu.
@@ -232,23 +235,34 @@ export default function LocationsScreen({
                     }}
                     style={[
                       styles.filterSticky,
-                      {
-                        backgroundColor: colors.page,
-                        borderBottomColor: filterPinned ? colors.border : "transparent",
+                      bleedBand && styles.filterBleed,
+                      filterPinned && {
+                        backgroundColor: colors.card,
+                        borderBottomColor: colors.border,
                       },
                     ]}
                   >
-                    <LocationsFilterBar
-                      seats={seats}
-                      onSeatsChange={setSeats}
-                      date={date}
-                      onDateChange={setDateOverride}
-                      today={today}
-                      meal={meal}
-                      onMealChange={setMeal}
-                      summary={summary}
-                      compact={isCompact}
-                    />
+                    <View
+                      style={
+                        bleedBand && [
+                          styles.filterBandInner,
+                          isCompact && styles.filterBandInnerCompact,
+                        ]
+                      }
+                    >
+                      <LocationsFilterBar
+                        seats={seats}
+                        onSeatsChange={setSeats}
+                        date={date}
+                        onDateChange={setDateOverride}
+                        today={today}
+                        meal={meal}
+                        onMealChange={setMeal}
+                        summary={summary}
+                        compact={isCompact}
+                        flat={filterPinned}
+                      />
+                    </View>
                   </View>
 
                   <View style={styles.list}>

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -207,20 +207,48 @@ describe("LocationsScreen", () => {
     expect(screen.getByTestId("locations-filter-bar")).toBeTruthy();
   });
 
-  it("pins the filter bar over the cards rather than letting them paint across it", async () => {
+  it("leaves the resting filter bar part of the list rather than a toolbar", async () => {
     (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
     renderWithProviders(<LocationsScreen />);
     await waitFor(() => expect(screen.getByTestId("locations-filter-sticky")).toBeTruthy());
 
     const style = StyleSheet.flatten(screen.getByTestId("locations-filter-sticky").props.style);
     expect(style.zIndex).toBe(5);
-    // An opaque band, or the cards show through the bar's rounded corners on the way past.
-    expect(style.backgroundColor).toBeTruthy();
+    // The band is only a surface once pinned; at rest it must not paint over the page.
+    expect(style.backgroundColor).toBeUndefined();
+    expect(style.borderBottomColor).toBe("transparent");
     // The band — top gap, bottom gap and its edge — costs the resting list no height.
     expect(style.paddingTop + style.marginTop).toBe(0);
     expect(style.paddingBottom + style.marginBottom + style.borderBottomWidth).toBe(0);
-    // At rest the bar is part of the list, not a toolbar: no edge until it pins.
-    expect(style.borderBottomColor).toBe("transparent");
+
+    // And the bar keeps its own card treatment while it is one row of the list.
+    const bar = StyleSheet.flatten(screen.getByTestId("locations-filter-bar").props.style);
+    expect(bar.backgroundColor).toBeTruthy();
+    expect(bar.backgroundColor).not.toBe("transparent");
+    expect(bar.borderRadius).toBeGreaterThan(0);
+  });
+
+  it("hands the bar's surface to the band once it pins, so only one shape is drawn", async () => {
+    (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+    renderWithProviders(<LocationsScreen />);
+    await waitFor(() => expect(screen.getByTestId("locations-filter-sticky")).toBeTruthy());
+
+    fireEvent(screen.getByTestId("locations-filter-sticky"), "layout", {
+      nativeEvent: { layout: { y: 120 } },
+    });
+    fireEvent.scroll(screen.UNSAFE_getByType(ScrollView), {
+      nativeEvent: { contentOffset: { y: 400 } },
+    });
+
+    const band = StyleSheet.flatten(screen.getByTestId("locations-filter-sticky").props.style);
+    expect(band.backgroundColor).toBeTruthy();
+    expect(band.borderBottomColor).not.toBe("transparent");
+
+    // The bar gives up its card treatment at the same moment, leaving the band as the only
+    // surface: a rounded card inside the square band is the two-shape bug this replaced.
+    const bar = StyleSheet.flatten(screen.getByTestId("locations-filter-bar").props.style);
+    expect(bar.backgroundColor).toBe("transparent");
+    expect(bar.borderRadius).toBe(0);
   });
 
   it("drives every card from the same party size, date and meal window", async () => {

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -214,21 +214,20 @@ describe("LocationsScreen", () => {
 
     const style = StyleSheet.flatten(screen.getByTestId("locations-filter-sticky").props.style);
     expect(style.zIndex).toBe(5);
-    // The band is only a surface once pinned; at rest it must not paint over the page.
+    // The band paints nothing until the bar pins: at rest the bar is one row of the list.
     expect(style.backgroundColor).toBeUndefined();
-    expect(style.borderBottomColor).toBe("transparent");
-    // The band — top gap, bottom gap and its edge — costs the resting list no height.
+    expect(style.backgroundImage).toBeUndefined();
+    // Its top and bottom gaps cost the resting list no height.
     expect(style.paddingTop + style.marginTop).toBe(0);
-    expect(style.paddingBottom + style.marginBottom + style.borderBottomWidth).toBe(0);
+    expect(style.paddingBottom + style.marginBottom).toBe(0);
 
-    // And the bar keeps its own card treatment while it is one row of the list.
+    // The bar sits in the page rather than over it, so it takes no shadow.
     const bar = StyleSheet.flatten(screen.getByTestId("locations-filter-bar").props.style);
-    expect(bar.backgroundColor).toBeTruthy();
-    expect(bar.backgroundColor).not.toBe("transparent");
     expect(bar.borderRadius).toBeGreaterThan(0);
+    expect(bar.shadowOpacity).toBeUndefined();
   });
 
-  it("hands the bar's surface to the band once it pins, so only one shape is drawn", async () => {
+  it("floats the pinned bar over the list instead of boxing it into a header", async () => {
     (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
     renderWithProviders(<LocationsScreen />);
     await waitFor(() => expect(screen.getByTestId("locations-filter-sticky")).toBeTruthy());
@@ -240,15 +239,18 @@ describe("LocationsScreen", () => {
       nativeEvent: { contentOffset: { y: 400 } },
     });
 
+    // A mask, not a surface: it hides the list in the gap above the pill and fades out
+    // rather than ending on an edge, which is what made the old band read as a header.
     const band = StyleSheet.flatten(screen.getByTestId("locations-filter-sticky").props.style);
-    expect(band.backgroundColor).toBeTruthy();
-    expect(band.borderBottomColor).not.toBe("transparent");
+    expect(band.backgroundImage).toContain("linear-gradient");
+    expect(band.backgroundColor).toBeUndefined();
+    expect(band.borderBottomWidth).toBeUndefined();
 
-    // The bar gives up its card treatment at the same moment, leaving the band as the only
-    // surface: a rounded card inside the square band is the two-shape bug this replaced.
+    // The bar keeps its pill shape throughout and lifts off the page to earn the overlap.
     const bar = StyleSheet.flatten(screen.getByTestId("locations-filter-bar").props.style);
-    expect(bar.backgroundColor).toBe("transparent");
-    expect(bar.borderRadius).toBe(0);
+    expect(bar.borderRadius).toBeGreaterThan(0);
+    expect(bar.backgroundColor).not.toBe("transparent");
+    expect(bar.shadowOpacity).toBeGreaterThan(0);
   });
 
   it("drives every card from the same party size, date and meal window", async () => {
@@ -480,26 +482,23 @@ describe("LocationsScreen", () => {
     );
   });
 
-  it("draws the filter bar's edge once the list has scrolled under it", async () => {
+  it("lifts the filter bar only once the list has scrolled under it", async () => {
     (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
     renderWithProviders(<LocationsScreen />);
     await waitFor(() => expect(screen.getByTestId("locations-filter-sticky")).toBeTruthy());
 
     const band = screen.getByTestId("locations-filter-sticky");
     fireEvent(band, "layout", { nativeEvent: { layout: { y: 120 } } });
+    const barStyle = () =>
+      StyleSheet.flatten(screen.getByTestId("locations-filter-bar").props.style);
 
     const scrollView = screen.UNSAFE_getByType(ScrollView);
+    // Scrolled, but not yet past the bar: still sitting in the list, still unlifted.
     fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 60 } } });
-    expect(
-      StyleSheet.flatten(screen.getByTestId("locations-filter-sticky").props.style)
-        .borderBottomColor
-    ).toBe("transparent");
+    expect(barStyle().shadowOpacity).toBeUndefined();
 
     fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 400 } } });
-    expect(
-      StyleSheet.flatten(screen.getByTestId("locations-filter-sticky").props.style)
-        .borderBottomColor
-    ).not.toBe("transparent");
+    expect(barStyle().shadowOpacity).toBeGreaterThan(0);
   });
 
   it("onScroll handler updates scrollY", async () => {


### PR DESCRIPTION
Pinned, the filter bar kept its rounded card treatment inside the page-coloured band that backs it, so the header read as two competing shapes: a rounded card sitting inside a square bar whose bottom rule stopped at the content column rather than running the width of the page.

The bar now keeps its pill shape at every scroll position and floats over the list, rather than turning into page chrome on pin.

## Change

| | At rest | Pinned |
|---|---|---|
| Bar | pill, `colors.card`, flat | same pill, lifted on `shadows.lg` |
| Band | paints nothing | page colour under the pill, fading out over its bottom padding |

The band is a mask, not a surface. Solid to the pill's lower edge is what stops cards appearing in the gap between it and the navbar; fading rather than stopping is what removes the edge that made it read as a square header around a round pill. The last gradient stop is the page colour at zero alpha rather than `transparent`, which Safari resolves to transparent *black* and would grey the fade on a light page.

The band's top and bottom padding are still cancelled by matching negative margins, so the resting list sits exactly where it did.

## Verification

Measured headless in Chrome against `npm run dev`, light and dark:

- **At rest**: band paints nothing (`background-image: none`, no background colour, no border), bar has no shadow, band in flow at `top: 158`.
- **Pinned**: band carries `linear-gradient(rgb(242,243,245) 0, rgb(242,243,245) calc(100% - 12px), rgba(242,243,245,0) 100%)` (and the dark equivalent), bar has `rgba(0,0,0,0.1) 0 4px 12px` and keeps its 14px radius, band at `top: 64` flush under the navbar.
- Bar box `254/772` matches the card box `254/772` in both states.

Screenshots confirm the list fading out under the pill in both themes, with no hard cut and no visible band edge.

`npm run check` clean, `tsc` clean, 2454 frontend tests pass.

Three tests changed. The old `pins the filter bar…` asserted the band was opaque at all times, which was the previous design's way of masking the pill's rounded corners; `draws the filter bar's edge…` asserted a bottom rule that no longer exists. Replaced with one test per state plus a pin-transition test keyed on the lift.

E2E not run locally (the compose stack is down), so the `e2e-smoke` job on this PR is the first real routing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)