### PR TITLE
fix: put the FAB beside the content column and the locations footer under both panes

### DIFF
--- a/openresto-frontend/components/common/ScrollToTopFab.styles.ts
+++ b/openresto-frontend/components/common/ScrollToTopFab.styles.ts
@@ -1,12 +1,20 @@
 import { StyleSheet } from "react-native";
 
+export const FAB_SIZE = 48;
+
 export const styles = StyleSheet.create({
-  fab: {
+  // Spans the container so the FAB can be laid out against its content column rather than
+  // its own corner; `box-none` keeps the strip from swallowing presses meant for the page.
+  lane: {
     position: "absolute",
-    right: 20,
-    width: 48,
-    height: 48,
-    borderRadius: 24,
+    left: 0,
+    right: 0,
+    alignItems: "flex-end",
+  },
+  fab: {
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: FAB_SIZE / 2,
     alignItems: "center",
     justifyContent: "center",
     elevation: 6,

--- a/openresto-frontend/components/common/ScrollToTopFab.tsx
+++ b/openresto-frontend/components/common/ScrollToTopFab.tsx
@@ -1,11 +1,30 @@
-import { Pressable } from "react-native";
+import { useState } from "react";
+import { LayoutChangeEvent, Pressable, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAppTheme } from "@/hooks/use-app-theme";
-import { styles } from "./ScrollToTopFab.styles";
+import { CONTENT_MAX_WIDTH, CONTENT_PADDING_H } from "@/constants/breakpoints";
+import { FAB_SIZE, styles } from "./ScrollToTopFab.styles";
 import { Icon } from "@/components/common/Icon";
 
 /** Scroll distance past which the return-to-top shortcut is worth offering. */
 export const SHOW_AFTER_SCROLL_Y = 300;
+
+/** Inset used once the container is no wider than the content column and has no gutter to sit in. */
+export const FAB_MIN_GUTTER = 20;
+
+/**
+ * Right inset for the FAB inside a container of `containerWidth`. Above the content
+ * column's cap the container has a gutter either side of it, and the FAB goes in the
+ * right-hand one with its left edge against the column — beside the page rather than out
+ * at the viewport corner, and clear of the footer's own row, which ends on that same edge.
+ *
+ * @see [ScrollToTopFab.test.tsx](../../tests/components/ScrollToTopFab.test.tsx) — pins
+ * that it tucks against the column above the cap and holds the plain inset below it.
+ */
+export function fabGutter(containerWidth: number): number {
+  const columnEdge = (containerWidth - CONTENT_MAX_WIDTH) / 2 + CONTENT_PADDING_H;
+  return Math.max(FAB_MIN_GUTTER, columnEdge - FAB_SIZE);
+}
 
 interface Props {
   visible: boolean;
@@ -15,19 +34,33 @@ interface Props {
 export default function ScrollToTopFab({ visible, onPress }: Props) {
   const { primaryColor } = useAppTheme();
   const insets = useSafeAreaInsets();
+  // The lane spans whatever box the FAB was mounted into — the page on most screens, a
+  // single column on Locations once its booking drawer takes the other one — so the FAB
+  // follows the column it belongs to rather than the window.
+  const [laneWidth, setLaneWidth] = useState(0);
 
   // Deliberately not gated on width or orientation. Every screen that mounts this
   // is long enough to bury its own header on a desktop window too.
   if (!visible) return null;
 
   return (
-    <Pressable
-      style={[styles.fab, { backgroundColor: primaryColor, bottom: insets.bottom + 20 }]}
-      onPress={onPress}
-      accessibilityLabel="Scroll to top"
-      accessibilityRole="button"
+    <View
+      testID="scroll-to-top-lane"
+      pointerEvents="box-none"
+      onLayout={(e: LayoutChangeEvent) => setLaneWidth(e.nativeEvent.layout.width)}
+      style={[
+        styles.lane,
+        { bottom: insets.bottom + FAB_MIN_GUTTER, paddingRight: fabGutter(laneWidth) },
+      ]}
     >
-      <Icon name="chevron-up" size={22} color="#fff" />
-    </Pressable>
+      <Pressable
+        style={[styles.fab, { backgroundColor: primaryColor }]}
+        onPress={onPress}
+        accessibilityLabel="Scroll to top"
+        accessibilityRole="button"
+      >
+        <Icon name="chevron-up" size={22} color="#fff" />
+      </Pressable>
+    </View>
   );
 }

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -190,7 +190,15 @@ export default function LocationsScreen({
   }
 
   const summary = availabilitySummary(availability, restaurants.length);
-  const sideDrawer = drawer && !isCompact;
+  /**
+   * Two panes rather than an overlay, so the drawer takes its width off everything in the
+   * list column — the footer included, which is why the footer moves out from under the
+   * list to sit beneath both panes instead.
+   *
+   * @see [LocationsScreen.test.tsx](../../tests/components/restaurant/LocationsScreen.test.tsx)
+   * — pins that the footer leaves the column for the side drawer and stays for the sheet.
+   */
+  const sideDrawer = Boolean(drawer) && !isCompact;
   // Where the navbar's own content ends: its column is capped at CONTENT_MAX_WIDTH but
   // tracks the viewport below that, and it insets its contents by CONTENT_PADDING_H
   // either side. Matching it is what puts the drawer's edge under the overflow menu.
@@ -270,7 +278,7 @@ export default function LocationsScreen({
               )}
             </PageContainer>
 
-            <Footer />
+            {!sideDrawer && <Footer />}
           </ScrollView>
 
           <ScrollToTopFab visible={fabVisible} onPress={scrollToTop} />
@@ -292,6 +300,8 @@ export default function LocationsScreen({
           />
         )}
       </View>
+
+      {sideDrawer && <Footer />}
     </ThemedView>
   );
 }

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -3,7 +3,14 @@
  */
 import React from "react";
 import { screen, fireEvent } from "@testing-library/react-native";
-import ScrollToTopFab, { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+import { StyleSheet } from "react-native";
+import ScrollToTopFab, {
+  fabGutter,
+  FAB_MIN_GUTTER,
+  SHOW_AFTER_SCROLL_Y,
+} from "@/components/common/ScrollToTopFab";
+import { FAB_SIZE } from "@/components/common/ScrollToTopFab.styles";
+import { CONTENT_MAX_WIDTH, CONTENT_PADDING_H } from "@/constants/breakpoints";
 import { renderWithProviders } from "@/tests/helpers/renderWithProviders";
 
 const mockWindowDimensions = { width: 375, height: 812 };
@@ -44,6 +51,47 @@ describe("ScrollToTopFab", () => {
     } finally {
       wdModule.default = original;
     }
+  });
+
+  // The FAB used to be pinned to its container's own corner, which on a wide monitor left
+  // it stranded a few hundred pixels out from everything else on the page (#352). It now
+  // lives in the gutter beside the content column, tucked against the column's right edge
+  // — which is also where the footer's own row ends, so the two no longer collide.
+  describe("fabGutter", () => {
+    const columnEdge = (width: number) => (width - CONTENT_MAX_WIDTH) / 2 + CONTENT_PADDING_H;
+
+    it.each([1440, 1680, 2560])("puts its left edge on the content column at %ipx", (width) => {
+      expect(fabGutter(width) + FAB_SIZE).toBe(columnEdge(width));
+    });
+
+    // Below the column's cap the container has no gutter to sit in, so the FAB falls back
+    // to a plain inset rather than climbing over the content.
+    it.each([1320, 768, 390])(
+      "holds the plain inset at %ipx, where there is no gutter",
+      (width) => {
+        expect(fabGutter(width)).toBe(FAB_MIN_GUTTER);
+      }
+    );
+
+    // The boundary itself: the gutter has to be wider than the FAB before it can hold one.
+    it("switches over once the gutter is wider than the FAB", () => {
+      const tight = CONTENT_MAX_WIDTH + 2 * (FAB_SIZE + FAB_MIN_GUTTER - CONTENT_PADDING_H);
+      expect(fabGutter(tight)).toBe(FAB_MIN_GUTTER);
+      expect(fabGutter(tight + 2)).toBeGreaterThan(FAB_MIN_GUTTER);
+    });
+  });
+
+  // The lane measures the box the FAB was mounted into, not the window: on Locations the
+  // FAB sits in the list column, which the booking drawer takes half of.
+  it("lays the FAB out against the column it was mounted in, not the window", () => {
+    renderWithProviders(<ScrollToTopFab visible onPress={jest.fn()} />);
+    const lane = screen.getByTestId("scroll-to-top-lane");
+
+    fireEvent(lane, "layout", { nativeEvent: { layout: { width: 1680, height: 48 } } });
+    expect(StyleSheet.flatten(lane.props.style).paddingRight).toBe(fabGutter(1680));
+
+    fireEvent(lane, "layout", { nativeEvent: { layout: { width: 760, height: 48 } } });
+    expect(StyleSheet.flatten(lane.props.style).paddingRight).toBe(FAB_MIN_GUTTER);
   });
 
   it("calls onPress when pressed", () => {

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { screen, waitFor, fireEvent } from "@testing-library/react-native";
+import { screen, waitFor, fireEvent, within } from "@testing-library/react-native";
 import { ScrollView, StyleSheet } from "react-native";
 import LocationsScreen, { availabilitySummary } from "@/components/restaurant/LocationsScreen";
 import { fetchRestaurants } from "@/api/restaurants";
@@ -406,6 +406,43 @@ describe("LocationsScreen", () => {
 
       fireEvent.press(screen.getByTestId("drawer-close"));
       await waitFor(() => expect(screen.queryByTestId("mock-drawer")).toBeNull());
+    });
+
+    // The footer is page chrome. Left in the list column it loses the drawer's width off
+    // its own row and wraps into a squashed block beside the booking form (#353), so an
+    // open side drawer hands it back the page and it sits under both panes.
+    it("keeps the footer in the list column while the drawer is closed", async () => {
+      dimensionsSpy.mockReturnValue({ width: 1440, height: 900, scale: 1, fontScale: 1 });
+      (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+      renderWithProviders(<LocationsScreen />);
+      await waitFor(() => expect(screen.getByTestId("book-1")).toBeTruthy());
+
+      expect(within(screen.getByTestId("locations-row")).getByTestId("mock-footer")).toBeTruthy();
+    });
+
+    it("lifts the footer clear of the column the side drawer squeezes", async () => {
+      dimensionsSpy.mockReturnValue({ width: 1440, height: 900, scale: 1, fontScale: 1 });
+      (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+      renderWithProviders(<LocationsScreen />);
+      await waitFor(() => expect(screen.getByTestId("book-1")).toBeTruthy());
+
+      fireEvent.press(screen.getByTestId("book-1"));
+      await waitFor(() => expect(screen.getByTestId("mock-drawer")).toBeTruthy());
+
+      expect(screen.getByTestId("mock-footer")).toBeTruthy();
+      expect(within(screen.getByTestId("locations-row")).queryByTestId("mock-footer")).toBeNull();
+    });
+
+    it("leaves the footer in the column for the phone sheet, which takes no width off it", async () => {
+      dimensionsSpy.mockReturnValue({ width: 390, height: 844, scale: 1, fontScale: 1 });
+      (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+      renderWithProviders(<LocationsScreen />);
+      await waitFor(() => expect(screen.getByTestId("book-1")).toBeTruthy());
+
+      fireEvent.press(screen.getByTestId("book-1"));
+      await waitFor(() => expect(screen.getByTestId("mock-drawer")).toBeTruthy());
+
+      expect(within(screen.getByTestId("locations-row")).getByTestId("mock-footer")).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Summary

Two layout fixes in the same corner of the page, both web/desktop-only in effect.

**#352 — the FAB.** The scroll-to-top button was pinned to its container's own right edge (`right: 20`), so on a wide monitor it drifted out to the raw viewport corner, a few hundred pixels clear of everything else on the page. It now sits in the gutter beside the content column — the one the navbar and footer lay their contents out in — with its left edge against the column, falling back to the old plain inset once the container is too narrow to have a gutter at all.

Two details are load-bearing. The inset comes from the box the FAB was **mounted into** rather than from the window, so on Locations it follows the list column once the booking drawer takes the other one. And it tucks *against* the column rather than level *with* it: the footer's own row ends on that same edge, so a flush FAB would land on top of the Admin link at the bottom of a scroll.

**#353 — the locations footer.** The footer sat inside the list column, so opening the side drawer took the drawer's width off the footer's row too and wrapped it into a squashed block beside the booking form. It now moves out of the column while the side drawer is open and spans the page beneath both panes. The phone sheet overlays rather than sits beside, so it takes no width off anything and the footer stays where it is.

## Related issue

Closes #352
Closes #353

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `ScrollToTopFab` renders into a `box-none` lane spanning its container, measures it with `onLayout`, and lays the button out with `fabGutter(containerWidth)`.
- New exported `fabGutter` / `FAB_MIN_GUTTER` / `FAB_SIZE`, derived from the existing `CONTENT_MAX_WIDTH` / `CONTENT_PADDING_H` so the FAB moves with the rest of the app if the column ever changes.
- `LocationsScreen` renders `<Footer />` inside the list column's `ScrollView` only when no side drawer is open, and beneath the two-pane row when one is.
- Tests: `fabGutter` pinned on both sides of the cap plus the switchover boundary; a render test that the lane follows the measured container, not the window; three `LocationsScreen` tests pinning where the footer lives with the drawer closed, with the side drawer, and with the phone sheet.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally — not run; no backend files touched.
- [x] Frontend tests/build pass locally — full Jest suite (187 suites / 2699 tests), `tsc --noEmit`, `npm run check`, `npm run check:doc-links`. Coverage on `ScrollToTopFab.tsx` and `.styles.ts` is 100%; `LocationsScreen.tsx` is unchanged from its baseline on statements/lines and up slightly on branches.
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — backend + Expo web against the demo dataset, screenshotting `/locations`, `/` and `/lookup` at 1680, 1440, 1280 and 390, with the drawer both open and closed. The two `ScrollToTopFab` E2E tests in `customer-nav.spec.ts` also pass against that stack, which covers the lane not swallowing the press.

Docker isn't available in this environment, so the full `docker compose` E2E suite was not run — that's left to CI.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed — no API contract or setup change.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Rsp1NBCZwXWLNUXbJ3RtD)_