### PR TITLE
Widen the compact seat trigger so the guest count doesn't clip on mobile

### DIFF
--- a/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.styles.ts
@@ -37,9 +37,13 @@ export const styles = StyleSheet.create({
   // leaves the seat trigger 64px, which is less than its own icon, digits and chevron, so
   // the count ellipsised down to a stray dot. The floors are what each trigger actually
   // needs, and the bar wraps when they no longer fit rather than squeezing one of them.
+  //
+  // 80 was sized for the icon, chevron and padding plus a single digit, but left the digit
+  // itself under 10px — real device font rendering clipped it rather than showing it in
+  // full, and party size goes up to 10, which needs two. 100 gives the number actual room.
   controlCompactSeats: {
     flex: 1,
-    minWidth: 80,
+    minWidth: 100,
   },
   controlCompactWide: {
     flex: 2,


### PR DESCRIPTION
## Summary

On the mobile Locations page, the compact seat-count trigger in the (pinned) filter bar clipped its number instead of showing it fully.

## Related issue

Closes #

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `LocationsFilterBar.styles.ts`: raised `controlCompactSeats.minWidth` from 80 to 100.

The previous 80px floor was sized for the icon, chevron and padding plus a single digit, but that left under 10px for the digit itself — tight enough that real-device font rendering clipped the character rather than drawing it in full, and it never accounted for the two-digit `10` party size (`SEAT_OPTIONS` goes up to 10 guests). 100px gives the number real breathing room in both the single- and double-digit case.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally (`LocationsFilterBar.test.tsx`, `LocationsScreen.test.tsx`, `npm run check`)
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — seeded the demo dataset, ran the backend + frontend locally, and drove the Locations page with a real browser at mobile viewport widths (320–428px) in both the resting and pinned/sticky states, and with both single-digit and two-digit (`10`) guest counts.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed

---
_Generated by [Claude Code](https://claude.ai/code/session_015CXaSD3LdF7N9oe9aaBkgS)_