### PR TITLE
Fix booking lookup matching (#358) and close out the schedule spike (#359, #362, #363)

### DIFF
--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -435,6 +435,37 @@ public class AdminServiceTests : IDisposable
         Assert.Equal("ABC123", results[0].BookingRef);
     }
 
+    // The admin lookup used to split the typed term into "email if it has an @, else booking
+    // reference", so a partial email matched nothing and a customer name matched nothing at all.
+    // One free-text param spans all three fields instead (#358).
+    [Theory]
+    [InlineData("ali")]           // partial name
+    [InlineData("ALICE@EX")]      // partial email, wrong case
+    [InlineData("bc12")]          // mid-string slice of the booking reference
+    public async Task GetBookingsAsync_QueryFilter_MatchesNameEmailAndRefPartially(string query)
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "ABC123", CustomerName = "Alice Smith", CustomerEmail = "Alice@Example.com" });
+        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "XYZ789", CustomerName = "Bob Jones", CustomerEmail = "bob@example.com" });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> results = await svc.GetBookingsAsync(1, null, "all", query: query);
+
+        Assert.Equal("ABC123", Assert.Single(results).BookingRef);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_QueryFilter_ReturnsNothingWhenTheTermMatchesNoField()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, SectionId = 1, TableId = 1, Date = DateTime.UtcNow, BookingRef = "ABC123", CustomerName = "Alice Smith", CustomerEmail = "alice@example.com" });
+        await _db.SaveChangesAsync();
+
+        Assert.Empty(await svc.GetBookingsAsync(1, null, "all", query: "zzz"));
+    }
+
     [Fact]
     public async Task GetBookingAsync_ReturnsNull_WhenNotFound()
     {

--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -72,6 +72,46 @@ public class AdminServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOverviewAsync_CountsBookingsStrandedByEveryLocationsSchedule()
+    {
+        AdminService svc = CreateService();
+        // Two Monday-only locations, each holding one Monday sitting and one Tuesday sitting.
+        // Only the Tuesdays are stranded, and the count has to span both locations.
+        _db.Restaurants.Add(new Restaurant { Id = 1, Name = "A", Timezone = "UTC", OpenDays = "1" });
+        _db.Restaurants.Add(new Restaurant { Id = 2, Name = "B", Timezone = "UTC", OpenDays = "1" });
+        var monday = new DateTime(2099, 1, 5, 12, 0, 0, DateTimeKind.Utc);
+        var tuesday = new DateTime(2099, 1, 6, 12, 0, 0, DateTimeKind.Utc);
+        _db.Bookings.Add(new Booking { Id = 1, RestaurantId = 1, Date = monday, Seats = 2, BookingRef = "a1" });
+        _db.Bookings.Add(new Booking { Id = 2, RestaurantId = 1, Date = tuesday, Seats = 2, BookingRef = "a2" });
+        _db.Bookings.Add(new Booking { Id = 3, RestaurantId = 2, Date = tuesday, Seats = 2, BookingRef = "b1" });
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(2, overview.ScheduleConflictsCount);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_CountsNoConflicts_WhenEveryBookingStillFits()
+    {
+        AdminService svc = CreateService();
+        _db.Restaurants.Add(new Restaurant { Id = 1, Name = "A", Timezone = "UTC", OpenDays = "1,2,3,4,5,6,7" });
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            Date = new DateTime(2099, 1, 5, 12, 0, 0, DateTimeKind.Utc),
+            Seats = 2,
+            BookingRef = "a1",
+        });
+        await _db.SaveChangesAsync();
+
+        AdminOverviewDto overview = await svc.GetOverviewAsync();
+
+        Assert.Equal(0, overview.ScheduleConflictsCount);
+    }
+
+    [Fact]
     public async Task GetOverviewAsync_TotalSeats_HandlesNull()
     {
         AdminService svc = CreateService();

--- a/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AvailabilityServiceTests.cs
@@ -1014,4 +1014,48 @@ public class AvailabilityServiceTests
         Assert.DoesNotContain(2, slot1200.AvailableTableIds);
         Assert.DoesNotContain(3, slot1200.AvailableTableIds);
     }
+
+    /// <summary>
+    /// The gate the picker offers a slot through and the gate the hold endpoint judges it by
+    /// have to agree. They did not: availability builds Saturday's 18:00–02:00 window and emits
+    /// the after-midnight slots as part of Saturday's service, while the hold gate resolved
+    /// 00:30 against Sunday and refused it whenever Sunday's schedule differed.
+    /// </summary>
+    [Fact]
+    public async Task GetAvailabilityAsync_OnlyOffersSlotsTheHoldGateAccepts_ForAnOvernightService()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetAvailabilityAsync_OnlyOffersSlotsTheHoldGateAccepts_ForAnOvernightService));
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "Late",
+            OpenTime = "18:00",
+            CloseTime = "02:00",
+            OpenDays = "6", // Saturday only, so Sunday carries the tail but opens nothing itself
+            Timezone = "UTC",
+        });
+        db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 2, SectionId = 1 });
+        db.SaveChanges();
+
+        var svc = new AvailabilityService(new BookingRepository(db), new RestaurantRepository(db), new Mock<IHoldService>().Object);
+        var saturday = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+
+        AvailabilityResponseDto result = await svc.GetAvailabilityAsync(1, saturday, 2);
+        Restaurant restaurant = db.Restaurants.Find(1)!;
+
+        Assert.Contains(result.Slots, s => s.Time == "00:30");
+        Assert.All(result.Slots, slot =>
+        {
+            DateTime slotUtc = SlotInstant(saturday, slot.Time);
+            Assert.True(restaurant.IsOpenAt(slotUtc), $"availability offered {slot.Time} but the hold gate refuses it");
+        });
+    }
+
+    /// <summary>A slot time past the opening hour belongs to the same day; one before it has wrapped.</summary>
+    private static DateTime SlotInstant(DateTime localDate, string slotTime)
+    {
+        TimeSpan timeOfDay = TimeSpan.Parse(slotTime, System.Globalization.CultureInfo.InvariantCulture);
+        return timeOfDay >= TimeSpan.FromHours(18) ? localDate + timeOfDay : localDate.AddDays(1) + timeOfDay;
+    }
 }

--- a/OpenRestoApi.Tests/Services/BookingServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/BookingServiceTests.cs
@@ -504,6 +504,44 @@ public partial class BookingServiceTests
         Assert.Equal(created.BookingRef, result!.BookingRef);
     }
 
+    // References are minted lowercase and guests paste them out of a confirmation email, so a
+    // capitalised or space-padded ref is the guest's keyboard, not a wrong reference (#358).
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task GetBookingByRefAsync_ToleratesCaseAndSurroundingWhitespace(bool upper, bool padded)
+    {
+        using AppDbContext db = TestDbFactory.Create($"{nameof(GetBookingByRefAsync_ToleratesCaseAndSurroundingWhitespace)}-{upper}-{padded}");
+        TestSeed.BasicRestaurant(db);
+
+        BookingService svc = CreateService(db);
+        BookingDto created = await svc.CreateBookingAsync(new BookingDto
+        {
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            CustomerEmail = "guest@example.com",
+            Seats = 2,
+            Date = DateTime.UtcNow.AddDays(7)
+        });
+
+        string typed = created.BookingRef!;
+        if (upper)
+        {
+            typed = typed.ToUpperInvariant();
+        }
+
+        if (padded)
+        {
+            typed = $"  {typed} ";
+        }
+
+        BookingDto? result = await svc.GetBookingByRefAsync(typed);
+
+        Assert.Equal(created.BookingRef, result?.BookingRef);
+    }
+
     [Fact]
     public async Task GetBookingByRefAsync_ReturnsNull_WhenNotFound()
     {

--- a/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/RestaurantManagementServiceTests.cs
@@ -19,6 +19,106 @@ public class RestaurantManagementServiceTests
         new TableGroupRepository(db));
 
     [Fact]
+    public async Task GetScheduleConflictsAsync_ReturnsNull_WhenRestaurantNotFound()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetScheduleConflictsAsync_ReturnsNull_WhenRestaurantNotFound));
+        Assert.Null(await CreateService(db).GetScheduleConflictsAsync(999));
+    }
+
+    [Fact]
+    public async Task GetScheduleConflictsAsync_FlagsBookingsLeftOutsideNarrowedHours()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetScheduleConflictsAsync_FlagsBookingsLeftOutsideNarrowedHours));
+        // Taken while the location opened at 11:00; it now opens at 17:00.
+        await SeedScheduleFixtureAsync(db, openTime: "17:00", bookingHourUtc: 12);
+
+        List<ScheduleConflictDto>? conflicts = await CreateService(db).GetScheduleConflictsAsync(1);
+
+        ScheduleConflictDto conflict = Assert.Single(conflicts!);
+        Assert.Equal("outsideHours", conflict.Reason);
+        Assert.Equal("ABC123", conflict.BookingRef);
+        Assert.Equal("Ada", conflict.CustomerName);
+        Assert.Equal(2, conflict.Seats);
+    }
+
+    [Fact]
+    public async Task GetScheduleConflictsAsync_IgnoresBookingsThatStillFit()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetScheduleConflictsAsync_IgnoresBookingsThatStillFit));
+        await SeedScheduleFixtureAsync(db, openTime: "17:00", bookingHourUtc: 19);
+
+        Assert.Empty((await CreateService(db).GetScheduleConflictsAsync(1))!);
+    }
+
+    [Fact]
+    public async Task GetScheduleConflictsAsync_IgnoresCancelledBookings()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetScheduleConflictsAsync_IgnoresCancelledBookings));
+        await SeedScheduleFixtureAsync(db, openTime: "17:00", bookingHourUtc: 12, cancelled: true);
+
+        Assert.Empty((await CreateService(db).GetScheduleConflictsAsync(1))!);
+    }
+
+    [Fact]
+    public async Task GetScheduleConflictsAsync_IgnoresBookingsAlreadyInThePast()
+    {
+        // A sitting that has already happened cannot be moved, so it is not the admin's problem.
+        using AppDbContext db = TestDbFactory.Create(nameof(GetScheduleConflictsAsync_IgnoresBookingsAlreadyInThePast));
+        await SeedScheduleFixtureAsync(db, openTime: "17:00", bookingHourUtc: 12, daysAhead: -7);
+
+        Assert.Empty((await CreateService(db).GetScheduleConflictsAsync(1))!);
+    }
+
+    [Fact]
+    public async Task GetScheduleConflictsAsync_FlagsBookingsOnceTheLocationTurnsWalkInOnly()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(GetScheduleConflictsAsync_FlagsBookingsOnceTheLocationTurnsWalkInOnly));
+        await SeedScheduleFixtureAsync(db, bookingHourUtc: 19, walkInOnly: true);
+
+        Assert.Equal("walkInOnly", Assert.Single((await CreateService(db).GetScheduleConflictsAsync(1))!).Reason);
+    }
+
+    /// <summary>
+    /// One upcoming booking at <paramref name="bookingHourUtc"/> against a UTC location whose
+    /// schedule is whatever the caller passes — i.e. the schedule as edited <em>after</em> the
+    /// booking was taken.
+    /// </summary>
+    private static async Task SeedScheduleFixtureAsync(
+        AppDbContext db,
+        int bookingHourUtc,
+        string openTime = "11:00",
+        bool walkInOnly = false,
+        bool cancelled = false,
+        int daysAhead = 7)
+    {
+        db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "R1",
+            Timezone = "UTC",
+            OpenTime = openTime,
+            CloseTime = "23:00",
+            OpenDays = "1,2,3,4,5,6,7",
+            WalkInOnly = walkInOnly,
+        });
+
+        DateTime day = DateTime.UtcNow.Date.AddDays(daysAhead);
+        db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            Date = day.AddHours(bookingHourUtc),
+            Seats = 2,
+            CustomerName = "Ada",
+            BookingRef = "ABC123",
+            IsCancelled = cancelled,
+            CancelledAt = cancelled ? DateTime.UtcNow : null,
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
     public async Task GetAllAsync_ReturnsAll()
     {
         using AppDbContext db = TestDbFactory.Create(nameof(GetAllAsync_ReturnsAll));

--- a/OpenRestoApi.Tests/Services/ScheduleConflictHelperTests.cs
+++ b/OpenRestoApi.Tests/Services/ScheduleConflictHelperTests.cs
@@ -1,0 +1,170 @@
+using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Tests.Services;
+
+public class ScheduleConflictHelperTests
+{
+    private static Restaurant Restaurant(
+        string openTime = "11:00",
+        string closeTime = "23:00",
+        string openDays = "1,2,3,4,5,6,7",
+        string? openHoursJson = null,
+        bool walkInOnly = false,
+        string? walkInDays = null) => new()
+        {
+            Id = 1,
+            Name = "R",
+            Timezone = "UTC",
+            OpenTime = openTime,
+            CloseTime = closeTime,
+            OpenDays = openDays,
+            OpenHoursJson = openHoursJson,
+            WalkInOnly = walkInOnly,
+            WalkInDays = walkInDays,
+        };
+
+    // 2026-08-24 is a Monday, so the ISO day of each instant below is unambiguous.
+    private static DateTime MondayAt(int hour, int minute = 0)
+        => new(2026, 8, 24, hour, minute, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Evaluate_KeepsSittingInsideTheCurrentWindow()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.None,
+            ScheduleConflictHelper.Evaluate(Restaurant(), MondayAt(19)));
+    }
+
+    [Fact]
+    public void Evaluate_FlagsSittingBeforeTheNarrowedOpeningTime()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.OutsideHours,
+            ScheduleConflictHelper.Evaluate(Restaurant(openTime: "17:00"), MondayAt(12)));
+    }
+
+    [Fact]
+    public void Evaluate_KeepsSittingAtTheOpeningTimeItself()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.None,
+            ScheduleConflictHelper.Evaluate(Restaurant(openTime: "17:00"), MondayAt(17)));
+    }
+
+    [Fact]
+    public void Evaluate_FlagsSittingAtTheNewClosingTime()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.OutsideHours,
+            ScheduleConflictHelper.Evaluate(Restaurant(closeTime: "21:00"), MondayAt(21)));
+    }
+
+    [Fact]
+    public void Evaluate_KeepsSittingJustBeforeTheNewClosingTime()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.None,
+            ScheduleConflictHelper.Evaluate(Restaurant(closeTime: "21:00"), MondayAt(20, 59)));
+    }
+
+    [Fact]
+    public void Evaluate_FlagsSittingOnADayThatIsNoLongerOpen()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.ClosedDay,
+            ScheduleConflictHelper.Evaluate(Restaurant(openDays: "2,3,4,5,6,7"), MondayAt(19)));
+    }
+
+    [Fact]
+    public void Evaluate_FlagsSittingAgainstThePerDayOverrideRatherThanTheUniformHours()
+    {
+        // Monday closes at 20:00 through the override; the uniform CloseTime would still allow 21:00.
+        Restaurant restaurant = Restaurant(openHoursJson: """{"1":{"open":"11:00","close":"20:00"}}""");
+
+        Assert.Equal(
+            ScheduleConflictReason.OutsideHours,
+            ScheduleConflictHelper.Evaluate(restaurant, MondayAt(21)));
+    }
+
+    [Fact]
+    public void Evaluate_KeepsAfterMidnightSittingOfAnOvernightService()
+    {
+        // Sunday runs 18:00–02:00, so a 00:30 sitting belongs to Sunday's service even though
+        // it lands on Monday. AvailabilityService sells that slot; flagging it would be a false
+        // positive on every late-night venue.
+        Restaurant restaurant = Restaurant(openTime: "18:00", closeTime: "02:00");
+
+        Assert.Equal(
+            ScheduleConflictReason.None,
+            ScheduleConflictHelper.Evaluate(restaurant, MondayAt(0, 30)));
+    }
+
+    [Fact]
+    public void Evaluate_FlagsAfterMidnightSittingWhenThePreviousDayIsClosed()
+    {
+        // Same overnight window, but Sunday is no longer an open day — nothing serves 00:30 now.
+        Restaurant restaurant = Restaurant(openTime: "18:00", closeTime: "02:00", openDays: "1,2,3,4,5,6");
+
+        Assert.Equal(
+            ScheduleConflictReason.OutsideHours,
+            ScheduleConflictHelper.Evaluate(restaurant, MondayAt(0, 30)));
+    }
+
+    [Fact]
+    public void Evaluate_FlagsSittingOnceTheLocationTurnsWalkInOnly()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.WalkInOnly,
+            ScheduleConflictHelper.Evaluate(Restaurant(walkInOnly: true), MondayAt(19)));
+    }
+
+    [Fact]
+    public void Evaluate_FlagsSittingOnADayTurnedWalkInOnly()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.WalkInOnly,
+            ScheduleConflictHelper.Evaluate(Restaurant(walkInDays: "1"), MondayAt(19)));
+    }
+
+    [Fact]
+    public void Evaluate_KeepsSittingOnADayOtherLocationDaysTurnedWalkInOnly()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.None,
+            ScheduleConflictHelper.Evaluate(Restaurant(walkInDays: "2,3"), MondayAt(19)));
+    }
+
+    [Fact]
+    public void Evaluate_ReportsTheClosedDayRatherThanTheWalkInSwitchWhenBothApply()
+    {
+        // A closed day is the harder problem: the guest has nowhere to be seated at all, where a
+        // walk-in day still opens. Reporting the milder reason would understate the fix needed.
+        Restaurant restaurant = Restaurant(openDays: "2,3,4,5,6,7", walkInOnly: true);
+
+        Assert.Equal(
+            ScheduleConflictReason.ClosedDay,
+            ScheduleConflictHelper.Evaluate(restaurant, MondayAt(19)));
+    }
+
+    [Fact]
+    public void Evaluate_ResolvesTheSittingInTheLocationTimezone()
+    {
+        // 02:00 UTC is 21:00 the previous day in New York — inside an 11:00–23:00 service.
+        // Reading the instant as UTC would place it before opening and flag it.
+        Restaurant restaurant = Restaurant();
+        restaurant.Timezone = "America/New_York";
+
+        Assert.Equal(
+            ScheduleConflictReason.None,
+            ScheduleConflictHelper.Evaluate(restaurant, MondayAt(2)));
+    }
+
+    [Fact]
+    public void Evaluate_KeepsEverySittingWhenOpenAndCloseMatch()
+    {
+        Assert.Equal(
+            ScheduleConflictReason.None,
+            ScheduleConflictHelper.Evaluate(Restaurant(openTime: "00:00", closeTime: "00:00"), MondayAt(4)));
+    }
+}

--- a/OpenRestoApi.Tests/Services/ScheduleConflictHelperTests.cs
+++ b/OpenRestoApi.Tests/Services/ScheduleConflictHelperTests.cs
@@ -167,4 +167,33 @@ public class ScheduleConflictHelperTests
             ScheduleConflictReason.None,
             ScheduleConflictHelper.Evaluate(Restaurant(openTime: "00:00", closeTime: "00:00"), MondayAt(4)));
     }
+
+    [Fact]
+    public void Conflicting_ReturnsOnlyTheBookingsTheScheduleNoLongerAccepts()
+    {
+        // Open 11:00-23:00, so the 09:00 sitting is stranded and the other two still fit.
+        Restaurant restaurant = Restaurant();
+        List<Booking> bookings =
+        [
+            new() { Id = 1, Date = MondayAt(12), BookingRef = "fits" },
+            new() { Id = 2, Date = MondayAt(9), BookingRef = "stranded" },
+            new() { Id = 3, Date = MondayAt(22), BookingRef = "fits-late" },
+        ];
+
+        List<(Booking Booking, ScheduleConflictReason Reason)> conflicts =
+            ScheduleConflictHelper.Conflicting(restaurant, bookings);
+
+        (Booking booking, ScheduleConflictReason reason) = Assert.Single(conflicts);
+        Assert.Equal("stranded", booking.BookingRef);
+        Assert.Equal(ScheduleConflictReason.OutsideHours, reason);
+    }
+
+    [Fact]
+    public void Conflicting_ReturnsNothing_WhenEveryBookingStillFits()
+    {
+        Restaurant restaurant = Restaurant();
+        List<Booking> bookings = [new() { Id = 1, Date = MondayAt(12), BookingRef = "fits" }];
+
+        Assert.Empty(ScheduleConflictHelper.Conflicting(restaurant, bookings));
+    }
 }

--- a/OpenRestoApi.Tests/Services/ServiceWindowHelperTests.cs
+++ b/OpenRestoApi.Tests/Services/ServiceWindowHelperTests.cs
@@ -1,0 +1,183 @@
+using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Tests.Services;
+
+public class ServiceWindowHelperTests
+{
+    private static Restaurant NewRestaurant(
+        string openTime = "09:00",
+        string closeTime = "22:00",
+        string openDays = "1,2,3,4,5,6,7",
+        string? openHoursJson = null,
+        string timezone = "UTC")
+        => new()
+        {
+            Id = 1,
+            Name = "T",
+            OpenTime = openTime,
+            CloseTime = closeTime,
+            OpenDays = openDays,
+            OpenHoursJson = openHoursJson,
+            Timezone = timezone,
+        };
+
+    // 2026-01-10 is a Saturday, so 2026-01-11 is the Sunday that carries its overnight tail.
+    private static DateTime SaturdayAt(int hour, int minute = 0) => new(2026, 1, 10, hour, minute, 0, DateTimeKind.Utc);
+    private static DateTime SundayAt(int hour, int minute = 0) => new(2026, 1, 11, hour, minute, 0, DateTimeKind.Utc);
+
+    private const string Saturday = "6";
+    private const string Sunday = "7";
+
+    // ── The overnight tail belongs to the day the service opened ───────────────
+
+    [Fact]
+    public void IsServingAt_AllowsAfterMidnightTailOfThePreviousDaysService()
+    {
+        // Saturday-only late-night venue, 18:00 through 02:00. The 00:30 sitting lands on
+        // Sunday, a day the venue never opens, but it was sold as part of Saturday's service.
+        Restaurant r = NewRestaurant(openTime: "18:00", closeTime: "02:00", openDays: Saturday);
+
+        Assert.True(ServiceWindowHelper.IsServingAt(r, SundayAt(0, 30)));
+    }
+
+    [Fact]
+    public void IsServingAt_RejectsAfterMidnightTailWhenTheOpeningDayIsClosed()
+    {
+        // Same 00:30 instant, but now Sunday is the open day and Saturday is closed, so no
+        // service reaches it: Sunday's own window has not started and Saturday runs nothing.
+        Restaurant r = NewRestaurant(openTime: "18:00", closeTime: "02:00", openDays: Sunday);
+
+        Assert.False(ServiceWindowHelper.IsServingAt(r, SundayAt(0, 30)));
+    }
+
+    [Fact]
+    public void IsServingAt_RejectsAfterMidnightTailAttributedToItsOwnDay()
+    {
+        // Saturday 00:30 is the tail of *Friday's* service, and Friday is closed. Crediting a
+        // wrapping window's far side to the day it opened is what made the availability and
+        // hold gates disagree.
+        Restaurant r = NewRestaurant(openTime: "18:00", closeTime: "02:00", openDays: Saturday);
+
+        Assert.False(ServiceWindowHelper.IsServingAt(r, SaturdayAt(0, 30)));
+        Assert.True(ServiceWindowHelper.IsServingAt(r, SaturdayAt(19)));
+    }
+
+    [Fact]
+    public void IsServingAt_ResolvesTheTailAgainstTheOpeningDaysHours_NotTheLandingDays()
+    {
+        // Saturday runs 18:00–02:00, Sunday runs a lunch service. Sunday 00:30 is inside
+        // neither of Sunday's own hours nor a uniform fallback — only Saturday's tail.
+        Restaurant r = NewRestaurant(
+            openHoursJson: """{"6":{"open":"18:00","close":"02:00"},"7":{"open":"11:00","close":"15:00"}}""");
+
+        Assert.True(ServiceWindowHelper.IsServingAt(r, SundayAt(0, 30)));
+        Assert.False(ServiceWindowHelper.IsServingAt(r, SundayAt(3)));
+    }
+
+    [Fact]
+    public void IsServingAt_EndsTheTailAtTheOpeningDaysClosingTime()
+    {
+        Restaurant r = NewRestaurant(openTime: "18:00", closeTime: "02:00", openDays: Saturday);
+
+        Assert.True(ServiceWindowHelper.IsServingAt(r, SundayAt(1, 59)));
+        Assert.False(ServiceWindowHelper.IsServingAt(r, SundayAt(2)));
+    }
+
+    // ── The ordinary same-day window ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData(9, true)]      // opens on the hour, inclusive
+    [InlineData(12, true)]
+    [InlineData(8, false)]
+    [InlineData(22, false)]    // closes on the hour, exclusive
+    public void IsServingAt_CoversTheDaysOwnWindow(int hour, bool expected)
+    {
+        Restaurant r = NewRestaurant();
+
+        Assert.Equal(expected, ServiceWindowHelper.IsServingAt(r, SaturdayAt(hour)));
+    }
+
+    [Fact]
+    public void IsServingAt_TreatsEqualOpenAndCloseAsAllDay()
+    {
+        Restaurant r = NewRestaurant(openTime: "00:00", closeTime: "00:00");
+
+        Assert.True(ServiceWindowHelper.IsServingAt(r, SaturdayAt(3)));
+    }
+
+    [Fact]
+    public void IsServingAt_FallsBackToDefaultHours_WhenStoredTimesAreUnparseable()
+    {
+        Restaurant r = NewRestaurant(openTime: "", closeTime: "");
+
+        Assert.True(ServiceWindowHelper.IsServingAt(r, SaturdayAt(12)));
+    }
+
+    [Fact]
+    public void IsServingAt_ResolvesTheInstantThroughTheRestaurantsTimezone()
+    {
+        // 03:00 UTC is 22:00 the previous day in New York, inside a 09:00–22:59 window.
+        Restaurant r = NewRestaurant(openTime: "09:00", closeTime: "22:59", timezone: "America/New_York");
+
+        Assert.True(ServiceWindowHelper.IsServingAt(r, SundayAt(3)));
+        Assert.False(ServiceWindowHelper.IsServingAt(r, SundayAt(8)));
+    }
+
+    // ── IsOpenOn ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsOpenOn_TreatsAnEmptyDayListAsEveryDay()
+    {
+        Restaurant r = NewRestaurant(openDays: "");
+
+        Assert.True(ServiceWindowHelper.IsOpenOn(r, 1));
+        Assert.True(ServiceWindowHelper.IsOpenOn(r, 7));
+    }
+
+    [Fact]
+    public void IsOpenOn_RejectsADayTheListOmits()
+    {
+        Restaurant r = NewRestaurant(openDays: Saturday);
+
+        Assert.True(ServiceWindowHelper.IsOpenOn(r, 6));
+        Assert.False(ServiceWindowHelper.IsOpenOn(r, 7));
+    }
+
+    // ── LocalWindowFor ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LocalWindowFor_KeepsASameDayWindowOnItsOwnDate()
+    {
+        Restaurant r = NewRestaurant(openTime: "11:00", closeTime: "23:00");
+        var localDate = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Unspecified);
+
+        (DateTime start, DateTime end) = ServiceWindowHelper.LocalWindowFor(r, localDate, 6);
+
+        Assert.Equal(new DateTime(2026, 1, 10, 11, 0, 0), start);
+        Assert.Equal(new DateTime(2026, 1, 10, 23, 0, 0), end);
+    }
+
+    [Fact]
+    public void LocalWindowFor_RollsAWrappingWindowIntoTheFollowingDay()
+    {
+        Restaurant r = NewRestaurant(openTime: "18:00", closeTime: "02:00");
+        var localDate = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Unspecified);
+
+        (DateTime start, DateTime end) = ServiceWindowHelper.LocalWindowFor(r, localDate, 6);
+
+        Assert.Equal(new DateTime(2026, 1, 10, 18, 0, 0), start);
+        Assert.Equal(new DateTime(2026, 1, 11, 2, 0, 0), end);
+    }
+
+    [Fact]
+    public void LocalWindowFor_SpansAFullDay_WhenOpenEqualsClose()
+    {
+        Restaurant r = NewRestaurant(openTime: "00:00", closeTime: "00:00");
+        var localDate = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Unspecified);
+
+        (DateTime start, DateTime end) = ServiceWindowHelper.LocalWindowFor(r, localDate, 6);
+
+        Assert.Equal(TimeSpan.FromDays(1), end - start);
+    }
+}

--- a/OpenRestoApi/Controllers/AdminController.cs
+++ b/OpenRestoApi/Controllers/AdminController.cs
@@ -25,11 +25,12 @@ public class AdminController(AdminService adminService) : ControllerBase
         [FromQuery] bookingStatus status = bookingStatus.active,
         [FromQuery] bool cancelled = false,
         [FromQuery] string? email = null,
-        [FromQuery] string? bookingRef = null)
+        [FromQuery] string? bookingRef = null,
+        [FromQuery] string? query = null)
     {
         //this is business logic that should likely belong in the service but its OK for now
         string effectiveStatus = cancelled ? nameof(bookingStatus.cancelled) : status.ToString();
-        return Ok(await _adminService.GetBookingsAsync(restaurantId, date, effectiveStatus, email, bookingRef));
+        return Ok(await _adminService.GetBookingsAsync(restaurantId, date, effectiveStatus, email, bookingRef, query));
     }
 
     [HttpGet("bookings/{id}")]

--- a/OpenRestoApi/Controllers/RestaurantsController.cs
+++ b/OpenRestoApi/Controllers/RestaurantsController.cs
@@ -112,6 +112,18 @@ public class RestaurantsController(RestaurantManagementService service) : Contro
         return result == null ? NotFound() : Ok(result);
     }
 
+    // Bookings taken under an older schedule (#359). Editing hours/open days/walk-in policy is
+    // silent by design — it leaves existing rows alone — so the admin UI reads this after an edit
+    // to show who is now booked into a service the location no longer runs. 404 when the
+    // restaurant doesn't exist, so the caller can drop the panel rather than block the form.
+    [HttpGet("{id}/schedule-conflicts")]
+    [Authorize(Policy = AuthPolicies.RequireAdmin)]
+    public async Task<IActionResult> GetScheduleConflicts(int id)
+    {
+        List<ScheduleConflictDto>? result = await _service.GetScheduleConflictsAsync(id);
+        return result == null ? NotFound() : Ok(result);
+    }
+
     // ── Combinable table groups (#271) ──────────────────────────────────────
     //
     // Schema + CRUD only here. Wiring groups into availability/auto-assign/holds is the next issue

--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -21,6 +21,13 @@ public class AdminOverviewDto
     public int TotalSeats { get; set; }
     public int ActiveHoldsCount { get; set; }
     public int PausedRestaurantsCount { get; set; }
+
+    /// <summary>
+    /// Upcoming bookings across every active location that its current schedule would no longer
+    /// accept. The locations screen reports these per location, but an admin who narrows hours
+    /// and navigates away never sees that panel again.
+    /// </summary>
+    public int ScheduleConflictsCount { get; set; }
     public List<int> OccupancyData { get; set; } = [];
     public List<string> OccupancyDates { get; set; } = [];
     public List<int> OccupancyCounts { get; set; } = [];

--- a/OpenRestoApi/Core/Application/DTOs/BookingFilter.cs
+++ b/OpenRestoApi/Core/Application/DTOs/BookingFilter.cs
@@ -14,4 +14,12 @@ public sealed class BookingFilter
     public string Status { get; init; } = "active";
     public string? Email { get; init; }
     public string? BookingRef { get; init; }
+
+    /// <summary>
+    /// Free-text admin search, matched as a case-insensitive substring against the customer
+    /// name, the customer email and the booking reference at once. Combines with
+    /// <see cref="Email"/>/<see cref="BookingRef"/> rather than replacing them: those stay the
+    /// narrow single-field filters the deep links use.
+    /// </summary>
+    public string? Query { get; init; }
 }

--- a/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/RestaurantDto.cs
@@ -124,6 +124,26 @@ public class DeleteImpactDto
     public int Bookings { get; set; }
 }
 
+// ── Schedule conflicts (#359) ─────────────────────────────────────────────
+
+/// <summary>
+/// An upcoming booking that no longer fits the location's current schedule, so the admin who
+/// narrowed the hours can see who they have to move or call.
+/// </summary>
+public class ScheduleConflictDto
+{
+    public int BookingId { get; set; }
+    public string BookingRef { get; set; } = string.Empty;
+    public string? CustomerName { get; set; }
+
+    /// <summary>Sitting start, UTC — the client renders it in the location's timezone.</summary>
+    public DateTime Date { get; set; }
+    public int Seats { get; set; }
+
+    /// <summary>"closedDay" | "outsideHours" | "walkInOnly" — see <c>ScheduleConflictReason</c>.</summary>
+    public string Reason { get; set; } = string.Empty;
+}
+
 // ── Combinable table groups (#271) ────────────────────────────────────────
 
 public class CreateTableGroupRequest

--- a/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IBookingRepository.cs
@@ -126,4 +126,11 @@ public interface IBookingRepository
 
     /// <summary>All bookings whose TableGroupId matches — used by RestaurantManagementService.DeleteTableGroupAsync to FK-null them.</summary>
     Task<List<Booking>> GetByTableGroupAsync(int tableGroupId);
+
+    /// <summary>
+    /// Non-cancelled bookings for a restaurant starting at or after <paramref name="nowUtc"/>, oldest
+    /// first and with no navigation properties loaded — the set the schedule-conflict read re-evaluates
+    /// against the location's current opening hours and walk-in policy.
+    /// </summary>
+    Task<List<Booking>> GetFutureForRestaurantAsync(int restaurantId, DateTime nowUtc);
 }

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -79,6 +79,7 @@ public class AdminService(
 
         int todayBookingsCount = 0;
         int pausedRestaurantsCount = 0;
+        int scheduleConflictsCount = 0;
         List<BookingDetailDto> todayBookingsList = [];
         foreach (Restaurant? r in restaurants)
         {
@@ -86,6 +87,9 @@ public class AdminService(
             List<Booking> rTodayBookings = await _bookingRepository.GetForRestaurantInUtcRangeAsync(r.Id, start, end);
             todayBookingsCount += rTodayBookings.Count;
             todayBookingsList.AddRange(rTodayBookings.Select(ToDetailDto));
+
+            List<Booking> upcoming = await _bookingRepository.GetFutureForRestaurantAsync(r.Id, nowUtc);
+            scheduleConflictsCount += ScheduleConflictHelper.Conflicting(r, upcoming).Count;
 
             if (r.BookingsPausedUntil.HasValue && r.BookingsPausedUntil.Value > nowUtc)
             {
@@ -104,6 +108,7 @@ public class AdminService(
             TotalSeats = totalSeats,
             ActiveHoldsCount = _holdService.GetActiveHoldsCount(),
             PausedRestaurantsCount = pausedRestaurantsCount,
+            ScheduleConflictsCount = scheduleConflictsCount,
             OccupancyData = occupancyData,
             OccupancyDates = occupancyDates,
             OccupancyCounts = rawCounts,

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -151,7 +151,7 @@ public class AdminService(
     [ExcludeFromCodeCoverage(Justification = "Unreachable: the 7-iteration loop above always populates rawCounts, so Count is never 0 at this call site.")]
     private static int MaxOrZero(List<int> counts) => counts.Count > 0 ? counts.Max() : 0;
 
-    public virtual async Task<List<BookingDetailDto>> GetBookingsAsync(int? restaurantId, DateTime? bookingDate, string status, string? email = null, string? bookingRef = null)
+    public virtual async Task<List<BookingDetailDto>> GetBookingsAsync(int? restaurantId, DateTime? bookingDate, string status, string? email = null, string? bookingRef = null, string? query = null)
     {
         List<Booking> bookings = await _bookingFilterRepository.QueryAsync(new BookingFilter
         {
@@ -160,6 +160,7 @@ public class AdminService(
             Status = status,
             Email = email,
             BookingRef = bookingRef,
+            Query = query,
         });
 
         return bookings.Select(ToDetailDto).ToList();

--- a/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
+++ b/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
@@ -30,12 +30,12 @@ public sealed class AvailabilityService(
         DateTime localDate = bookingDate.Date;
         int isoDay = IsoDay.Of(localDate);
 
-        if (WalkInHelper.IsWalkInOnlyOn(restaurant, isoDay) || !IsOpenOn(restaurant, isoDay))
+        if (WalkInHelper.IsWalkInOnlyOn(restaurant, isoDay) || !ServiceWindowHelper.IsOpenOn(restaurant, isoDay))
         {
             return NoSlots(restaurantId, bookingDate);
         }
 
-        (DateTime localStart, DateTime localEnd) = ServiceWindowOn(restaurant, localDate, isoDay);
+        (DateTime localStart, DateTime localEnd) = ServiceWindowHelper.LocalWindowFor(restaurant, localDate, isoDay);
         var reservations = new UnitReservations(restaurant, activeBookings);
         List<Table> eligibleTables = EligibleTables(restaurant, seats);
         List<TableGroup> eligibleGroups = EligibleGroups(restaurant, seats);
@@ -98,30 +98,6 @@ public sealed class AvailabilityService(
 
     private static string FormatSlotTime(DateTime local)
         => local.ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture);
-
-    private static bool IsOpenOn(Restaurant restaurant, int isoDay)
-    {
-        HashSet<int> openDays = IsoDay.ParseList(restaurant.OpenDays);
-        return openDays.Count == 0 || openDays.Contains(isoDay);
-    }
-
-    private static (DateTime Start, DateTime End) ServiceWindowOn(Restaurant restaurant, DateTime localDate, int isoDay)
-    {
-        (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(restaurant, isoDay);
-        if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
-        {
-            (openHour, openMin) = OpeningHourDefaults.OpenAt;
-        }
-        if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
-        {
-            (closeHour, closeMin) = OpeningHourDefaults.CloseAt;
-        }
-
-        DateTime start = localDate.AddHours(openHour).AddMinutes(openMin);
-        DateTime end = localDate.AddHours(closeHour).AddMinutes(closeMin);
-        bool closesAfterMidnight = end <= start;
-        return (start, closesAfterMidnight ? end.AddDays(1) : end);
-    }
 
     /// <summary>
     /// A zero or negative stored interval would spin the slot loop forever. Validation keeps

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -579,6 +579,48 @@ public class RestaurantManagementService(
         return new DeleteImpactDto { Bookings = bookings };
     }
 
+    /// <summary>
+    /// Upcoming bookings that the location's <em>current</em> schedule would no longer accept.
+    /// Narrowing opening hours, closing a day or switching to walk-in only never touches the
+    /// bookings already on the books, so this read is the only thing that surfaces the guests
+    /// left stranded by the edit. Returns null when the restaurant doesn't exist.
+    /// </summary>
+    /// <seealso>RestaurantManagementServiceTests.GetScheduleConflictsAsync_FlagsBookingsLeftOutsideNarrowedHours</seealso>
+    /// <seealso>RestaurantManagementServiceTests.GetScheduleConflictsAsync_IgnoresBookingsThatStillFit</seealso>
+    public async Task<List<ScheduleConflictDto>?> GetScheduleConflictsAsync(int restaurantId)
+    {
+        Restaurant? restaurant = await _restaurantRepository.GetByIdAsync(restaurantId);
+        if (restaurant == null)
+        {
+            return null;
+        }
+
+        List<Booking> upcoming = await _bookingRepository.GetFutureForRestaurantAsync(restaurantId, DateTime.UtcNow);
+
+        return upcoming
+            .Select(b => (Booking: b, Reason: ScheduleConflictHelper.Evaluate(restaurant, b.Date)))
+            .Where(x => x.Reason != ScheduleConflictReason.None)
+            .Select(x => new ScheduleConflictDto
+            {
+                BookingId = x.Booking.Id,
+                BookingRef = x.Booking.BookingRef,
+                CustomerName = x.Booking.CustomerName,
+                Date = x.Booking.Date,
+                Seats = x.Booking.Seats,
+                Reason = ReasonKey(x.Reason),
+            })
+            .ToList();
+    }
+
+    private static string ReasonKey(ScheduleConflictReason reason) => reason switch
+    {
+        ScheduleConflictReason.ClosedDay => "closedDay",
+        ScheduleConflictReason.OutsideHours => "outsideHours",
+        ScheduleConflictReason.WalkInOnly => "walkInOnly",
+        // Unreachable: GetScheduleConflictsAsync filters None out before mapping.
+        _ => "unknown",
+    };
+
     public async Task<DeleteImpactDto?> GetSectionDeleteImpactAsync(int restaurantId, int sectionId)
     {
         Section? section = await _sectionRepository.GetWithTablesForRestaurantAsync(sectionId, restaurantId);

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -597,9 +597,7 @@ public class RestaurantManagementService(
 
         List<Booking> upcoming = await _bookingRepository.GetFutureForRestaurantAsync(restaurantId, DateTime.UtcNow);
 
-        return upcoming
-            .Select(b => (Booking: b, Reason: ScheduleConflictHelper.Evaluate(restaurant, b.Date)))
-            .Where(x => x.Reason != ScheduleConflictReason.None)
+        return ScheduleConflictHelper.Conflicting(restaurant, upcoming)
             .Select(x => new ScheduleConflictDto
             {
                 BookingId = x.Booking.Id,

--- a/OpenRestoApi/Core/Application/Services/ScheduleConflictHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/ScheduleConflictHelper.cs
@@ -1,0 +1,102 @@
+using OpenRestoApi.Core.Application.Utilities;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Core.Application.Services;
+
+/// <summary>
+/// Why an already-taken booking no longer fits its location's schedule. Editing opening
+/// hours, open days or the walk-in policy never touches existing rows, so a booking taken
+/// under the old schedule survives the edit and is only discoverable by re-evaluating it
+/// against the current one.
+/// </summary>
+public enum ScheduleConflictReason
+{
+    /// <summary>The booking still falls inside a service the location currently runs.</summary>
+    None,
+
+    /// <summary>The booking's local day is no longer in <see cref="Restaurant.OpenDays"/>.</summary>
+    ClosedDay,
+
+    /// <summary>The day is open, but the booking starts outside that day's service window.</summary>
+    OutsideHours,
+
+    /// <summary>The location still opens then, but no longer takes bookings for that day.</summary>
+    WalkInOnly,
+}
+
+/// <summary>
+/// Re-evaluates an existing booking against the schedule a location has <em>now</em>.
+/// <para>
+/// The window arithmetic deliberately does not reuse <see cref="Restaurant.IsOpenAt"/>: that
+/// one resolves an overnight service against the ISO day the instant itself falls on, so a
+/// 00:30 sitting sold as part of Saturday's 18:00–02:00 service is judged against Sunday.
+/// <c>AvailabilityService</c> emits exactly that slot, so reusing it would report a conflict
+/// for a booking the product sold on purpose.
+/// </para>
+/// </summary>
+/// <seealso>ScheduleConflictHelperTests.Evaluate_KeepsAfterMidnightSittingOfAnOvernightService</seealso>
+/// <seealso>ScheduleConflictHelperTests.Evaluate_FlagsSittingOnADayThatIsNoLongerOpen</seealso>
+public static class ScheduleConflictHelper
+{
+    public static ScheduleConflictReason Evaluate(Restaurant restaurant, DateTime bookingUtc)
+    {
+        DateTime local = TimeZoneHelper.ConvertUtcToLocal(bookingUtc, restaurant.Timezone);
+        int isoDay = IsoDay.Of(local);
+        int previousDay = isoDay == IsoDay.Monday ? IsoDay.Sunday : isoDay - 1;
+
+        bool servedToday = IsOpenOn(restaurant, isoDay) && DayWindowCovers(restaurant, isoDay, local.TimeOfDay);
+        bool servedByOvernightTail = IsOpenOn(restaurant, previousDay)
+            && OvernightTailCovers(restaurant, previousDay, local.TimeOfDay);
+
+        if (!servedToday && !servedByOvernightTail)
+        {
+            return IsOpenOn(restaurant, isoDay) ? ScheduleConflictReason.OutsideHours : ScheduleConflictReason.ClosedDay;
+        }
+
+        return WalkInHelper.IsWalkInOnlyAt(restaurant, bookingUtc)
+            ? ScheduleConflictReason.WalkInOnly
+            : ScheduleConflictReason.None;
+    }
+
+    private static bool IsOpenOn(Restaurant restaurant, int isoDay)
+    {
+        HashSet<int> openDays = IsoDay.ParseList(restaurant.OpenDays);
+        return openDays.Count == 0 || openDays.Contains(isoDay);
+    }
+
+    /// <summary>The part of <paramref name="isoDay"/>'s service that falls on that same day.</summary>
+    private static bool DayWindowCovers(Restaurant restaurant, int isoDay, TimeSpan timeOfDay)
+    {
+        (TimeSpan open, TimeSpan close) = ServiceWindowOn(restaurant, isoDay);
+        if (open == close)
+        {
+            return true;
+        }
+
+        return close < open ? timeOfDay >= open : timeOfDay >= open && timeOfDay < close;
+    }
+
+    /// <summary>The part of <paramref name="isoDay"/>'s service that spills past midnight onto the next day.</summary>
+    private static bool OvernightTailCovers(Restaurant restaurant, int isoDay, TimeSpan timeOfDay)
+    {
+        (TimeSpan open, TimeSpan close) = ServiceWindowOn(restaurant, isoDay);
+        return close < open && timeOfDay < close;
+    }
+
+    private static (TimeSpan Open, TimeSpan Close) ServiceWindowOn(Restaurant restaurant, int isoDay)
+    {
+        (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(restaurant, isoDay);
+
+        if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
+        {
+            (openHour, openMin) = OpeningHourDefaults.OpenAt;
+        }
+
+        if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
+        {
+            (closeHour, closeMin) = OpeningHourDefaults.CloseAt;
+        }
+
+        return (new TimeSpan(openHour, openMin, 0), new TimeSpan(closeHour, closeMin, 0));
+    }
+}

--- a/OpenRestoApi/Core/Application/Services/ScheduleConflictHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/ScheduleConflictHelper.cs
@@ -25,14 +25,9 @@ public enum ScheduleConflictReason
 }
 
 /// <summary>
-/// Re-evaluates an existing booking against the schedule a location has <em>now</em>.
-/// <para>
-/// The window arithmetic deliberately does not reuse <see cref="Restaurant.IsOpenAt"/>: that
-/// one resolves an overnight service against the ISO day the instant itself falls on, so a
-/// 00:30 sitting sold as part of Saturday's 18:00–02:00 service is judged against Sunday.
-/// <c>AvailabilityService</c> emits exactly that slot, so reusing it would report a conflict
-/// for a booking the product sold on purpose.
-/// </para>
+/// Re-evaluates an existing booking against the schedule a location has <em>now</em>. Editing
+/// hours, open days or the walk-in policy never touches rows already taken, so a booking sold
+/// under the old schedule is only discoverable by asking this again.
 /// </summary>
 /// <seealso>ScheduleConflictHelperTests.Evaluate_KeepsAfterMidnightSittingOfAnOvernightService</seealso>
 /// <seealso>ScheduleConflictHelperTests.Evaluate_FlagsSittingOnADayThatIsNoLongerOpen</seealso>
@@ -40,63 +35,16 @@ public static class ScheduleConflictHelper
 {
     public static ScheduleConflictReason Evaluate(Restaurant restaurant, DateTime bookingUtc)
     {
-        DateTime local = TimeZoneHelper.ConvertUtcToLocal(bookingUtc, restaurant.Timezone);
-        int isoDay = IsoDay.Of(local);
-        int previousDay = isoDay == IsoDay.Monday ? IsoDay.Sunday : isoDay - 1;
-
-        bool servedToday = IsOpenOn(restaurant, isoDay) && DayWindowCovers(restaurant, isoDay, local.TimeOfDay);
-        bool servedByOvernightTail = IsOpenOn(restaurant, previousDay)
-            && OvernightTailCovers(restaurant, previousDay, local.TimeOfDay);
-
-        if (!servedToday && !servedByOvernightTail)
+        if (!ServiceWindowHelper.IsServingAt(restaurant, bookingUtc))
         {
-            return IsOpenOn(restaurant, isoDay) ? ScheduleConflictReason.OutsideHours : ScheduleConflictReason.ClosedDay;
+            DateTime local = TimeZoneHelper.ConvertUtcToLocal(bookingUtc, restaurant.Timezone);
+            return ServiceWindowHelper.IsOpenOn(restaurant, IsoDay.Of(local))
+                ? ScheduleConflictReason.OutsideHours
+                : ScheduleConflictReason.ClosedDay;
         }
 
         return WalkInHelper.IsWalkInOnlyAt(restaurant, bookingUtc)
             ? ScheduleConflictReason.WalkInOnly
             : ScheduleConflictReason.None;
-    }
-
-    private static bool IsOpenOn(Restaurant restaurant, int isoDay)
-    {
-        HashSet<int> openDays = IsoDay.ParseList(restaurant.OpenDays);
-        return openDays.Count == 0 || openDays.Contains(isoDay);
-    }
-
-    /// <summary>The part of <paramref name="isoDay"/>'s service that falls on that same day.</summary>
-    private static bool DayWindowCovers(Restaurant restaurant, int isoDay, TimeSpan timeOfDay)
-    {
-        (TimeSpan open, TimeSpan close) = ServiceWindowOn(restaurant, isoDay);
-        if (open == close)
-        {
-            return true;
-        }
-
-        return close < open ? timeOfDay >= open : timeOfDay >= open && timeOfDay < close;
-    }
-
-    /// <summary>The part of <paramref name="isoDay"/>'s service that spills past midnight onto the next day.</summary>
-    private static bool OvernightTailCovers(Restaurant restaurant, int isoDay, TimeSpan timeOfDay)
-    {
-        (TimeSpan open, TimeSpan close) = ServiceWindowOn(restaurant, isoDay);
-        return close < open && timeOfDay < close;
-    }
-
-    private static (TimeSpan Open, TimeSpan Close) ServiceWindowOn(Restaurant restaurant, int isoDay)
-    {
-        (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(restaurant, isoDay);
-
-        if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
-        {
-            (openHour, openMin) = OpeningHourDefaults.OpenAt;
-        }
-
-        if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
-        {
-            (closeHour, closeMin) = OpeningHourDefaults.CloseAt;
-        }
-
-        return (new TimeSpan(openHour, openMin, 0), new TimeSpan(closeHour, closeMin, 0));
     }
 }

--- a/OpenRestoApi/Core/Application/Services/ScheduleConflictHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/ScheduleConflictHelper.cs
@@ -33,6 +33,21 @@ public enum ScheduleConflictReason
 /// <seealso>ScheduleConflictHelperTests.Evaluate_FlagsSittingOnADayThatIsNoLongerOpen</seealso>
 public static class ScheduleConflictHelper
 {
+    /// <summary>
+    /// The bookings among <paramref name="bookings"/> that <paramref name="restaurant"/>'s current
+    /// schedule would no longer accept, each with the reason. Callers differ in what they do with
+    /// the result — the locations panel lists them, the dashboard counts them — but which bookings
+    /// are stranded is one question with one answer.
+    /// </summary>
+    /// <seealso>ScheduleConflictHelperTests.Conflicting_ReturnsOnlyTheBookingsTheScheduleNoLongerAccepts</seealso>
+    public static List<(Booking Booking, ScheduleConflictReason Reason)> Conflicting(
+        Restaurant restaurant,
+        IEnumerable<Booking> bookings)
+        => bookings
+            .Select(b => (Booking: b, Reason: Evaluate(restaurant, b.Date)))
+            .Where(x => x.Reason != ScheduleConflictReason.None)
+            .ToList();
+
     public static ScheduleConflictReason Evaluate(Restaurant restaurant, DateTime bookingUtc)
     {
         if (!ServiceWindowHelper.IsServingAt(restaurant, bookingUtc))

--- a/OpenRestoApi/Core/Application/Services/ServiceWindowHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/ServiceWindowHelper.cs
@@ -1,0 +1,113 @@
+using OpenRestoApi.Core.Application.Utilities;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Core.Application.Services;
+
+/// <summary>
+/// The service a location runs on a given ISO day, and whether an instant falls inside one.
+/// <para>
+/// A window whose close is earlier than its open runs past midnight, and all of it belongs to
+/// the day it <em>opened</em>: a 00:30 sitting sold as part of Saturday's 18:00–02:00 service
+/// is Saturday's, not Sunday's. Judging that instant against Sunday instead is what let
+/// <c>AvailabilityService</c> offer a slot <c>HoldPolicyService</c> then refused, so every
+/// caller answers the question here rather than re-deriving it.
+/// </para>
+/// </summary>
+/// <seealso>ServiceWindowHelperTests.IsServingAt_AllowsAfterMidnightTailOfThePreviousDaysService</seealso>
+/// <seealso>ServiceWindowHelperTests.IsServingAt_RejectsAfterMidnightTailWhenTheOpeningDayIsClosed</seealso>
+/// <seealso>ServiceWindowHelperTests.IsServingAt_RejectsAfterMidnightTailAttributedToItsOwnDay</seealso>
+public static class ServiceWindowHelper
+{
+    /// <summary>
+    /// Whether <paramref name="isoDay"/> is one the location opens at all. An empty
+    /// <see cref="Restaurant.OpenDays"/> means every day.
+    /// </summary>
+    public static bool IsOpenOn(Restaurant restaurant, int isoDay)
+    {
+        HashSet<int> openDays = IsoDay.ParseList(restaurant.OpenDays);
+        return openDays.Count == 0 || openDays.Contains(isoDay);
+    }
+
+    /// <summary>
+    /// Whether any service the location currently runs covers <paramref name="utc"/>. Two
+    /// services can reach it: the one opening on its own local day, and the previous day's,
+    /// if that one runs past midnight.
+    /// </summary>
+    public static bool IsServingAt(Restaurant restaurant, DateTime utc)
+    {
+        DateTime local = TimeZoneHelper.ConvertUtcToLocal(utc, restaurant.Timezone);
+        int isoDay = IsoDay.Of(local);
+
+        return OpensOntoTimeOfDay(restaurant, isoDay, local.TimeOfDay)
+            || SpillsPastMidnightOnto(restaurant, DayBefore(isoDay), local.TimeOfDay);
+    }
+
+    /// <summary>
+    /// Local start and end of the service opening on <paramref name="isoDay"/>, anchored on
+    /// <paramref name="localDate"/>. An end at or before the start runs into the next day and
+    /// is rolled forward, so the pair is always ordered.
+    /// </summary>
+    public static (DateTime Start, DateTime End) LocalWindowFor(Restaurant restaurant, DateTime localDate, int isoDay)
+    {
+        (TimeSpan open, TimeSpan close) = TimesOn(restaurant, isoDay);
+
+        DateTime start = localDate.Date + open;
+        DateTime end = localDate.Date + close;
+        return (start, end <= start ? end.AddDays(1) : end);
+    }
+
+    private static int DayBefore(int isoDay) => isoDay == IsoDay.Monday ? IsoDay.Sunday : isoDay - 1;
+
+    /// <summary>
+    /// The part of <paramref name="isoDay"/>'s service that falls on <paramref name="isoDay"/>
+    /// itself. A window that wraps has no upper bound here — its far side is the next day's
+    /// problem, and crediting it to this day is what made the two callers disagree.
+    /// </summary>
+    private static bool OpensOntoTimeOfDay(Restaurant restaurant, int isoDay, TimeSpan timeOfDay)
+    {
+        if (!IsOpenOn(restaurant, isoDay))
+        {
+            return false;
+        }
+
+        (TimeSpan open, TimeSpan close) = TimesOn(restaurant, isoDay);
+        if (open == close)
+        {
+            return true;
+        }
+
+        return close < open ? timeOfDay >= open : timeOfDay >= open && timeOfDay < close;
+    }
+
+    /// <summary>
+    /// The part of <paramref name="isoDay"/>'s service that runs past midnight onto the
+    /// following day, measured as a time of day on that following day.
+    /// </summary>
+    private static bool SpillsPastMidnightOnto(Restaurant restaurant, int isoDay, TimeSpan timeOfDay)
+    {
+        if (!IsOpenOn(restaurant, isoDay))
+        {
+            return false;
+        }
+
+        (TimeSpan open, TimeSpan close) = TimesOn(restaurant, isoDay);
+        return close < open && timeOfDay < close;
+    }
+
+    private static (TimeSpan Open, TimeSpan Close) TimesOn(Restaurant restaurant, int isoDay)
+    {
+        (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(restaurant, isoDay);
+
+        if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
+        {
+            (openHour, openMin) = OpeningHourDefaults.OpenAt;
+        }
+
+        if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
+        {
+            (closeHour, closeMin) = OpeningHourDefaults.CloseAt;
+        }
+
+        return (new TimeSpan(openHour, openMin, 0), new TimeSpan(closeHour, closeMin, 0));
+    }
+}

--- a/OpenRestoApi/Core/Domain/Restaurant.cs
+++ b/OpenRestoApi/Core/Domain/Restaurant.cs
@@ -152,59 +152,12 @@ public class Restaurant
         => WalkInHelper.IsWalkInOnlyAt(this, utc);
 
     /// <summary>
-    /// True when the restaurant is open at the given UTC instant, resolved through
-    /// <see cref="Timezone"/> — which falls back to UTC when it is not a known IANA id.
+    /// True when a service the restaurant runs covers the given UTC instant, resolved through
+    /// <see cref="Timezone"/> — which falls back to UTC when it is not a known IANA id. A
+    /// service that closes after midnight belongs to the day it opened, so an 01:00 sitting is
+    /// open only if the <em>previous</em> day runs that late.
     /// </summary>
     /// <seealso>RestaurantTests.IsOpenAt_True_ForOvernightWindow_AfterMidnightClose</seealso>
     /// <seealso>RestaurantTests.IsOpenAt_False_ForOvernightWindow_OutsideBothSegments</seealso>
-    public bool IsOpenAt(DateTime utc)
-    {
-        DateTime localTime = TimeZoneHelper.ConvertUtcToLocal(utc, Timezone);
-        int isoDay = IsoDay.Of(localTime);
-
-        if (!IsOpenOn(isoDay))
-        {
-            return false;
-        }
-
-        (TimeSpan open, TimeSpan close) = ServiceWindowOn(isoDay);
-        return Covers(open, close, localTime.TimeOfDay);
-    }
-
-    private bool IsOpenOn(int isoDay)
-    {
-        HashSet<int> openDays = IsoDay.ParseList(OpenDays);
-        return openDays.Count == 0 || openDays.Contains(isoDay);
-    }
-
-    private (TimeSpan Open, TimeSpan Close) ServiceWindowOn(int isoDay)
-    {
-        (string openTime, string closeTime) = OpeningHoursHelper.GetHoursForDay(this, isoDay);
-
-        if (!OpeningHoursHelper.TryParseTime(openTime, out int openHour, out int openMin))
-        {
-            (openHour, openMin) = OpeningHourDefaults.OpenAt;
-        }
-
-        if (!OpeningHoursHelper.TryParseTime(closeTime, out int closeHour, out int closeMin))
-        {
-            (closeHour, closeMin) = OpeningHourDefaults.CloseAt;
-        }
-
-        return (new TimeSpan(openHour, openMin, 0), new TimeSpan(closeHour, closeMin, 0));
-    }
-
-    private static bool Covers(TimeSpan open, TimeSpan close, TimeSpan timeOfDay)
-    {
-        bool openAllDay = open == close;
-        if (openAllDay)
-        {
-            return true;
-        }
-
-        bool closesAfterMidnight = close < open;
-        return closesAfterMidnight
-            ? timeOfDay >= open || timeOfDay < close
-            : timeOfDay >= open && timeOfDay < close;
-    }
+    public bool IsOpenAt(DateTime utc) => ServiceWindowHelper.IsServingAt(this, utc);
 }

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingFilterRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingFilterRepository.cs
@@ -129,6 +129,17 @@ internal class BookingFilterRepository(AppDbContext db) : IBookingFilterReposito
 #pragma warning restore CA1862, CA1311, CA1304
         }
 
+        if (!string.IsNullOrWhiteSpace(filter.Query))
+        {
+            string normalizedQuery = filter.Query.Trim().ToLowerInvariant();
+#pragma warning disable CA1862, CA1311, CA1304
+            q = q.Where(b =>
+                (b.CustomerName != null && b.CustomerName.ToLower().Contains(normalizedQuery))
+                || (b.CustomerEmail != null && b.CustomerEmail.ToLower().Contains(normalizedQuery))
+                || (b.BookingRef != null && b.BookingRef.ToLower().Contains(normalizedQuery)));
+#pragma warning restore CA1862, CA1311, CA1304
+        }
+
         return await q
             .OrderBy(b => b.Date)
             .ToListAsync();

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingRepository.cs
@@ -47,6 +47,7 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
 
         public async Task<Booking?> GetByRefAsync(string bookingRef)
         {
+            string normalized = bookingRef.Trim().ToLowerInvariant();
             return await _db.Bookings
                 .Include(b => b.Table)
                 .Include(b => b.Section)
@@ -54,7 +55,12 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
                     .ThenInclude(g => g.Members)
                         .ThenInclude(m => m.Table)
                 .Include(b => b.Restaurant)
-                .FirstOrDefaultAsync(b => b.BookingRef == bookingRef);
+                // Refs are minted lowercase, so matching case-insensitively costs nothing and
+                // spares a guest whose keyboard or mail client capitalised the ref they pasted.
+                // Still an exact match: a prefix match would let anyone enumerate other bookings.
+#pragma warning disable CA1862, CA1311, CA1304 // ToLower in LINQ-to-EF is intentional (ToLowerInvariant is not translatable)
+                .FirstOrDefaultAsync(b => b.BookingRef.ToLower() == normalized);
+#pragma warning restore CA1862, CA1311, CA1304
         }
 
         public async Task<IEnumerable<Booking>> GetBookingsByRestaurantIdAsync(int restaurantId)
@@ -276,6 +282,14 @@ namespace OpenRestoApi.Infrastructure.Persistence.Repositories
         public async Task<List<Booking>> GetByTableAsync(int tableId)
         {
             return await _db.Bookings.Where(b => b.TableId == tableId).ToListAsync();
+        }
+
+        public async Task<List<Booking>> GetFutureForRestaurantAsync(int restaurantId, DateTime nowUtc)
+        {
+            return await _db.Bookings
+                .Where(b => b.RestaurantId == restaurantId && !b.IsCancelled && b.Date >= nowUtc)
+                .OrderBy(b => b.Date)
+                .ToListAsync();
         }
 
         public async Task<int> CountFutureByTableAsync(int tableId, DateTime nowUtc)

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -127,16 +127,14 @@ export async function getAdminBookings(
   restaurantId?: number,
   date?: string,
   status: BookingStatusFilter = "active",
-  email?: string,
-  bookingRef?: string
+  search?: string
 ): Promise<BookingDetailDto[]> {
   try {
     const params = new URLSearchParams();
     if (restaurantId != null) params.set("restaurantId", String(restaurantId));
     if (date) params.set("date", date);
     if (status !== "active") params.set("status", status);
-    if (email) params.set("email", email);
-    if (bookingRef) params.set("bookingRef", bookingRef);
+    if (search) params.set("query", search);
     const query = params.toString() ? `?${params}` : "";
     const res = await get(`/admin/bookings${query}`);
     if (!res.ok) throw new Error("Failed to fetch admin bookings");
@@ -147,15 +145,16 @@ export async function getAdminBookings(
   }
 }
 
+/**
+ * Free-text booking search across every location. One `query` param, matched server-side as a
+ * substring of the customer name, the customer email and the booking reference at once — the
+ * caller does not have to guess which field the admin typed.
+ *
+ * @see [admin.test.ts](../tests/api/admin.test.ts) — pins that a partial name, a partial
+ * email and a partial reference all go out as the same `query` param.
+ */
 export async function adminLookupBookings(query: string): Promise<BookingDetailDto[]> {
-  const isEmail = query.includes("@");
-  return getAdminBookings(
-    undefined,
-    undefined,
-    "all",
-    isEmail ? query : undefined,
-    isEmail ? undefined : query
-  );
+  return getAdminBookings(undefined, undefined, "all", query);
 }
 
 export async function getAdminBooking(id: number): Promise<BookingDetailDto | null> {

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -7,6 +7,7 @@ export interface AdminOverviewDto {
   totalSeats: number;
   activeHoldsCount?: number;
   pausedRestaurantsCount?: number;
+  scheduleConflictsCount?: number;
   occupancyData?: number[];
   occupancyDates?: string[];
   occupancyCounts?: number[];
@@ -29,6 +30,7 @@ export interface AdminDashboardStats {
   todayCount: number;
   activeHoldsCount: number;
   pausedCount: number;
+  scheduleConflictsCount: number;
   totalCovers: number;
   occupancyData: number[];
   occupancyDates: string[];
@@ -46,6 +48,7 @@ export async function getAdminDashboardStats(): Promise<AdminDashboardStats | nu
       todayCount: overview.todayBookings,
       activeHoldsCount: overview.activeHoldsCount ?? 0,
       pausedCount: overview.pausedRestaurantsCount ?? 0,
+      scheduleConflictsCount: overview.scheduleConflictsCount ?? 0,
       totalCovers: overview.totalSeats,
       occupancyData: overview.occupancyData ?? [],
       occupancyDates: overview.occupancyDates ?? [],

--- a/openresto-frontend/api/restaurants.ts
+++ b/openresto-frontend/api/restaurants.ts
@@ -35,6 +35,24 @@ export interface DeleteImpactDto {
   bookings: number;
 }
 
+/** Why an upcoming booking no longer fits its location's current schedule. */
+export type ScheduleConflictReason = "closedDay" | "outsideHours" | "walkInOnly";
+
+/**
+ * An upcoming booking the location's current schedule would no longer accept. Editing hours,
+ * open days or the walk-in policy leaves the bookings already taken exactly where they are, so
+ * this read is the only thing that surfaces the guests the edit stranded.
+ */
+export interface ScheduleConflictDto {
+  bookingId: number;
+  bookingRef: string;
+  customerName?: string | null;
+  /** Sitting start, UTC. */
+  date: string;
+  seats: number;
+  reason: ScheduleConflictReason;
+}
+
 export interface DayHoursDto {
   /** ISO 8601 day number: 1=Monday … 7=Sunday. */
   day: number;
@@ -340,6 +358,24 @@ export async function fetchTableDeleteImpact(
     return await res.json();
   } catch (err) {
     console.error("fetchTableDeleteImpact error:", err);
+    return null;
+  }
+}
+
+/**
+ * Upcoming bookings the location's current opening hours, open days or walk-in policy would no
+ * longer accept. Null (not an empty list) when the read failed, so the caller can tell "nothing
+ * stranded" from "could not check" and stay silent for the latter rather than claiming all-clear.
+ */
+export async function fetchScheduleConflicts(
+  restaurantId: number
+): Promise<ScheduleConflictDto[] | null> {
+  try {
+    const res = await get(`/restaurants/${restaurantId}/schedule-conflicts`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error("fetchScheduleConflicts error:", err);
     return null;
   }
 }

--- a/openresto-frontend/app/admin/bookings/index.tsx
+++ b/openresto-frontend/app/admin/bookings/index.tsx
@@ -84,16 +84,14 @@ export default function AdminBookingsScreen() {
   const router = useRouter();
   const {
     create,
-    email: emailParam,
-    bookingRef: bookingRefParam,
+    query: queryParam,
     restaurantId: restaurantIdParam,
   } = useLocalSearchParams<{
     create?: string;
-    email?: string;
-    bookingRef?: string;
+    query?: string;
     restaurantId?: string;
   }>();
-  const searchQuery = emailParam || bookingRefParam || null;
+  const searchQuery = queryParam || null;
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -156,7 +154,7 @@ export default function AdminBookingsScreen() {
       let cancelled = false;
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setLoading(true);
-      getAdminBookings(undefined, undefined, "all", emailParam, bookingRefParam).then((b) => {
+      getAdminBookings(undefined, undefined, "all", searchQuery).then((b) => {
         if (!cancelled) {
           setBookings(b);
           setLoading(false);
@@ -179,7 +177,7 @@ export default function AdminBookingsScreen() {
     return () => {
       cancelled = true;
     };
-  }, [statusFilter, selectedRestaurantId, searchQuery, emailParam, bookingRefParam, refreshKey]);
+  }, [statusFilter, selectedRestaurantId, searchQuery, refreshKey]);
 
   const handleSelectRestaurant = (id: number) => {
     if (id === selectedRestaurantId) return;
@@ -271,11 +269,7 @@ export default function AdminBookingsScreen() {
         setSelectedBookingId(results[0].id);
       } else {
         setLookupStatus("multiple");
-        const isEmail = q.includes("@");
-        router.replace({
-          pathname: "/admin/bookings",
-          params: isEmail ? { email: q } : { bookingRef: q },
-        });
+        router.replace({ pathname: "/admin/bookings", params: { query: q } });
       }
     } finally {
       setLookupLoading(false);

--- a/openresto-frontend/app/admin/dashboard.tsx
+++ b/openresto-frontend/app/admin/dashboard.tsx
@@ -19,6 +19,7 @@ import RestaurantActionModal from "@/components/admin/bookings/RestaurantActionM
 import AlertModal from "@/components/common/AlertModal";
 import { styles } from "@/styles/admin/dashboard.styles";
 import { Icon, type IconName } from "@/components/common/Icon";
+import { ScheduleConflictsBanner } from "@/components/admin/dashboard/ScheduleConflictsBanner";
 
 export default function AdminDashboardScreen() {
   const [stats, setStats] = useState<AdminDashboardStats | null>(null);
@@ -142,6 +143,7 @@ export default function AdminDashboardScreen() {
           />
         ) : (
           <>
+            <ScheduleConflictsBanner count={stats?.scheduleConflictsCount ?? 0} />
             <View style={[styles.metricsGrid, isWide && styles.metricsGridWide]}>
               {metricCards.map((stat) => (
                 <MetricCard key={stat.label} stat={stat} colors={colors} />

--- a/openresto-frontend/app/admin/locations.tsx
+++ b/openresto-frontend/app/admin/locations.tsx
@@ -363,19 +363,19 @@ export default function AdminLocationsScreen() {
         </View>
       ) : selectedRestaurant ? (
         <View style={styles.section}>
+          <ScheduleConflictsPanel
+            restaurantId={selectedRestaurant.id}
+            timezone={selectedRestaurant.timezone ?? "UTC"}
+            refreshKey={scheduleRevision}
+            borderColor={borderColor}
+            mutedColor={mutedColor}
+            cardBg={cardBg}
+          />
           <LocationCard
             key={selectedRestaurant.id}
             restaurant={selectedRestaurant}
             onSaved={(patch) => patchRestaurant(selectedRestaurant.id, patch)}
             isDark={isDark}
-            borderColor={borderColor}
-            mutedColor={mutedColor}
-            cardBg={cardBg}
-          />
-          <ScheduleConflictsPanel
-            restaurantId={selectedRestaurant.id}
-            timezone={selectedRestaurant.timezone ?? "UTC"}
-            refreshKey={scheduleRevision}
             borderColor={borderColor}
             mutedColor={mutedColor}
             cardBg={cardBg}

--- a/openresto-frontend/app/admin/locations.tsx
+++ b/openresto-frontend/app/admin/locations.tsx
@@ -375,6 +375,7 @@ export default function AdminLocationsScreen() {
             key={selectedRestaurant.id}
             restaurant={selectedRestaurant}
             onSaved={(patch) => patchRestaurant(selectedRestaurant.id, patch)}
+            upcomingBookingsCount={selectedSummary?.upcomingBookingsCount ?? 0}
             isDark={isDark}
             borderColor={borderColor}
             mutedColor={mutedColor}

--- a/openresto-frontend/app/admin/locations.tsx
+++ b/openresto-frontend/app/admin/locations.tsx
@@ -23,6 +23,7 @@ import { AddLocationForm } from "@/components/admin/locations/AddLocationForm";
 import { LocationPills } from "@/components/admin/locations/LocationPills";
 import { ArchiveLocationRow } from "@/components/admin/locations/ArchiveLocationRow";
 import { ArchivedLocationPanel } from "@/components/admin/locations/ArchivedLocationPanel";
+import { ScheduleConflictsPanel } from "@/components/admin/locations/ScheduleConflictsPanel";
 import { styles } from "@/components/admin/settings/settings.styles";
 import { Icon } from "@/components/common/Icon";
 
@@ -51,6 +52,9 @@ export default function AdminLocationsScreen() {
   const [archiving, setArchiving] = useState(false);
   const [archiveFailed, setArchiveFailed] = useState(false);
   const [deletedName, setDeletedName] = useState<string | null>(null);
+  // The location form autosaves, so there is no submit to hang a re-read off; bumping this on
+  // every committed patch is what makes the schedule-conflict panel reflect the edit just made.
+  const [scheduleRevision, setScheduleRevision] = useState(0);
 
   const { colors, isDark, primaryColor } = useAppTheme();
   const borderColor = colors.border;
@@ -60,6 +64,7 @@ export default function AdminLocationsScreen() {
 
   function patchRestaurant(id: number, patch: Partial<RestaurantDto>) {
     setRestaurants((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+    setScheduleRevision((n) => n + 1);
     // The pills read the admin list, so a rename has to reach it or the selector keeps
     // showing the old name until the next load.
     if (patch.name !== undefined) {
@@ -363,6 +368,14 @@ export default function AdminLocationsScreen() {
             restaurant={selectedRestaurant}
             onSaved={(patch) => patchRestaurant(selectedRestaurant.id, patch)}
             isDark={isDark}
+            borderColor={borderColor}
+            mutedColor={mutedColor}
+            cardBg={cardBg}
+          />
+          <ScheduleConflictsPanel
+            restaurantId={selectedRestaurant.id}
+            timezone={selectedRestaurant.timezone ?? "UTC"}
+            refreshKey={scheduleRevision}
             borderColor={borderColor}
             mutedColor={mutedColor}
             cardBg={cardBg}

--- a/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
+++ b/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
@@ -7,14 +7,37 @@ import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
 import { Icon } from "@/components/common/Icon";
 
-function buildTimeSlots(openTime: string, closeTime: string) {
+/** 12-hour clock labels, indexed by 24-hour hour. Midnight reads 12a, not 0a. */
+const HOUR_LABELS = Array.from({ length: 24 }, (_, h) =>
+  h === 0 ? "12a" : h < 12 ? `${h}a` : h === 12 ? "12p" : `${h - 12}p`
+);
+
+/**
+ * The hour columns to draw: the service window, plus an extra column for any hour a booking
+ * actually falls on. Editing a location's hours leaves the bookings taken under the old ones
+ * where they are, so a window-only grid quietly stops rendering them — the timetable is where
+ * staff would notice, which makes it the worst place to hide them.
+ *
+ * Hours are laid out forward from opening, so an overnight service (18:00–02:00) reads
+ * 6p…11p, 12a, 1a rather than collapsing to a single column.
+ *
+ * @see [AvailabilityGrid.test.tsx](../../../tests/components/AvailabilityGrid.test.tsx)
+ * — pins that a booking outside the current hours still gets a column, and that an overnight
+ * window spans the night instead of one hour.
+ */
+function buildTimeSlots(openTime: string, closeTime: string, bookedHours: number[] = []) {
   const startHour = parseInt(openTime.split(":")[0], 10);
-  const endHour = parseInt(closeTime.split(":")[0], 10);
-  return Array.from({ length: Math.max(endHour - startHour, 1) }, (_, i) => {
-    const h = startHour + i;
-    const label = h < 12 ? `${h}a` : h === 12 ? "12p" : `${h - 12}p`;
-    return { hour: h, label };
-  });
+  const rawEndHour = parseInt(closeTime.split(":")[0], 10);
+  const span = (rawEndHour - startHour + 24) % 24 || 24;
+
+  const hours = new Set<number>();
+  for (let i = 0; i < span; i++) hours.add((startHour + i) % 24);
+  for (const hour of bookedHours) hours.add(hour);
+
+  const sinceOpening = (hour: number) => (hour - startHour + 24) % 24;
+  return [...hours]
+    .sort((a, b) => sinceOpening(a) - sinceOpening(b))
+    .map((h) => ({ hour: h, label: HOUR_LABELS[h] }));
 }
 
 export const COL_W = 68;
@@ -53,7 +76,10 @@ export function AvailabilityGrid({
   closeTime?: string;
   timezone?: string;
 }) {
-  const timeSlots = buildTimeSlots(openTime, closeTime);
+  const bookedHours = bookings
+    .filter((b) => b.tableId != null)
+    .map((b) => getRestaurantHour(b.date, timezone));
+  const timeSlots = buildTimeSlots(openTime, closeTime, bookedHours);
   const colors = getThemeColors(isDark);
   const borderColor = colors.border;
   const headerBg = isDark ? "#28292b" : "#f4f5f6";

--- a/openresto-frontend/components/admin/bookings/BookingLookupBar.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingLookupBar.tsx
@@ -50,7 +50,7 @@ export function BookingLookupBar({
               minWidth: 180,
             },
           ]}
-          placeholder="Email or reference…"
+          placeholder="Name, email or reference…"
           placeholderTextColor={placeholderColor}
           value={query}
           onChangeText={onQueryChange}

--- a/openresto-frontend/components/admin/dashboard/ScheduleConflictsBanner.styles.ts
+++ b/openresto-frontend/components/admin/dashboard/ScheduleConflictsBanner.styles.ts
@@ -1,0 +1,24 @@
+import { StyleSheet } from "react-native";
+import { theme } from "@/theme/theme";
+
+export const styles = StyleSheet.create({
+  banner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.md,
+    padding: theme.spacing.lg,
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.lg,
+    marginBottom: theme.spacing.xxl,
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    borderRadius: theme.borderRadius.lg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  copy: { flex: 1 },
+  title: { ...theme.typography.bodyBold },
+  sub: { ...theme.typography.caption, marginTop: 2 },
+});

--- a/openresto-frontend/components/admin/dashboard/ScheduleConflictsBanner.tsx
+++ b/openresto-frontend/components/admin/dashboard/ScheduleConflictsBanner.tsx
@@ -1,0 +1,54 @@
+import { Pressable, View } from "react-native";
+import { useRouter } from "expo-router";
+import { ThemedText } from "@/components/themed-text";
+import { Icon } from "@/components/common/Icon";
+import { useAppTheme } from "@/hooks/use-app-theme";
+import { styles } from "./ScheduleConflictsBanner.styles";
+
+/**
+ * Upcoming bookings that their location's current schedule would no longer accept, totalled
+ * across every active location.
+ *
+ * `/admin/locations` reports these per location, but only while that location is selected, so an
+ * admin who narrows hours and navigates away never sees the panel again. This is the standing
+ * reminder, and it is a control rather than a tile because a count you cannot act on just moves
+ * the hunt to a different screen.
+ *
+ * Renders nothing at zero: an all-clear shown every day trains the eye to skip the row this
+ * needs to be noticed in.
+ *
+ * @see [ScheduleConflictsBanner.test.tsx](../../../tests/components/admin/dashboard/ScheduleConflictsBanner.test.tsx)
+ * — pins that it stays silent at zero and links through to the locations screen.
+ */
+export function ScheduleConflictsBanner({ count }: { count: number }) {
+  const { colors } = useAppTheme();
+  const router = useRouter();
+
+  if (count <= 0) return null;
+
+  const bookings = `${count} upcoming booking${count === 1 ? "" : "s"}`;
+
+  return (
+    <Pressable
+      testID="dashboard-schedule-conflicts"
+      accessibilityRole="button"
+      accessibilityLabel={`${bookings} no longer fit their location's schedule. Review locations.`}
+      onPress={() => router.push("/admin/locations")}
+      style={[styles.banner, { backgroundColor: colors.card, borderColor: colors.warning }]}
+    >
+      <View style={[styles.icon, { backgroundColor: `${colors.warning}1f` }]}>
+        <Icon name="alert-circle-outline" size="xl" color={colors.warning} />
+      </View>
+      <View style={styles.copy}>
+        <ThemedText style={styles.title}>
+          {bookings} no longer fit their location&apos;s schedule
+        </ThemedText>
+        <ThemedText style={[styles.sub, { color: colors.muted }]}>
+          Taken before the current hours and still on the books. The guests have not been told
+          anything changed. Review locations.
+        </ThemedText>
+      </View>
+      <Icon name="chevron-forward" size="md" color={colors.muted} />
+    </Pressable>
+  );
+}

--- a/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.styles.ts
+++ b/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.styles.ts
@@ -1,0 +1,37 @@
+import { StyleSheet } from "react-native";
+import { theme } from "@/theme/theme";
+
+export const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.lg,
+    overflow: "hidden",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: theme.spacing.md,
+    padding: theme.spacing.lg,
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    borderRadius: theme.borderRadius.lg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  copy: { flex: 1 },
+  title: { ...theme.typography.bodyBold },
+  sub: { ...theme.typography.caption, marginTop: 2 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.md,
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.md,
+    borderTopWidth: 1,
+  },
+  rowCopy: { flex: 1 },
+  rowTitle: { ...theme.typography.bodyBold },
+  rowSub: { ...theme.typography.caption, marginTop: 1 },
+});

--- a/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.tsx
+++ b/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from "react";
+import { View } from "react-native";
+import { useRouter } from "expo-router";
+import { ThemedText } from "@/components/themed-text";
+import { Icon } from "@/components/common/Icon";
+import { RowTextButton } from "@/components/common/RowTextButton";
+import { useAppTheme } from "@/hooks/use-app-theme";
+import {
+  fetchScheduleConflicts,
+  ScheduleConflictDto,
+  ScheduleConflictReason,
+} from "@/api/restaurants";
+import { styles } from "./ScheduleConflictsPanel.styles";
+
+const REASON_LABELS: Record<ScheduleConflictReason, string> = {
+  closedDay: "Now a closed day",
+  outsideHours: "Now outside opening hours",
+  walkInOnly: "Now walk-in only",
+};
+
+function formatSitting(dateUtc: string, timezone: string): string {
+  return new Date(dateUtc).toLocaleString(undefined, {
+    timeZone: timezone,
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Upcoming bookings the location's current schedule would no longer accept.
+ *
+ * Editing hours, open days or the walk-in policy autosaves and never touches the bookings
+ * already taken, so without this the guests an edit strands are invisible until they turn up.
+ * Deliberately a report rather than a gate: the admin narrowing hours usually knows they have
+ * bookings to move, and blocking the edit would leave them unable to stop taking new ones.
+ *
+ * @see [ScheduleConflictsPanel.test.tsx](../../../tests/components/admin/locations/ScheduleConflictsPanel.test.tsx)
+ * — pins that a failed read stays silent rather than reporting all-clear.
+ */
+export function ScheduleConflictsPanel({
+  restaurantId,
+  timezone,
+  /** Bumped by the parent after a save, so the panel re-reads against the new schedule. */
+  refreshKey,
+  borderColor,
+  mutedColor,
+  cardBg,
+}: {
+  restaurantId: number;
+  timezone: string;
+  refreshKey: number;
+  borderColor: string;
+  mutedColor: string;
+  cardBg: string;
+}) {
+  const { colors } = useAppTheme();
+  const router = useRouter();
+  const [conflicts, setConflicts] = useState<ScheduleConflictDto[] | null>(null);
+
+  const load = useCallback(() => {
+    let cancelled = false;
+    fetchScheduleConflicts(restaurantId).then((result) => {
+      if (!cancelled) setConflicts(result);
+    });
+    /* istanbul ignore next */
+    return () => {
+      cancelled = true;
+    };
+  }, [restaurantId]);
+
+  useEffect(load, [load, refreshKey]);
+
+  // Null is "could not check", not "all clear" — saying nothing beats a false all-clear.
+  if (conflicts === null || conflicts.length === 0) return null;
+
+  return (
+    <View
+      testID="schedule-conflicts-panel"
+      style={[styles.card, { backgroundColor: cardBg, borderColor: colors.warning }]}
+    >
+      <View style={styles.header}>
+        <View style={[styles.icon, { backgroundColor: `${colors.warning}1f` }]}>
+          <Icon name="alert-circle-outline" size="xl" color={colors.warning} />
+        </View>
+        <View style={styles.copy}>
+          <ThemedText style={styles.title}>
+            {conflicts.length} upcoming booking{conflicts.length === 1 ? "" : "s"} no longer fit
+            this schedule
+          </ThemedText>
+          <ThemedText style={[styles.sub, { color: mutedColor }]}>
+            These were taken before the current hours and are still on the books. Move or cancel
+            them — the guests have not been told anything changed.
+          </ThemedText>
+        </View>
+      </View>
+
+      {conflicts.map((conflict) => (
+        <View key={conflict.bookingId} style={[styles.row, { borderTopColor: borderColor }]}>
+          <View style={styles.rowCopy}>
+            <ThemedText style={styles.rowTitle}>
+              {conflict.customerName || conflict.bookingRef} ·{" "}
+              {formatSitting(conflict.date, timezone)}
+            </ThemedText>
+            <ThemedText style={[styles.rowSub, { color: mutedColor }]}>
+              {REASON_LABELS[conflict.reason]} · {conflict.seats} guest
+              {conflict.seats === 1 ? "" : "s"} · {conflict.bookingRef}
+            </ThemedText>
+          </View>
+          <RowTextButton
+            label="Open"
+            icon="open-outline"
+            color={colors.text}
+            accessibilityLabel={`Open booking ${conflict.bookingRef}`}
+            onPress={() =>
+              router.push({
+                pathname: "/admin/bookings",
+                params: { query: conflict.bookingRef },
+              })
+            }
+          />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/openresto-frontend/components/admin/settings/LocationCard.tsx
+++ b/openresto-frontend/components/admin/settings/LocationCard.tsx
@@ -47,6 +47,7 @@ function StatChip({
 export function LocationCard({
   restaurant,
   onSaved,
+  upcomingBookingsCount = 0,
   isDark,
   borderColor,
   mutedColor,
@@ -54,6 +55,8 @@ export function LocationCard({
 }: {
   restaurant: RestaurantDto;
   onSaved: (patch: Partial<RestaurantDto>) => void;
+  /** Forwarded to the timezone warning; 0 keeps it hidden. */
+  upcomingBookingsCount?: number;
   isDark: boolean;
   borderColor: string;
   mutedColor: string;
@@ -163,7 +166,11 @@ export function LocationCard({
         />
       </View>
 
-      <RestaurantInfoForm restaurant={restaurant} onSaved={onSaved} />
+      <RestaurantInfoForm
+        restaurant={restaurant}
+        onSaved={onSaved}
+        upcomingBookingsCount={upcomingBookingsCount}
+      />
 
       <View style={[settingsStyles.secCard, { backgroundColor: cardBg, borderColor }]}>
         <AccordionCardHeader

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.styles.ts
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.styles.ts
@@ -29,6 +29,9 @@ export const styles = StyleSheet.create({
   // maxWidth is what stops the last field of a wrapped row from stretching across the whole
   // card on its own; flexBasis keeps the columns an even width above that.
   gridField: { flexGrow: 1, flexBasis: 240, minWidth: 220, maxWidth: 420, gap: theme.spacing.xxs },
+  fieldWarning: { flexDirection: "row", alignItems: "flex-start", gap: theme.spacing.xxs },
+  fieldWarningText: { flex: 1 },
+
   // Pulled back up under the two-column contact row, which already carries its own gap.
   contactHint: { fontSize: 11, lineHeight: 15, marginTop: -8 },
 

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.styles.ts
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet } from "react-native";
+import { Platform, StyleSheet } from "react-native";
 import { theme } from "@/theme/theme";
 
 export const styles = StyleSheet.create({
@@ -32,11 +32,19 @@ export const styles = StyleSheet.create({
   // Pulled back up under the two-column contact row, which already carries its own gap.
   contactHint: { fontSize: 11, lineHeight: 15, marginTop: -8 },
 
-  footer: {
-    padding: theme.spacing.lg,
+  // The form is a run of sibling section cards, not one card with a footer, so the autosave
+  // outcome has no corner to sit in. Given its own card it reads as an empty box between edits,
+  // since SaveStatus holds its row open on purpose. A bare bar, stuck to the foot of the
+  // viewport on web, keeps the outcome and its 10s undo reachable from whichever card was
+  // edited rather than parked below the last one.
+  statusBar: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    justifyContent: "flex-end",
     alignItems: "center",
     gap: theme.spacing.md,
+    paddingHorizontal: theme.spacing.xs,
+    paddingVertical: theme.spacing.xs,
+    // Opaque: stuck to the foot of the scrollport it has the rest of the form passing behind it.
+    ...(Platform.OS === "web" ? ({ position: "sticky", bottom: 0 } as object) : null),
   },
 });

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -787,18 +787,16 @@ export function RestaurantInfoForm({
         surface2={surface2}
       />
 
-      <View style={[sharedStyles.secCard, { backgroundColor: colors.card, borderColor }]}>
-        <View style={styles.footer}>
-          <SaveStatus
-            status={status}
-            error={error}
-            onRetry={retry}
-            onUndo={undo}
-            mutedColor={mutedColor}
-            blockedReason={blockedReason}
-            testID="location-save-status"
-          />
-        </View>
+      <View style={[styles.statusBar, { backgroundColor: colors.page }]}>
+        <SaveStatus
+          status={status}
+          error={error}
+          onRetry={retry}
+          onUndo={undo}
+          mutedColor={mutedColor}
+          blockedReason={blockedReason}
+          testID="location-save-status"
+        />
       </View>
     </>
   );

--- a/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
+++ b/openresto-frontend/components/admin/settings/RestaurantInfoForm.tsx
@@ -170,12 +170,54 @@ function buildOpenHoursPayload(
   return payload;
 }
 
+/**
+ * What changing a location's timezone does to the bookings it already holds.
+ *
+ * Every sitting is stored in UTC, so the booking does not move: the guest is still expected at
+ * the same real moment. What moves is the wall-clock time that moment reads as, which is the
+ * time the confirmation email told them. Nothing re-sends, and the schedule-conflict read does
+ * not catch it either, because the sitting usually still lands inside the new local window.
+ *
+ * Deliberately a warning and not a gate or a rebase. Silently rewriting confirmed bookings as a
+ * side effect of a settings edit is the failure mode this whole area exists to avoid.
+ *
+ * @see [RestaurantInfoForm.test.tsx](../../../tests/components/admin/settings/RestaurantInfoForm.test.tsx)
+ * — pins that it stays out of the way until the location actually holds bookings.
+ */
+function TimezoneRebaseWarning({
+  upcomingBookingsCount,
+  warningColor,
+}: {
+  upcomingBookingsCount: number;
+  warningColor: string;
+}) {
+  if (upcomingBookingsCount <= 0) return null;
+
+  const bookings = `${upcomingBookingsCount} upcoming booking${upcomingBookingsCount === 1 ? "" : "s"}`;
+
+  return (
+    <View testID="timezone-rebase-warning" style={styles.fieldWarning}>
+      <Icon name="alert-circle-outline" size="sm" color={warningColor} />
+      <ThemedText style={[styles.fieldHint, styles.fieldWarningText, { color: warningColor }]}>
+        {bookings} on the books. Changing this does not move them — they are stored in UTC — but it
+        changes the local time each guest was told, and nothing is sent to them.
+      </ThemedText>
+    </View>
+  );
+}
+
 export function RestaurantInfoForm({
   restaurant,
   onSaved,
+  /**
+   * Drives the timezone warning only. Zero means there is nothing a timezone change could
+   * reinterpret, so the warning stays out of the way on a location with no bookings yet.
+   */
+  upcomingBookingsCount = 0,
 }: {
   restaurant: RestaurantDto;
   onSaved: (patch: Partial<RestaurantDto>) => void;
+  upcomingBookingsCount?: number;
 }) {
   const { colors, isDark, primaryColor } = useAppTheme();
 
@@ -675,6 +717,10 @@ export function RestaurantInfoForm({
                   If this value differs from the customer&apos;s device timezone, a note will appear
                   on the booking page.
                 </ThemedText>
+                <TimezoneRebaseWarning
+                  upcomingBookingsCount={upcomingBookingsCount}
+                  warningColor={colors.warning}
+                />
               </View>
               <View style={styles.gridField}>
                 <ThemedText style={[sharedStyles.fieldLabel, { color: mutedColor }]}>

--- a/openresto-frontend/components/layout/AdminSidebar.tsx
+++ b/openresto-frontend/components/layout/AdminSidebar.tsx
@@ -144,11 +144,7 @@ export default function AdminSidebar() {
         setSelectedBookingId(results[0].id);
       } else {
         setLookupStatus("multiple");
-        const isEmail = q.includes("@");
-        router.push({
-          pathname: "/admin/bookings",
-          params: isEmail ? { email: q } : { bookingRef: q },
-        });
+        router.push({ pathname: "/admin/bookings", params: { query: q } });
       }
     } finally {
       setLookupLoading(false);
@@ -275,7 +271,7 @@ export default function AdminSidebar() {
               backgroundColor: colors.input,
             },
           ]}
-          placeholder="Email or reference…"
+          placeholder="Name, email or reference…"
           placeholderTextColor={colors.muted}
           value={lookupQuery}
           onChangeText={(t) => {

--- a/openresto-frontend/e2e/cancel-past-booking.spec.ts
+++ b/openresto-frontend/e2e/cancel-past-booking.spec.ts
@@ -85,7 +85,7 @@ test.describe("Cancel a past booking (#159)", () => {
     await gotoAdminDashboard(page);
     await page.goto("/admin/bookings");
 
-    const searchInput = page.getByPlaceholder("Email or reference…").nth(1);
+    const searchInput = page.getByPlaceholder("Name, email or reference…").nth(1);
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
     await searchInput.fill(bookingRef);
     await page.getByText("Find", { exact: true }).click();
@@ -105,7 +105,7 @@ test.describe("Cancel a past booking (#159)", () => {
     await gotoAdminDashboard(page);
     await page.goto("/admin/bookings");
 
-    const searchInput = page.getByPlaceholder("Email or reference…").nth(1);
+    const searchInput = page.getByPlaceholder("Name, email or reference…").nth(1);
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
     await searchInput.fill(bookingRef);
     await page.getByText("Find", { exact: true }).click();

--- a/openresto-frontend/e2e/helpers.ts
+++ b/openresto-frontend/e2e/helpers.ts
@@ -187,7 +187,7 @@ export async function gotoAdminDashboard(page: Page, loginFirst = false): Promis
   }
   await page.goto("/admin/dashboard");
   await page.waitForURL(/.*dashboard.*/, { timeout: 20_000 });
-  await page.waitForSelector('input[placeholder="Email or reference…"]', { timeout: 10_000 });
+  await page.waitForSelector('input[placeholder="Name, email or reference…"]', { timeout: 10_000 });
 }
 
 /** @deprecated Use gotoAdminDashboard instead. */

--- a/openresto-frontend/e2e/keyboard-shortcuts.spec.ts
+++ b/openresto-frontend/e2e/keyboard-shortcuts.spec.ts
@@ -100,7 +100,7 @@ test.describe("Admin keyboard shortcuts", () => {
     // .first() = the AdminSidebar's global lookup input (present on every
     // admin route) — the page-local bookings-list search is a separate
     // instance further down the DOM. See issue #140 Correction #7/#8.
-    const sidebarLookupInput = page.getByPlaceholder("Email or reference…").first();
+    const sidebarLookupInput = page.getByPlaceholder("Name, email or reference…").first();
     await page.keyboard.press("/");
 
     await expect(sidebarLookupInput).toBeFocused();
@@ -144,7 +144,7 @@ test.describe("Admin keyboard shortcuts", () => {
         } else {
           await page.goto("/admin/bookings");
         }
-        const searchInput = page.getByPlaceholder("Email or reference…").nth(1);
+        const searchInput = page.getByPlaceholder("Name, email or reference…").nth(1);
         await expect(searchInput).toBeVisible({ timeout: 10_000 });
         await searchInput.fill(uniqueEmail);
         await page.getByText("Find", { exact: true }).click();

--- a/openresto-frontend/e2e/lookup.spec.ts
+++ b/openresto-frontend/e2e/lookup.spec.ts
@@ -148,7 +148,7 @@ test.describe("Booking lookup", { tag: "@smoke" }, () => {
     await page.goto("/admin/bookings");
 
     // .nth(1) = the bookings-page header search input (AdminSidebar has its own at nth(0))
-    const searchInput = page.getByPlaceholder("Email or reference…").nth(1);
+    const searchInput = page.getByPlaceholder("Name, email or reference…").nth(1);
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
     await searchInput.fill(lookupEmail);
     await page.getByText("Find", { exact: true }).click();
@@ -164,7 +164,7 @@ test.describe("Booking lookup", { tag: "@smoke" }, () => {
     await page.goto("/admin/bookings");
 
     // .nth(1) = the bookings-page header search input (AdminSidebar has its own at nth(0))
-    const searchInput = page.getByPlaceholder("Email or reference…").nth(1);
+    const searchInput = page.getByPlaceholder("Name, email or reference…").nth(1);
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
     await searchInput.fill(bookingRef);
     await page.getByText("Find", { exact: true }).click();

--- a/openresto-frontend/tests/api/admin.test.ts
+++ b/openresto-frontend/tests/api/admin.test.ts
@@ -99,6 +99,7 @@ describe("getAdminDashboardStats", () => {
       todayCount: 5,
       activeHoldsCount: 0,
       pausedCount: 0,
+      scheduleConflictsCount: 0,
       totalCovers: 100,
       occupancyData: [],
       occupancyDates: [],

--- a/openresto-frontend/tests/api/admin.test.ts
+++ b/openresto-frontend/tests/api/admin.test.ts
@@ -943,25 +943,21 @@ describe("adminDeleteHighlight", () => {
 // ---------- Lookup / new booking helpers ----------
 
 describe("adminLookupBookings", () => {
-  it("passes email param when query contains @", async () => {
+  // One free-text param whatever the admin typed. Splitting the term into email-vs-reference on
+  // the client is what stopped a partial email — and any customer name at all — from matching.
+  it.each([
+    ["a partial email", "user@exam"],
+    ["a partial reference", "crispy-bas"],
+    ["a customer name", "Ada Lovelace"],
+  ])("sends %s as the single query param", async (_label, term) => {
     mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
 
-    await adminLookupBookings("user@example.com");
+    await adminLookupBookings(term);
 
     const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("email=user%40example.com");
-    expect(url).not.toContain("bookingRef=");
-    expect(url).toContain("status=all");
-  });
-
-  it("passes bookingRef param when query does not contain @", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
-
-    await adminLookupBookings("REF123");
-
-    const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("bookingRef=REF123");
+    expect(url).toContain(new URLSearchParams({ query: term }).toString());
     expect(url).not.toContain("email=");
+    expect(url).not.toContain("bookingRef=");
     expect(url).toContain("status=all");
   });
 

--- a/openresto-frontend/tests/api/restaurants.groups.test.ts
+++ b/openresto-frontend/tests/api/restaurants.groups.test.ts
@@ -5,6 +5,7 @@ import {
   deleteTableGroup,
   fetchTableDeleteImpact,
   fetchSectionDeleteImpact,
+  fetchScheduleConflicts,
 } from "@/api/restaurants";
 
 const mockFetch = jest.fn();
@@ -185,5 +186,35 @@ describe("fetchSectionDeleteImpact", () => {
   it("returns null on a network error", async () => {
     mockFetch.mockRejectedValueOnce(new Error("offline"));
     expect(await fetchSectionDeleteImpact(1, 2)).toBeNull();
+  });
+});
+
+describe("fetchScheduleConflicts", () => {
+  const conflict = {
+    bookingId: 7,
+    bookingRef: "crispy-basil-truffle",
+    customerName: "Ada",
+    date: "2026-09-02T10:00:00Z",
+    seats: 2,
+    reason: "outsideHours",
+  };
+
+  it("returns the conflicts when the response is ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [conflict] });
+
+    expect(await fetchScheduleConflicts(1)).toEqual([conflict]);
+    expect(mockFetch.mock.calls[0][0]).toContain("/api/restaurants/1/schedule-conflicts");
+  });
+
+  // Null, not [] — the caller renders nothing for null and would otherwise announce all-clear.
+  it("returns null on a non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    expect(await fetchScheduleConflicts(1)).toBeNull();
+  });
+
+  it("returns null on a network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    expect(await fetchScheduleConflicts(1)).toBeNull();
+    expect(console.error).toHaveBeenCalled();
   });
 });

--- a/openresto-frontend/tests/app/admin/bookings-index.test.tsx
+++ b/openresto-frontend/tests/app/admin/bookings-index.test.tsx
@@ -188,7 +188,7 @@ describe("AdminBookingsScreen", () => {
     render(<AdminBookingsScreen />);
     await waitFor(() => expect(screen.getByText("Bookings")).toBeTruthy());
 
-    const input = screen.getByPlaceholderText("Email or reference…");
+    const input = screen.getByPlaceholderText("Name, email or reference…");
     fireEvent.changeText(input, "unknown@example.com");
     await act(async () => {
       fireEvent.press(screen.getByText("Find"));
@@ -203,7 +203,7 @@ describe("AdminBookingsScreen", () => {
     render(<AdminBookingsScreen />);
     await waitFor(() => expect(screen.getByText("Bookings")).toBeTruthy());
 
-    const input = screen.getByPlaceholderText("Email or reference…");
+    const input = screen.getByPlaceholderText("Name, email or reference…");
     fireEvent.changeText(input, "john@example.com");
     await act(async () => {
       fireEvent.press(screen.getByText("Find"));
@@ -219,7 +219,7 @@ describe("AdminBookingsScreen", () => {
     render(<AdminBookingsScreen />);
     await waitFor(() => expect(screen.getByText("Bookings")).toBeTruthy());
 
-    const input = screen.getByPlaceholderText("Email or reference…");
+    const input = screen.getByPlaceholderText("Name, email or reference…");
     fireEvent.changeText(input, "john@example.com");
     await act(async () => {
       fireEvent.press(screen.getByText("Find"));
@@ -235,7 +235,7 @@ describe("AdminBookingsScreen", () => {
     render(<AdminBookingsScreen />);
     await waitFor(() => expect(screen.getByText("Bookings")).toBeTruthy());
 
-    const searchInput = screen.getByPlaceholderText("Email or reference…");
+    const searchInput = screen.getByPlaceholderText("Name, email or reference…");
     fireEvent.changeText(searchInput, "test");
     await act(async () => {
       fireEvent.press(screen.getByText("Find"));
@@ -254,7 +254,7 @@ describe("AdminBookingsScreen", () => {
   });
 
   it("shows search results when emailParam is provided", async () => {
-    mockSearchParams.email = "john@example.com";
+    mockSearchParams.query = "john@example.com";
     render(<AdminBookingsScreen />);
     await waitFor(() => {
       expect(screen.getByText("Search Results")).toBeTruthy();
@@ -262,7 +262,7 @@ describe("AdminBookingsScreen", () => {
   });
 
   it("shows clear button when searchQuery is present", async () => {
-    mockSearchParams.email = "john@example.com";
+    mockSearchParams.query = "john@example.com";
     render(<AdminBookingsScreen />);
     await waitFor(() => {
       expect(screen.getByText("Clear")).toBeTruthy();
@@ -327,21 +327,15 @@ describe("AdminBookingsScreen", () => {
     await waitFor(() => expect(getAdminBookings).toHaveBeenCalled(), { timeout: 3000 });
   });
 
-  it("loads bookings when bookingRef search param is provided", async () => {
-    mockSearchParams.bookingRef = "REF-ABCD";
+  it("loads bookings when the query search param is provided", async () => {
+    mockSearchParams.query = "REF-ABCD";
     render(<AdminBookingsScreen />);
     await waitFor(() => expect(screen.getByText("Search Results")).toBeTruthy());
-    expect(getAdminBookings).toHaveBeenCalledWith(
-      undefined,
-      undefined,
-      "all",
-      undefined,
-      "REF-ABCD"
-    );
+    expect(getAdminBookings).toHaveBeenCalledWith(undefined, undefined, "all", "REF-ABCD");
   });
 
   it("clears search results when Clear button is pressed", async () => {
-    mockSearchParams.email = "john@example.com";
+    mockSearchParams.query = "john@example.com";
     render(<AdminBookingsScreen />);
     await waitFor(() => expect(screen.getByText("Clear")).toBeTruthy());
     fireEvent.press(screen.getByText("Clear"));
@@ -384,7 +378,7 @@ describe("AdminBookingsScreen", () => {
     await waitFor(() => expect(getAdminBookings).toHaveBeenCalled());
   });
 
-  it("lookup with multiple results using bookingRef navigates with bookingRef param", async () => {
+  it("lookup with multiple results navigates with the query param", async () => {
     (adminLookupBookings as jest.Mock).mockResolvedValue([
       { ...mockBookings[0], id: 1 },
       { ...mockBookings[0], id: 2 },
@@ -392,7 +386,7 @@ describe("AdminBookingsScreen", () => {
     render(<AdminBookingsScreen />);
     await waitFor(() => expect(screen.getByText("Bookings")).toBeTruthy());
 
-    const input = screen.getByPlaceholderText("Email or reference…");
+    const input = screen.getByPlaceholderText("Name, email or reference…");
     fireEvent.changeText(input, "REF-XYZ");
     await act(async () => {
       fireEvent.press(screen.getByText("Find"));
@@ -400,7 +394,7 @@ describe("AdminBookingsScreen", () => {
     await waitFor(() => expect(mockReplace).toHaveBeenCalled());
     expect(mockReplace).toHaveBeenCalledWith(
       expect.objectContaining({
-        params: expect.objectContaining({ bookingRef: "REF-XYZ" }),
+        params: expect.objectContaining({ query: "REF-XYZ" }),
       })
     );
   });

--- a/openresto-frontend/tests/app/admin/dashboard.test.tsx
+++ b/openresto-frontend/tests/app/admin/dashboard.test.tsx
@@ -72,6 +72,7 @@ const mockStats: AdminDashboardStats = {
   todayCount: 5,
   activeHoldsCount: 3,
   pausedCount: 1,
+  scheduleConflictsCount: 0,
   totalCovers: 100,
   occupancyData: [10, 20, 30, 40, 50, 60, 70],
   occupancyCounts: [1, 2, 3, 4, 5, 6, 12],

--- a/openresto-frontend/tests/app/admin/locations.test.tsx
+++ b/openresto-frontend/tests/app/admin/locations.test.tsx
@@ -4,7 +4,7 @@
 import React from "react";
 import { screen, waitFor, fireEvent, act } from "@testing-library/react-native";
 import AdminLocationsScreen from "@/app/admin/locations";
-import { fetchRestaurants, createRestaurant } from "@/api/restaurants";
+import { fetchRestaurants, createRestaurant, fetchScheduleConflicts } from "@/api/restaurants";
 import {
   adminGetRestaurants,
   adminDeleteRestaurant,
@@ -26,8 +26,10 @@ jest.mock("@/api/admin", () => ({
   unpauseRestaurantBookings: jest.fn(),
   extendRestaurantBookings: jest.fn(),
 }));
+const mockPush = jest.fn();
 jest.mock("expo-router", () => ({
   Stack: { Screen: () => null },
+  useRouter: () => ({ push: mockPush }),
 }));
 jest.mock("@/api/auth", () => ({
   checkSession: jest.fn(),
@@ -65,6 +67,7 @@ describe("AdminLocationsScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     signedInAs("Owner");
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([]);
     (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
     (adminGetRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
     (pauseRestaurantBookings as jest.Mock).mockResolvedValue(true);
@@ -326,6 +329,7 @@ describe("AdminLocationsScreen archive and delete", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     signedInAs("Owner");
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([]);
     (fetchRestaurants as jest.Mock).mockResolvedValue([
       { id: 1, name: "Resto 1", sections: [], activeBookingsCount: 0 },
     ]);
@@ -537,6 +541,7 @@ describe("AdminLocationsScreen selected-location persistence", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     signedInAs("Owner");
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([]);
     Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
     localStorage.clear();
     (fetchRestaurants as jest.Mock).mockResolvedValue(twoRestaurants);

--- a/openresto-frontend/tests/components/AvailabilityGrid.test.tsx
+++ b/openresto-frontend/tests/components/AvailabilityGrid.test.tsx
@@ -66,4 +66,53 @@ describe("AvailabilityGrid", () => {
     render(<AvailabilityGrid {...props} isDark={true} />);
     expect(screen.getByText("Table 1")).toBeTruthy();
   });
+
+  // Narrowing a location's opening hours does not move the bookings already taken under the
+  // old ones (#359). The timetable is where staff would look for them, so it has to widen to
+  // cover a sitting the current window no longer contains.
+  it("keeps a booking that now falls outside the opening hours visible", () => {
+    render(<AvailabilityGrid {...props} openTime="17:00" closeTime="23:00" timezone="UTC" />);
+
+    expect(screen.getByText("12p")).toBeTruthy();
+    expect(screen.getByText("booked")).toBeTruthy();
+  });
+
+  it("does not draw a column for an hour with no booking in it", () => {
+    render(<AvailabilityGrid {...props} openTime="17:00" closeTime="23:00" timezone="UTC" />);
+
+    expect(screen.queryByText("1p")).toBeNull();
+  });
+
+  it("spans the night for an overnight service rather than collapsing to one column", () => {
+    render(
+      <AvailabilityGrid
+        {...props}
+        bookings={[]}
+        openTime="18:00"
+        closeTime="02:00"
+        timezone="UTC"
+      />
+    );
+
+    expect(screen.getByText("6p")).toBeTruthy();
+    expect(screen.getByText("11p")).toBeTruthy();
+    expect(screen.getByText("12a")).toBeTruthy();
+    expect(screen.getByText("1a")).toBeTruthy();
+    expect(screen.queryByText("2a")).toBeNull();
+  });
+
+  it("draws the full day when opening and closing time match", () => {
+    render(
+      <AvailabilityGrid
+        {...props}
+        bookings={[]}
+        openTime="00:00"
+        closeTime="00:00"
+        timezone="UTC"
+      />
+    );
+
+    expect(screen.getByText("12a")).toBeTruthy();
+    expect(screen.getByText("11p")).toBeTruthy();
+  });
 });

--- a/openresto-frontend/tests/components/AvailabilityGrid.test.tsx
+++ b/openresto-frontend/tests/components/AvailabilityGrid.test.tsx
@@ -27,7 +27,9 @@ describe("AvailabilityGrid", () => {
     {
       id: 10,
       tableId: 101,
-      date: new Date(new Date().setHours(12, 0, 0, 0)).toISOString(), // 12:00 PM
+      // setUTCHours, not setHours: the grid resolves the hour through the timezone prop, so a
+      // date pinned to the machine's local noon lands on a different column anywhere but UTC.
+      date: new Date(new Date().setUTCHours(12, 0, 0, 0)).toISOString(),
       seats: 2,
       customerEmail: "booked@test.com",
     },

--- a/openresto-frontend/tests/components/admin/bookings/BookingLookupBar.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingLookupBar.test.tsx
@@ -26,7 +26,7 @@ describe("BookingLookupBar", () => {
         {...theme}
       />
     );
-    expect(screen.getByPlaceholderText("Email or reference…")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Name, email or reference…")).toBeTruthy();
     expect(screen.getByText("Find")).toBeTruthy();
   });
 
@@ -42,7 +42,10 @@ describe("BookingLookupBar", () => {
         {...theme}
       />
     );
-    fireEvent.changeText(screen.getByPlaceholderText("Email or reference…"), "alice@test.com");
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Name, email or reference…"),
+      "alice@test.com"
+    );
     expect(onQueryChange).toHaveBeenCalledWith("alice@test.com");
   });
 

--- a/openresto-frontend/tests/components/admin/dashboard/ScheduleConflictsBanner.test.tsx
+++ b/openresto-frontend/tests/components/admin/dashboard/ScheduleConflictsBanner.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { ScheduleConflictsBanner } from "@/components/admin/dashboard/ScheduleConflictsBanner";
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: () => ({ primaryColor: "#0a7ea4", appName: "Open Resto" }),
+}));
+
+describe("ScheduleConflictsBanner", () => {
+  beforeEach(() => mockPush.mockClear());
+
+  it("stays silent when nothing is stranded", () => {
+    render(<ScheduleConflictsBanner count={0} />);
+
+    expect(screen.queryByTestId("dashboard-schedule-conflicts")).toBeNull();
+  });
+
+  it("reports the total across every location", () => {
+    render(<ScheduleConflictsBanner count={4} />);
+
+    expect(screen.getByText(/4 upcoming bookings no longer fit/)).toBeTruthy();
+  });
+
+  it("keeps the count singular for one booking", () => {
+    render(<ScheduleConflictsBanner count={1} />);
+
+    expect(screen.getByText(/1 upcoming booking no longer fits?/)).toBeTruthy();
+    expect(screen.queryByText(/bookings/)).toBeNull();
+  });
+
+  it("opens the locations screen, where the bookings can be acted on", () => {
+    render(<ScheduleConflictsBanner count={2} />);
+
+    fireEvent.press(screen.getByTestId("dashboard-schedule-conflicts"));
+
+    expect(mockPush).toHaveBeenCalledWith("/admin/locations");
+  });
+
+  it("treats a negative count as nothing to report", () => {
+    render(<ScheduleConflictsBanner count={-1} />);
+
+    expect(screen.queryByTestId("dashboard-schedule-conflicts")).toBeNull();
+  });
+});

--- a/openresto-frontend/tests/components/admin/locations/ScheduleConflictsPanel.test.tsx
+++ b/openresto-frontend/tests/components/admin/locations/ScheduleConflictsPanel.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react-native";
+import { ScheduleConflictsPanel } from "@/components/admin/locations/ScheduleConflictsPanel";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/api/restaurants", () => ({
+  fetchScheduleConflicts: jest.fn(),
+}));
+
+const { fetchScheduleConflicts } = require("@/api/restaurants");
+
+const conflict = {
+  bookingId: 7,
+  bookingRef: "crispy-basil-truffle",
+  customerName: "Ada Lovelace",
+  date: "2026-09-02T10:00:00Z",
+  seats: 2,
+  reason: "outsideHours" as const,
+};
+
+const props = {
+  restaurantId: 1,
+  timezone: "UTC",
+  refreshKey: 0,
+  borderColor: "#eee",
+  mutedColor: "#888",
+  cardBg: "#fff",
+};
+
+describe("ScheduleConflictsPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("lists an upcoming booking the current schedule no longer accepts", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([conflict]);
+
+    render(<ScheduleConflictsPanel {...props} />);
+
+    await waitFor(() => expect(screen.getByTestId("schedule-conflicts-panel")).toBeTruthy());
+    expect(screen.getByText(/1 upcoming booking no longer fit/)).toBeTruthy();
+    expect(screen.getByText(/Ada Lovelace/)).toBeTruthy();
+    expect(screen.getByText(/Now outside opening hours/)).toBeTruthy();
+  });
+
+  it("renders nothing when every upcoming booking still fits", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([]);
+
+    render(<ScheduleConflictsPanel {...props} />);
+
+    await waitFor(() => expect(fetchScheduleConflicts).toHaveBeenCalled());
+    expect(screen.queryByTestId("schedule-conflicts-panel")).toBeNull();
+  });
+
+  // A failed read is not an all-clear. Rendering the empty state for it would tell the admin
+  // their edit stranded nobody, which is the one thing this panel exists to disprove.
+  it("stays silent when the read fails rather than reporting all-clear", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue(null);
+
+    render(<ScheduleConflictsPanel {...props} />);
+
+    await waitFor(() => expect(fetchScheduleConflicts).toHaveBeenCalled());
+    expect(screen.queryByTestId("schedule-conflicts-panel")).toBeNull();
+  });
+
+  it("re-reads when the schedule is saved again", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([]);
+
+    const { rerender } = render(<ScheduleConflictsPanel {...props} />);
+    await waitFor(() => expect(fetchScheduleConflicts).toHaveBeenCalledTimes(1));
+
+    rerender(<ScheduleConflictsPanel {...props} refreshKey={1} />);
+    await waitFor(() => expect(fetchScheduleConflicts).toHaveBeenCalledTimes(2));
+  });
+
+  it("opens the stranded booking through the admin booking search", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([conflict]);
+
+    render(<ScheduleConflictsPanel {...props} />);
+    await waitFor(() => expect(screen.getByTestId("schedule-conflicts-panel")).toBeTruthy());
+
+    fireEvent.press(screen.getByLabelText("Open booking crispy-basil-truffle"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/admin/bookings",
+      params: { query: "crispy-basil-truffle" },
+    });
+  });
+
+  it("falls back to the reference when the booking has no customer name", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([
+      { ...conflict, customerName: null, reason: "closedDay", seats: 1 },
+    ]);
+
+    render(<ScheduleConflictsPanel {...props} />);
+
+    await waitFor(() => expect(screen.getByText(/crispy-basil-truffle ·/)).toBeTruthy());
+    expect(screen.getByText(/Now a closed day · 1 guest/)).toBeTruthy();
+  });
+
+  it("labels a booking stranded by the walk-in switch", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([
+      { ...conflict, reason: "walkInOnly" },
+    ]);
+
+    render(<ScheduleConflictsPanel {...props} />);
+
+    await waitFor(() => expect(screen.getByText(/Now walk-in only/)).toBeTruthy());
+  });
+});

--- a/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/RestaurantInfoForm.test.tsx
@@ -1098,4 +1098,52 @@ describe("RestaurantInfoForm", () => {
       expect(screen.queryByText("Default booking duration")).toBeNull();
     });
   });
+
+  // Changing a location's timezone reinterprets the local wall-clock time of every booking it
+  // already holds, without moving the booking or telling the guest (#362). A warning, not a
+  // gate: the bookings are correct, only the time the guest was told has drifted.
+  describe("timezone warning", () => {
+    it("warns when the location already holds upcoming bookings", () => {
+      render(
+        <RestaurantInfoForm
+          restaurant={mockRestaurant}
+          onSaved={onSaved}
+          upcomingBookingsCount={3}
+        />
+      );
+
+      expect(screen.getByTestId("timezone-rebase-warning")).toBeTruthy();
+      expect(screen.getByText(/3 upcoming bookings on the books/)).toBeTruthy();
+    });
+
+    it("stays out of the way when the location holds none", () => {
+      render(
+        <RestaurantInfoForm
+          restaurant={mockRestaurant}
+          onSaved={onSaved}
+          upcomingBookingsCount={0}
+        />
+      );
+
+      expect(screen.queryByTestId("timezone-rebase-warning")).toBeNull();
+    });
+
+    it("keeps the count singular for one booking", () => {
+      render(
+        <RestaurantInfoForm
+          restaurant={mockRestaurant}
+          onSaved={onSaved}
+          upcomingBookingsCount={1}
+        />
+      );
+
+      expect(screen.getByText(/1 upcoming booking on the books/)).toBeTruthy();
+    });
+
+    it("hides when the count is absent, rather than assuming there are bookings", () => {
+      render(<RestaurantInfoForm restaurant={mockRestaurant} onSaved={onSaved} />);
+
+      expect(screen.queryByTestId("timezone-rebase-warning")).toBeNull();
+    });
+  });
 });

--- a/openresto-frontend/tests/components/layout/AdminSidebar.test.tsx
+++ b/openresto-frontend/tests/components/layout/AdminSidebar.test.tsx
@@ -183,7 +183,9 @@ describe("AdminSidebar", () => {
         <AdminSidebar />
       </AuthProvider>
     );
-    await waitFor(() => expect(screen.getByPlaceholderText("Email or reference…")).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Name, email or reference…")).toBeTruthy()
+    );
     expect(screen.getByText("Search")).toBeTruthy();
   });
 
@@ -195,8 +197,10 @@ describe("AdminSidebar", () => {
         <AdminSidebar />
       </AuthProvider>
     );
-    await waitFor(() => expect(screen.getByPlaceholderText("Email or reference…")).toBeTruthy());
-    fireEvent.changeText(screen.getByPlaceholderText("Email or reference…"), "unknown");
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Name, email or reference…")).toBeTruthy()
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("Name, email or reference…"), "unknown");
     await act(async () => {
       fireEvent.press(screen.getByText("Search"));
     });
@@ -211,8 +215,13 @@ describe("AdminSidebar", () => {
         <AdminSidebar />
       </AuthProvider>
     );
-    await waitFor(() => expect(screen.getByPlaceholderText("Email or reference…")).toBeTruthy());
-    fireEvent.changeText(screen.getByPlaceholderText("Email or reference…"), "john@example.com");
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Name, email or reference…")).toBeTruthy()
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Name, email or reference…"),
+      "john@example.com"
+    );
     await act(async () => {
       fireEvent.press(screen.getByText("Search"));
     });
@@ -227,8 +236,13 @@ describe("AdminSidebar", () => {
         <AdminSidebar />
       </AuthProvider>
     );
-    await waitFor(() => expect(screen.getByPlaceholderText("Email or reference…")).toBeTruthy());
-    fireEvent.changeText(screen.getByPlaceholderText("Email or reference…"), "multi@example.com");
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Name, email or reference…")).toBeTruthy()
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Name, email or reference…"),
+      "multi@example.com"
+    );
     await act(async () => {
       fireEvent.press(screen.getByText("Search"));
     });
@@ -261,13 +275,15 @@ describe("AdminSidebar", () => {
         <AdminSidebar />
       </AuthProvider>
     );
-    await waitFor(() => expect(screen.getByPlaceholderText("Email or reference…")).toBeTruthy());
-    fireEvent.changeText(screen.getByPlaceholderText("Email or reference…"), "test");
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Name, email or reference…")).toBeTruthy()
+    );
+    fireEvent.changeText(screen.getByPlaceholderText("Name, email or reference…"), "test");
     await act(async () => {
       fireEvent.press(screen.getByText("Search"));
     });
     await waitFor(() => expect(screen.getByText("No booking found.")).toBeTruthy());
-    fireEvent.changeText(screen.getByPlaceholderText("Email or reference…"), "new");
+    fireEvent.changeText(screen.getByPlaceholderText("Name, email or reference…"), "new");
     expect(screen.queryByText("No booking found.")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Two things. The admin booking lookup could not match a partial email or a customer name at all, and editing a location's schedule silently stranded bookings already on the books.

**#358.** `adminLookupBookings` split the typed term client-side into "email if it contains `@`, else booking reference", duplicated in three places. So `alice@exam` went to the `bookingRef` filter and matched nothing, and a customer name matched nothing whichever branch it took. Both server-side filters were already partial and case-insensitive; the client was routing the term to the wrong one. Replaced with a single free-text `query` param matched against customer name, customer email and booking reference at once.

**#359 (spike).** `RestaurantManagementService.UpdateAsync` is field-by-field assignment then `SaveChangesAsync`. It never reads the `Bookings` table. So narrowing hours, closing a day or switching to walk-in only leaves every booking taken under the old schedule active, confirmed, and invisible to everyone until the guest turns up on a day the restaurant is now closed. Full spike writeup, options weighed and remaining questions in [a comment on #359](https://github.com/karanshukla/openresto/issues/359#issuecomment-5373934607).

**#363.** The spike turned up that `AvailabilityService` and `HoldPolicyService` resolved an overnight window against different days, so the picker offered after-midnight slots the hold endpoint refused. Now fixed here too.

## Related issue

Closes #358
Closes #359
Closes #362
Closes #363

Everything the spike spun out is now covered here.

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

**Booking lookup (#358)**

- `BookingFilter.Query` + `BookingFilterRepository`: case-insensitive substring across `CustomerName`, `CustomerEmail`, `BookingRef`. Combines with the existing `email`/`bookingRef` params rather than replacing them, those stay the narrow single-field filters.
- `GET /api/admin/bookings?query=` wired through `AdminService.GetBookingsAsync`.
- Frontend collapses the `@` heuristic in `api/admin.ts`, `AdminSidebar` and `app/admin/bookings/index.tsx` to one param. The search-results deep link is now `?query=` instead of `?email=` / `?bookingRef=`.
- Lookup placeholder is now "Name, email or reference…", since names actually work.
- `BookingRepository.GetByRefAsync` trims and lowercases before matching. Refs are minted lowercase and guests paste them out of a confirmation email, so a capitalised ref was the guest's keyboard, not a wrong reference. Still an exact match, a prefix match there would let anyone enumerate other people's bookings.

**Schedule conflicts (#359)**

- `ScheduleConflictHelper.Evaluate` re-evaluates a booking against a location's current schedule and returns `ClosedDay` / `OutsideHours` / `WalkInOnly` / `None`.
- `GET /api/restaurants/{id}/schedule-conflicts` (RequireAdmin) returns the upcoming non-cancelled bookings that no longer fit, with reason, ref, name, sitting time and party size.
- `ScheduleConflictsPanel` on `/admin/locations`, above the form, with a link straight into the booking (which lands on the search fixed above).

Deliberately a report, not a gate. Blocking the edit would leave an admin unable to stop taking new bookings, and auto-cancelling a guest's confirmed table as a side effect of a settings edit is the worst available failure mode. Null from the read means "could not check" and renders nothing, only an empty list is an all-clear.

**Overnight services in one place (#363)**

`ServiceWindowHelper` is now the single answer to "does a service the location runs cover this instant". `Restaurant.IsOpenAt`, `AvailabilityService` and `ScheduleConflictHelper` all defer to it instead of each carrying their own window arithmetic.

The rule it encodes: a window whose close is earlier than its open runs past midnight, and **all of it belongs to the day it opened**. A 00:30 sitting sold as part of Saturday's 18:00 to 02:00 service is Saturday's, not Sunday's. The old `Restaurant.IsOpenAt` judged it against Sunday, which is why `HoldPolicyService` rejected slots `AvailabilityService` had just offered. It also means the wrap tail is no longer credited to its own day, so the case that previously passed for the wrong reason (next day open with the same hours) now passes for the right one.

**Timezone warning (#362)**

Bookings are stored UTC, so changing `Restaurant.Timezone` moves no rows: the guest is still expected at the same real moment. What moves is the wall-clock time that moment reads as, which is the time their confirmation email told them. Nothing re-sends, and the `schedule-conflicts` read does not catch it either, since the sitting usually still lands inside the new local window.

A warning under the field, not a gate and not a rebase. Silently rewriting confirmed bookings as a side effect of a settings edit is the failure mode this whole area exists to avoid, and blocking the edit would leave an admin unable to correct a wrong timezone at all.

Gated on the location actually holding upcoming bookings, so a fresh location carries no standing warning about a consequence it cannot have. The count is already on the admin lookup list for the archive confirmation, so it threads through rather than adding a read.

**Dashboard count**

The panel only renders while its location is selected, so an admin who narrows hours and navigates away never sees it again. `AdminOverviewDto.ScheduleConflictsCount` totals the stranded bookings across every active location, and `ScheduleConflictsBanner` reports it on the dashboard with a link into `/admin/locations`.

A banner rather than a fifth metric tile: the wide grid is `flexWrap: nowrap` with a 200px floor per card, so a fifth would squeeze the row at every width, and a metric tile is not pressable, which would just move the hunt to another screen. Silent at zero, unlike the panel: a dashboard total has no failed-read state to be honest about, and a daily all-clear trains the eye to skip the row this needs to be noticed in.

`ScheduleConflictHelper.Conflicting` now returns the booking/reason pairs, so which bookings a schedule has stranded is answered in one place: the panel maps them to DTOs, the overview counts them. `GetOverviewAsync` folds the read into the per-restaurant loop it already runs, costing one extra query per active location.

**Two grid bugs the spike turned up**, both in `AvailabilityGrid.buildTimeSlots`:

- Columns were built from `openTime` to `closeTime` only, so a booking outside the current hours had no column to be drawn in and simply vanished from the timetable. It now widens to cover any hour a booking occupies.
- `Math.max(endHour - startHour, 1)` on an overnight window (18:00 to 02:00) gave one column for the whole night. Hours now lay out forward from opening and wrap through midnight. Midnight also rendered as `0a`, now `12a`.

## Testing

- [x] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests pass locally (2735 passed, 190 suites), `npm run check` and `npm run check:doc-links` clean
- [x] CI passes: Backend CI, Frontend CI, Route Manifest, Doc Links, E2E Smoke, Docker + ZAP, CodeQL all green
- [ ] Manually verified the change end-to-end

New coverage: `RestaurantInfoForm.test.tsx` timezone-warning cases (shown with bookings, hidden without, hidden when the count is absent), `ScheduleConflictsBanner.test.tsx` (incl. that it stays silent at zero), `AdminServiceTests` overview-count cases, `ScheduleConflictHelperTests.Conflicting`, `ServiceWindowHelperTests` (incl. the after-midnight tail accepted via the opening day, rejected when that day is closed, and rejected when attributed to its own day), `ScheduleConflictHelperTests`, `AvailabilityServiceTests` overnight cases, `RestaurantManagementServiceTests` schedule-conflict cases, `AdminServiceTests` partial-query theory, `BookingServiceTests` ref case/whitespace theory, `ScheduleConflictsPanel.test.tsx` (incl. that a failed read stays silent rather than reporting all-clear), and `AvailabilityGrid.test.tsx` for both grid bugs.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

No schema change, so `migration-check` correctly did not trigger. `schedule-conflicts` is a read over existing columns.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed
