### PR TITLE
fix: lift the scroll-to-top FAB clear of the footer at the end of a scroll

### DIFF
--- a/openresto-frontend/app/(user)/index.tsx
+++ b/openresto-frontend/app/(user)/index.tsx
@@ -8,8 +8,9 @@ import RestaurantCard from "@/components/restaurant/RestaurantCard";
 import RestaurantCardSkeleton from "@/components/restaurant/RestaurantCardSkeleton";
 import HorizontalScroller from "@/components/common/HorizontalScroller";
 import { useAppTheme } from "@/hooks/use-app-theme";
-import ScrollToTopFab, { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 import Footer from "@/components/layout/Footer";
+import { useScrollToTopFab } from "@/hooks/use-scroll-to-top-fab";
 import { isMobileWidth } from "@/constants/breakpoints";
 import { styles } from "@/styles/user/index.styles";
 import { hexToRgb } from "@/utils/colors";
@@ -39,10 +40,10 @@ export default function HomeScreen() {
   const [restaurants, setRestaurants] = useState<RestaurantDto[]>(_cachedRestaurants ?? []);
   const [highlights, setHighlights] = useState<HighlightDto[]>(_cachedHighlights ?? []);
   const [loading, setLoading] = useState(_cachedRestaurants === null);
-  const [scrollY, setScrollY] = useState(0);
   const { width } = useWindowDimensions();
   const { brand, colors, primaryColor, isDark } = useAppTheme();
   const scrollRef = useRef<ScrollView>(null);
+  const fab = useScrollToTopFab();
 
   const isMobile = isMobileWidth(width);
 
@@ -139,7 +140,7 @@ export default function HomeScreen() {
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
-        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        onScroll={fab.trackScroll}
         scrollEventThrottle={100}
         {...(HOME_SCROLL_TIMELINE as object)}
       >
@@ -337,10 +338,10 @@ export default function HomeScreen() {
           </View>
         </View>
 
-        <Footer />
+        <Footer onLayout={fab.measureFooter} />
       </ScrollView>
 
-      <ScrollToTopFab visible={scrollY > SHOW_AFTER_SCROLL_Y} onPress={scrollToTop} />
+      <ScrollToTopFab visible={fab.visible} lift={fab.lift} onPress={scrollToTop} />
     </ThemedView>
   );
 }

--- a/openresto-frontend/components/booking/LookupScreen.tsx
+++ b/openresto-frontend/components/booking/LookupScreen.tsx
@@ -9,7 +9,8 @@ import ButtonRow from "@/components/common/ButtonRow";
 import { Icon } from "@/components/common/Icon";
 import PageContainer from "@/components/layout/PageContainer";
 import Footer from "@/components/layout/Footer";
-import ScrollToTopFab, { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+import { useScrollToTopFab } from "@/hooks/use-scroll-to-top-fab";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import AlertModal from "@/components/common/AlertModal";
 import SlidePanel from "@/components/common/SlidePanel";
@@ -49,8 +50,8 @@ export default function LookupScreen({
   const [refInput, setRefInput] = useState(initialRef ?? "");
   const [emailInput, setEmailInput] = useState(initialEmail ?? "");
   const [cached, setCached] = useState<CachedBooking[]>([]);
-  const [scrollY, setScrollY] = useState(0);
   const scrollRef = useRef<ScrollView>(null);
+  const fab = useScrollToTopFab();
   const refInputRef = useRef<TextInput>(null);
   const didDeepLink = useRef(false);
   const hasTyped = useRef(false);
@@ -206,7 +207,7 @@ export default function LookupScreen({
         ref={scrollRef}
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
-        onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+        onScroll={fab.trackScroll}
         scrollEventThrottle={100}
       >
         <PageContainer style={[styles.page, twoColumn ? styles.pageWide : styles.pageIdle]}>
@@ -315,7 +316,7 @@ export default function LookupScreen({
           </View>
         </PageContainer>
 
-        <Footer />
+        <Footer onLayout={fab.measureFooter} />
       </ScrollView>
 
       {isCompact && showPanel && (
@@ -324,7 +325,7 @@ export default function LookupScreen({
         </SlidePanel>
       )}
 
-      <ScrollToTopFab visible={scrollY > SHOW_AFTER_SCROLL_Y} onPress={scrollToTop} />
+      <ScrollToTopFab visible={fab.visible} lift={fab.lift} onPress={scrollToTop} />
 
       {showCancelConfirm && (
         <ConfirmModal

--- a/openresto-frontend/components/common/ScrollToTopFab.tsx
+++ b/openresto-frontend/components/common/ScrollToTopFab.tsx
@@ -29,9 +29,14 @@ export function fabGutter(containerWidth: number): number {
 interface Props {
   visible: boolean;
   onPress: () => void;
+  /**
+   * How far to rise off the bottom of the container, on top of the resting gutter, so the
+   * FAB clears a footer scrolling into view underneath it. See `useScrollToTopFab`.
+   */
+  lift?: number;
 }
 
-export default function ScrollToTopFab({ visible, onPress }: Props) {
+export default function ScrollToTopFab({ visible, onPress, lift = 0 }: Props) {
   const { primaryColor } = useAppTheme();
   const insets = useSafeAreaInsets();
   // The lane spans whatever box the FAB was mounted into — the page on most screens, a
@@ -50,7 +55,12 @@ export default function ScrollToTopFab({ visible, onPress }: Props) {
       onLayout={(e: LayoutChangeEvent) => setLaneWidth(e.nativeEvent.layout.width)}
       style={[
         styles.lane,
-        { bottom: insets.bottom + FAB_MIN_GUTTER, paddingRight: fabGutter(laneWidth) },
+        {
+          // The footer carries the safe-area inset itself, so once it is tall enough to
+          // govern the two never stack.
+          bottom: Math.max(insets.bottom, lift) + FAB_MIN_GUTTER,
+          paddingRight: fabGutter(laneWidth),
+        },
       ]}
     >
       <Pressable

--- a/openresto-frontend/components/layout/Footer.tsx
+++ b/openresto-frontend/components/layout/Footer.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { View, Pressable, Linking, useWindowDimensions } from "react-native";
+import {
+  View,
+  Pressable,
+  Linking,
+  useWindowDimensions,
+  type LayoutChangeEvent,
+} from "react-native";
 import { Link } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ThemedView } from "@/components/themed-view";
@@ -9,7 +15,8 @@ import { fetchSocialLinks, SocialLinkDto } from "@/api/restaurants";
 import { styles } from "./Footer.styles";
 import { Icon, type IconName } from "@/components/common/Icon";
 
-export default function Footer() {
+/** `onLayout` reports the band's height to a screen whose scroll-to-top FAB has to clear it. */
+export default function Footer({ onLayout }: { onLayout?: (e: LayoutChangeEvent) => void }) {
   const { brand, colors } = useAppTheme();
   const { width } = useWindowDimensions();
   const insets = useSafeAreaInsets();
@@ -27,6 +34,7 @@ export default function Footer() {
 
   return (
     <ThemedView
+      onLayout={onLayout}
       style={[styles.footer, { borderTopColor: colors.border, paddingBottom: insets.bottom }]}
     >
       <View style={[styles.inner, isMobile && styles.innerMobile]}>

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -12,8 +12,9 @@ import { useAppTheme } from "@/hooks/use-app-theme";
 import { fetchRestaurants, RestaurantDto } from "@/api/restaurants";
 import PageContainer from "@/components/layout/PageContainer";
 import PageLoader from "@/components/common/PageLoader";
-import ScrollToTopFab, { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+import ScrollToTopFab from "@/components/common/ScrollToTopFab";
 import Footer from "@/components/layout/Footer";
+import { useScrollToTopFab } from "@/hooks/use-scroll-to-top-fab";
 import { scrollIntoView } from "@/utils/scrollIntoView";
 import { getRestaurantDate } from "@/utils/restaurantTime";
 import { CONTENT_MAX_WIDTH, CONTENT_PADDING_H, isMobileWidth } from "@/constants/breakpoints";
@@ -63,7 +64,7 @@ export default function LocationsScreen({
   // Raw scroll offsets live in refs; state holds only the booleans the UI reacts to, so
   // scrolling re-renders the list on transitions instead of every scroll event.
   const [filterPinned, setFilterPinned] = useState(false);
-  const [fabVisible, setFabVisible] = useState(false);
+  const fab = useScrollToTopFab();
   const { colors } = useAppTheme();
   const { width } = useWindowDimensions();
   const isCompact = isMobileWidth(width);
@@ -73,6 +74,15 @@ export default function LocationsScreen({
   const [dateOverride, setDateOverride] = useState<string | null>(null);
   const [meal, setMeal] = useState<MealWindow>("All");
   const [drawer, setDrawer] = useState<DrawerTarget | null>(null);
+  /**
+   * Two panes rather than an overlay, so the drawer takes its width off everything in the
+   * list column — the footer included, which is why the footer moves out from under the
+   * list to sit beneath both panes instead.
+   *
+   * @see [LocationsScreen.test.tsx](../../tests/components/restaurant/LocationsScreen.test.tsx)
+   * — pins that the footer leaves the column for the side drawer and stays for the sheet.
+   */
+  const sideDrawer = Boolean(drawer) && !isCompact;
   const [availability, setAvailability] = useState<Record<number, number | null>>({});
   // Where the filter bar's band sits in the unscrolled list, so the page can tell a pinned
   // bar from one still sitting under the heading and only draw its edge once it is pinned.
@@ -86,11 +96,13 @@ export default function LocationsScreen({
     scrollRef.current?.scrollTo({ y: 0, animated: true });
   }, []);
 
-  const handleScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const y = e.nativeEvent.contentOffset.y;
-    setFilterPinned(y > filterTop.current);
-    setFabVisible(y > SHOW_AFTER_SCROLL_Y);
-  }, []);
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      setFilterPinned(e.nativeEvent.contentOffset.y > filterTop.current);
+      fab.trackScroll(e);
+    },
+    [fab]
+  );
 
   const loadRestaurants = useCallback(() => {
     setLoading(true);
@@ -116,6 +128,13 @@ export default function LocationsScreen({
   const registerRef = useCallback((id: number, ref: View | null) => {
     itemRefs.current[id] = ref;
   }, []);
+
+  // With the footer out of the column there is nothing left in this scroll for the FAB to
+  // climb over, and a height measured before the drawer opened would lift it over nothing.
+  const { setFooterHeight } = fab;
+  useEffect(() => {
+    if (sideDrawer) setFooterHeight(0);
+  }, [sideDrawer, setFooterHeight]);
 
   const scrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(
@@ -190,15 +209,6 @@ export default function LocationsScreen({
   }
 
   const summary = availabilitySummary(availability, restaurants.length);
-  /**
-   * Two panes rather than an overlay, so the drawer takes its width off everything in the
-   * list column — the footer included, which is why the footer moves out from under the
-   * list to sit beneath both panes instead.
-   *
-   * @see [LocationsScreen.test.tsx](../../tests/components/restaurant/LocationsScreen.test.tsx)
-   * — pins that the footer leaves the column for the side drawer and stays for the sheet.
-   */
-  const sideDrawer = Boolean(drawer) && !isCompact;
   // Where the navbar's own content ends: its column is capped at CONTENT_MAX_WIDTH but
   // tracks the viewport below that, and it insets its contents by CONTENT_PADDING_H
   // either side. Matching it is what puts the drawer's edge under the overflow menu.
@@ -278,10 +288,10 @@ export default function LocationsScreen({
               )}
             </PageContainer>
 
-            {!sideDrawer && <Footer />}
+            {!sideDrawer && <Footer onLayout={fab.measureFooter} />}
           </ScrollView>
 
-          <ScrollToTopFab visible={fabVisible} onPress={scrollToTop} />
+          <ScrollToTopFab visible={fab.visible} lift={fab.lift} onPress={scrollToTop} />
         </View>
 
         {drawer && (

--- a/openresto-frontend/hooks/use-scroll-to-top-fab.ts
+++ b/openresto-frontend/hooks/use-scroll-to-top-fab.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from "react";
+import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+import { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+
+/**
+ * How far the FAB has to rise to stay off a footer `footerHeight` tall, with
+ * `fromBottom` px of the scroll still to go. Zero until the footer starts entering the
+ * viewport, then tracks it one for one, so the FAB comes to rest on the footer's top edge
+ * rather than on the links in it. The footer's own height is the ceiling: a bouncing
+ * scroll reports a negative distance, which would otherwise walk the FAB up the page.
+ *
+ * @see [use-scroll-to-top-fab.test.ts](../tests/hooks/use-scroll-to-top-fab.test.ts) —
+ * pins that it stays flat while the footer is off screen, lifts once it is not, and
+ * holds at the footer's top edge through an overscroll.
+ */
+export function fabLift(footerHeight: number, fromBottom: number): number {
+  return Math.min(footerHeight, Math.max(0, footerHeight - fromBottom));
+}
+
+/**
+ * Drives the scroll-to-top FAB for a screen whose scroll ends in a `<Footer />`: when it
+ * shows, and how far it has to rise to stay clear of that footer.
+ *
+ * `measureFooter` goes on the footer inside the scroll. A screen that takes the footer
+ * back out of the scroll passes 0 through `setFooterHeight`, since the FAB then has
+ * nothing to climb over.
+ */
+export function useScrollToTopFab() {
+  const [visible, setVisible] = useState(false);
+  const [lift, setLift] = useState(0);
+  const [footerHeight, setFooterHeight] = useState(0);
+
+  const trackScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
+      setVisible(contentOffset.y > SHOW_AFTER_SCROLL_Y);
+      const fromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
+      setLift(fabLift(footerHeight, fromBottom));
+    },
+    [footerHeight]
+  );
+
+  const measureFooter = useCallback((e: LayoutChangeEvent) => {
+    setFooterHeight(e.nativeEvent.layout.height);
+  }, []);
+
+  return { visible, lift, trackScroll, measureFooter, setFooterHeight };
+}

--- a/openresto-frontend/tests/app/(user)/index.test.tsx
+++ b/openresto-frontend/tests/app/(user)/index.test.tsx
@@ -47,6 +47,19 @@ jest.setTimeout(15000);
 // app/(user)/_layout.tsx, which renders the shared Navbar once for every
 // (user) route (see issue #140 review, Concern 9: this page previously lived
 // outside the (user) group and duplicated Navbar rendering itself).
+/**
+ * A scroll event carrying the full geometry RN reports. The scroll-to-top FAB reads the
+ * content/viewport pair to work out how close the footer is, so a partial event is not a
+ * scroll it can answer.
+ */
+const scrollEvent = (y: number) => ({
+  nativeEvent: {
+    contentOffset: { y },
+    contentSize: { height: 4000 },
+    layoutMeasurement: { height: 900 },
+  },
+});
+
 describe("HomeScreen", () => {
   const mockRestaurants = [
     {
@@ -302,7 +315,7 @@ describe("HomeScreen", () => {
     renderWithProviders(<HomeScreen />);
     await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
     const scrollView = screen.UNSAFE_getByType(ScrollView);
-    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 200 } } });
+    fireEvent.scroll(scrollView, scrollEvent(200));
     // Line covered — no assertion needed beyond no crash
   });
 
@@ -314,7 +327,7 @@ describe("HomeScreen", () => {
     await waitFor(() => expect(screen.queryByTestId("loading-screen")).toBeNull());
 
     const scrollView = screen.UNSAFE_getByType(ScrollView);
-    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 400 } } });
+    fireEvent.scroll(scrollView, scrollEvent(400));
 
     fireEvent.press(screen.getByLabelText("Scroll to top"));
     // scrollRef.current?.scrollTo is a no-op in tests — asserts no crash and

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -94,6 +94,21 @@ describe("ScrollToTopFab", () => {
     expect(StyleSheet.flatten(lane.props.style).paddingRight).toBe(FAB_MIN_GUTTER);
   });
 
+  // The lift is what keeps the FAB off the footer's own links at the end of a scroll; see
+  // useScrollToTopFab for where the number comes from.
+  it("rises off the bottom by the lift it is given", () => {
+    const { unmount } = renderWithProviders(<ScrollToTopFab visible onPress={jest.fn()} />);
+    expect(StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style).bottom).toBe(
+      FAB_MIN_GUTTER
+    );
+    unmount();
+
+    renderWithProviders(<ScrollToTopFab visible lift={88} onPress={jest.fn()} />);
+    expect(StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style).bottom).toBe(
+      88 + FAB_MIN_GUTTER
+    );
+  });
+
   it("calls onPress when pressed", () => {
     const onPress = jest.fn();
     renderWithProviders(<ScrollToTopFab visible onPress={onPress} />);

--- a/openresto-frontend/tests/components/booking/LookupScreen.test.tsx
+++ b/openresto-frontend/tests/components/booking/LookupScreen.test.tsx
@@ -72,6 +72,19 @@ function setWidth(width: number) {
     .mockReturnValue({ width, height: 800 });
 }
 
+/**
+ * A scroll event carrying the full geometry RN reports. The scroll-to-top FAB reads the
+ * content/viewport pair to work out how close the footer is, so a partial event is not a
+ * scroll it can answer.
+ */
+const scrollEvent = (y: number) => ({
+  nativeEvent: {
+    contentOffset: { y },
+    contentSize: { height: 4000 },
+    layoutMeasurement: { height: 900 },
+  },
+});
+
 describe("LookupScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -533,7 +546,7 @@ describe("LookupScreen", () => {
     renderWithProviders(<LookupScreen />);
     const { ScrollView } = require("react-native");
     const scrollViews = screen.UNSAFE_getAllByType(ScrollView);
-    fireEvent.scroll(scrollViews[0], { nativeEvent: { contentOffset: { y: 400 } } });
+    fireEvent.scroll(scrollViews[0], scrollEvent(400));
     expect(screen.getByText("Find my booking")).toBeTruthy();
   });
 });

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -23,7 +23,13 @@ jest.mock("@/utils/scrollIntoView", () => ({
 
 jest.mock("@/components/layout/Footer", () => {
   const { View } = require("react-native");
-  return { __esModule: true, default: () => <View testID="mock-footer" /> };
+  return {
+    __esModule: true,
+    // Forwards onLayout: the screen measures the footer so the FAB can clear it.
+    default: ({ onLayout }: { onLayout?: (e: unknown) => void }) => (
+      <View testID="mock-footer" onLayout={onLayout} />
+    ),
+  };
 });
 
 jest.mock("@/components/booking/BookingDrawer", () => {
@@ -134,6 +140,19 @@ function mockViewport(width: number) {
 
 jest.setTimeout(15000);
 
+/**
+ * A scroll event carrying the full geometry RN reports. The scroll-to-top FAB reads the
+ * content/viewport pair to work out how close the footer is, so a partial event is not a
+ * scroll it can answer.
+ */
+const scrollEvent = (y: number) => ({
+  nativeEvent: {
+    contentOffset: { y },
+    contentSize: { height: 4000 },
+    layoutMeasurement: { height: 900 },
+  },
+});
+
 describe("availabilitySummary", () => {
   it("stays silent until every location has reported", () => {
     expect(availabilitySummary({ 1: 3 }, 2)).toBeNull();
@@ -235,9 +254,7 @@ describe("LocationsScreen", () => {
     fireEvent(screen.getByTestId("locations-filter-sticky"), "layout", {
       nativeEvent: { layout: { y: 120 } },
     });
-    fireEvent.scroll(screen.UNSAFE_getByType(ScrollView), {
-      nativeEvent: { contentOffset: { y: 400 } },
-    });
+    fireEvent.scroll(screen.UNSAFE_getByType(ScrollView), scrollEvent(400));
 
     // A mask, not a surface: it hides the list in the gap above the pill and fades out
     // rather than ending on an edge, which is what made the old band read as a header.
@@ -433,6 +450,62 @@ describe("LocationsScreen", () => {
       expect(within(screen.getByTestId("locations-row")).queryByTestId("mock-footer")).toBeNull();
     });
 
+    // The FAB used to rest in the column's own bottom corner whatever was under it, so at
+    // the end of the list it landed on the footer's links.
+    it("lifts the FAB over the footer it measured once the list reaches the end", async () => {
+      (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+      renderWithProviders(<LocationsScreen />);
+      await waitFor(() => expect(screen.getByTestId("book-1")).toBeTruthy());
+
+      fireEvent(screen.getByTestId("mock-footer"), "layout", {
+        nativeEvent: { layout: { height: 88, width: 1280, x: 0, y: 0 } },
+      });
+      const scrollView = screen.UNSAFE_getByType(ScrollView);
+
+      fireEvent.scroll(scrollView, scrollEvent(400));
+      const lane = () => StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
+      const resting = lane().bottom;
+
+      fireEvent.scroll(scrollView, {
+        nativeEvent: {
+          contentOffset: { y: 3100 },
+          contentSize: { height: 4000 },
+          layoutMeasurement: { height: 900 },
+        },
+      });
+      expect(lane().bottom).toBe(resting + 88);
+    });
+
+    it("drops the lift again when the drawer takes the footer out of the column", async () => {
+      (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
+      renderWithProviders(<LocationsScreen />);
+      await waitFor(() => expect(screen.getByTestId("book-1")).toBeTruthy());
+
+      fireEvent(screen.getByTestId("mock-footer"), "layout", {
+        nativeEvent: { layout: { height: 88, width: 1280, x: 0, y: 0 } },
+      });
+      const scrollView = screen.UNSAFE_getByType(ScrollView);
+      const atEnd = {
+        nativeEvent: {
+          contentOffset: { y: 3100 },
+          contentSize: { height: 4000 },
+          layoutMeasurement: { height: 900 },
+        },
+      };
+      fireEvent.scroll(scrollView, atEnd);
+      const lifted = StyleSheet.flatten(
+        screen.getByTestId("scroll-to-top-lane").props.style
+      ).bottom;
+
+      fireEvent.press(screen.getByTestId("book-1"));
+      await waitFor(() => expect(screen.getByTestId("mock-drawer")).toBeTruthy());
+      fireEvent.scroll(scrollView, atEnd);
+
+      expect(
+        StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style).bottom
+      ).toBeLessThan(lifted);
+    });
+
     it("leaves the footer in the column for the phone sheet, which takes no width off it", async () => {
       dimensionsSpy.mockReturnValue({ width: 390, height: 844, scale: 1, fontScale: 1 });
       (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
@@ -533,10 +606,10 @@ describe("LocationsScreen", () => {
 
     const scrollView = screen.UNSAFE_getByType(ScrollView);
     // Scrolled, but not yet past the bar: still sitting in the list, still unlifted.
-    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 60 } } });
+    fireEvent.scroll(scrollView, scrollEvent(60));
     expect(barStyle().shadowOpacity).toBeUndefined();
 
-    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 400 } } });
+    fireEvent.scroll(scrollView, scrollEvent(400));
     expect(barStyle().shadowOpacity).toBeGreaterThan(0);
   });
 
@@ -545,7 +618,7 @@ describe("LocationsScreen", () => {
     renderWithProviders(<LocationsScreen />);
     await waitFor(() => expect(screen.getByText("Downtown Bistro")).toBeTruthy());
     const scrollView = screen.UNSAFE_getByType(ScrollView);
-    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 400 } } });
+    fireEvent.scroll(scrollView, scrollEvent(400));
     // Line covered — no assertion needed beyond no crash.
   });
 
@@ -556,7 +629,7 @@ describe("LocationsScreen", () => {
     await waitFor(() => expect(screen.getByText("Downtown Bistro")).toBeTruthy());
 
     const scrollView = screen.UNSAFE_getByType(ScrollView);
-    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 400 } } });
+    fireEvent.scroll(scrollView, scrollEvent(400));
 
     fireEvent.press(screen.getByLabelText("Scroll to top"));
     // scrollRef.current?.scrollTo is a no-op in tests — asserts no crash and

--- a/openresto-frontend/tests/hooks/use-scroll-to-top-fab.test.ts
+++ b/openresto-frontend/tests/hooks/use-scroll-to-top-fab.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { fabLift, useScrollToTopFab } from "@/hooks/use-scroll-to-top-fab";
+import { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+
+const FOOTER_HEIGHT = 88;
+
+/** A scroll event `fromBottom` px short of the end of a page one viewport taller than its scroll. */
+const scrollEvent = (y: number, fromBottom = 1000) =>
+  ({
+    nativeEvent: {
+      contentOffset: { y },
+      layoutMeasurement: { height: 900 },
+      contentSize: { height: 900 + y + fromBottom },
+    },
+  }) as never;
+
+const layoutEvent = (height: number) =>
+  ({ nativeEvent: { layout: { height, width: 1280, x: 0, y: 0 } } }) as never;
+
+describe("fabLift", () => {
+  // The FAB used to sit in its container's bottom corner whatever was under it, so at the
+  // end of a scroll it came to rest on the footer's own links (#352 follow-up).
+  it("stays flat while the footer is still below the fold", () => {
+    expect(fabLift(FOOTER_HEIGHT, FOOTER_HEIGHT + 1)).toBe(0);
+    expect(fabLift(FOOTER_HEIGHT, 1000)).toBe(0);
+  });
+
+  it("rises with the footer once it starts entering the viewport", () => {
+    expect(fabLift(FOOTER_HEIGHT, FOOTER_HEIGHT - 1)).toBe(1);
+    expect(fabLift(FOOTER_HEIGHT, 20)).toBe(FOOTER_HEIGHT - 20);
+  });
+
+  // At the very bottom the whole footer is on screen, so the FAB rests on its top edge.
+  it("clears the whole footer at the end of the scroll", () => {
+    expect(fabLift(FOOTER_HEIGHT, 0)).toBe(FOOTER_HEIGHT);
+  });
+
+  // Overscroll on iOS reports a negative distance; the FAB must not chase it up the page.
+  it("does not keep climbing past the footer when the scroll overshoots", () => {
+    expect(fabLift(FOOTER_HEIGHT, -60)).toBe(FOOTER_HEIGHT);
+    expect(fabLift(0, -60)).toBe(0);
+  });
+});
+
+describe("useScrollToTopFab", () => {
+  it("shows the FAB only once the scroll is worth undoing", () => {
+    const { result } = renderHook(() => useScrollToTopFab());
+    expect(result.current.visible).toBe(false);
+
+    act(() => result.current.trackScroll(scrollEvent(SHOW_AFTER_SCROLL_Y)));
+    expect(result.current.visible).toBe(false);
+
+    act(() => result.current.trackScroll(scrollEvent(SHOW_AFTER_SCROLL_Y + 1)));
+    expect(result.current.visible).toBe(true);
+  });
+
+  it("lifts the FAB by the footer it measured, not by a guess", () => {
+    const { result } = renderHook(() => useScrollToTopFab());
+
+    act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
+    act(() => result.current.trackScroll(scrollEvent(600, 1000)));
+    expect(result.current.lift).toBe(0);
+
+    act(() => result.current.trackScroll(scrollEvent(600, 0)));
+    expect(result.current.lift).toBe(FOOTER_HEIGHT);
+  });
+
+  // A screen that takes the footer back out of its scroll — Locations, once the booking
+  // drawer opens — hands the FAB nothing to climb over.
+  it("drops the lift when the footer leaves the scroll", () => {
+    const { result } = renderHook(() => useScrollToTopFab());
+
+    act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
+    act(() => result.current.trackScroll(scrollEvent(600, 0)));
+    expect(result.current.lift).toBe(FOOTER_HEIGHT);
+
+    act(() => result.current.setFooterHeight(0));
+    act(() => result.current.trackScroll(scrollEvent(600, 0)));
+    expect(result.current.lift).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #354, which left one thing unfixed and called it out at the time.

The FAB rested in its container's bottom corner whatever happened to be under it, so at the end of a scroll it came down on the footer's own row — on the Admin link at any width where the footer's links reach that far. #354 moved the FAB out into the gutter beside the content column, which sidesteps the clash on wide windows; at or below the column's cap (≤1320px, so every phone and most laptops) there is no gutter to sit in, the FAB keeps its plain 20px inset, and the overlap was still there.

It now rises with the footer as the footer enters the viewport, coming to rest on its top edge instead of on the links in it. Two details are load-bearing:

- The lift is clamped to the footer's height. A bouncing scroll reports a negative distance-to-bottom, which would otherwise walk the FAB up the page — the unit test caught this on the first run.
- Locations moves its footer out of the scroll while the side drawer is open, so it clears the measured height then. The FAB has nothing left in that column to climb over, and a height measured before the drawer opened would lift it over nothing.

The three scrolling screens were each tracking scroll position by hand to decide whether the FAB shows; that plus the new lift now lives in one `useScrollToTopFab`, so home and lookup each lose a `scrollY` state in the process.

## Related issue

No issue — follow-up to the caveat noted on #354.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- New `hooks/use-scroll-to-top-fab.ts`: `fabLift(footerHeight, fromBottom)` plus a `useScrollToTopFab` that owns the FAB's visibility, its lift, and the footer measurement.
- `ScrollToTopFab` takes an optional `lift`, applied as `max(insets.bottom, lift) + gutter` so the safe-area inset and the footer's own bottom padding never stack.
- `Footer` accepts an optional `onLayout` so its height is measured rather than assumed.
- Home, Lookup and Locations move to the hook; Locations composes it with its existing filter-bar scroll tracking and clears the footer height when the side drawer takes the footer out of the scroll.
- Tests: `fabLift` pinned on both sides of the boundary plus the overscroll clamp; hook tests for visibility, measured lift, and the drop when the footer leaves the scroll; a render test that the FAB applies the lift; and two `LocationsScreen` tests covering the wiring end to end.
- Three existing scroll fixtures fired partial `nativeEvent`s (`contentOffset` only). They now carry the content/viewport pair RN always reports, via a local `scrollEvent` helper — the hook reads that pair, and a defensive branch for a shape the platform guarantees would have needed a test for something that cannot happen.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally — not run; no backend files touched.
- [x] Frontend tests/build pass locally — full Jest suite (188 suites / 2709 tests), `tsc --noEmit`, `npm run check`, `npm run check:doc-links`. `use-scroll-to-top-fab.ts`, `ScrollToTopFab.tsx` and `.styles.ts` are at 100%; `Footer.tsx` branch coverage is unchanged from baseline (same uncovered `hovered &&` branch, shifted line number).
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — backend + Expo web against the demo dataset, screenshotting the bottom of the scroll on `/locations` at 1680/1280 and `/` at 390. The FAB now sits above the footer's top border at every width instead of on the Admin link. The two `ScrollToTopFab` E2E tests in `customer-nav.spec.ts` also pass against that stack.

Docker isn't available in this environment, so the full `docker compose` E2E suite is left to CI.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed — no API contract or setup change.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Rsp1NBCZwXWLNUXbJ3RtD)_