### PR TITLE
refactor: replace explanatory comments with abstraction, subfunctions, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,24 @@ jobs:
       - name: Check Route Manifest
         run: npm run routes:check
 
+  doc-links:
+    name: Doc Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      # The comment policy lets a test carry a business rule in place of prose, which
+      # only holds while the code still points at that test. A link has no compiler
+      # behind it, so a renamed test rots it silently and the rule goes undocumented.
+      - name: Check Doc Links
+        run: npm run check:doc-links
+
   backend:
     name: Backend CI
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,43 @@ OPENRESTO_VERSION=1.0.0 docker compose -f docker-compose.release.yml up -d
 
 ## Code comments
 
-Don't add comments above functions or inline unless the WHY is genuinely non-obvious (a hidden constraint, a subtle invariant, a workaround for a specific bug). Well-named identifiers should make the WHAT self-evident. Before reaching for a comment, check whether the explanation can instead be expressed through abstraction or encapsulation — e.g. business logic embedded in a controller should move to a self-commenting, domain-named method in `Core/Application/Services` rather than being explained in a comment. Favor human-readable, domain-driven names and logical flow over prose explanations, while keeping code legible to agents working in this repo.
+A comment is the last resort, not the first. Work down this ladder and only write prose when all four rungs fail:
+
+1. **Abstraction and encapsulation.** Business logic explained by a comment in a controller belongs in a domain-named method in `Core/Application/Services` instead. Arithmetic spelled out in a comment (`// 44px target minus 30px of rendered height`) belongs in named constants that compute it. The same coercion explained in two places belongs in one named helper (`ContactFields.Normalize`, `OpeningHoursHelper.GetHoursForDay`).
+2. **Human-readable subfunctions.** A comment labelling a block (`// Step 2: resolve the local day`, `// --- Sections ---`) means the block wants to be a method, or the line below already says it. Name it and delete the label. Sentinel values get names too: `UnlimitedOversize` beats `null // = no cap`.
+3. **Unit tests that pin the rule, on both sides of its boundary.** A comment stating a business rule is a rule nothing enforces. Replace it with a pair of tests, one inside the boundary and one outside, named after the rule. A cap of four spare seats becomes "offers a table four seats over the party size" and "rejects a table five seats over", not `// max 4 spare seats`. The pair is the point: a single happy-path test documents a case, whereas the pair documents the limit and fails the day someone moves it. A comment goes stale silently.
+4. **Integration/E2E tests for rules that only exist across a boundary.** Same idea one level up. A rule that only shows up end to end (an archived location staying out of `RestaurantDto`, a hold surviving into `POST /api/bookings`, a settings round-trip clearing a field) gets a spec, not a paragraph above the code.
+5. **Whatever 1–4 can't reach.** Hidden constraints, upstream bugs, production-incident history, protocol requirements, reachability arguments for coverage suppressions. These stay, but keep them tight: state the constraint, not its biography. "Consolidates the check previously duplicated across four services" is biography; the reader needs the invariant, not the changelog.
+
+Tests augment the rule rather than merely restating it: the rule becomes executable, and the boundary that prose only asserted is now enforced. What is left over after the rule is pinned (a threat model, an incident, an upstream bug) is rung 5 and can stay, but it should be the residue, not the rule written twice.
+
+### Point at the test that carries the rule
+
+When rung 3 or 4 is what replaced a comment, leave a link to the test so the rule stays findable from the code it governs. Use the form each toolchain understands:
+
+- **TypeScript**: a markdown link in JSDoc, path relative to the file. VS Code renders it clickable on hover:
+
+  ```ts
+  /**
+   * @see [walkIn.test.ts](../__tests__/utils/walkIn.test.ts) — pins that a
+   * per-day walk-in flag closes only that day.
+   */
+  ```
+
+- **C#**: `<seealso>` naming the test method. `cref` can't reach `OpenRestoApi.Tests` (the reference points the other way), so the name goes in the tag body and the checker resolves it:
+
+  ```csharp
+  /// <seealso>RestaurantTests.IsPausedFor_BlocksSittingInsideWindow</seealso>
+  /// <seealso>RestaurantTests.IsPausedFor_AllowsSittingAfterWindow</seealso>
+  ```
+
+Say which rule the test pins, not just that one exists. A bare `@see` is noise.
+
+`npm run check:doc-links` (run in CI by the `doc-links` job in `ci.yml`) fails on a `@see [name](path)` whose file is missing and on a `<seealso>` naming a method that no test class declares. Without it a renamed test rots the link silently, which is the same staleness problem the comment had.
+
+### What this does not license
+
+`<summary>` on a public domain property whose meaning is a data format (`OpenDays` being comma-separated ISO day numbers, `OpenHoursJson`'s shape) stays — that is rung 5 constraint documentation, not narration. Coverage and analyzer suppressions keep their justification (`[ExcludeFromCodeCoverage]` reasons, `#pragma warning disable` rationale). What goes is the summary that restates the signature, the block label, and the changelog entry about which method the code used to live in.
 
 ## Architecture
 

--- a/OpenRestoApi.Tests/Domain/RestaurantTests.cs
+++ b/OpenRestoApi.Tests/Domain/RestaurantTests.cs
@@ -236,4 +236,45 @@ public class RestaurantTests
         var tuesday = new DateTime(2026, 1, 6, 12, 0, 0, DateTimeKind.Utc); // Tuesday
         Assert.False(r.IsOpenAt(tuesday));
     }
+
+    // ── CanSeat ────────────────────────────────────────────────────────────────
+    //
+    // Availability, holds, booking creation/update and auto-assign all ask this one question,
+    // so the boundary has to be stated here rather than re-derived at each call site.
+
+    [Fact]
+    public void CanSeat_True_WhenTheUnitIsExactlyAtTheOversizeCap()
+    {
+        Restaurant r = NewRestaurant();
+        r.MaxTableOversizeSeats = 2;
+
+        Assert.True(r.CanSeat(unitSeats: 6, partySize: 4));
+    }
+
+    [Fact]
+    public void CanSeat_False_WhenTheUnitIsOneSeatOverTheCap()
+    {
+        Restaurant r = NewRestaurant();
+        r.MaxTableOversizeSeats = 2;
+
+        Assert.False(r.CanSeat(unitSeats: 7, partySize: 4));
+    }
+
+    [Fact]
+    public void CanSeat_False_WhenTheUnitIsSmallerThanTheParty()
+    {
+        Restaurant r = NewRestaurant();
+        r.MaxTableOversizeSeats = null;
+
+        Assert.False(r.CanSeat(unitSeats: 2, partySize: 4));
+    }
+
+    [Fact]
+    public void CanSeat_True_ForAnyLargerUnit_WhenNoCapIsSet()
+    {
+        Restaurant r = NewRestaurant();
+        r.MaxTableOversizeSeats = null;
+
+        Assert.True(r.CanSeat(unitSeats: 10, partySize: 2));
+    }
 }

--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -1309,6 +1309,70 @@ public partial class BookingServiceTests
         Assert.NotEmpty(result.BookingRef!);
     }
 
+    // ── CreateBookingAsync — booking pause ────────────────────────────────────
+    //
+    // A pause closes the sittings that start inside its window, not booking as a whole. The
+    // pair is what states that: a single "rejects while paused" test passes just as happily
+    // against a service that refuses every booking until the pause expires.
+
+    [Fact]
+    public async Task CreateBookingAsync_RejectsBooking_InsideThePauseWindow()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_RejectsBooking_InsideThePauseWindow));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "Paused Bistro",
+            Timezone = "UTC",
+            BookingsPausedUntil = DateTime.UtcNow.AddHours(4)
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        db.SaveChanges();
+
+        BookingService svc = CreateService(db);
+
+        await Assert.ThrowsAsync<ConflictException>(() => svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = DateTime.UtcNow.AddHours(2)
+        }));
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_AllowsBooking_AfterThePauseWindow()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateBookingAsync_AllowsBooking_AfterThePauseWindow));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "Paused Bistro",
+            Timezone = "UTC",
+            BookingsPausedUntil = DateTime.UtcNow.AddHours(4)
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        db.SaveChanges();
+
+        BookingService svc = CreateService(db);
+
+        BookingDto result = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = DateTime.UtcNow.AddHours(6)
+        });
+
+        Assert.NotEmpty(result.BookingRef!);
+    }
+
     // ── CreateBookingAsync — auto-assign ("Any section") ──────────────────────
     //
     // When TableId/SectionId are both null, the service picks the smallest fitting free

--- a/OpenRestoApi.Tests/Utilities/IsoDayTests.cs
+++ b/OpenRestoApi.Tests/Utilities/IsoDayTests.cs
@@ -1,0 +1,47 @@
+using OpenRestoApi.Core.Application.Utilities;
+
+namespace OpenRestoApi.Tests.Utilities;
+
+public class IsoDayTests
+{
+    [Fact]
+    public void Of_MapsSundayToSeven_RatherThanZero()
+    {
+        var sunday = new DateTime(2026, 1, 4, 12, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(7, IsoDay.Of(sunday));
+    }
+
+    [Fact]
+    public void Of_MapsMondayToOne()
+    {
+        var monday = new DateTime(2026, 1, 5, 12, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(1, IsoDay.Of(monday));
+    }
+
+    // The availability feed and Restaurant.IsOpenAt read the same OpenDays column. These two
+    // pin the boundary between what the parser accepts and what it drops, so a value one path
+    // reads as Monday can no longer be a value the other silently discards.
+
+    [Fact]
+    public void ParseList_ReadsDayNamesAndNumbers()
+    {
+        HashSet<int> days = IsoDay.ParseList("mon, Tuesday, 3, sun");
+
+        Assert.Equal(new HashSet<int> { 1, 2, 3, 7 }, days);
+    }
+
+    [Fact]
+    public void ParseList_DiscardsUnrecognisedEntries()
+    {
+        HashSet<int> days = IsoDay.ParseList("1, 0, 8, funday, ");
+
+        Assert.Equal(new HashSet<int> { 1 }, days);
+    }
+
+    [Fact]
+    public void ParseList_ReturnsEmpty_ForBlankInput()
+    {
+        Assert.Empty(IsoDay.ParseList(null));
+        Assert.Empty(IsoDay.ParseList("   "));
+    }
+}

--- a/OpenRestoApi/Controllers/HoldsController.cs
+++ b/OpenRestoApi/Controllers/HoldsController.cs
@@ -119,8 +119,7 @@ public class HoldsController(
         }
 
         Restaurant restaurant = policy.Restaurant!;
-        if (restaurant.MaxTableOversizeSeats.HasValue
-            && group.CombinedSeats - request.Seats > restaurant.MaxTableOversizeSeats.Value)
+        if (restaurant.ExceedsOversizeCap(group.CombinedSeats, request.Seats))
         {
             return Conflict(new MessageResponse
             {

--- a/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
@@ -190,8 +190,8 @@ public class DayHoursDto
 {
     /// <summary>ISO 8601 day number: 1=Monday … 7=Sunday.</summary>
     public int Day { get; set; }
-    public string Open { get; set; } = "09:00";
-    public string Close { get; set; } = "22:00";
+    public string Open { get; set; } = OpeningHourDefaults.Open;
+    public string Close { get; set; } = OpeningHourDefaults.Close;
 }
 
 public class RestaurantDto
@@ -199,8 +199,8 @@ public class RestaurantDto
     public int Id { get; set; }
     public string Name { get; set; } = null!;
     public string? Address { get; set; }
-    public string OpenTime { get; set; } = "09:00";
-    public string CloseTime { get; set; } = "22:00";
+    public string OpenTime { get; set; } = OpeningHourDefaults.Open;
+    public string CloseTime { get; set; } = OpeningHourDefaults.Close;
 
     /// <summary>Resolved hours for every day of the week (always 7 entries).</summary>
     public List<DayHoursDto> OpenHours { get; set; } = new();

--- a/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
@@ -19,19 +19,18 @@ public interface IBookingRepository
     Task<bool> IsTableBookedOnDateAsync(int tableId, DateTime bookingDate, int durationMinutes = 60);
 
     /// <summary>
-    /// Group-aware conflict check used wherever a table OR a combinable-table group is being booked.
-    /// A physical <paramref name="tableId"/> is considered reserved for the window when ANY of these
-    /// overlap it:
-    /// <list type="bullet">
-    /// <item>a single-table booking on that table (<c>Booking.TableId == tableId</c>);</item>
-    /// <item>a group booking on the group that the table belongs to — because booking the group
-    /// reserves every member. The membership is resolved from <c>TableGroupMemberships</c>.</item>
-    /// </list>
-    /// A <paramref name="tableGroupId"/> (the unit being booked) is considered reserved when ANY
-    /// booking overlaps that targets the same group <em>or</em> any of its member tables individually.
-    /// This closes the double-booking gap: a persisted group booking stores <c>TableId = null</c>, so
-    /// the table-only <see cref="IsTableBookedOnDateAsync"/> cannot see it; this method can.
+    /// The conflict check every booking path uses, because a table and the group it belongs to
+    /// reserve the same physical furniture. A <paramref name="tableId"/> is reserved by a booking
+    /// on that table <em>or</em> by a booking on its group; a <paramref name="tableGroupId"/> is
+    /// reserved by a booking on the group <em>or</em> on any member individually.
+    /// <para>
+    /// A group booking stores <c>TableId = null</c>, so
+    /// <see cref="IsTableBookedOnDateAsync"/> cannot see it — reaching for that one instead is
+    /// how the same table gets booked twice.
+    /// </para>
     /// </summary>
+    /// <seealso>BookingServiceTests.CreateBookingAsync_GroupBooking_RejectsWhenMemberIsBooked</seealso>
+    /// <seealso>BookingServiceTests.CreateBookingAsync_SingleTable_RejectsWhenItsGroupAlreadyBooked</seealso>
     Task<bool> IsUnitBookedOnDateAsync(
         int? tableId,
         int? tableGroupId,

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -73,25 +73,8 @@ public class AdminService(
             }
         }
 
-        // Calculate Occupancy Data (Last 7 days) — raw counts first, then normalize to 0-100
-        // relative to the peak day so the busiest day fills the chart and others are proportional.
-        // OccupancyDates carries the ISO calendar date (yyyy-MM-dd) for each bar so the client can
-        // toggle between the T-x relative labels and actual calendar dates (see issue #180).
-        List<int> rawCounts = [];
-        List<string> occupancyDates = [];
-        for (int i = 6; i >= 0; i--)
-        {
-            DateTime dayStart = DateTime.SpecifyKind(nowUtc.Date.AddDays(-i), DateTimeKind.Utc);
-            DateTime dayEnd = dayStart.AddDays(1);
-            int dayBookings = await _bookingRepository.CountActiveByDayAsync(dayStart, dayEnd);
-            rawCounts.Add(dayBookings);
-            occupancyDates.Add(dayStart.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
-        }
-
-        int maxCount = MaxOrZero(rawCounts);
-        List<int> occupancyData = rawCounts
-            .Select(count => maxCount > 0 ? (int)Math.Round((double)count / maxCount * 100) : 0)
-            .ToList();
+        (List<int> rawCounts, List<string> occupancyDates) = await CountBookingsPerDayAsync(nowUtc, OccupancyChartDays);
+        List<int> occupancyData = AsPercentagesOfPeak(rawCounts);
 
         return new AdminOverviewDto
         {
@@ -108,10 +91,43 @@ public class AdminService(
         };
     }
 
-    // The loop that builds rawCounts always runs exactly 7 times (i = 6..0), so it can never
-    // be empty here — the `Count > 0` guard is unreachable defensive coding for a scenario
-    // (an empty rawCounts) that this call site can't produce. Isolated into its own method so
-    // the exclusion doesn't hide coverage on GetOverviewAsync's other, genuinely-tested branches.
+    private const int OccupancyChartDays = 7;
+
+    /// <summary>
+    /// Booking counts for the <paramref name="days"/> ending on <paramref name="nowUtc"/>, oldest
+    /// first, alongside each day's ISO calendar date — the client toggles its bar labels between
+    /// those and relative T-x ones, so both have to come back from the same walk.
+    /// </summary>
+    private async Task<(List<int> Counts, List<string> Dates)> CountBookingsPerDayAsync(DateTime nowUtc, int days)
+    {
+        List<int> counts = [];
+        List<string> dates = [];
+
+        for (int daysAgo = days - 1; daysAgo >= 0; daysAgo--)
+        {
+            DateTime dayStart = DateTime.SpecifyKind(nowUtc.Date.AddDays(-daysAgo), DateTimeKind.Utc);
+            counts.Add(await _bookingRepository.CountActiveByDayAsync(dayStart, dayStart.AddDays(1)));
+            dates.Add(dayStart.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        return (counts, dates);
+    }
+
+    /// <summary>
+    /// Scales relative to the busiest day rather than to an absolute ceiling, so the peak day
+    /// always fills the chart and quiet weeks still read as a shape.
+    /// </summary>
+    private static List<int> AsPercentagesOfPeak(List<int> counts)
+    {
+        int peak = MaxOrZero(counts);
+        return counts
+            .Select(count => peak > 0 ? (int)Math.Round((double)count / peak * 100) : 0)
+            .ToList();
+    }
+
+    // CountBookingsPerDayAsync always appends OccupancyChartDays entries, so the empty-list guard
+    // is unreachable from this call site. Isolated into its own method so excluding it doesn't
+    // hide coverage on the branches around it.
     [ExcludeFromCodeCoverage(Justification = "Unreachable: the 7-iteration loop above always populates rawCounts, so Count is never 0 at this call site.")]
     private static int MaxOrZero(List<int> counts) => counts.Count > 0 ? counts.Max() : 0;
 
@@ -145,7 +161,6 @@ public class AdminService(
             throw new ValidationException("Section does not belong to this restaurant.");
         }
 
-        // Normalize date: if Unspecified, treat as restaurant local and convert to UTC
         DateTime newStart = TimeZoneHelper.ConvertLocalToUtc(req.Date, table.Section.Restaurant!.Timezone);
 
         int durationMinutes = table.Section!.Restaurant!.DefaultBookingDurationMinutes;
@@ -178,7 +193,6 @@ public class AdminService(
 
         await _bookingRepository.AddAsync(booking);
 
-        // Reload via the eager-loading GetByIdAsync to populate names and ensure UTC consistency.
         Booking? reloaded = await _bookingRepository.GetByIdAsync(booking.Id);
         if (reloaded != null)
         {
@@ -202,8 +216,6 @@ public class AdminService(
             return null;
         }
 
-        // Use EndTime if it's valid (after Date), otherwise fall back to the
-        // restaurant's configured booking duration.
         DateTime from;
         if (booking.EndTime.HasValue && booking.EndTime.Value > booking.Date)
         {
@@ -287,7 +299,6 @@ public class AdminService(
             return null;
         }
 
-        // Validate restaurant exists if changing
         Restaurant? restaurant = booking.Restaurant;
         if (req.RestaurantId.HasValue && req.RestaurantId.Value != booking.RestaurantId)
         {
@@ -302,7 +313,6 @@ public class AdminService(
 
         int durationMinutes = restaurant?.DefaultBookingDurationMinutes ?? 60;
 
-        // Validate table exists and belongs to the (possibly new) restaurant
         if (req.TableId.HasValue && req.TableId.Value != booking.TableId)
         {
             Table? table = await _tableRepository.GetWithSectionForRestaurantAsync(req.TableId.Value, booking.RestaurantId);
@@ -319,38 +329,20 @@ public class AdminService(
             throw new ValidationException("Provide tableId when reassigning to a different section.");
         }
 
-        // Update other fields
         if (req.Date.HasValue && req.Date.Value != booking.Date)
         {
-            // If date changed, we should also shift EndTime by the same amount to keep duration
-            if (booking.EndTime.HasValue)
-            {
-                TimeSpan duration = booking.EndTime.Value - booking.Date;
-                booking.EndTime = req.Date.Value + duration;
-            }
-            else
-            {
-                // Default to the restaurant's configured booking duration if EndTime was missing for some reason
-                booking.EndTime = req.Date.Value.AddMinutes(durationMinutes);
-            }
-            booking.Date = req.Date.Value;
+            RescheduleKeepingDuration(booking, req.Date.Value, durationMinutes);
         }
 
-        // Final safety check: EndTime should never be before Date
         if (booking.EndTime.HasValue && booking.EndTime.Value < booking.Date)
         {
             booking.EndTime = booking.Date.AddMinutes(durationMinutes);
         }
 
-        // --- CONFLICT CHECK ---
-        // If either the Date or Table changed, verify that the new slot doesn't conflict with existing bookings.
-        // NOTE: booking.Date/booking.TableId are mutated above before this guard runs, so both
-        // comparisons inside it are always false and it is unreachable dead code today
-        // (pre-existing, out of scope here — see
-        // AdminServiceTests.AdminUpdateBookingAsync_ConflictCheckGuard_IsUnreachable_DueToPreExistingDeadCodeBug,
-        // which pins the current behaviour). Extracted to its own method and excluded from
-        // coverage rather than chased with a contrived test; the real fix (compare against
-        // the pre-mutation values) is a separate, unrelated follow-up.
+        // Dead code today: booking.Date/booking.TableId are mutated above, so this guard's
+        // comparisons are always false. Pinned as-is by
+        // AdminServiceTests.AdminUpdateBookingAsync_ConflictCheckGuard_IsUnreachable_DueToPreExistingDeadCodeBug;
+        // the fix — comparing against the pre-mutation values — is an unrelated follow-up.
         await CheckSlotConflictIfChangedAsync(booking, req, id, durationMinutes);
 
         if (req.Seats.HasValue)
@@ -381,14 +373,20 @@ public class AdminService(
 
         await _bookingRepository.UpdateAsync(booking);
 
-        // Reload via the eager-loading GetByIdAsync to get updated names.
+        // Reloaded through the eager-loading read so the DTO carries the updated names.
         Booking? reloaded = await _bookingRepository.GetByIdAsync(id);
         return reloaded == null ? ToDetailDto(booking) : ToDetailDto(reloaded);
     }
 
-    // Unreachable with the current call site: booking.Date/booking.TableId are already
-    // mutated to req.Date/req.TableId by the time this runs, so both comparisons below are
-    // always false. See AdminUpdateBookingAsync_ConflictCheckGuard_IsUnreachable_DueToPreExistingDeadCodeBug.
+    /// <summary>Moves the sitting while keeping its length, so a reschedule never silently resizes it.</summary>
+    private static void RescheduleKeepingDuration(Booking booking, DateTime newDate, int fallbackDurationMinutes)
+    {
+        booking.EndTime = booking.EndTime.HasValue
+            ? newDate + (booking.EndTime.Value - booking.Date)
+            : newDate.AddMinutes(fallbackDurationMinutes);
+        booking.Date = newDate;
+    }
+
     [ExcludeFromCodeCoverage(Justification = "Pre-existing dead code: caller mutates booking.Date/TableId before calling this, so the guard never trips. Kept as-is; not fixed here.")]
     private async Task CheckSlotConflictIfChangedAsync(Booking booking, AdminUpdateBookingRequest req, int id, int durationMinutes)
     {
@@ -470,7 +468,6 @@ public class AdminService(
 
         DateTime nowUtc = DateTime.UtcNow;
 
-        // Active bookings are those that are currently in progress and not cancelled
         List<Booking> activeBookings = await _bookingRepository.GetInProgressForRestaurantAsync(restaurantId, nowUtc, restaurant.DefaultBookingDurationMinutes);
 
         foreach (Booking? booking in activeBookings)
@@ -603,7 +600,6 @@ public class AdminService(
 
     private static BookingDetailDto ToDetailDto(Booking b)
     {
-        // Force UTC kind to ensure JSON serializer adds the 'Z' suffix
         DateTime dateUtc = b.Date.Kind == DateTimeKind.Unspecified
             ? DateTime.SpecifyKind(b.Date, DateTimeKind.Utc)
             : b.Date.ToUniversalTime();

--- a/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
+++ b/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
@@ -22,234 +22,55 @@ public sealed class AvailabilityService(
 
         TimeZoneInfo tz = TimeZoneHelper.Resolve(restaurant.Timezone);
 
-        // 1. Fetch all active bookings for this restaurant on this date (broad UTC range)
         IEnumerable<Booking> activeBookings = await _bookingRepository.GetActiveBookingsForDateAsync(restaurantId, bookingDate);
 
-        // 2. Define the local operating hours for the requested date.
-        // bookingDate is sent as YYYY-MM-DD from the frontend (already the local date in the
-        // restaurant's timezone), so use it directly rather than converting from UTC — converting
-        // from UTC would shift midnight into the previous day for any UTC-negative timezone.
+        // bookingDate arrives as YYYY-MM-DD, already the local date in the restaurant's
+        // timezone. Converting it from UTC would shift midnight into the previous day for any
+        // UTC-negative timezone.
         DateTime localDate = bookingDate.Date;
+        int isoDay = IsoDay.Of(localDate);
 
-        int jsDay = (int)localDate.DayOfWeek; // 0=Sun…6=Sat
-        int isoDay = jsDay == 0 ? 7 : jsDay;  // 1=Mon…7=Sun
-
-        // Walk-in-only locations/days take no online bookings, so expose no slots.
-        if (WalkInHelper.IsWalkInOnlyOn(restaurant, isoDay))
+        if (WalkInHelper.IsWalkInOnlyOn(restaurant, isoDay) || !IsOpenOn(restaurant, isoDay))
         {
-            return new AvailabilityResponseDto
-            {
-                RestaurantId = restaurantId,
-                Date = bookingDate,
-                Slots = new List<TimeSlotDto>()
-            };
+            return NoSlots(restaurantId, bookingDate);
         }
 
-        // Check if this day of week is an open day
-        if (!string.IsNullOrEmpty(restaurant.OpenDays))
-        {
-            var openDaysList = restaurant.OpenDays
-                .Split(',', StringSplitOptions.RemoveEmptyEntries)
-                .Select(d => ParseDayOfWeek(d.Trim()))
-                .Where(d => d > 0)
-                .ToHashSet();
-            if (openDaysList.Count > 0 && !openDaysList.Contains(isoDay))
-            {
-                return new AvailabilityResponseDto
-                {
-                    RestaurantId = restaurantId,
-                    Date = bookingDate,
-                    Slots = new List<TimeSlotDto>()
-                };
-            }
-        }
+        (DateTime localStart, DateTime localEnd) = ServiceWindowOn(restaurant, localDate, isoDay);
+        var reservations = new UnitReservations(restaurant, activeBookings);
+        List<Table> eligibleTables = EligibleTables(restaurant, seats);
+        List<TableGroup> eligibleGroups = EligibleGroups(restaurant, seats);
 
-        (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(restaurant, isoDay);
-        if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
-        {
-            openHour = 9; openMin = 0;
-        }
-        if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
-        {
-            closeHour = 22; closeMin = 0;
-        }
-
-        DateTime localStart = localDate.AddHours(openHour).AddMinutes(openMin);
-        DateTime localEnd = localDate.AddHours(closeHour).AddMinutes(closeMin);
-        if (localEnd <= localStart)
-        {
-            localEnd = localEnd.AddDays(1);
-        }
-
-        // 3. Generate slots stepping by the restaurant's configured interval
-        // (decoupled from DefaultBookingDurationMinutes — see Restaurant.BookingSlotIntervalMinutes).
-        // Fall back to 30 min if the stored value is somehow degenerate (0/negative), which
-        // would otherwise spin the while-loop below forever — server-side validation keeps
-        // this to 15/30/60, but we defend against stale/corrupt rows regardless.
-        int slotIntervalMinutes = restaurant.BookingSlotIntervalMinutes > 0
-            ? restaurant.BookingSlotIntervalMinutes
-            : 30;
         var slots = new List<TimeSlotDto>();
-        DateTime current = localStart;
-
-        // Fetch all tables for the restaurant to check capacity. The lower bound keeps a
-        // party off a too-small table; the optional upper bound (Restaurant.MaxTableOversizeSeats)
-        // keeps a small party off a much larger table a restaurant would rather hold for a
-        // bigger group. Mirrored in BookingService and TableAutoAssigner so the customer-facing
-        // options always match what the server will accept.
-        var eligibleTables = restaurant.Sections
-            ?.SelectMany(s => s.Tables ?? new List<Table>())
-            .Where(t => t != null && t.Seats >= seats
-                && (restaurant.MaxTableOversizeSeats == null
-                    || t.Seats - seats <= restaurant.MaxTableOversizeSeats.Value))
-            .ToList() ?? new List<Table>();
-
-        // Combinable-table groups (#272): a group is bookable when its CombinedSeats fits the party
-        // and the same optional oversize cap is satisfied. Per slot, a group is free iff ALL of its
-        // members are free. Member tables stay in AvailableTableIds — tables 8 and 9 still seat 4
-        // each on their own (#242) — and the member/group mutual exclusion is enforced per slot by
-        // IsTableReserved/IsGroupReserved rather than by hiding the members.
-        var eligibleGroups = (restaurant.Groups ?? Enumerable.Empty<TableGroup>())
-            .Where(g => g.CombinedSeats >= seats
-                && (restaurant.MaxTableOversizeSeats == null
-                    || g.CombinedSeats - seats <= restaurant.MaxTableOversizeSeats.Value))
-            .ToList();
-
-        // Optimize: index single-table bookings by table id and group bookings by group id. A group
-        // booking stores TableId = null, so it would be invisible to a table-only lookup — index it by
-        // its group id and resolve member table ids from the restaurant's loaded groups so the per-slot
-        // loops can detect it (otherwise a group/member reserved by a group booking would be advertised
-        // as available).
-        var bookingsByTable = activeBookings
-            .Where(b => b.TableId.HasValue)
-            .GroupBy(b => b.TableId!.Value)
-            .ToDictionary(g => g.Key, g => g.ToList());
-
-        var groupBookings = activeBookings.Where(b => b.TableGroupId.HasValue).ToList();
-
-        // groupId → set of member table ids, from the restaurant's loaded combinable groups.
-        var groupMemberTableIds = (restaurant.Groups ?? Enumerable.Empty<TableGroup>())
-            .ToDictionary(g => g.Id, g => g.Members.Select(m => m.TableId).ToHashSet());
-
-        // All physical table ids reserved by any group booking (the booked group's members). A standalone
-        // table in this set is effectively taken for the relevant slots even though no row sets its TableId.
-        var groupBookedTableIdsByGroup = groupBookings
-            .Where(b => b.TableGroupId.HasValue && groupMemberTableIds.ContainsKey(b.TableGroupId!.Value))
-            .SelectMany(b => groupMemberTableIds[b.TableGroupId!.Value].Select(id => (id, b)))
-            .ToList();
-
-        bool Overlaps(Booking b, DateTime slotUtc, DateTime slotEndUtc) =>
-            b.Date < slotEndUtc &&
-            (b.EndTime ?? b.Date.AddMinutes(restaurant.DefaultBookingDurationMinutes)) > slotUtc;
-
-        bool IsTableReserved(int tableId, DateTime slotUtc, DateTime slotEndUtc)
-        {
-            if (bookingsByTable.TryGetValue(tableId, out List<Booking>? tableBookings)
-                && tableBookings.Any(b => Overlaps(b, slotUtc, slotEndUtc)))
-            {
-                return true;
-            }
-
-            // Reserved by a group booking whose group counts this table as a member.
-            return groupBookedTableIdsByGroup.Any(x => x.id == tableId && Overlaps(x.b, slotUtc, slotEndUtc));
-        }
-
-        bool IsGroupReserved(TableGroup group, DateTime slotUtc, DateTime slotEndUtc)
-        {
-            // The group itself already booked for this slot.
-            if (groupBookings.Any(b => b.TableGroupId == group.Id && Overlaps(b, slotUtc, slotEndUtc)))
-            {
-                return true;
-            }
-
-            // Any member reserved individually, or by a sibling group booking, makes the group unavailable.
-            foreach (TableGroupMembership member in group.Members)
-            {
-                if (IsTableReserved(member.TableId, slotUtc, slotEndUtc))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        while (current < localEnd)
+        for (DateTime current = localStart; current < localEnd; current = current.AddMinutes(SlotInterval(restaurant)))
         {
             DateTime slotUtc = TimeZoneInfo.ConvertTimeToUtc(current, tz);
-            var availableTableIds = new List<int>();
 
             // A pause closes the slots inside its window only; later sittings — including
             // later today — stay bookable.
-            if (!restaurant.IsPausedFor(slotUtc))
+            if (restaurant.IsPausedFor(slotUtc))
             {
-                // A slot is available if AT LEAST ONE eligible table is free for the
-                // restaurant's configured booking duration.
-                DateTime slotEndUtc = slotUtc.AddMinutes(restaurant.DefaultBookingDurationMinutes);
-
-                foreach (Table? table in eligibleTables)
-                {
-                    // Group-aware booking check (catches single-table + group bookings reserving it).
-                    if (IsTableReserved(table.Id, slotUtc, slotEndUtc))
-                    {
-                        continue;
-                    }
-
-                    // Check holds
-                    if (_holdService.IsTableHeld(table.Id, slotUtc, durationMinutes: restaurant.DefaultBookingDurationMinutes))
-                    {
-                        continue;
-                    }
-
-                    availableTableIds.Add(table.Id);
-                }
-
-                // Combinable groups: a group is free iff it isn't already booked and ALL members are free.
-                var availableGroupIds = new List<int>();
-                foreach (TableGroup group in eligibleGroups)
-                {
-                    if (IsGroupReserved(group, slotUtc, slotEndUtc))
-                    {
-                        continue;
-                    }
-
-                    bool allMembersFreeOfHolds = true;
-                    foreach (TableGroupMembership member in group.Members)
-                    {
-                        if (_holdService.IsTableHeld(member.TableId, slotUtc, durationMinutes: restaurant.DefaultBookingDurationMinutes))
-                        {
-                            allMembersFreeOfHolds = false;
-                            break;
-                        }
-                    }
-
-                    if (allMembersFreeOfHolds)
-                    {
-                        availableGroupIds.Add(group.Id);
-                    }
-                }
-
-                slots.Add(new TimeSlotDto
-                {
-                    Time = current.ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture),
-                    IsAvailable = availableTableIds.Count > 0 || availableGroupIds.Count > 0,
-                    AvailableTableIds = availableTableIds,
-                    AvailableGroupIds = availableGroupIds,
-                    Category = GetCategory(current)
-                });
-            }
-            else
-            {
-                slots.Add(new TimeSlotDto
-                {
-                    Time = current.ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture),
-                    IsAvailable = false,
-                    AvailableTableIds = availableTableIds,
-                    Category = GetCategory(current)
-                });
+                slots.Add(ClosedSlot(current));
+                continue;
             }
 
-            current = current.AddMinutes(slotIntervalMinutes);
+            DateTime slotEndUtc = slotUtc.AddMinutes(restaurant.DefaultBookingDurationMinutes);
+            List<int> availableTableIds = eligibleTables
+                .Where(t => IsTableFree(t.Id, restaurant, reservations, slotUtc, slotEndUtc))
+                .Select(t => t.Id)
+                .ToList();
+            List<int> availableGroupIds = eligibleGroups
+                .Where(g => IsGroupFree(g, restaurant, reservations, slotUtc, slotEndUtc))
+                .Select(g => g.Id)
+                .ToList();
+
+            slots.Add(new TimeSlotDto
+            {
+                Time = FormatSlotTime(current),
+                IsAvailable = availableTableIds.Count > 0 || availableGroupIds.Count > 0,
+                AvailableTableIds = availableTableIds,
+                AvailableGroupIds = availableGroupIds,
+                Category = GetCategory(current)
+            });
         }
 
         return new AvailabilityResponseDto
@@ -260,9 +81,138 @@ public sealed class AvailabilityService(
         };
     }
 
-    // Category windows are calibrated to North American restaurant data (Toast/Square/Yelp):
-    // Lunch peak is 12–1 PM; 2 PM begins the afternoon dead zone.
-    // Dinner now peaks at 6 PM (22% at 5 PM, 37% at 6 PM, drops sharply after 9 PM).
+    private static AvailabilityResponseDto NoSlots(int restaurantId, DateTime bookingDate) => new()
+    {
+        RestaurantId = restaurantId,
+        Date = bookingDate,
+        Slots = new List<TimeSlotDto>()
+    };
+
+    private static TimeSlotDto ClosedSlot(DateTime local) => new()
+    {
+        Time = FormatSlotTime(local),
+        IsAvailable = false,
+        AvailableTableIds = new List<int>(),
+        Category = GetCategory(local)
+    };
+
+    private static string FormatSlotTime(DateTime local)
+        => local.ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture);
+
+    private static bool IsOpenOn(Restaurant restaurant, int isoDay)
+    {
+        HashSet<int> openDays = IsoDay.ParseList(restaurant.OpenDays);
+        return openDays.Count == 0 || openDays.Contains(isoDay);
+    }
+
+    private static (DateTime Start, DateTime End) ServiceWindowOn(Restaurant restaurant, DateTime localDate, int isoDay)
+    {
+        (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(restaurant, isoDay);
+        if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
+        {
+            (openHour, openMin) = OpeningHourDefaults.OpenAt;
+        }
+        if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
+        {
+            (closeHour, closeMin) = OpeningHourDefaults.CloseAt;
+        }
+
+        DateTime start = localDate.AddHours(openHour).AddMinutes(openMin);
+        DateTime end = localDate.AddHours(closeHour).AddMinutes(closeMin);
+        bool closesAfterMidnight = end <= start;
+        return (start, closesAfterMidnight ? end.AddDays(1) : end);
+    }
+
+    /// <summary>
+    /// A zero or negative stored interval would spin the slot loop forever. Validation keeps
+    /// the column to 15/30/60, so this only ever catches a stale or hand-edited row.
+    /// </summary>
+    private static int SlotInterval(Restaurant restaurant)
+        => restaurant.BookingSlotIntervalMinutes > 0 ? restaurant.BookingSlotIntervalMinutes : 30;
+
+    private static List<Table> EligibleTables(Restaurant restaurant, int seats)
+        => restaurant.Sections
+            ?.SelectMany(s => s.Tables ?? new List<Table>())
+            .Where(t => t != null && restaurant.CanSeat(t.Seats, seats))
+            .ToList() ?? new List<Table>();
+
+    /// <summary>
+    /// Combinable groups are bookable units alongside the individual tables. Member tables
+    /// stay in the eligible set — grouping a table does not stop it being booked on its own —
+    /// so the mutual exclusion between a member and its group is resolved per slot by
+    /// <see cref="UnitReservations"/> rather than by hiding the members here.
+    /// </summary>
+    /// <seealso>AvailabilityServiceTests.GetAvailabilityAsync_StillOffersGroupMembers_Individually</seealso>
+    /// <seealso>AvailabilityServiceTests.GetAvailabilityAsync_RemovesGroupMember_WhenReservedByItsGroupBooking</seealso>
+    private static List<TableGroup> EligibleGroups(Restaurant restaurant, int seats)
+        => (restaurant.Groups ?? Enumerable.Empty<TableGroup>())
+            .Where(g => restaurant.CanSeat(g.CombinedSeats, seats))
+            .ToList();
+
+    private bool IsTableFree(int tableId, Restaurant restaurant, UnitReservations reservations, DateTime slotUtc, DateTime slotEndUtc)
+        => !reservations.IsTableReserved(tableId, slotUtc, slotEndUtc)
+            && !_holdService.IsTableHeld(tableId, slotUtc, durationMinutes: restaurant.DefaultBookingDurationMinutes);
+
+    private bool IsGroupFree(TableGroup group, Restaurant restaurant, UnitReservations reservations, DateTime slotUtc, DateTime slotEndUtc)
+        => !reservations.IsGroupReserved(group, slotUtc, slotEndUtc)
+            && group.Members.All(m => !_holdService.IsTableHeld(m.TableId, slotUtc, durationMinutes: restaurant.DefaultBookingDurationMinutes));
+
+    /// <summary>
+    /// Indexes the day's bookings so each slot can be answered without rescanning them. A
+    /// group booking stores <c>TableId = null</c>, so it is invisible to a table-keyed lookup;
+    /// its members' table ids are resolved up front, or a table reserved by its group's
+    /// booking would be advertised as available.
+    /// </summary>
+    private sealed class UnitReservations
+    {
+        private readonly int _defaultDurationMinutes;
+        private readonly Dictionary<int, List<Booking>> _byTable;
+        private readonly List<Booking> _groupBookings;
+        private readonly List<(int TableId, Booking Booking)> _tablesHeldByGroupBookings;
+
+        public UnitReservations(Restaurant restaurant, IEnumerable<Booking> activeBookings)
+        {
+            _defaultDurationMinutes = restaurant.DefaultBookingDurationMinutes;
+
+            _byTable = activeBookings
+                .Where(b => b.TableId.HasValue)
+                .GroupBy(b => b.TableId!.Value)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            _groupBookings = activeBookings.Where(b => b.TableGroupId.HasValue).ToList();
+
+            Dictionary<int, HashSet<int>> memberTableIdsByGroup = (restaurant.Groups ?? Enumerable.Empty<TableGroup>())
+                .ToDictionary(g => g.Id, g => g.Members.Select(m => m.TableId).ToHashSet());
+
+            _tablesHeldByGroupBookings = _groupBookings
+                .Where(b => memberTableIdsByGroup.ContainsKey(b.TableGroupId!.Value))
+                .SelectMany(b => memberTableIdsByGroup[b.TableGroupId!.Value].Select(id => (id, b)))
+                .ToList();
+        }
+
+        public bool IsTableReserved(int tableId, DateTime slotUtc, DateTime slotEndUtc)
+        {
+            if (_byTable.TryGetValue(tableId, out List<Booking>? tableBookings)
+                && tableBookings.Any(b => Overlaps(b, slotUtc, slotEndUtc)))
+            {
+                return true;
+            }
+
+            return _tablesHeldByGroupBookings.Any(x => x.TableId == tableId && Overlaps(x.Booking, slotUtc, slotEndUtc));
+        }
+
+        public bool IsGroupReserved(TableGroup group, DateTime slotUtc, DateTime slotEndUtc)
+            => _groupBookings.Any(b => b.TableGroupId == group.Id && Overlaps(b, slotUtc, slotEndUtc))
+                || group.Members.Any(m => IsTableReserved(m.TableId, slotUtc, slotEndUtc));
+
+        private bool Overlaps(Booking booking, DateTime slotUtc, DateTime slotEndUtc)
+            => booking.Date < slotEndUtc
+                && (booking.EndTime ?? booking.Date.AddMinutes(_defaultDurationMinutes)) > slotUtc;
+    }
+
+    // Windows are calibrated to North American restaurant data (Toast/Square/Yelp): lunch
+    // peaks 12–1 PM with 2 PM starting the afternoon dead zone, dinner peaks at 6 PM (22% at
+    // 5 PM, 37% at 6 PM) and drops sharply after 9 PM.
     private static string GetCategory(DateTime time)
     {
         TimeSpan t = time.TimeOfDay;
@@ -275,23 +225,5 @@ public sealed class AvailabilityService(
             return "Dinner";
         }
         return "Off-Peak";
-    }
-
-    private static int ParseDayOfWeek(string day)
-    {
-        if (int.TryParse(day, out int dayNum) && dayNum >= 1 && dayNum <= 7)
-            return dayNum;
-
-        return day.ToLowerInvariant() switch
-        {
-            "mon" or "monday" => 1,
-            "tue" or "tues" or "tuesday" => 2,
-            "wed" or "wednesday" => 3,
-            "thu" or "thurs" or "thursday" => 4,
-            "fri" or "friday" => 5,
-            "sat" or "saturday" => 6,
-            "sun" or "sunday" => 7,
-            _ => 0
-        };
     }
 }

--- a/OpenRestoApi/Core/Application/Services/BookingNotificationService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingNotificationService.cs
@@ -224,7 +224,6 @@ public sealed class BookingNotificationService(
             _pushSubscriptionRepository.RemoveRange(stale);
         }
 
-        // Update the notification record with push outcome
         AdminNotification? record = await _notificationRepository.FindByIdAsync(notificationId);
         if (record is not null)
         {

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -30,59 +30,17 @@ public class BookingService(
     private readonly IBookingConfirmationService? _confirmationService = confirmationService;
     private readonly INotificationQueue? _notificationQueue = notificationQueue;
 
-    /// <summary>
-    /// Creates a booking after validating:
-    /// 1. No confirmed booking exists for the same table on the same date.
-    /// 2. No other user holds the table for the same date (the submitter's own hold is excluded).
-    /// If a holdId is provided and valid, it is released after the booking is persisted.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when the table is unavailable.</exception>
     public virtual async Task<BookingDto> CreateBookingAsync(BookingDto bookingDto)
     {
-        // 1. Resolve the restaurant first — its timezone normalizes every check below.
-        Restaurant? restaurant = await _restaurantRepository.GetByIdAsync(bookingDto.RestaurantId);
-        if (restaurant == null)
-        {
-            throw new NotFoundException("Restaurant not found.");
-        }
+        Restaurant restaurant = await _restaurantRepository.GetByIdAsync(bookingDto.RestaurantId)
+            ?? throw new NotFoundException("Restaurant not found.");
 
-        // 2. Normalize date: if Unspecified, treat as restaurant local and convert to UTC
+        // An Unspecified date is the restaurant's local time; every check below runs on UTC.
         DateTime bookingDate = TimeZoneHelper.ConvertLocalToUtc(bookingDto.Date, restaurant.Timezone);
 
-        // 0. Reject bookings in the past (same 5-min tolerance as booking cancellation).
-        if (bookingDate < DateTime.UtcNow.AddMinutes(-Booking.CancellationGraceMinutes))
-        {
-            throw new ConflictException("Cannot create a booking in the past.");
-        }
+        RejectIfClosedToOnlineBookings(restaurant, bookingDate);
+        RejectIfPartySizeOutOfRange(bookingDto.Seats);
 
-        // A pause only closes the sittings inside its window, so this is checked against the
-        // requested time rather than against "now".
-        if (restaurant.IsPausedFor(bookingDate))
-        {
-            throw new ConflictException(PauseHelper.RejectionMessage(restaurant));
-        }
-
-        // Walk-in-only locations (or walk-in-only days) never take online bookings.
-        // Admin-recorded bookings use AdminService.CreateBookingAsync and are unaffected.
-        if (restaurant.IsWalkInOnlyAt(bookingDate))
-        {
-            throw new ConflictException(restaurant.WalkInOnly
-                ? "This location accepts walk-ins only and does not take online bookings."
-                : "This location accepts walk-ins only on the selected day. Please choose another day or just come in.");
-        }
-
-        // Party size guard — defense in depth behind the DTO [Range] annotation. Rejects 0/negative
-        // or absurdly large parties with a clear message; without this, a 0-seat booking on a concrete
-        // table would pass the upper-bound capacity check and persist.
-        if (bookingDto.Seats < BookingLimits.MinSeats || bookingDto.Seats > BookingLimits.MaxSeats)
-        {
-            throw new ValidationException(
-                $"Party size must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.");
-        }
-
-        // A combinable-table group booking (#272) selected explicitly takes precedence: route it
-        // before the TableId/SectionId + auto-assign logic, which assumes a single table. (Auto-assign
-        // that resolves to a group sets TableGroupId too and re-enters this branch below.)
         if (bookingDto.TableGroupId.HasValue && bookingDto.TableId is null)
         {
             return await CreateGroupBookingAsync(bookingDto, restaurant, bookingDate);
@@ -90,10 +48,8 @@ public class BookingService(
 
         if (bookingDto.TableId is null || bookingDto.SectionId is null)
         {
-            // Exactly one of the two is null — that's ambiguous; reject. Both null means
-            // "Any section" auto-assign, which we resolve below before the rest of the
-            // method (which assumes concrete ids).
-            if (bookingDto.TableId is null ^ bookingDto.SectionId is null)
+            bool ambiguousSelection = bookingDto.TableId is null ^ bookingDto.SectionId is null;
+            if (ambiguousSelection)
             {
                 throw new ValidationException("Specify both TableId and SectionId, or neither for auto-assign.");
             }
@@ -101,61 +57,35 @@ public class BookingService(
             await ResolveAutoAssignAsync(bookingDto, restaurant, bookingDate);
         }
 
-        // Auto-assign may have resolved to a group (TableGroupId set, TableId null). Route into the
-        // group path here; the explicit-group case above already returned.
+        // Auto-assign may have landed on a group rather than a table.
         if (bookingDto.TableGroupId.HasValue)
         {
             return await CreateGroupBookingAsync(bookingDto, restaurant, bookingDate);
         }
 
-        // After auto-assign resolution (or an explicit selection) both ids are guaranteed set.
         int tableId = bookingDto.TableId!.Value;
         int sectionId = bookingDto.SectionId!.Value;
 
-        // 1. Check DB for an existing confirmed booking on the same table+date. Group-aware: a table
-        //    is also "booked" when its combinable group (or any sibling member) has a booking for the
-        //    window, since those bookings reserve the same physical tables. A persisted group booking
-        //    stores TableId = null, so the table-only check would miss it — IsUnitBookedOnDateAsync
-        //    resolves the membership and matches it.
         bool alreadyBooked = await _bookingRepository.IsUnitBookedOnDateAsync(
             tableId, tableGroupId: null, bookingDate, restaurant.DefaultBookingDurationMinutes);
-
         if (alreadyBooked)
         {
             throw new ConflictException("This table is already booked for that time.");
         }
 
-        // 2. Check for an active hold by someone else
         bool heldByOther = _holdService.IsTableHeld(
             tableId, bookingDate, excludeHoldId: bookingDto.HoldId,
             durationMinutes: restaurant.DefaultBookingDurationMinutes);
-
         if (heldByOther)
         {
             throw new ConflictException("This table is currently being held by another user. Please try again shortly.");
         }
 
-        // 3. Check for seat capacity
         Table? table = await _tableRepository.GetByIdAsync(tableId);
-        if (table != null && bookingDto.Seats > table.Seats)
-        {
-            throw new ConflictException($"This table only has {table.Seats} seats, but {bookingDto.Seats} guests were requested.");
-        }
+        RejectIfTableCannotSeat(table, restaurant, bookingDto.Seats);
 
-        // 3b. Reject oversized tables when the restaurant caps spare seats. Mirrors the
-        // lower bound above and the AvailabilityService eligible-table filter, so a direct
-        // POST (or an auto-assigned pick that slipped past the candidate filter) can't seat
-        // a small party at a table the restaurant wants held for larger groups.
-        if (table != null && restaurant.MaxTableOversizeSeats.HasValue
-            && table.Seats - bookingDto.Seats > restaurant.MaxTableOversizeSeats.Value)
-        {
-            throw new ConflictException(
-                $"This table has {table.Seats} seats, which is too large for a party of {bookingDto.Seats}.");
-        }
-
-        // 4. Persist the booking
         Booking booking = _mapper.ToEntity(bookingDto);
-        booking.Date = bookingDate; // Use normalized date
+        booking.Date = bookingDate;
         booking.BookingRef = BookingRefFactory.GenerateFor(restaurant);
         booking.EndTime = bookingDate.AddMinutes(restaurant.DefaultBookingDurationMinutes);
         booking.Table = table!;
@@ -164,90 +94,103 @@ public class BookingService(
 
         Booking newBooking = await _bookingRepository.AddAsync(booking);
 
-        // 5. Release the hold now that the booking is confirmed
         if (!string.IsNullOrEmpty(bookingDto.HoldId))
         {
             _holdService.ReleaseHold(bookingDto.HoldId);
         }
 
-        // 6. Admin push notification (fire-and-forget via background queue)
-        if (_notificationQueue != null)
-        {
-            _notificationQueue.EnqueueBookingCreated(newBooking, restaurant.Name);
-            _notificationQueue.EnqueueCapacityCheck(restaurant.Id, restaurant.Name, newBooking.Date);
-        }
-
-        // 7. Send booking confirmation email (best-effort, never fails the booking).
-        // Delegated to BookingConfirmationService — BookingService no longer owns template
-        // building or SMTP orchestration.
-        if (_confirmationService != null)
-        {
-            await _confirmationService.SendConfirmationAsync(newBooking, restaurant);
-        }
+        await AnnounceBookingAsync(newBooking, restaurant);
 
         return _mapper.ToDtoWithGroup(newBooking);
     }
 
     /// <summary>
-    /// Resolves a "Any section" auto-assign booking request: populates
-    /// <paramref name="bookingDto"/>.TableId/SectionId (and HoldId when a fresh hold is placed)
-    /// so the caller's downstream checks and persistence work unchanged. If a valid
-    /// <see cref="BookingDto.HoldId"/> was provided, the held table/section are adopted
-    /// directly; otherwise the candidate pool is built and a new hold is placed atomically
-    /// via <see cref="IHoldService.PlaceAutoHold"/>. Throws <see cref="ConflictException"/>
-    /// when no candidate is free.
+    /// The three ways a location refuses an online booking for a given sitting. Admin-recorded
+    /// bookings go through <c>AdminService.CreateBookingAsync</c> and are deliberately exempt
+    /// from all of them, so staff can still log a walk-in during a pause.
+    /// </summary>
+    /// <seealso>BookingServiceTests.CreateBookingAsync_RejectsBooking_InsideThePauseWindow</seealso>
+    /// <seealso>BookingServiceTests.CreateBookingAsync_AllowsBooking_AfterThePauseWindow</seealso>
+    private static void RejectIfClosedToOnlineBookings(Restaurant restaurant, DateTime bookingDate)
+    {
+        if (bookingDate < DateTime.UtcNow.AddMinutes(-Booking.CancellationGraceMinutes))
+        {
+            throw new ConflictException("Cannot create a booking in the past.");
+        }
+
+        if (restaurant.IsPausedFor(bookingDate))
+        {
+            throw new ConflictException(PauseHelper.RejectionMessage(restaurant));
+        }
+
+        if (restaurant.IsWalkInOnlyAt(bookingDate))
+        {
+            throw new ConflictException(restaurant.WalkInOnly
+                ? "This location accepts walk-ins only and does not take online bookings."
+                : "This location accepts walk-ins only on the selected day. Please choose another day or just come in.");
+        }
+    }
+
+    /// <summary>
+    /// Defence in depth behind the DTO's <c>[Range]</c>: without it a party of zero clears the
+    /// upper-bound capacity check on any table and persists.
+    /// </summary>
+    private static void RejectIfPartySizeOutOfRange(int seats)
+    {
+        if (seats < BookingLimits.MinSeats || seats > BookingLimits.MaxSeats)
+        {
+            throw new ValidationException(
+                $"Party size must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.");
+        }
+    }
+
+    private static void RejectIfTableCannotSeat(Table? table, Restaurant? restaurant, int seats)
+    {
+        if (table == null)
+        {
+            return;
+        }
+
+        if (seats > table.Seats)
+        {
+            throw new ConflictException($"This table only has {table.Seats} seats, but {seats} guests were requested.");
+        }
+
+        if (restaurant?.ExceedsOversizeCap(table.Seats, seats) == true)
+        {
+            throw new ConflictException(
+                $"This table has {table.Seats} seats, which is too large for a party of {seats}.");
+        }
+    }
+
+    /// <summary>Best-effort side effects: neither the push nor the email may fail the booking.</summary>
+    private async Task AnnounceBookingAsync(Booking booking, Restaurant restaurant)
+    {
+        if (_notificationQueue != null)
+        {
+            _notificationQueue.EnqueueBookingCreated(booking, restaurant.Name);
+            _notificationQueue.EnqueueCapacityCheck(restaurant.Id, restaurant.Name, booking.Date);
+        }
+
+        if (_confirmationService != null)
+        {
+            await _confirmationService.SendConfirmationAsync(booking, restaurant);
+        }
+    }
+
+    /// <summary>
+    /// Resolves an "Any section" request by writing concrete ids back onto
+    /// <paramref name="bookingDto"/>, so everything downstream runs unchanged. A hold the caller
+    /// already owns is adopted rather than re-raced; otherwise a fresh one is placed atomically.
+    /// The resulting <see cref="BookingDto.HoldId"/> is always the one to release after persisting.
     /// </summary>
     private async Task ResolveAutoAssignAsync(BookingDto bookingDto, Restaurant restaurant, DateTime bookingDate)
     {
-        // 1. If the caller already holds an auto-assigned table (or group), adopt it. This avoids a
-        //    second race: the hold was placed atomically, so the held unit is "ours" until the booking
-        //    lands or the hold expires.
-        if (!string.IsNullOrEmpty(bookingDto.HoldId))
+        if (await TryAdoptExistingHoldAsync(bookingDto, restaurant, bookingDate))
         {
-            HoldEntry? held = _holdService.GetHold(bookingDto.HoldId);
-            if (held is not null && held.RestaurantId == restaurant.Id)
-            {
-                if (held.IsGroup)
-                {
-                    // Group hold — verify the group is still free of a confirmed booking (group-aware:
-                    // catches the group itself, a member booked individually, or a member reserved by a
-                    // sibling group booking), then adopt.
-                    bool groupBooked = await _bookingRepository.IsUnitBookedOnDateAsync(
-                        tableId: null,
-                        tableGroupId: held.TableGroupId,
-                        bookingDate,
-                        restaurant.DefaultBookingDurationMinutes);
-
-                    if (!groupBooked)
-                    {
-                        bookingDto.TableGroupId = held.TableGroupId;
-                        bookingDto.MemberTableIds = held.Members;
-                        bookingDto.SectionId = held.SectionId;
-                        bookingDto.TableId = null;
-                        return;
-                    }
-                }
-                else
-                {
-                    // The hold is on a specific table — verify it still fits and isn't double-booked
-                    // in the DB (the hold only guards against other in-memory holds). Group-aware: a
-                    // group booking on this table's group would reserve it too. If something changed
-                    // under us, fall through to the candidate search.
-                    bool booked = await _bookingRepository.IsUnitBookedOnDateAsync(
-                        held.TableId, tableGroupId: null, bookingDate, restaurant.DefaultBookingDurationMinutes);
-                    if (!booked)
-                    {
-                        bookingDto.TableId = held.TableId;
-                        bookingDto.SectionId = held.SectionId;
-                        return;
-                    }
-                }
-            }
+            return;
         }
 
-        // 2. No usable hold — build candidates and place a fresh hold atomically. The new
-        // hold id is stashed on the DTO so the existing "release hold after persist" step
-        // at the end of CreateBookingAsync cleans it up.
         IReadOnlyList<TableCandidate> candidates = await _autoAssigner.BuildCandidatesAsync(
             restaurant, bookingDto.Seats, bookingDate);
 
@@ -256,83 +199,99 @@ public class BookingService(
             throw new ConflictException("No tables are available for the requested time and party size.");
         }
 
-        AutoAssignResult? assigned = _holdService.PlaceAutoHold(
+        AutoAssignResult assigned = _holdService.PlaceAutoHold(
             restaurant.Id,
             candidates,
             bookingDate,
             currentHoldId: bookingDto.HoldId,
-            restaurant.DefaultBookingDurationMinutes);
-
-        if (assigned is null)
-        {
-            throw new ConflictException("All suitable tables are currently being held by other users. Please try again shortly.");
-        }
+            restaurant.DefaultBookingDurationMinutes)
+            ?? throw new ConflictException("All suitable tables are currently being held by other users. Please try again shortly.");
 
         if (assigned.IsGroup)
         {
-            // Auto-assign resolved to a combinable group — record the group identity (and clear any
-            // stale TableId) so CreateBookingAsync routes into the group-booking path.
-            bookingDto.TableGroupId = assigned.TableGroupId;
-            bookingDto.MemberTableIds = assigned.Members;
-            bookingDto.SectionId = assigned.SectionId;
-            bookingDto.TableId = null;
+            AssignGroup(bookingDto, assigned.TableGroupId, assigned.Members, assigned.SectionId);
         }
         else
         {
             bookingDto.TableId = assigned.TableId;
             bookingDto.SectionId = assigned.SectionId;
         }
-        bookingDto.HoldId = assigned.HoldId; // ensure the release-at-end step tears it down
+
+        bookingDto.HoldId = assigned.HoldId;
     }
 
     /// <summary>
-    /// Persists a combinable-table group booking (#272). Validates the group exists and belongs to the
-    /// restaurant, the party fits within <see cref="TableGroup.CombinedSeats"/> (and the restaurant's
-    /// optional oversize cap), and that <b>every member table</b> is free of a conflicting confirmed
-    /// booking or another user's hold for the slot. The booking is written with <see cref="Booking.TableGroupId"/>
-    /// set and <see cref="Booking.TableId"/> null — a group booking reserves the group, not one table.
+    /// A hold was placed atomically, so the unit behind it is the caller's until the booking lands
+    /// or the hold expires — adopting it avoids racing for a second one. The hold only guards
+    /// against other in-memory holds though, so the database is still asked whether the unit was
+    /// booked in the meantime; if it was, the caller falls through to a fresh candidate search.
+    /// </summary>
+    private async Task<bool> TryAdoptExistingHoldAsync(BookingDto bookingDto, Restaurant restaurant, DateTime bookingDate)
+    {
+        if (string.IsNullOrEmpty(bookingDto.HoldId))
+        {
+            return false;
+        }
+
+        HoldEntry? held = _holdService.GetHold(bookingDto.HoldId);
+        if (held is null || held.RestaurantId != restaurant.Id)
+        {
+            return false;
+        }
+
+        bool booked = await _bookingRepository.IsUnitBookedOnDateAsync(
+            tableId: held.IsGroup ? null : held.TableId,
+            tableGroupId: held.TableGroupId,
+            bookingDate,
+            restaurant.DefaultBookingDurationMinutes);
+        if (booked)
+        {
+            return false;
+        }
+
+        if (held.IsGroup)
+        {
+            AssignGroup(bookingDto, held.TableGroupId, held.Members, held.SectionId);
+        }
+        else
+        {
+            bookingDto.TableId = held.TableId;
+            bookingDto.SectionId = held.SectionId;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// A group booking reserves the group, not one of its tables, so <c>TableId</c> is cleared —
+    /// leaving a stale one behind would route the request back down the single-table path.
+    /// </summary>
+    private static void AssignGroup(BookingDto bookingDto, int? tableGroupId, IReadOnlyList<int> memberTableIds, int sectionId)
+    {
+        bookingDto.TableGroupId = tableGroupId;
+        bookingDto.MemberTableIds = memberTableIds;
+        bookingDto.SectionId = sectionId;
+        bookingDto.TableId = null;
+    }
+
+    /// <summary>
+    /// Persists a booking against a combinable-table group. The booking is written with
+    /// <see cref="Booking.TableGroupId"/> set and <see cref="Booking.TableId"/> null: it reserves
+    /// the group, not one of its tables.
     /// </summary>
     private async Task<BookingDto> CreateGroupBookingAsync(BookingDto bookingDto, Restaurant restaurant, DateTime bookingDate)
     {
-        TableGroup? group = await _tableGroupRepository.GetByIdWithMembersAsync(bookingDto.TableGroupId!.Value, restaurant.Id);
-        if (group == null)
-        {
-            throw new NotFoundException("The selected table group no longer exists.");
-        }
+        TableGroup group = await _tableGroupRepository.GetByIdWithMembersAsync(bookingDto.TableGroupId!.Value, restaurant.Id)
+            ?? throw new NotFoundException("The selected table group no longer exists.");
 
-        // A group that has lost members (e.g. a member table was deleted) is not a combinable unit
-        // any more and its CombinedSeats no longer describes anything real — refuse rather than seat
-        // a party against phantom capacity.
-        if (group.Members.Count < 2)
-        {
-            throw new ConflictException("These tables can no longer be combined. Please pick another time or table.");
-        }
+        RejectIfGroupCannotSeat(group, restaurant, bookingDto.Seats);
 
-        // Capacity: party must fit within the group's stored combined capacity.
-        if (bookingDto.Seats > group.CombinedSeats)
-        {
-            throw new ConflictException(
-                $"This group only has {group.CombinedSeats} combined seats, but {bookingDto.Seats} guests were requested.");
-        }
-
-        // Oversize cap applies to groups too — don't seat a small party at a much larger combined group.
-        if (restaurant.MaxTableOversizeSeats.HasValue
-            && group.CombinedSeats - bookingDto.Seats > restaurant.MaxTableOversizeSeats.Value)
-        {
-            throw new ConflictException(
-                $"This group has {group.CombinedSeats} combined seats, which is too large for a party of {bookingDto.Seats}.");
-        }
-
-        // Member tables always come from the persisted group, never from the request: MemberTableIds
-        // is part of the public POST body, so trusting it would let a caller submit an empty/partial
-        // list and skip the other-user hold check below for the members it omitted.
+        // Member tables come from the persisted group, never from the request: MemberTableIds is
+        // part of the public POST body, so trusting it would let a caller omit members and skip the
+        // hold check for the ones they left out.
         var memberIds = group.Members.Select(m => m.TableId).ToList();
         int durationMinutes = restaurant.DefaultBookingDurationMinutes;
 
-        // Group-aware conflict check: a single query covers (a) any member already booked on its own,
-        // (b) the group already booked, and (c) a member reserved by a sibling/other group booking
-        // (those bookings store TableId = null, so the old table-only check could not see them and
-        // allowed the same physical table to be double-booked).
         bool groupConflict = await _bookingRepository.IsUnitBookedOnDateAsync(
             tableId: null, tableGroupId: group.Id, bookingDate, durationMinutes);
         if (groupConflict)
@@ -340,20 +299,12 @@ public class BookingService(
             throw new ConflictException("One of the combined tables is already booked for that time.");
         }
 
-        foreach (int memberId in memberIds)
+        bool anyMemberHeldByOther = memberIds.Any(id => _holdService.IsTableHeld(
+            id, bookingDate, excludeHoldId: bookingDto.HoldId, durationMinutes: durationMinutes));
+        if (anyMemberHeldByOther)
         {
-            bool heldByOther = _holdService.IsTableHeld(
-                memberId, bookingDate, excludeHoldId: bookingDto.HoldId, durationMinutes: durationMinutes);
-            if (heldByOther)
-            {
-                throw new ConflictException("One of the combined tables is currently being held by another user. Please try again shortly.");
-            }
+            throw new ConflictException("One of the combined tables is currently being held by another user. Please try again shortly.");
         }
-
-        // Persist the booking against the group. TableId stays null (1:1 with the group); SectionId is
-        // set from the first member so the admin grid can still group by section.
-        int? sectionId = bookingDto.SectionId
-            ?? group.Members.OrderBy(m => m.TableId).FirstOrDefault()?.Table?.SectionId;
 
         Booking booking = _mapper.ToEntity(bookingDto);
         booking.Date = bookingDate;
@@ -361,30 +312,44 @@ public class BookingService(
         booking.EndTime = bookingDate.AddMinutes(durationMinutes);
         booking.TableId = null;
         booking.TableGroupId = group.Id;
-        booking.TableGroup = group; // Attach the loaded group so the DTO/email display enrichment works.
-        booking.SectionId = sectionId;
+        booking.TableGroup = group;
+        // Kept so the admin grid can still group the booking by section.
+        booking.SectionId = bookingDto.SectionId
+            ?? group.Members.OrderBy(m => m.TableId).FirstOrDefault()?.Table?.SectionId;
         booking.Restaurant = restaurant;
 
         Booking newBooking = await _bookingRepository.AddAsync(booking);
 
-        // Release the hold now that the booking is confirmed.
         if (!string.IsNullOrEmpty(bookingDto.HoldId))
         {
             _holdService.ReleaseHold(bookingDto.HoldId);
         }
 
-        if (_notificationQueue != null)
-        {
-            _notificationQueue.EnqueueBookingCreated(newBooking, restaurant.Name);
-            _notificationQueue.EnqueueCapacityCheck(restaurant.Id, restaurant.Name, newBooking.Date);
-        }
-
-        if (_confirmationService != null)
-        {
-            await _confirmationService.SendConfirmationAsync(newBooking, restaurant);
-        }
+        await AnnounceBookingAsync(newBooking, restaurant);
 
         return _mapper.ToDtoWithGroup(newBooking);
+    }
+
+    private static void RejectIfGroupCannotSeat(TableGroup group, Restaurant restaurant, int seats)
+    {
+        // A group that has lost members — a member table was deleted — is no longer a combinable
+        // unit, and its stored CombinedSeats no longer describes anything real.
+        if (group.Members.Count < 2)
+        {
+            throw new ConflictException("These tables can no longer be combined. Please pick another time or table.");
+        }
+
+        if (seats > group.CombinedSeats)
+        {
+            throw new ConflictException(
+                $"This group only has {group.CombinedSeats} combined seats, but {seats} guests were requested.");
+        }
+
+        if (restaurant.ExceedsOversizeCap(group.CombinedSeats, seats))
+        {
+            throw new ConflictException(
+                $"This group has {group.CombinedSeats} combined seats, which is too large for a party of {seats}.");
+        }
     }
 
     public virtual async Task<BookingDto?> GetBookingByIdAsync(int id)
@@ -411,26 +376,12 @@ public class BookingService(
         Booking booking = _mapper.ToEntity(bookingDto);
         Restaurant? restaurant = await _restaurantRepository.GetByIdAsync(booking.RestaurantId);
 
-        // Check for seat capacity if seats are being updated
-        if (bookingDto.Seats > 0)
+        if (bookingDto.Seats > 0 && booking.TableId.HasValue)
         {
-            Table? table = booking.TableId.HasValue ? await _tableRepository.GetByIdAsync(booking.TableId.Value) : null;
-            if (table != null && bookingDto.Seats > table.Seats)
-            {
-                throw new ConflictException($"This table only has {table.Seats} seats, but {bookingDto.Seats} guests were requested.");
-            }
-
-            // Oversize check — mirrors CreateBookingAsync and the availability feed so an edit
-            // can't move a small party onto a table the restaurant caps for larger groups.
-            if (table != null && restaurant?.MaxTableOversizeSeats.HasValue == true
-                && table.Seats - bookingDto.Seats > restaurant.MaxTableOversizeSeats.Value)
-            {
-                throw new ConflictException(
-                    $"This table has {table.Seats} seats, which is too large for a party of {bookingDto.Seats}.");
-            }
+            Table? table = await _tableRepository.GetByIdAsync(booking.TableId.Value);
+            RejectIfTableCannotSeat(table, restaurant, bookingDto.Seats);
         }
 
-        // Ensure EndTime is valid if it's being updated or if Date changed
         if (!booking.EndTime.HasValue || booking.EndTime.Value < booking.Date)
         {
             booking.EndTime = booking.Date.AddMinutes(restaurant?.DefaultBookingDurationMinutes ?? 60);

--- a/OpenRestoApi/Core/Application/Services/OpeningHoursHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/OpeningHoursHelper.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Exceptions;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Core.Application.Services;
@@ -18,10 +19,10 @@ public static class OpeningHoursHelper
     public class DayHours
     {
         [JsonPropertyName("open")]
-        public string Open { get; set; } = "09:00";
+        public string Open { get; set; } = OpeningHourDefaults.Open;
 
         [JsonPropertyName("close")]
-        public string Close { get; set; } = "22:00";
+        public string Close { get; set; } = OpeningHourDefaults.Close;
     }
 
     private static readonly JsonSerializerOptions _jsonOptions = new()

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -64,12 +64,8 @@ public class RestaurantManagementService(
         {
             Name = dto.Name,
             Address = dto.Address,
-            // Honor the hours/days/timezone the client sent (previously dropped here, which
-            // silently reverted every new restaurant to the entity's old 00:00 default and is
-            // what surfaced as "00:00" in the booking time picker). Guard the empty case so a
-            // create call that omits them still lands on the sensible 09:00–22:00 default.
-            OpenTime = string.IsNullOrWhiteSpace(dto.OpenTime) ? "09:00" : dto.OpenTime,
-            CloseTime = string.IsNullOrWhiteSpace(dto.CloseTime) ? "22:00" : dto.CloseTime,
+            OpenTime = string.IsNullOrWhiteSpace(dto.OpenTime) ? OpeningHourDefaults.Open : dto.OpenTime,
+            CloseTime = string.IsNullOrWhiteSpace(dto.CloseTime) ? OpeningHourDefaults.Close : dto.CloseTime,
             OpenDays = string.IsNullOrWhiteSpace(dto.OpenDays) ? "1,2,3,4,5,6,7" : dto.OpenDays,
             Timezone = string.IsNullOrWhiteSpace(dto.Timezone) ? "UTC" : dto.Timezone,
             PhoneNumber = dto.PhoneNumber == null ? null : ContactFields.NormalizePhone(dto.PhoneNumber),
@@ -88,9 +84,8 @@ public class RestaurantManagementService(
             }).ToList()
         };
 
-        // Apply per-day overrides (same helper UpdateAsync uses) so create supports non-uniform
-        // hours too. Runs after the entity is populated so ApplyOpenHours can collapse identical
-        // days back into OpenTime/CloseTime or store the JSON otherwise.
+        // After the entity is populated, so ApplyOpenHours can collapse identical days back
+        // into OpenTime/CloseTime rather than storing redundant JSON.
         if (dto.OpenHours is { Count: > 0 })
         {
             OpeningHoursHelper.ApplyOpenHours(entity, dto.OpenHours);
@@ -197,10 +192,8 @@ public class RestaurantManagementService(
             r.BookingSlotIntervalMinutes = req.BookingSlotIntervalMinutes.Value;
         }
 
-        // MaxTableOversizeSeats is nullable where null means "off/unrestricted". The settings
-        // form always sends the field (number or null), so it's assigned unconditionally —
-        // like Name/Address above — which is the only way selecting "Off" can clear a
-        // previously-set cap. Validate the non-null case is non-negative.
+        // Assigned unconditionally: null means "off", and the settings form always sends the
+        // field, so a conditional write would make selecting "Off" unable to clear a set cap.
         if (req.MaxTableOversizeSeats.HasValue && req.MaxTableOversizeSeats.Value < 0)
         {
             throw new ValidationException("MaxTableOversizeSeats must be zero or greater, or null to disable.");
@@ -293,8 +286,7 @@ public class RestaurantManagementService(
             return false;
         }
 
-        // FK-null affected bookings before removing the section. All entities share the same scoped
-        // DbContext, so the booking mutations + the section removal below flush in a single SaveChanges.
+        // FK-nulled before the section goes: bookings outlive the section they were seated in.
         var tableIds = section.Tables.Select(t => t.Id).ToList();
         List<Booking> affected = await _bookingRepository.GetBySectionOrTablesAsync(sectionId, tableIds);
         foreach (Booking b in affected)
@@ -346,9 +338,7 @@ public class RestaurantManagementService(
         table.Seats = seats;
         await _tableRepository.SaveChangesAsync();
 
-        // Resizing a member table changes what its combinable group can actually hold, so bring the
-        // group's stored CombinedSeats back inside the bounds ValidateCombinedSeats enforces on write.
-        // Runs after the save so the reconcile reads the new capacity, not the pre-edit one.
+        // After the save, so the reconcile reads the new capacity rather than the pre-edit one.
         await ReconcileTableGroupsAsync(restaurantId, Array.Empty<int>());
         await _tableRepository.SaveChangesAsync();
 
@@ -455,7 +445,6 @@ public class RestaurantManagementService(
             return false;
         }
 
-        // FK-null bookings on this table before removing it (same single-save pattern as DeleteSection).
         List<Booking> affected = await _bookingRepository.GetByTableAsync(tableId);
         foreach (Booking b in affected)
             b.TableId = null;
@@ -598,9 +587,7 @@ public class RestaurantManagementService(
             return false;
         }
 
-        // FK-null bookings referencing this group before removing it (same single-save pattern as
-        // DeleteSectionAsync/DeleteTableAsync). Bookings keep their other details; only the group
-        // reference is cleared.
+        // Bookings keep every other detail; only the group reference is cleared.
         List<Booking> affected = await _bookingRepository.GetByTableGroupAsync(groupId);
         foreach (Booking b in affected)
         {

--- a/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
+++ b/OpenRestoApi/Core/Application/Services/TableAutoAssigner.cs
@@ -5,10 +5,9 @@ namespace OpenRestoApi.Core.Application.Services;
 
 /// <summary>
 /// Computes the ordered candidate list for "Any section" auto-assignment, shared by the holds
-/// controller (hold placement) and <see cref="BookingService"/> (booking creation). The actual
-/// atomic pick happens inside <see cref="IHoldService.PlaceAutoHold"/>'s lock — this class only
-/// builds the pre-sorted pool (smallest fitting free table first, with combinable tables
-/// deprioritized within each size so they stay free for the larger parties that need them merged).
+/// controller and <see cref="BookingService"/>. This class only builds the pre-sorted pool; the
+/// atomic pick happens inside <see cref="IHoldService.PlaceAutoHold"/>'s lock, so a candidate
+/// here is a proposal, not a reservation.
 /// </summary>
 public sealed class TableAutoAssigner(
     IBookingRepository bookingRepository,
@@ -18,16 +17,13 @@ public sealed class TableAutoAssigner(
     private readonly IHoldService _holdService = holdService;
 
     /// <summary>
-    /// Returns the restaurant's bookable units — individual tables and combinable groups — that (a)
-    /// have at least <paramref name="seats"/> seats, (b) respect the optional
-    /// <see cref="Restaurant.MaxTableOversizeSeats"/> cap, and (c) have no overlapping confirmed
-    /// booking or active hold at <paramref name="bookingDateUtc"/>. Ordered smallest-fitting-first,
-    /// then by the deprioritization tier requested in #242 — an ungrouped table wins over a
-    /// combinable table of the same size, which in turn wins over a group of that size, so
-    /// combinable tables stay free as long as possible for the larger parties that need them pushed
-    /// together. Table id ties-breaks within a tier for deterministic ordering. Empty when nothing
-    /// fits.
+    /// The restaurant's bookable units that can seat <paramref name="seats"/> (see
+    /// <see cref="Restaurant.CanSeat"/>) and carry no overlapping booking or hold at
+    /// <paramref name="bookingDateUtc"/>, ordered smallest-fitting-first and then by
+    /// <see cref="DeprioritizationTier"/>. Empty when nothing fits.
     /// </summary>
+    /// <seealso>TableAutoAssignerTests.BuildCandidates_PrefersStandaloneTable_WhenPartyFitsBoth</seealso>
+    /// <seealso>TableAutoAssignerTests.BuildCandidates_OffersGroupOnly_WhenNoStandaloneTableFits</seealso>
     public async Task<IReadOnlyList<TableCandidate>> BuildCandidatesAsync(
         Restaurant restaurant,
         int seats,
@@ -38,37 +34,51 @@ public sealed class TableAutoAssigner(
             return Array.Empty<TableCandidate>();
         }
 
-        // Capacity filter first — same predicate as AvailabilityService.GetAvailabilityAsync's
-        // restaurant-wide eligible-table set, so the auto-assign pool matches what the
-        // availability feed advertises per slot. The optional upper bound
-        // (Restaurant.MaxTableOversizeSeats) keeps a small party off a much larger table.
-        var eligible = restaurant.Sections
-            .Where(s => s.Tables != null)
-            .SelectMany(s => s.Tables!.Where(t => t != null).Select(t => (table: t!, sectionId: s.Id)))
-            .Where(x => x.table.Seats >= seats
-                && (restaurant.MaxTableOversizeSeats == null
-                    || x.table.Seats - seats <= restaurant.MaxTableOversizeSeats.Value))
-            .ToList();
-
         int durationMinutes = restaurant.DefaultBookingDurationMinutes;
-
         var free = new List<TableCandidate>();
+        free.AddRange(await FreeTablesAsync(restaurant, seats, bookingDateUtc, durationMinutes));
+        free.AddRange(await FreeGroupsAsync(restaurant, seats, bookingDateUtc, durationMinutes));
 
-        // Membership of a combinable group does NOT remove a table from the individual pool: tables 8
-        // and 9 seat 4 each on their own and must keep taking parties of 4 (#242). It only pushes them
-        // down the ordering below, so they're the last of their size to fill. Mutual exclusion between
-        // a member booking and its group's booking is enforced by IsUnitBookedOnDateAsync/IsTableHeld,
-        // not by hiding the table.
-        var groupedTableIds = (restaurant.Groups ?? Enumerable.Empty<TableGroup>())
+        HashSet<int> groupedTableIds = GroupedTableIds(restaurant);
+
+        return free
+            .OrderBy(c => c.Seats)
+            .ThenBy(c => DeprioritizationTier(c, groupedTableIds))
+            .ThenBy(c => c.TableId)
+            .ToList();
+    }
+
+    /// <summary>
+    /// An ungrouped table beats a combinable table of the same size, which beats a group of that
+    /// size, so combinable tables stay free as long as possible for the larger parties that need
+    /// them pushed together. Grouping a table only moves it down this order — it never leaves the
+    /// individual pool, because a table in a group still seats its own capacity on its own.
+    /// </summary>
+    /// <seealso>TableAutoAssignerTests.BuildCandidates_OffersGroupedTablesIndividually_AfterUngroupedOnesOfTheSameSize</seealso>
+    /// <seealso>TableAutoAssignerTests.BuildCandidates_DeprioritizesGroups_AgainstStandaloneTablesOfEqualCapacity</seealso>
+    private static int DeprioritizationTier(TableCandidate candidate, HashSet<int> groupedTableIds)
+        => candidate.IsGroup ? 2 : groupedTableIds.Contains(candidate.TableId) ? 1 : 0;
+
+    private static HashSet<int> GroupedTableIds(Restaurant restaurant)
+        => (restaurant.Groups ?? Enumerable.Empty<TableGroup>())
             .SelectMany(g => g.Members).Select(m => m.TableId).ToHashSet();
 
-        // Drop tables with an existing confirmed booking overlapping this slot. Done serially
-        // because IsTableBookedOnDateAsync is per-table; the candidate count is small (one
-        // restaurant's tables) and this runs once per auto-assign request before the lock.
+    /// <summary>
+    /// Checked serially because the repository answers one unit at a time. The pool is a single
+    /// restaurant's tables and this runs once per auto-assign request, before the lock.
+    /// </summary>
+    private async Task<List<TableCandidate>> FreeTablesAsync(
+        Restaurant restaurant, int seats, DateTime bookingDateUtc, int durationMinutes)
+    {
+        var free = new List<TableCandidate>();
+
+        IEnumerable<(Table Table, int SectionId)> eligible = restaurant.Sections!
+            .Where(s => s.Tables != null)
+            .SelectMany(s => s.Tables!.Where(t => t != null).Select(t => (Table: t!, SectionId: s.Id)))
+            .Where(x => restaurant.CanSeat(x.Table.Seats, seats));
+
         foreach ((Table table, int sectionId) in eligible)
         {
-            // Group-aware: also blocks when the table is reserved by a group booking (which stores
-            // TableId = null and so is invisible to the table-only check).
             bool booked = await _bookingRepository.IsUnitBookedOnDateAsync(
                 table.Id, tableGroupId: null, bookingDateUtc, durationMinutes);
             if (!booked && !_holdService.IsTableHeld(table.Id, bookingDateUtc, durationMinutes: durationMinutes))
@@ -77,64 +87,47 @@ public sealed class TableAutoAssigner(
             }
         }
 
-        // Combinable groups: capacity check against CombinedSeats, all members must be free.
-        // The oversize cap applies to groups too (#272) — don't seat a party of 2 at an 8-seat
-        // combined group unless the cap allows it.
-        if (restaurant.Groups is { Count: > 0 })
+        return free;
+    }
+
+    private async Task<List<TableCandidate>> FreeGroupsAsync(
+        Restaurant restaurant, int seats, DateTime bookingDateUtc, int durationMinutes)
+    {
+        var free = new List<TableCandidate>();
+        if (restaurant.Groups is not { Count: > 0 })
         {
-            foreach (TableGroup group in restaurant.Groups)
-            {
-                if (group.CombinedSeats < seats) continue;
-                if (restaurant.MaxTableOversizeSeats.HasValue
-                    && group.CombinedSeats - seats > restaurant.MaxTableOversizeSeats.Value)
-                {
-                    continue;
-                }
-
-                var memberIds = group.Members.Select(m => m.TableId).ToList();
-                if (memberIds.Count == 0) continue;
-
-                // Group-aware: a single check catches the group already booked, a member booked
-                // individually, or a member reserved by a sibling group booking.
-                bool groupBooked = await _bookingRepository.IsUnitBookedOnDateAsync(
-                    tableId: null, tableGroupId: group.Id, bookingDateUtc, durationMinutes);
-
-                bool allMembersFreeOfHolds = !groupBooked;
-                if (allMembersFreeOfHolds)
-                {
-                    foreach (int memberId in memberIds)
-                    {
-                        if (_holdService.IsTableHeld(memberId, bookingDateUtc, durationMinutes: durationMinutes))
-                        {
-                            allMembersFreeOfHolds = false;
-                            break;
-                        }
-                    }
-                }
-
-                if (!allMembersFreeOfHolds) continue;
-
-                // Anchor to the first member's id/section so existing callers that read TableId/SectionId
-                // still get a concrete value; the group identity rides on TableGroupId + MemberTableIds.
-                TableGroupMembership anchor = group.Members.OrderBy(m => m.TableId).First();
-                free.Add(new TableCandidate(
-                    anchor.TableId,
-                    anchor.Table?.SectionId ?? 0,
-                    group.CombinedSeats,
-                    IsGroup: true,
-                    TableGroupId: group.Id,
-                    MemberTableIds: memberIds));
-            }
+            return free;
         }
 
-        // Smallest fitting free unit first, then the deprioritization tier (ungrouped table → grouped
-        // table → group), then id for deterministic ordering.
-        int Tier(TableCandidate c) => c.IsGroup ? 2 : groupedTableIds.Contains(c.TableId) ? 1 : 0;
+        foreach (TableGroup group in restaurant.Groups)
+        {
+            if (!restaurant.CanSeat(group.CombinedSeats, seats)) continue;
 
-        return free
-            .OrderBy(c => c.Seats)
-            .ThenBy(Tier)
-            .ThenBy(c => c.TableId)
-            .ToList();
+            var memberIds = group.Members.Select(m => m.TableId).ToList();
+            if (memberIds.Count == 0) continue;
+
+            // One query covers all three ways a group can be taken: the group itself booked, a
+            // member booked individually, or a member reserved by a sibling group's booking.
+            bool groupBooked = await _bookingRepository.IsUnitBookedOnDateAsync(
+                tableId: null, tableGroupId: group.Id, bookingDateUtc, durationMinutes);
+            if (groupBooked) continue;
+
+            bool anyMemberHeld = memberIds.Any(
+                id => _holdService.IsTableHeld(id, bookingDateUtc, durationMinutes: durationMinutes));
+            if (anyMemberHeld) continue;
+
+            // Anchored to the lowest member's id/section so callers reading TableId/SectionId still
+            // get a concrete value; the group identity rides on TableGroupId + MemberTableIds.
+            TableGroupMembership anchor = group.Members.OrderBy(m => m.TableId).First();
+            free.Add(new TableCandidate(
+                anchor.TableId,
+                anchor.Table?.SectionId ?? 0,
+                group.CombinedSeats,
+                IsGroup: true,
+                TableGroupId: group.Id,
+                MemberTableIds: memberIds));
+        }
+
+        return free;
     }
 }

--- a/OpenRestoApi/Core/Application/Services/WalkInHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/WalkInHelper.cs
@@ -14,24 +14,7 @@ namespace OpenRestoApi.Core.Application.Services;
 /// </summary>
 public static class WalkInHelper
 {
-    public static HashSet<int> ParseWalkInDays(string? walkInDays)
-    {
-        var result = new HashSet<int>();
-        if (string.IsNullOrWhiteSpace(walkInDays))
-        {
-            return result;
-        }
-
-        foreach (string part in walkInDays.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            if (int.TryParse(part, out int day) && day >= 1 && day <= 7)
-            {
-                result.Add(day);
-            }
-        }
-
-        return result;
-    }
+    public static HashSet<int> ParseWalkInDays(string? walkInDays) => IsoDay.ParseList(walkInDays);
 
     /// <summary>True when the restaurant does not take bookings on the given ISO day.</summary>
     public static bool IsWalkInOnlyOn(Restaurant restaurant, int isoDay)
@@ -52,13 +35,7 @@ public static class WalkInHelper
         }
 
         DateTime local = TimeZoneHelper.ConvertUtcToLocal(utc, restaurant.Timezone);
-        int isoDay = (int)local.DayOfWeek;
-        if (isoDay == 0)
-        {
-            isoDay = 7; // Sunday: 0 -> 7
-        }
-
-        return days.Contains(isoDay);
+        return days.Contains(IsoDay.Of(local));
     }
 
     /// <summary>

--- a/OpenRestoApi/Core/Application/Utilities/IsoDay.cs
+++ b/OpenRestoApi/Core/Application/Utilities/IsoDay.cs
@@ -1,0 +1,73 @@
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// ISO 8601 day numbers (1=Monday … 7=Sunday), the format every day-list column in the
+/// schema uses — <c>Restaurant.OpenDays</c> and <c>Restaurant.WalkInDays</c> alike.
+/// </summary>
+public static class IsoDay
+{
+    public const int Monday = 1;
+    public const int Sunday = 7;
+
+    /// <summary>
+    /// The ISO day number of <paramref name="local"/>. <see cref="DayOfWeek"/> numbers
+    /// Sunday 0, so it is remapped to 7 rather than silently sorting before Monday.
+    /// </summary>
+    public static int Of(DateTime local)
+    {
+        int dayOfWeek = (int)local.DayOfWeek;
+        return dayOfWeek == 0 ? Sunday : dayOfWeek;
+    }
+
+    /// <summary>
+    /// Parses a comma-separated day list, discarding anything it cannot recognise. Day names
+    /// are accepted alongside the numbers because hand-edited and seeded <c>OpenDays</c>
+    /// values in the wild carry both, and the availability endpoint and
+    /// <c>Restaurant.IsOpenAt</c> have to agree on which days a location is open — a value one
+    /// of them reads as Monday and the other discards shows open slots on a closed day.
+    /// Callers that must reject bad input use their own validating normalizer instead.
+    /// </summary>
+    /// <seealso>IsoDayTests.ParseList_ReadsDayNamesAndNumbers</seealso>
+    /// <seealso>IsoDayTests.ParseList_DiscardsUnrecognisedEntries</seealso>
+    public static HashSet<int> ParseList(string? csv)
+    {
+        var days = new HashSet<int>();
+        if (string.IsNullOrWhiteSpace(csv))
+        {
+            return days;
+        }
+
+        foreach (string part in csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int day = Parse(part);
+            if (day != Unrecognised)
+            {
+                days.Add(day);
+            }
+        }
+
+        return days;
+    }
+
+    private const int Unrecognised = 0;
+
+    private static int Parse(string day)
+    {
+        if (int.TryParse(day, out int number))
+        {
+            return number >= Monday && number <= Sunday ? number : Unrecognised;
+        }
+
+        return day.ToLowerInvariant() switch
+        {
+            "mon" or "monday" => 1,
+            "tue" or "tues" or "tuesday" => 2,
+            "wed" or "wednesday" => 3,
+            "thu" or "thurs" or "thursday" => 4,
+            "fri" or "friday" => 5,
+            "sat" or "saturday" => 6,
+            "sun" or "sunday" => Sunday,
+            _ => Unrecognised
+        };
+    }
+}

--- a/OpenRestoApi/Core/Application/Utilities/OpeningHourDefaults.cs
+++ b/OpenRestoApi/Core/Application/Utilities/OpeningHourDefaults.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// The service window a restaurant falls back to when it has no usable hours of its own.
+/// The entity, the DTOs it maps to, the create path and the unparseable-stored-time
+/// fallbacks in availability all read it from here: a booking time picker built from one
+/// default while the server enforces another offers slots the server then rejects.
+/// <c>"00:00"</c>/<c>"23:59"</c> remain valid stored values for a 24h venue — only the
+/// fallback lives here.
+/// </summary>
+public static class OpeningHourDefaults
+{
+    public const string Open = "09:00";
+    public const string Close = "22:00";
+
+    public static (int Hour, int Minute) OpenAt { get; } = Split(Open);
+    public static (int Hour, int Minute) CloseAt { get; } = Split(Close);
+
+    private static (int Hour, int Minute) Split(string time)
+    {
+        string[] parts = time.Split(':');
+        return (
+            int.Parse(parts[0], CultureInfo.InvariantCulture),
+            int.Parse(parts[1], CultureInfo.InvariantCulture));
+    }
+}

--- a/OpenRestoApi/Core/Domain/Restaurant.cs
+++ b/OpenRestoApi/Core/Domain/Restaurant.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Application.Utilities;
 
@@ -9,13 +8,8 @@ public class Restaurant
     public int Id { get; set; }
     public string Name { get; set; } = null!;
     public string? Address { get; set; }
-    // Defaults mirror RestaurantDto / DayHoursDto / UpdateRestaurantRequest so a restaurant
-    // constructed without explicit hours lands on a sensible 09:00–22:00 service window rather
-    // than 00:00, which previously leaked into the booking time picker (00:00 was the lone
-    // outlier default — every sibling used 09:00). "00:00"/"23:59" remain valid *values* for
-    // a 24h venue; only the default changes.
-    public string OpenTime { get; set; } = "09:00";
-    public string CloseTime { get; set; } = "22:00";
+    public string OpenTime { get; set; } = OpeningHourDefaults.Open;
+    public string CloseTime { get; set; } = OpeningHourDefaults.Close;
 
     /// <summary>
     /// Comma-separated day numbers (ISO 8601: 1=Monday, 7=Sunday).
@@ -36,14 +30,12 @@ public class Restaurant
     /// </summary>
     public string Timezone { get; set; } = "UTC";
 
-    // A restaurant can have multiple sections (e.g., indoor, patio)
     public ICollection<Section> Sections { get; set; } = new List<Section>();
 
-    /// <summary>Combinable-table groups defined for this restaurant (see <see cref="TableGroup"/>).</summary>
     public ICollection<TableGroup> Groups { get; set; } = new List<TableGroup>();
 
     /// <summary>
-    /// If set, new bookings are disabled until this time (UTC).
+    /// If set, sittings that start before this instant (UTC) are closed to new bookings.
     /// </summary>
     public DateTime? BookingsPausedUntil { get; set; }
 
@@ -100,116 +92,119 @@ public class Restaurant
     public int DefaultBookingDurationMinutes { get; set; } = 60;
 
     /// <summary>
-    /// Step, in minutes, between selectable booking start times in
-    /// <see cref="Application.Services.AvailabilityService.GetAvailabilityAsync"/>.
-    /// Decoupled from <see cref="DefaultBookingDurationMinutes"/> so a restaurant can
-    /// offer, say, 90-minute bookings while still letting diners start every 15 minutes.
-    /// Constrained to a small set (15/30/60) server-side; defaults to 30 to preserve the
-    /// pre-setting behaviour (the old hardcoded slot step).
+    /// Step, in minutes, between selectable booking start times. Deliberately independent of
+    /// <see cref="DefaultBookingDurationMinutes"/>, so a restaurant can offer 90-minute
+    /// sittings that still start every 15 minutes. Constrained to 15/30/60 server-side.
     /// </summary>
     public int BookingSlotIntervalMinutes { get; set; } = 30;
 
     /// <summary>
-    /// When set, the largest number of "spare" seats a table may have over the party size
-    /// and still be offered/booked — i.e. a table may be selected when
-    /// <c>table.Seats - partySize &lt;= MaxTableOversizeSeats</c>. Null means unrestricted
-    /// (a 2-top can be seated at a 10-top), preserving the pre-setting behaviour. Applied
-    /// symmetrically in availability, booking creation/update, and auto-assign so the
-    /// customer-facing options always match what the server will accept. Admin-recorded
-    /// walk-in bookings are intentionally exempt.
+    /// When set, the largest number of spare seats a table may carry over the party size and
+    /// still be offered — a table qualifies while
+    /// <c>table.Seats - partySize &lt;= MaxTableOversizeSeats</c>. Null is unrestricted. It has
+    /// to be applied identically in availability, booking creation/update and auto-assign, or
+    /// the customer is offered a table the server will then refuse. Admin-recorded walk-ins
+    /// are intentionally exempt.
     /// </summary>
     public int? MaxTableOversizeSeats { get; set; }
 
     /// <summary>
-    /// Shape of the booking references handed to this location's customers. Defaults to
-    /// <see cref="Domain.BookingRefFormat.AlphaNumeric"/> so existing locations keep the
-    /// word-based format. Only consulted when a reference is minted — changing it leaves
-    /// already-issued references alone.
+    /// True when a bookable unit of <paramref name="unitSeats"/> seats — a table or a
+    /// combinable group — may take a party of <paramref name="partySize"/>: large enough to
+    /// seat them, and not so much larger that <see cref="MaxTableOversizeSeats"/> would rather
+    /// hold it for a bigger group.
+    /// </summary>
+    /// <seealso>RestaurantTests.CanSeat_True_WhenTheUnitIsExactlyAtTheOversizeCap</seealso>
+    /// <seealso>RestaurantTests.CanSeat_False_WhenTheUnitIsOneSeatOverTheCap</seealso>
+    public bool CanSeat(int unitSeats, int partySize)
+        => unitSeats >= partySize && !ExceedsOversizeCap(unitSeats, partySize);
+
+    /// <summary>
+    /// The upper half of <see cref="CanSeat"/>, for the paths that reject a too-small unit
+    /// with their own message and only need the cap. Availability, holds, booking
+    /// creation/update and auto-assign must all answer this identically: a path that is more
+    /// permissive offers the customer a table the next one then refuses.
+    /// </summary>
+    public bool ExceedsOversizeCap(int unitSeats, int partySize)
+        => MaxTableOversizeSeats.HasValue && unitSeats - partySize > MaxTableOversizeSeats.Value;
+
+    /// <summary>
+    /// Shape of the booking references handed to this location's customers. Only consulted
+    /// when a reference is minted, so changing it leaves already-issued references alone.
     /// </summary>
     public BookingRefFormat BookingRefFormat { get; set; } = BookingRefFormat.AlphaNumeric;
 
-    /// <summary>
-    /// True when online bookings are paused: a future <see cref="BookingsPausedUntil"/>
-    /// is set. Consolidates the previously-inlined
-    /// <c>BookingsPausedUntil.HasValue &amp;&amp; BookingsPausedUntil.Value &gt; DateTime.UtcNow</c>
-    /// check that was duplicated across BookingService, HoldPolicyService, AvailabilityService,
-    /// and AdminService.GetOverview.
-    /// </summary>
+    /// <summary>True while a pause is running — for badges and counts, not as a booking gate.</summary>
     public bool IsPaused()
         => BookingsPausedUntil.HasValue && BookingsPausedUntil.Value > DateTime.UtcNow;
 
     /// <summary>
-    /// True when a sitting starting at <paramref name="bookingUtc"/> falls inside the active
-    /// pause window. Pausing is a "stop seating new arrivals for the next X hours" switch, so
-    /// it blocks the sittings inside that window only — next Saturday stays bookable while
-    /// tonight's service is paused.
+    /// The booking gate: true when a sitting starting at <paramref name="bookingUtc"/> falls
+    /// inside the active pause window. Pausing means "stop seating new arrivals for the next
+    /// X hours", so next Saturday stays bookable while tonight's service is paused.
     /// </summary>
+    /// <seealso>RestaurantTests.IsPausedFor_True_WhenTheSittingStartsInsideThePauseWindow</seealso>
+    /// <seealso>RestaurantTests.IsPausedFor_False_WhenTheSittingStartsAfterThePauseWindow</seealso>
     public bool IsPausedFor(DateTime bookingUtc)
         => IsPaused() && bookingUtc < BookingsPausedUntil!.Value;
 
-    /// <summary>
-    /// True when the restaurant does not take online bookings on the local day of
-    /// <paramref name="utc"/> — either globally (<see cref="WalkInOnly"/>) or because the
-    /// resolved local ISO day is in <see cref="WalkInDays"/>. Delegates to
-    /// <see cref="WalkInHelper.IsWalkInOnlyAt"/> for the timezone + ISO-day resolution.
-    /// </summary>
     public bool IsWalkInOnlyAt(DateTime utc)
         => WalkInHelper.IsWalkInOnlyAt(this, utc);
 
     /// <summary>
-    /// True when the restaurant is open at the given UTC instant. Resolves the local time
-    /// via <see cref="Timezone"/>, checks <see cref="OpenDays"/> membership, and consults
-    /// the per-day opening hours (with past-midnight wrap and 24h handling). Handles an
-    /// unparseable <see cref="Timezone"/> by falling back to UTC. Mirrors the logic
-    /// previously inlined as <c>HoldPolicyService.IsTimeWithinOpeningHours</c>.
+    /// True when the restaurant is open at the given UTC instant, resolved through
+    /// <see cref="Timezone"/> — which falls back to UTC when it is not a known IANA id.
     /// </summary>
+    /// <seealso>RestaurantTests.IsOpenAt_True_ForOvernightWindow_AfterMidnightClose</seealso>
+    /// <seealso>RestaurantTests.IsOpenAt_False_ForOvernightWindow_OutsideBothSegments</seealso>
     public bool IsOpenAt(DateTime utc)
     {
         DateTime localTime = TimeZoneHelper.ConvertUtcToLocal(utc, Timezone);
+        int isoDay = IsoDay.Of(localTime);
 
-        int isoDay = (int)localTime.DayOfWeek;
-        if (isoDay == 0)
+        if (!IsOpenOn(isoDay))
         {
-            isoDay = 7; // Sunday: 0 -> 7
+            return false;
         }
 
-        // Check OpenDays
-        if (!string.IsNullOrEmpty(OpenDays))
-        {
-            var openDaysList = OpenDays.Split(',').Select(s => s.Trim());
-            if (!openDaysList.Contains(isoDay.ToString(CultureInfo.InvariantCulture)))
-            {
-                return false;
-            }
-        }
+        (TimeSpan open, TimeSpan close) = ServiceWindowOn(isoDay);
+        return Covers(open, close, localTime.TimeOfDay);
+    }
 
+    private bool IsOpenOn(int isoDay)
+    {
+        HashSet<int> openDays = IsoDay.ParseList(OpenDays);
+        return openDays.Count == 0 || openDays.Contains(isoDay);
+    }
+
+    private (TimeSpan Open, TimeSpan Close) ServiceWindowOn(int isoDay)
+    {
         (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(this, isoDay);
+
         if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
         {
-            openHour = 9; openMin = 0;
+            (openHour, openMin) = OpeningHourDefaults.OpenAt;
         }
+
         if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
         {
-            closeHour = 22; closeMin = 0;
+            (closeHour, closeMin) = OpeningHourDefaults.CloseAt;
         }
 
-        TimeSpan open = new TimeSpan(openHour, openMin, 0);
-        TimeSpan close = new TimeSpan(closeHour, closeMin, 0);
-        TimeSpan current = localTime.TimeOfDay;
+        return (new TimeSpan(openHour, openMin, 0), new TimeSpan(closeHour, closeMin, 0));
+    }
 
-        if (close > open)
+    private static bool Covers(TimeSpan open, TimeSpan close, TimeSpan timeOfDay)
+    {
+        bool openAllDay = open == close;
+        if (openAllDay)
         {
-            return current >= open && current < close;
-        }
-        else if (close < open)
-        {
-            // Closes after midnight (e.g. 18:00 to 02:00)
-            return current >= open || current < close;
-        }
-        else
-        {
-            // close == open usually means 24h
             return true;
         }
+
+        bool closesAfterMidnight = close < open;
+        return closesAfterMidnight
+            ? timeOfDay >= open || timeOfDay < close
+            : timeOfDay >= open && timeOfDay < close;
     }
 }

--- a/OpenRestoApi/Extensions/DatabaseExtensions.cs
+++ b/OpenRestoApi/Extensions/DatabaseExtensions.cs
@@ -321,7 +321,7 @@ public static partial class DatabaseExtensions
             LogConnectionString(logger, connectionString);
             LogCurrentUser(logger, Environment.UserName);
 
-            // Ensure the DB directory exists (needed for Docker volume mounts)
+            // Docker volume mounts hand us the mount point, not the path inside it.
             string dbFile = connectionString;
             if (connectionString.Contains(';'))
             {

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
@@ -93,8 +93,8 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
             DateTime newEnd = newStart.AddMinutes(durationMinutes);
             DateTime thresholdStart = newStart.AddMinutes(-durationMinutes); // For legacy bookings without EndTime
 
-            // Check if any existing booking's time window overlaps the new one
-            // Condition: (ExistingStart < NewEnd) AND (ExistingEnd > NewStart)
+            // Half-open overlap: existing starts before the new window ends, and ends after it
+            // begins. A booking that ends exactly when this one starts is not a conflict.
             return await _db.Bookings.AnyAsync(b =>
                 b.TableId == tableId &&
                 !b.IsCancelled &&

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -1,7 +1,5 @@
 import { get, post, patch, del, put, buildUrl } from "./client";
 
-// ---------- Types ----------
-
 export interface AdminOverviewDto {
   totalRestaurants: number;
   totalBookings: number;
@@ -122,8 +120,6 @@ export async function getAdminOverview(): Promise<AdminOverviewDto | null> {
     return null;
   }
 }
-
-// ---------- Bookings ----------
 
 export type BookingStatusFilter = "active" | "past" | "cancelled" | "all";
 
@@ -579,8 +575,6 @@ export async function deleteHeroImage(): Promise<boolean> {
   }
 }
 
-// ---------- Highlights ----------
-
 export interface AdminHighlightDto {
   id: number;
   title: string;
@@ -667,8 +661,6 @@ export async function adminDeleteHighlight(id: number): Promise<boolean> {
     return false;
   }
 }
-
-// ---------- Social Links ----------
 
 export interface AdminSocialLinkDto {
   id: number;

--- a/openresto-frontend/api/auth.ts
+++ b/openresto-frontend/api/auth.ts
@@ -19,8 +19,6 @@ export async function logout(): Promise<void> {
   }
 }
 
-// ---------- Session check ----------
-
 /**
  * The signed-in admin, as returned by `GET /admin/auth/me`. Treat unknown extra fields as
  * additive — the server may grow this shape (permissions, scoping) without a client change.
@@ -42,8 +40,6 @@ export async function checkSession(): Promise<AuthUser | "rate-limited" | null> 
     return null;
   }
 }
-
-// ---------- Password management ----------
 
 export async function changePassword(
   currentPassword: string,
@@ -74,8 +70,6 @@ export async function changeEmail(
     return { ok: false, message: "Network error." };
   }
 }
-
-// ---------- PVQ (Personal Verification Questions) ----------
 
 export interface PvqStatus {
   isConfigured: boolean;

--- a/openresto-frontend/api/notifications.ts
+++ b/openresto-frontend/api/notifications.ts
@@ -1,7 +1,5 @@
 import { get, post, patch, del } from "./client";
 
-// ---------- Types ----------
-
 export type NotificationType = "BookingCreated" | "BookingCancelled" | "RestaurantNearlyFull";
 
 export interface AdminNotificationDto {
@@ -30,8 +28,6 @@ export interface PushSubscribeRequest {
   p256dh: string;
   auth: string;
 }
-
-// ---------- Functions ----------
 
 export async function getNotifications(params: {
   restaurantId?: number;

--- a/openresto-frontend/components/admin/settings/TableRow.tsx
+++ b/openresto-frontend/components/admin/settings/TableRow.tsx
@@ -26,6 +26,14 @@ export interface TableRowGroupContext {
   combinedSeats: number;
 }
 
+/**
+ * One table in the admin's section list, in four mutually exclusive modes: selection (picking
+ * tables to combine), delete confirmation, edit, and the default row.
+ *
+ * Destroying a table is two taps, and the confirmation replaces the row in place rather than
+ * opening a centre-screen modal, so the consequence it names — the count of future bookings that
+ * would lose their table reference — is read next to the table it applies to.
+ */
 export function TableRow({
   table,
   restaurantId,
@@ -68,11 +76,8 @@ export function TableRow({
   const [draftName, setDraftName] = useState(table.name ?? "");
   const [draftSeats, setDraftSeats] = useState(table.seats);
   const [saving, setSaving] = useState(false);
-  // Two-step delete friction (#270). `Delete…` reveals
-  // an inline confirmation (not a center-screen modal) that names the consequence and requires a
-  // second explicit tap to destroy. `impact` is the best-effort count of future bookings that would
-  // lose their table reference; null = still loading or unavailable → generic copy fallback.
   const [deleteStep, setDeleteStep] = useState<"idle" | "confirm">("idle");
+  /** Null while loading, and when the read fails — the confirmation falls back to generic copy. */
   const [impact, setImpact] = useState<number | null>(null);
   const [impactLoading, setImpactLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -81,8 +86,8 @@ export function TableRow({
   const { primaryColor } = useAppTheme();
 
   const tableName = table.name ?? `Table ${table.id}`;
-  // Surface tokens shared with SocialLinkRow / HighlightsCard so the table tiles are visually
-  // indistinguishable from the rest of the settings cards.
+  // Shared with SocialLinkRow / HighlightsCard so the table tiles are indistinguishable from the
+  // rest of the settings cards.
   const surface2 = isDark ? "#252729" : "#f9fafb";
   const cardBg = isDark ? "#1e2022" : "#ffffff";
 
@@ -91,8 +96,7 @@ export function TableRow({
     setImpact(null);
     setImpactLoading(true);
     const result = await fetchTableDeleteImpact(restaurantId, sectionId, table.id);
-    // Best-effort: a failure/404 leaves impact at null and the UI falls back to generic copy
-    // rather than blocking the destructive action.
+    // Best-effort: a failed read must not block the destructive action behind a count.
     setImpact(result?.bookings ?? null);
     setImpactLoading(false);
   };
@@ -110,8 +114,7 @@ export function TableRow({
     if (success) onDeleted();
   };
 
-  // Selection mode (#273): render a checkable tile for combining tables into a group. Already-grouped
-  // tables (disabledInSelection) are shown disabled with their chip; standalone tiles are selectable.
+  // A table already in a group keeps its chip but is locked: a table belongs to one group.
   if (selectionMode) {
     const isGrouped = !!group || disabledInSelection;
     return (
@@ -163,8 +166,6 @@ export function TableRow({
     );
   }
 
-  // Inline two-step delete confirmation (#270) — a tinted tile that replaces the row so the
-  // consequence is visible in context. Cancel returns to the row without destroying.
   if (!editing && deleteStep === "confirm") {
     return (
       <View
@@ -223,9 +224,6 @@ export function TableRow({
     );
   }
 
-  // Default row — a surface tile (matches SocialLinkRow / HighlightsCard): leading icon square,
-  // name + seats subtitle, trailing cluster of icon actions. Grouped rows append a remove-on-the-chip
-  // and skip the combine action.
   if (!editing) {
     return (
       <View style={[settingsStyles.tile, { backgroundColor: surface2, borderColor }]}>
@@ -308,7 +306,6 @@ export function TableRow({
     );
   }
 
-  // Edit mode — full-width inline form (kept intact; Save/Cancel are text buttons by design).
   return (
     <View
       style={[

--- a/openresto-frontend/components/booking/BookingForm.tsx
+++ b/openresto-frontend/components/booking/BookingForm.tsx
@@ -188,10 +188,10 @@ export default function BookingForm({
     value: i + 1,
   }));
 
-  // Hours for the selected date's day of week (falls back to uniform hours).
-  // For after-midnight closing (close <= open) let the picker run to end of day.
   const selectedDayHours = getHoursForDate(restaurant, date || getNowInTimezone(timezone).dateStr);
   const minPickerTime = selectedDayHours.open;
+  // A close time at or before the open time is a past-midnight service, so the picker runs to
+  // the end of the day rather than to a close that reads as earlier than the open.
   const maxPickerTime =
     selectedDayHours.close <= selectedDayHours.open ? "23:45" : selectedDayHours.close;
 
@@ -204,6 +204,17 @@ export default function BookingForm({
     isValidEmail(customerEmail) &&
     holdStatus === "held" &&
     !bookingBlocked;
+
+  /**
+   * Which seating unit the booking reserves. Null table and section ids route the create call
+   * into auto-assign, where the server adopts whatever the hold already reserved; a group id
+   * routes it into the group branch. The three are mutually exclusive by construction.
+   */
+  const seatingPayload = () => {
+    if (tableGroupId) return { tableId: null, sectionId: null, tableGroupId };
+    if (isAutoAssign) return { tableId: null, sectionId: null, tableGroupId: null };
+    return { tableId: tableId ?? null, sectionId, tableGroupId: null };
+  };
 
   const handleSubmit = async () => {
     if (!isValid || submitting) return;
@@ -222,13 +233,7 @@ export default function BookingForm({
         customerEmail,
         customerName,
         seats,
-        // For "Any section", defer table selection to the server (null ids trigger auto-assign
-        // on the booking create path; the server will adopt the held table from the hold id).
-        // For a combinable group selection, send the group id + null table so the booking-create
-        // path routes into the group-booking branch.
-        tableId: isAutoAssign || tableGroupId ? null : (tableId ?? null),
-        sectionId: isAutoAssign || tableGroupId ? null : sectionId,
-        tableGroupId: tableGroupId ?? null,
+        ...seatingPayload(),
         date,
         time,
         holdId,

--- a/openresto-frontend/components/booking/useBookingSeating.ts
+++ b/openresto-frontend/components/booking/useBookingSeating.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { RestaurantDto, TableDto } from "@/api/restaurants";
 import type { TimeSlotDto } from "@/api/availability";
 import { groupDropdownLabel, groupedTableIds } from "@/utils/tableGroups";
+import { seatsAtLeast } from "@/utils/seating";
 
 export const ANY_SECTION_ID = 0;
 
@@ -33,36 +34,30 @@ export interface UseBookingSeatingArgs {
 export function useBookingSeating({ restaurant, seats, currentSlot }: UseBookingSeatingArgs) {
   const [sectionId, setSectionId] = useState<number>(ANY_SECTION_ID);
   const [tableId, setTableId] = useState<number | undefined>();
-  // Combinable-group selection (#274): when set, the diner picked a combined-table group from the
-  // dropdown instead of a single table. Mutually exclusive with tableId in the submit payload.
+  /** Mutually exclusive with `tableId` in the submit payload: a booking reserves one or the other. */
   const [tableGroupId, setTableGroupId] = useState<number | undefined>();
 
   const allTables = restaurant.sections.flatMap((s) => s.tables);
   const allGroups = restaurant.groups ?? [];
-  // Tables flagged combinable. They stay individually bookable (#242) — this only deprioritizes
-  // them in the suggested-table pick below.
   const groupedTableIdSet = groupedTableIds(allGroups);
 
-  // Largest capacity at this location — the best single table OR the best combinable group (#274).
-  // Parties above this can't be seated even with pushed-together tables and must contact the
-  // restaurant directly. Computed client-side from the nested restaurant payload — no extra fetch.
+  // Parties above the best single table *or* the best combinable group can't be seated even with
+  // tables pushed together, and have to contact the restaurant directly.
   const maxSingleTableSeats = allTables.length > 0 ? Math.max(...allTables.map((t) => t.seats)) : 0;
   const maxGroupSeats =
     allGroups.length > 0 ? Math.max(...allGroups.map((g) => g.combinedSeats)) : 0;
   const maxTableCapacity = Math.max(maxSingleTableSeats, maxGroupSeats);
   const partyTooLarge = maxTableCapacity > 0 && seats > maxTableCapacity;
 
-  // "Any section" is the default option (value 0); concrete sections follow. When selected,
-  // the form hides the table dropdown and lets the server pick the best available table.
   const sectionOptions = [
     { label: "Any section", value: ANY_SECTION_ID },
     ...restaurant.sections.map((s) => ({ label: s.name, value: s.id })),
   ];
   const isAutoAssign = sectionId === ANY_SECTION_ID;
   const tablesInSection = restaurant.sections.find((s) => s.id === sectionId)?.tables ?? allTables;
-  // Groups belong to the picked section only when *every* member sits in it — booking a group is
-  // booking all its tables, so one member elsewhere means the party would be split across sections.
-  // TableDto carries no sectionId, so membership is resolved through the section's own table ids.
+  // A group belongs to the picked section only when *every* member sits in it: booking a group
+  // books all its tables, so one member elsewhere would split the party across sections. TableDto
+  // carries no sectionId, hence resolving membership through the section's own table ids.
   const sectionTableIds = new Set(tablesInSection.map((t) => t.id));
   const groupsInSection = isAutoAssign
     ? allGroups
@@ -75,21 +70,13 @@ export function useBookingSeating({ restaurant, seats, currentSlot }: UseBooking
 
   function bestTableFor(seatCount: number, availableIds?: number[], candidateTables?: TableDto[]) {
     const pool = candidateTables ?? allTables;
-    // Lower bound: table must seat the party. Upper bound: when the restaurant caps spare
-    // seats, drop tables too large for the group. Mirrors the server-side eligible-table
-    // filter (AvailabilityService) so the auto-suggested pick is always one the API accepts.
-    let eligible = pool.filter(
-      (t) =>
-        t.seats >= seatCount &&
-        (restaurant.maxTableOversizeSeats == null ||
-          t.seats <= seatCount + restaurant.maxTableOversizeSeats)
-    );
+    let eligible = seatsAtLeast(pool, seatCount, restaurant.maxTableOversizeSeats, (t) => t.seats);
     if (availableIds && availableIds.length > 0) {
       eligible = eligible.filter((t) => availableIds.includes(t.id));
     }
-    // Smallest fitting table, but a combinable table loses to an ungrouped one of the same size —
-    // the same deprioritization the server applies when auto-assigning, so the suggested default
-    // leaves the mergeable tables free for the parties that need them pushed together.
+    // Smallest fitting table, and a combinable table loses to an ungrouped one of the same size —
+    // the deprioritization the server applies when auto-assigning, so the suggested default leaves
+    // mergeable tables free for the parties that need them pushed together.
     eligible.sort((a, b) => {
       if (a.seats !== b.seats) return a.seats - b.seats;
       return Number(groupedTableIdSet.has(a.id)) - Number(groupedTableIdSet.has(b.id));
@@ -97,7 +84,6 @@ export function useBookingSeating({ restaurant, seats, currentSlot }: UseBooking
     return eligible[0]?.id ?? pool[0]?.id;
   }
 
-  // Auto-assign mode: the server picks the table, so no pre-selection here.
   useEffect(() => {
     if (isAutoAssign) {
       if (tableId !== undefined) setTableId(undefined);
@@ -132,31 +118,21 @@ export function useBookingSeating({ restaurant, seats, currentSlot }: UseBooking
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sectionId]);
 
-  const eligibleTables = tablesInSection
-    .filter(
-      (t) =>
-        t.seats >= seats &&
-        (restaurant.maxTableOversizeSeats == null ||
-          t.seats <= seats + restaurant.maxTableOversizeSeats)
-    )
-    .filter((t) => {
-      if (currentSlot) {
-        return availableTableIds.includes(t.id);
-      }
-      return true;
-    })
+  const eligibleTables = seatsAtLeast(
+    tablesInSection,
+    seats,
+    restaurant.maxTableOversizeSeats,
+    (t) => t.seats
+  )
+    .filter((t) => (currentSlot ? availableTableIds.includes(t.id) : true))
     .sort((a, b) => a.seats - b.seats);
 
-  // Combinable groups (#274): a group is selectable when it sits in the picked section, its combined
-  // capacity fits the party, it respects the optional oversize cap, and (when availability data is
-  // present) the group's id is in the slot's availableGroupIds.
-  const eligibleGroups = groupsInSection
-    .filter(
-      (g) =>
-        g.combinedSeats >= seats &&
-        (restaurant.maxTableOversizeSeats == null ||
-          g.combinedSeats <= seats + restaurant.maxTableOversizeSeats)
-    )
+  const eligibleGroups = seatsAtLeast(
+    groupsInSection,
+    seats,
+    restaurant.maxTableOversizeSeats,
+    (g) => g.combinedSeats
+  )
     .filter((g) => (currentSlot ? availableGroupIds.includes(g.id) : true))
     .sort((a, b) => a.combinedSeats - b.combinedSeats);
 

--- a/openresto-frontend/components/booking/useTableHold.ts
+++ b/openresto-frontend/components/booking/useTableHold.ts
@@ -82,6 +82,26 @@ export function useTableHold({
 
   const lastAppliedParams = useRef<string>("");
 
+  /**
+   * The three shapes a hold request comes in. A group hold names the group and lets the server
+   * resolve its members; auto-assign names nothing and lets the server pick; an explicit pick
+   * names the table and resolves its own section, because the caller only tracks the table id.
+   */
+  function holdTarget() {
+    if (tableGroupId) {
+      return { tableId: null, sectionId: null, tableGroupId, seats };
+    }
+    if (autoAssign) {
+      return { tableId: null, sectionId: null, tableGroupId: undefined, seats };
+    }
+    return {
+      tableId: tableId!,
+      sectionId: sections.find((s) => s.tables.some((t) => t.id === tableId))?.id ?? 0,
+      tableGroupId: undefined,
+      seats: undefined,
+    };
+  }
+
   function clearCountdown() {
     if (countdownTimer.current) {
       clearInterval(countdownTimer.current);
@@ -121,12 +141,9 @@ export function useTableHold({
     clearCountdown();
   }
 
-  // Debounced hold trigger
   useEffect(() => {
-    // Auto-assign fires without a table; explicit mode requires a tableId; a group hold requires a
-    // tableGroupId.
-    const hasTableForHold = autoAssign || (!!tableId && tableId > 0) || !!tableGroupId;
-    if (!enabled || !hasTableForHold || !date || !time || !isValidEmail(email)) {
+    const hasHoldableUnit = autoAssign || (!!tableId && tableId > 0) || !!tableGroupId;
+    if (!enabled || !hasHoldableUnit || !date || !time || !isValidEmail(email)) {
       if (debounceTimer.current) {
         clearTimeout(debounceTimer.current);
       }
@@ -150,41 +167,30 @@ export function useTableHold({
       const previousHoldId = currentHoldId.current;
       lastAppliedParams.current = paramsKey;
 
-      // Send naive ISO string (no 'Z' or offset) so backend can interpret as restaurant-local
+      // Naive ISO — no 'Z', no offset — so the server reads it as restaurant-local.
       const naiveIsoDate = `${date}T${time}:00`;
 
       const result = await createHold({
         restaurantId,
-        // A group hold sends tableGroupId + seats (null table/section); auto-assign sends null
-        // table/section + seats; explicit selection resolves the section from the tableId.
-        tableId: tableGroupId ? null : autoAssign ? null : tableId!,
-        sectionId: tableGroupId
-          ? null
-          : autoAssign
-            ? null
-            : (sections.find((s) => s.tables.some((t) => t.id === tableId))?.id ?? 0),
-        tableGroupId: tableGroupId ?? undefined,
-        seats: autoAssign || tableGroupId ? seats : undefined,
+        ...holdTarget(),
         date: naiveIsoDate,
         currentHoldId: previousHoldId ?? undefined,
       });
 
       if (result.ok) {
-        // Backend atomically released previousHoldId and placed the new hold
+        // The server released previousHoldId and placed this one in the same call.
         currentHoldId.current = result.hold.holdId;
         setHoldId(result.hold.holdId);
         setHold(result.hold);
         setHoldMessage(null);
-        // For auto-assigned/group holds, capture the server-resolved ids so the form can submit
-        // them with the booking (the booking create then "adopts" the held unit).
+        // The booking submit sends these back so the server adopts the held unit rather than
+        // racing for a second one.
         setResolvedTableId(result.hold.tableId ?? null);
         setResolvedSectionId(result.hold.sectionId ?? null);
         setResolvedGroupId(result.hold.tableGroupId ?? null);
         setHoldStatus("held");
         startCountdown(result.hold.expiresAt);
       } else {
-        // Hold rejected (already-held, past time, paused, closed, walk-in).
-        // Release our previous hold and surface the backend's reason.
         if (previousHoldId) releaseHold(previousHoldId);
         currentHoldId.current = null;
         setHoldId(null);
@@ -206,7 +212,6 @@ export function useTableHold({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tableId, date, time, email, autoAssign, seats, tableGroupId, enabled]);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (debounceTimer.current) {

--- a/openresto-frontend/tests/utils/seating.test.ts
+++ b/openresto-frontend/tests/utils/seating.test.ts
@@ -1,0 +1,46 @@
+import { canSeat, seatsAtLeast } from "@/utils/seating";
+
+describe("canSeat", () => {
+  // The pair is the point: the cap is a boundary, and only testing one side of it lets the
+  // client drift off the server's rule without anything failing.
+  it("accepts a unit exactly at the oversize cap", () => {
+    expect(canSeat(6, 4, 2)).toBe(true);
+  });
+
+  it("rejects a unit one seat over the cap", () => {
+    expect(canSeat(7, 4, 2)).toBe(false);
+  });
+
+  it("rejects a unit smaller than the party", () => {
+    expect(canSeat(2, 4, null)).toBe(false);
+  });
+
+  it("accepts a unit of any size when no cap is set", () => {
+    expect(canSeat(10, 2, null)).toBe(true);
+    expect(canSeat(10, 2, undefined)).toBe(true);
+  });
+
+  it("accepts an exact fit under a cap of zero", () => {
+    expect(canSeat(4, 4, 0)).toBe(true);
+    expect(canSeat(5, 4, 0)).toBe(false);
+  });
+});
+
+describe("seatsAtLeast", () => {
+  const tables = [
+    { id: 1, seats: 2 },
+    { id: 2, seats: 4 },
+    { id: 3, seats: 6 },
+    { id: 4, seats: 8 },
+  ];
+
+  it("keeps only the units the party fits into, within the cap", () => {
+    const eligible = seatsAtLeast(tables, 4, 2, (t) => t.seats);
+    expect(eligible.map((t) => t.id)).toEqual([2, 3]);
+  });
+
+  it("keeps every large-enough unit when no cap is set", () => {
+    const eligible = seatsAtLeast(tables, 4, null, (t) => t.seats);
+    expect(eligible.map((t) => t.id)).toEqual([2, 3, 4]);
+  });
+});

--- a/openresto-frontend/utils/seating.ts
+++ b/openresto-frontend/utils/seating.ts
@@ -1,0 +1,26 @@
+/**
+ * Which bookable units can take a party — the client's copy of the server's `Restaurant.CanSeat`.
+ * Every dropdown, suggested pick and eligibility list runs through this, because a unit offered
+ * here that the API then rejects reads to the diner as a broken booking form rather than as a
+ * capacity rule.
+ *
+ * @see [seating.test.ts](../tests/utils/seating.test.ts) — pins the boundary on both sides of the
+ * oversize cap, and that no cap means no upper bound.
+ */
+
+/** A location's optional cap on spare seats over the party size. Null means unrestricted. */
+export type OversizeCap = number | null | undefined;
+
+export function canSeat(unitSeats: number, partySize: number, cap: OversizeCap): boolean {
+  if (unitSeats < partySize) return false;
+  return cap == null || unitSeats - partySize <= cap;
+}
+
+export function seatsAtLeast<T>(
+  units: T[],
+  partySize: number,
+  cap: OversizeCap,
+  capacityOf: (unit: T) => number
+): T[] {
+  return units.filter((unit) => canSeat(capacityOf(unit), partySize, cap));
+}

--- a/openresto-frontend/utils/walkIn.ts
+++ b/openresto-frontend/utils/walkIn.ts
@@ -45,24 +45,33 @@ export function isWalkInOnlyOnDate(restaurant: WalkInSource, date: string): bool
   return isWalkInOnlyOnDay(restaurant, getIsoDayFromDateString(date));
 }
 
-/** Human summary of the walk-in days, e.g. "Saturdays and Sundays". */
+/**
+ * Human summary of the walk-in days. The label gets terser as the list grows, because it sits
+ * in a badge on a card: a couple of days are spelled out, a handful are abbreviated, and a run
+ * or a long list collapses to initialled ranges.
+ *
+ * @see [walkIn.test.ts](../tests/utils/walkIn.test.ts) — pins each tier and the boundary
+ * between them.
+ */
 export function walkInDaysLabel(restaurant: WalkInSource): string | null {
   const days = [...new Set(parseWalkInDays(restaurant.walkInDays))].sort((a, b) => a - b);
-  //the rules here are as follows
-  //consecutive days show first day and last day, e.g. "Mon–Wed"
-  //non-consecutive days show all days, e.g. "Mon, Wed and Fri" as long as its 3 or less days
-  //otherwise show the first letter representations
   if (days.length === 0) return null;
-  const isConsecutiveRun = days.length > 2 && days[days.length - 1] - days[0] + 1 === days.length;
-  if (days.length > 3 || isConsecutiveRun) return consecutiveDaysLabel(days);
-  const dayNames = days.length > 2 ? DAY_NAMES_SHORT : DAY_NAMES;
-  const names = days.map((d) => dayNames[d - 1]);
-  if (names.length === 1) return names[0];
-  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+
+  const isUnbrokenRun = days.length > 2 && days[days.length - 1] - days[0] + 1 === days.length;
+  if (isUnbrokenRun || days.length > 3) return initialledRangesLabel(days);
+
+  return listLabel(days, days.length > 2 ? DAY_NAMES_SHORT : DAY_NAMES);
 }
 
-/** Groups consecutive ISO days, e.g. "Mon–Wed, Fri" for [1,2,3,5]. */
-function consecutiveDaysLabel(days: number[]): string {
+/** "Saturdays and Sundays", "Mon, Wed and Fri". */
+function listLabel(days: number[], names: string[]): string {
+  const labels = days.map((d) => names[d - 1]);
+  if (labels.length === 1) return labels[0];
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+}
+
+/** "M–W, Sat" for [1,2,3,6] — consecutive days collapse into a range. */
+function initialledRangesLabel(days: number[]): string {
   const groups = days.reduce<number[][]>((groups, day) => {
     const lastGroup = groups[groups.length - 1];
     if (lastGroup && day === lastGroup[lastGroup.length - 1] + 1) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "concurrently --names \"api,fe\" --prefix-colors \"cyan,magenta\" \"dotnet watch --project OpenRestoApi\" \"npm run dev --prefix openresto-frontend\"",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "check:doc-links": "node scripts/check-doc-links.mjs",
     "prepare": "husky"
   },
   "repository": {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Fails when a code comment points at a test that no longer exists. The comment
+// policy in CLAUDE.md lets a test carry a business rule in place of prose, which
+// only holds while the link resolves.
+//
+// Two forms are checked: the TypeScript JSDoc "see" tag followed by a markdown
+// link to a relative path, and the C# `<seealso>` tag naming a test method,
+// which must match a method declared by a class in OpenRestoApi.Tests.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST_PROJECT = join(REPO_ROOT, "OpenRestoApi.Tests");
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "bin",
+  "obj",
+  "dist",
+  "build",
+  "coverage",
+  "coverage-report",
+  "coverage-report-seeder",
+  "test-results",
+  "playwright-report",
+  "Migrations",
+]);
+
+const TS_EXTENSIONS = [".ts", ".tsx", ".mjs", ".js"];
+
+function walk(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") && entry.name !== ".github") continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...walk(full));
+    } else {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function fileExists(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+// A markdown link after the tag, plus the bare relative-path form.
+const TS_MARKDOWN_LINK = /@see\s+\[[^\]]+\]\(([^)]+)\)/g;
+const TS_BARE_LINK = /@see\s+((?:\.{1,2}\/)[^\s)]+)/g;
+const CS_SEEALSO = /<seealso>([^<]+)<\/seealso>/g;
+const CS_CLASS_DECL = /^\s*(?:public|internal|sealed|static|abstract|partial|\s)*class\s+([A-Za-z0-9_]+)/gm;
+const CS_METHOD_DECL = /^\s*(?:public|private|internal|protected|static|async|override|virtual|sealed|\s)+[A-Za-z0-9_<>,.\[\]?]+\s+([A-Za-z0-9_]+)\s*\(/gm;
+
+function checkTypeScript(files) {
+  const failures = [];
+
+  for (const file of files) {
+    if (!TS_EXTENSIONS.some((ext) => file.endsWith(ext))) continue;
+
+    const source = readFileSync(file, "utf8");
+    const targets = new Set();
+
+    for (const [, target] of source.matchAll(TS_MARKDOWN_LINK)) targets.add(target);
+    for (const [, target] of source.matchAll(TS_BARE_LINK)) targets.add(target);
+
+    for (const target of targets) {
+      if (/^[a-z]+:\/\//.test(target) || target.startsWith("#")) continue;
+
+      const resolved = resolve(dirname(file), target.split("#")[0]);
+      if (!fileExists(resolved)) {
+        failures.push(`${relative(REPO_ROOT, file)} -> ${target} (no such file)`);
+      }
+    }
+  }
+
+  return failures;
+}
+
+function indexTestMethods() {
+  const methodsByClass = new Map();
+
+  for (const file of walk(TEST_PROJECT)) {
+    if (!file.endsWith(".cs")) continue;
+
+    const source = readFileSync(file, "utf8");
+    const classNames = [...source.matchAll(CS_CLASS_DECL)].map(([, name]) => name);
+    if (classNames.length === 0) continue;
+
+    const methodNames = new Set([...source.matchAll(CS_METHOD_DECL)].map(([, name]) => name));
+    for (const className of classNames) {
+      const known = methodsByClass.get(className) ?? new Set();
+      for (const method of methodNames) known.add(method);
+      methodsByClass.set(className, known);
+    }
+  }
+
+  return methodsByClass;
+}
+
+function checkCSharp(files) {
+  const methodsByClass = indexTestMethods();
+  const allMethods = new Set([...methodsByClass.values()].flatMap((names) => [...names]));
+  const failures = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".cs")) continue;
+    if (file.startsWith(TEST_PROJECT)) continue;
+
+    for (const [, target] of readFileSync(file, "utf8").matchAll(CS_SEEALSO)) {
+      const reference = target.trim();
+      const [className, methodName] = reference.includes(".")
+        ? reference.split(".")
+        : [null, reference];
+
+      if (className === null) {
+        if (!allMethods.has(methodName)) {
+          failures.push(`${relative(REPO_ROOT, file)} -> ${reference} (no test declares it)`);
+        }
+        continue;
+      }
+
+      const known = methodsByClass.get(className);
+      if (!known) {
+        failures.push(`${relative(REPO_ROOT, file)} -> ${reference} (no such test class)`);
+      } else if (!known.has(methodName)) {
+        failures.push(`${relative(REPO_ROOT, file)} -> ${reference} (no such test method)`);
+      }
+    }
+  }
+
+  return failures;
+}
+
+const files = walk(REPO_ROOT);
+const failures = [...checkTypeScript(files), ...checkCSharp(files)];
+
+if (failures.length > 0) {
+  console.error(`Broken doc links (${failures.length}):\n`);
+  for (const failure of failures) console.error(`  ${failure}`);
+  console.error("\nEvery link must resolve, or the rule it points at is undocumented again.");
+  process.exit(1);
+}
+
+console.log("All doc links resolve.");


### PR DESCRIPTION
## Summary

Applies the comment refactor from [navyfragen-app#355](https://github.com/karanshukla/navyfragen-app/pull/355) to this repo. Comments were carrying explanations that the code, its structure, or a test should carry instead. `CLAUDE.md`'s **Code comments** section becomes the same five-rung ladder — abstraction → named subfunctions → boundary-pair unit tests → integration/E2E tests → prose as the last resort — adapted to C#/TypeScript, and the code is brought in line with it.

Most of the change is structural, not deletion. Raw comment-line count moves 4110 → 4002 across production code, but that number understates it: several *new* doc comments were added at the abstractions the old ones were scattered around, and what left was the summary restating the signature, the block label, and the changelog entry about where the code used to live.

## Related issue

Closes #339

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

**New abstractions (rung 1) — each replacing a rule that was hand-rolled and re-explained at every site**

- `Restaurant.CanSeat` / `ExceedsOversizeCap` — the oversize-cap predicate was written out at **seven** sites across availability, holds, booking create/update and auto-assign, five of them carrying a comment saying the other six had to agree.
- `Core/Application/Utilities/IsoDay` — the `DayOfWeek`-Sunday-is-0 remap appeared three times under the same `// Sunday: 0 -> 7`.
- `Core/Application/Utilities/OpeningHourDefaults` — the 09:00–22:00 fallback was six literals under a comment explaining they had to match.
- `openresto-frontend/utils/seating.ts` — the client's copy of the capacity rule, spelled out three times in `useBookingSeating` under three separate comments about mirroring the server.

**Named subfunctions (rung 2) — replacing block labels**

- `AvailabilityService`: a 240-line method with a `// 1.` / `// 2.` / `// 3.` walkthrough becomes an orchestration over `ServiceWindowOn` / `EligibleTables` / `EligibleGroups` / `SlotInterval`, plus a `UnitReservations` index that owns the group-vs-member exclusion.
- `BookingService`: `RejectIfClosedToOnlineBookings`, `RejectIfPartySizeOutOfRange`, `RejectIfTableCannotSeat`, `RejectIfGroupCannotSeat`, `TryAdoptExistingHoldAsync`, `AnnounceBookingAsync` replace the `0/1/2/3/3b/4/5/6/7` labels.
- `TableAutoAssigner` (`DeprioritizationTier`, `FreeTablesAsync`, `FreeGroupsAsync`), `AdminService` (`CountBookingsPerDayAsync`, `AsPercentagesOfPeak`, `RescheduleKeepingDuration`), `useTableHold` (`holdTarget`), `BookingForm` (`seatingPayload`), `TableRow` (per-mode labels → one component doc), `walkIn.ts` (`listLabel` / `initialledRangesLabel`).
- ~9 `// ---------- Types ----------` banners deleted; the declaration below said it.

**New tests (rung 3) — a comment asserting behavior is a missing test**

- `IsoDayTests` — day-name/number parsing and what gets discarded.
- `RestaurantTests.CanSeat_*` — the boundary pair at, and one seat over, the oversize cap.
- `BookingServiceTests.CreateBookingAsync_{RejectsBooking_InsideThePauseWindow, AllowsBooking_AfterThePauseWindow}` — the rule that a pause closes the *sittings inside its window* rather than booking as a whole had **no test at all**; a single "rejects while paused" test would pass against a service that refused everything until the pause expired.
- `tests/utils/seating.test.ts` — the same boundary pair on the client.

**Doc links + CI enforcement**

Where a test now carries a rule, the code points at it: a markdown link in JSDoc for TypeScript, a `&lt;seealso&gt;` tag naming the test method for C# (`cref` can't reach `OpenRestoApi.Tests` — the project reference points the other way). `scripts/check-doc-links.mjs` + a new `doc-links` CI job fail on a link that no longer resolves; without it a renamed test rots the link silently and the rule is undocumented again. Verified it passes clean and fails on both breakage types.

## Behaviour change worth a look

Folding `AvailabilityService`'s day-name parser into `IsoDay.ParseList` fixes a real divergence rather than just deduplicating one. `Restaurant.IsOpenAt` compared ISO numbers as strings, so an `OpenDays` value of `"mon,tue"` read as **closed every day**, while `/api/availability` read it as Monday and Tuesday and happily advertised slots the booking path would then reject. Same for an entirely unparseable value. Both now resolve through one parser, matching the availability feed's (more permissive) behaviour. Existing tests for both paths pass unchanged; `IsoDayTests` pins it.

Two smaller notes: `AdminService.GetOverviewAsync`'s paused-restaurant count still compares against the captured `nowUtc` rather than `IsPaused()`, deliberately, to keep the semantics identical; and `AdminUpdateBookingAsync`'s known-dead conflict guard is untouched — its comment was trimmed to the constraint, but the fix stays a separate follow-up as the existing test says.

## Testing

- [x] `OpenRestoApi.Tests` pass locally — 1599 passed, 0 failed (99.08% line coverage, unchanged)
- [x] Frontend tests/build pass locally — 2493 passed across 179 suites; coverage 97.62% vs 97.63% before (the same pre-existing uncovered lines, renumbered)
- [x] `npm run check` (prettier + oxlint), `tsc --noEmit`, `npm run routes:check` (31 routes, snapshot matches), `npm run check:doc-links`
- [x] CI passes — Backend, Frontend, Doc Links, Route Manifest, CodeQL, Docker + ZAP and the Playwright smoke suite are all green
- [ ] Manually verified the change end-to-end — not run; this is a structure-only change and the suites above cover the paths it touches

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

No schema change, so `migration-check` won't trigger.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed — `CLAUDE.md`'s comment policy rewritten; no API contract changed
