### PR TITLE
Open a stranded booking in the popup, not the bookings search

### DIFF
--- a/openresto-frontend/app/admin/locations.tsx
+++ b/openresto-frontend/app/admin/locations.tsx
@@ -24,6 +24,7 @@ import { LocationPills } from "@/components/admin/locations/LocationPills";
 import { ArchiveLocationRow } from "@/components/admin/locations/ArchiveLocationRow";
 import { ArchivedLocationPanel } from "@/components/admin/locations/ArchivedLocationPanel";
 import { ScheduleConflictsPanel } from "@/components/admin/locations/ScheduleConflictsPanel";
+import { BookingDetailPopup } from "@/components/admin/bookings/BookingDetailPopup";
 import { styles } from "@/components/admin/settings/settings.styles";
 import { Icon } from "@/components/common/Icon";
 
@@ -55,6 +56,7 @@ export default function AdminLocationsScreen() {
   // The location form autosaves, so there is no submit to hang a re-read off; bumping this on
   // every committed patch is what makes the schedule-conflict panel reflect the edit just made.
   const [scheduleRevision, setScheduleRevision] = useState(0);
+  const [conflictBookingId, setConflictBookingId] = useState<number | null>(null);
 
   const { colors, isDark, primaryColor } = useAppTheme();
   const borderColor = colors.border;
@@ -164,234 +166,247 @@ export default function AdminLocationsScreen() {
   }
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      {Platform.OS !== "web" && <Stack.Screen options={{ title: "Locations" }} />}
+    <>
+      <ScrollView contentContainerStyle={styles.container}>
+        {Platform.OS !== "web" && <Stack.Screen options={{ title: "Locations" }} />}
 
-      <View style={styles.pageHeader}>
-        <View style={{ gap: 2 }}>
-          <ThemedText type="h1">Locations</ThemedText>
-          <ThemedText style={[styles.pageSub, { color: mutedColor }]}>
-            {locationCountSummary(allRestaurants.length - archivedCount, archivedCount)}
-          </ThemedText>
-        </View>
-        <Button
-          size="md"
-          icon="add"
-          onPress={() => setAddingLocation(true)}
-          disabled={addingLocation}
-          accessibilityLabel="Add location"
-        >
-          Add location
-        </Button>
-      </View>
-
-      {deletedName && (
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-          <Icon name="checkmark-circle-outline" size="lg" color={colors.success} />
-          <ThemedText style={{ fontSize: 13, color: mutedColor }}>
-            {deletedName} was permanently deleted.
-          </ThemedText>
-        </View>
-      )}
-
-      {addingLocation && (
-        <AddLocationForm
-          value={newLocationName}
-          saving={savingLocation}
-          isDark={isDark}
-          mutedColor={mutedColor}
-          primaryColor={primaryColor}
-          onValueChange={setNewLocationName}
-          onSubmit={async () => {
-            if (!newLocationName.trim()) return;
-            setSavingLocation(true);
-            const created = await createRestaurant(newLocationName.trim());
-            setSavingLocation(false);
-            if (created) {
-              setRestaurants((prev) => [...prev, { ...created, sections: [] }]);
-              setAllRestaurants((prev) => [...prev, { id: created.id, name: created.name }]);
-              selectAndRemember(created.id);
-            }
-            setNewLocationName("");
-            setAddingLocation(false);
-          }}
-          onCancel={() => {
-            setAddingLocation(false);
-            setNewLocationName("");
-          }}
-        />
-      )}
-
-      {allRestaurants.length > 0 && (
-        <LocationPills
-          restaurants={allRestaurants}
-          selectedId={selectedId}
-          onSelect={handleSelectLocation}
-        />
-      )}
-
-      {selectedRestaurant && (
-        <View style={styles.bulkActions}>
+        <View style={styles.pageHeader}>
+          <View style={{ gap: 2 }}>
+            <ThemedText type="h1">Locations</ThemedText>
+            <ThemedText style={[styles.pageSub, { color: mutedColor }]}>
+              {locationCountSummary(allRestaurants.length - archivedCount, archivedCount)}
+            </ThemedText>
+          </View>
           <Button
-            variant="secondary"
-            tone={isPaused ? "success" : "warning"}
             size="md"
-            style={styles.bulkAction}
-            icon={isPaused ? "play-circle-outline" : "pause-circle-outline"}
-            disabled={pausing}
-            loading={pausing}
-            accessibilityLabel={
-              isPaused
-                ? `Resume bookings for ${selectedRestaurant.name}`
-                : `Pause the next hour of bookings at ${selectedRestaurant.name}`
-            }
-            onPress={async () => {
-              setPausing(true);
-              if (isPaused) {
-                await unpauseRestaurantBookings(selectedRestaurant.id);
-                setAllRestaurants((prev) =>
-                  prev.map((r) =>
-                    r.id === selectedRestaurant.id ? { ...r, bookingsPausedUntil: undefined } : r
-                  )
-                );
-              } else {
-                await pauseRestaurantBookings(selectedRestaurant.id, 60);
-                setAllRestaurants((prev) =>
-                  prev.map((r) =>
-                    r.id === selectedRestaurant.id
-                      ? {
-                          ...r,
-                          bookingsPausedUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-                        }
-                      : r
-                  )
-                );
-              }
-              setPausing(false);
-            }}
+            icon="add"
+            onPress={() => setAddingLocation(true)}
+            disabled={addingLocation}
+            accessibilityLabel="Add location"
           >
-            {pausing
-              ? "Saving…"
-              : isPaused
-                ? `Resume New Bookings now (paused up to ${pausedUntilText})`
-                : "Pause New Bookings for the next 60m"}
+            Add location
           </Button>
+        </View>
 
-          <Button
-            variant="secondary"
-            size="md"
-            style={styles.bulkAction}
-            icon="timer-outline"
-            disabled={extending || extendedBookings !== null || extendNoActive || activeCount === 0}
-            loading={extending}
-            accessibilityLabel={`Extend all active bookings at ${selectedRestaurant.name} by an hour`}
-            onPress={async () => {
-              setExtending(true);
-              const result = await extendRestaurantBookings(selectedRestaurant.id, 60);
-              setExtending(false);
-              if (result.ok) {
-                if (result.extendedBookings.length > 0) {
-                  setExtendedBookings(result.extendedBookings);
+        {deletedName && (
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+            <Icon name="checkmark-circle-outline" size="lg" color={colors.success} />
+            <ThemedText style={{ fontSize: 13, color: mutedColor }}>
+              {deletedName} was permanently deleted.
+            </ThemedText>
+          </View>
+        )}
+
+        {addingLocation && (
+          <AddLocationForm
+            value={newLocationName}
+            saving={savingLocation}
+            isDark={isDark}
+            mutedColor={mutedColor}
+            primaryColor={primaryColor}
+            onValueChange={setNewLocationName}
+            onSubmit={async () => {
+              if (!newLocationName.trim()) return;
+              setSavingLocation(true);
+              const created = await createRestaurant(newLocationName.trim());
+              setSavingLocation(false);
+              if (created) {
+                setRestaurants((prev) => [...prev, { ...created, sections: [] }]);
+                setAllRestaurants((prev) => [...prev, { id: created.id, name: created.name }]);
+                selectAndRemember(created.id);
+              }
+              setNewLocationName("");
+              setAddingLocation(false);
+            }}
+            onCancel={() => {
+              setAddingLocation(false);
+              setNewLocationName("");
+            }}
+          />
+        )}
+
+        {allRestaurants.length > 0 && (
+          <LocationPills
+            restaurants={allRestaurants}
+            selectedId={selectedId}
+            onSelect={handleSelectLocation}
+          />
+        )}
+
+        {selectedRestaurant && (
+          <View style={styles.bulkActions}>
+            <Button
+              variant="secondary"
+              tone={isPaused ? "success" : "warning"}
+              size="md"
+              style={styles.bulkAction}
+              icon={isPaused ? "play-circle-outline" : "pause-circle-outline"}
+              disabled={pausing}
+              loading={pausing}
+              accessibilityLabel={
+                isPaused
+                  ? `Resume bookings for ${selectedRestaurant.name}`
+                  : `Pause the next hour of bookings at ${selectedRestaurant.name}`
+              }
+              onPress={async () => {
+                setPausing(true);
+                if (isPaused) {
+                  await unpauseRestaurantBookings(selectedRestaurant.id);
+                  setAllRestaurants((prev) =>
+                    prev.map((r) =>
+                      r.id === selectedRestaurant.id ? { ...r, bookingsPausedUntil: undefined } : r
+                    )
+                  );
                 } else {
-                  setExtendNoActive(true);
+                  await pauseRestaurantBookings(selectedRestaurant.id, 60);
+                  setAllRestaurants((prev) =>
+                    prev.map((r) =>
+                      r.id === selectedRestaurant.id
+                        ? {
+                            ...r,
+                            bookingsPausedUntil: new Date(
+                              Date.now() + 60 * 60 * 1000
+                            ).toISOString(),
+                          }
+                        : r
+                    )
+                  );
                 }
-              }
-            }}
-          >
-            {extending
-              ? "Extending…"
-              : extendedBookings !== null
-                ? `Extended ${extendedBookings.length} active bookings +60m`
-                : extendNoActive
-                  ? "No active bookings to extend"
-                  : activeCount > 0
-                    ? `Extend ${activeCount} active Bookings by 60m`
-                    : "No active bookings"}
-          </Button>
-        </View>
-      )}
+                setPausing(false);
+              }}
+            >
+              {pausing
+                ? "Saving…"
+                : isPaused
+                  ? `Resume New Bookings now (paused up to ${pausedUntilText})`
+                  : "Pause New Bookings for the next 60m"}
+            </Button>
 
-      {allRestaurants.length === 0 ? (
-        <View
-          style={{
-            alignItems: "center",
-            justifyContent: "center",
-            paddingVertical: 72,
-            gap: 12,
-          }}
-        >
+            <Button
+              variant="secondary"
+              size="md"
+              style={styles.bulkAction}
+              icon="timer-outline"
+              disabled={
+                extending || extendedBookings !== null || extendNoActive || activeCount === 0
+              }
+              loading={extending}
+              accessibilityLabel={`Extend all active bookings at ${selectedRestaurant.name} by an hour`}
+              onPress={async () => {
+                setExtending(true);
+                const result = await extendRestaurantBookings(selectedRestaurant.id, 60);
+                setExtending(false);
+                if (result.ok) {
+                  if (result.extendedBookings.length > 0) {
+                    setExtendedBookings(result.extendedBookings);
+                  } else {
+                    setExtendNoActive(true);
+                  }
+                }
+              }}
+            >
+              {extending
+                ? "Extending…"
+                : extendedBookings !== null
+                  ? `Extended ${extendedBookings.length} active bookings +60m`
+                  : extendNoActive
+                    ? "No active bookings to extend"
+                    : activeCount > 0
+                      ? `Extend ${activeCount} active Bookings by 60m`
+                      : "No active bookings"}
+            </Button>
+          </View>
+        )}
+
+        {allRestaurants.length === 0 ? (
           <View
             style={{
-              width: 64,
-              height: 64,
-              borderRadius: 32,
-              borderWidth: 1,
-              borderColor,
               alignItems: "center",
               justifyContent: "center",
-              marginBottom: 4,
+              paddingVertical: 72,
+              gap: 12,
             }}
           >
-            <Icon name="storefront-outline" size={28} color={mutedColor} />
+            <View
+              style={{
+                width: 64,
+                height: 64,
+                borderRadius: 32,
+                borderWidth: 1,
+                borderColor,
+                alignItems: "center",
+                justifyContent: "center",
+                marginBottom: 4,
+              }}
+            >
+              <Icon name="storefront-outline" size={28} color={mutedColor} />
+            </View>
+            <ThemedText style={{ fontSize: 16, fontWeight: "700", textAlign: "center" }}>
+              No locations yet
+            </ThemedText>
+            <ThemedText
+              style={{
+                fontSize: 14,
+                color: mutedColor,
+                textAlign: "center",
+                maxWidth: 280,
+                lineHeight: 22,
+              }}
+            >
+              Add your first location to start accepting bookings.
+            </ThemedText>
           </View>
-          <ThemedText style={{ fontSize: 16, fontWeight: "700", textAlign: "center" }}>
-            No locations yet
-          </ThemedText>
-          <ThemedText
-            style={{
-              fontSize: 14,
-              color: mutedColor,
-              textAlign: "center",
-              maxWidth: 280,
-              lineHeight: 22,
-            }}
-          >
-            Add your first location to start accepting bookings.
-          </ThemedText>
-        </View>
-      ) : selectedSummary && isArchived ? (
-        <View style={[styles.secCard, { backgroundColor: cardBg, borderColor }]}>
-          <ArchivedLocationPanel
-            id={selectedSummary.id}
-            name={selectedSummary.name}
-            restoring={archiving}
-            restoreFailed={archiveFailed}
-            onRestore={() => handleSetArchived(selectedSummary.id, false)}
-            canDelete={canDeleteLocation}
-            onDeleted={handleDeleted}
-          />
-        </View>
-      ) : selectedRestaurant ? (
-        <View style={styles.section}>
-          <ScheduleConflictsPanel
-            restaurantId={selectedRestaurant.id}
-            timezone={selectedRestaurant.timezone ?? "UTC"}
-            refreshKey={scheduleRevision}
-            borderColor={borderColor}
-            mutedColor={mutedColor}
-            cardBg={cardBg}
-          />
-          <LocationCard
-            key={selectedRestaurant.id}
-            restaurant={selectedRestaurant}
-            onSaved={(patch) => patchRestaurant(selectedRestaurant.id, patch)}
-            upcomingBookingsCount={selectedSummary?.upcomingBookingsCount ?? 0}
-            isDark={isDark}
-            borderColor={borderColor}
-            mutedColor={mutedColor}
-            cardBg={cardBg}
-          />
+        ) : selectedSummary && isArchived ? (
           <View style={[styles.secCard, { backgroundColor: cardBg, borderColor }]}>
-            <ArchiveLocationRow
-              name={selectedRestaurant.name}
-              upcomingBookingsCount={selectedSummary?.upcomingBookingsCount ?? 0}
-              archiving={archiving}
-              failed={archiveFailed}
-              onArchive={() => handleSetArchived(selectedRestaurant.id, true)}
+            <ArchivedLocationPanel
+              id={selectedSummary.id}
+              name={selectedSummary.name}
+              restoring={archiving}
+              restoreFailed={archiveFailed}
+              onRestore={() => handleSetArchived(selectedSummary.id, false)}
+              canDelete={canDeleteLocation}
+              onDeleted={handleDeleted}
             />
           </View>
-        </View>
-      ) : null}
-    </ScrollView>
+        ) : selectedRestaurant ? (
+          <View style={styles.section}>
+            <ScheduleConflictsPanel
+              restaurantId={selectedRestaurant.id}
+              timezone={selectedRestaurant.timezone ?? "UTC"}
+              refreshKey={scheduleRevision}
+              onOpenBooking={setConflictBookingId}
+              borderColor={borderColor}
+              mutedColor={mutedColor}
+              cardBg={cardBg}
+            />
+            <LocationCard
+              key={selectedRestaurant.id}
+              restaurant={selectedRestaurant}
+              onSaved={(patch) => patchRestaurant(selectedRestaurant.id, patch)}
+              upcomingBookingsCount={selectedSummary?.upcomingBookingsCount ?? 0}
+              isDark={isDark}
+              borderColor={borderColor}
+              mutedColor={mutedColor}
+              cardBg={cardBg}
+            />
+            <View style={[styles.secCard, { backgroundColor: cardBg, borderColor }]}>
+              <ArchiveLocationRow
+                name={selectedRestaurant.name}
+                upcomingBookingsCount={selectedSummary?.upcomingBookingsCount ?? 0}
+                archiving={archiving}
+                failed={archiveFailed}
+                onArchive={() => handleSetArchived(selectedRestaurant.id, true)}
+              />
+            </View>
+          </View>
+        ) : null}
+      </ScrollView>
+      <BookingDetailPopup
+        bookingId={conflictBookingId}
+        onClose={() => setConflictBookingId(null)}
+        // A booking moved or cancelled out of the conflict is one the panel should stop listing.
+        onMutated={() => setScheduleRevision((n) => n + 1)}
+      />
+    </>
   );
 }

--- a/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.tsx
+++ b/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { View } from "react-native";
-import { useRouter } from "expo-router";
 import { ThemedText } from "@/components/themed-text";
 import { Icon } from "@/components/common/Icon";
 import { RowTextButton } from "@/components/common/RowTextButton";
@@ -43,6 +42,12 @@ function formatSitting(dateUtc: string, timezone: string): string {
 export function ScheduleConflictsPanel({
   restaurantId,
   timezone,
+  /**
+   * Hands the booking to the screen rather than routing to it. The bookings list can only be
+   * reached by leaving the location being edited, and it then has to be searched for the ref
+   * that was already in hand; the popup opens over the form the conflict came from.
+   */
+  onOpenBooking,
   /** Bumped by the parent after a save, so the panel re-reads against the new schedule. */
   refreshKey,
   borderColor,
@@ -51,13 +56,13 @@ export function ScheduleConflictsPanel({
 }: {
   restaurantId: number;
   timezone: string;
+  onOpenBooking: (bookingId: number) => void;
   refreshKey: number;
   borderColor: string;
   mutedColor: string;
   cardBg: string;
 }) {
   const { colors } = useAppTheme();
-  const router = useRouter();
   const [conflicts, setConflicts] = useState<ScheduleConflictDto[] | null>(null);
 
   const load = useCallback(() => {
@@ -114,12 +119,7 @@ export function ScheduleConflictsPanel({
             icon="open-outline"
             color={colors.text}
             accessibilityLabel={`Open booking ${conflict.bookingRef}`}
-            onPress={() =>
-              router.push({
-                pathname: "/admin/bookings",
-                params: { query: conflict.bookingRef },
-              })
-            }
+            onPress={() => onOpenBooking(conflict.bookingId)}
           />
         </View>
       ))}

--- a/openresto-frontend/tests/app/admin/locations.test.tsx
+++ b/openresto-frontend/tests/app/admin/locations.test.tsx
@@ -36,6 +36,17 @@ jest.mock("@/api/auth", () => ({
   logout: jest.fn(),
 }));
 
+jest.mock("@/components/admin/bookings/BookingDetailPopup", () => ({
+  BookingDetailPopup: ({ bookingId }: any) => {
+    const { View, Text } = require("react-native");
+    return bookingId == null ? null : (
+      <View testID="booking-popup">
+        <Text>{`booking ${bookingId}`}</Text>
+      </View>
+    );
+  },
+}));
+
 jest.mock("@/components/admin/settings/LocationCard", () => ({
   LocationCard: ({ onSaved }: any) => {
     const { View, Pressable, Text } = require("react-native");
@@ -590,5 +601,29 @@ describe("AdminLocationsScreen selected-location persistence", () => {
     await waitFor(() => expect(screen.getByText("Resto 2")).toBeTruthy());
     fireEvent.press(screen.getByText("Resto 2"));
     await waitFor(() => expect(screen.getByText("Archived")).toBeTruthy());
+  });
+
+  // The panel used to route to /admin/bookings with the ref as a search term, which left the
+  // location being edited and made the admin search for a booking it already had in hand.
+  it("opens a stranded booking in the popup instead of leaving for the bookings list", async () => {
+    (fetchScheduleConflicts as jest.Mock).mockResolvedValue([
+      {
+        bookingId: 42,
+        bookingRef: "crispy-basil-truffle",
+        customerName: "Ada Lovelace",
+        date: "2026-09-02T10:00:00Z",
+        seats: 2,
+        reason: "outsideHours",
+      },
+    ]);
+
+    renderScreen();
+    await waitFor(() => expect(screen.getByTestId("schedule-conflicts-panel")).toBeTruthy());
+    expect(screen.queryByTestId("booking-popup")).toBeNull();
+
+    fireEvent.press(screen.getByLabelText("Open booking crispy-basil-truffle"));
+
+    await waitFor(() => expect(screen.getByText("booking 42")).toBeTruthy());
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/openresto-frontend/tests/components/admin/locations/ScheduleConflictsPanel.test.tsx
+++ b/openresto-frontend/tests/components/admin/locations/ScheduleConflictsPanel.test.tsx
@@ -6,11 +6,6 @@ jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
 }));
 
-const mockPush = jest.fn();
-jest.mock("expo-router", () => ({
-  useRouter: () => ({ push: mockPush }),
-}));
-
 jest.mock("@/api/restaurants", () => ({
   fetchScheduleConflicts: jest.fn(),
 }));
@@ -26,9 +21,12 @@ const conflict = {
   reason: "outsideHours" as const,
 };
 
+const onOpenBooking = jest.fn();
+
 const props = {
   restaurantId: 1,
   timezone: "UTC",
+  onOpenBooking,
   refreshKey: 0,
   borderColor: "#eee",
   mutedColor: "#888",
@@ -81,7 +79,9 @@ describe("ScheduleConflictsPanel", () => {
     await waitFor(() => expect(fetchScheduleConflicts).toHaveBeenCalledTimes(2));
   });
 
-  it("opens the stranded booking through the admin booking search", async () => {
+  // The id, not the ref: the screen opens the booking popup over the form the conflict came
+  // from, rather than sending the admin to the bookings list to search for a ref it already had.
+  it("hands the stranded booking up by id instead of routing to it", async () => {
     (fetchScheduleConflicts as jest.Mock).mockResolvedValue([conflict]);
 
     render(<ScheduleConflictsPanel {...props} />);
@@ -89,10 +89,7 @@ describe("ScheduleConflictsPanel", () => {
 
     fireEvent.press(screen.getByLabelText("Open booking crispy-basil-truffle"));
 
-    expect(mockPush).toHaveBeenCalledWith({
-      pathname: "/admin/bookings",
-      params: { query: "crispy-basil-truffle" },
-    });
+    expect(onOpenBooking).toHaveBeenCalledWith(7);
   });
 
   it("falls back to the reference when the booking has no customer name", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #361, spotted on prod. The schedule-conflicts panel's **Open** button routed to `/admin/bookings` with the booking ref as a search term. That leaves the location being edited, drops the form's scroll position, and makes the admin search for a booking whose id the panel already had in hand. `BookingDetailPopup` is the better surface and was already the one the dashboard opens bookings with.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `ScheduleConflictsPanel` takes `onOpenBooking(bookingId)` and drops its own `useRouter`. It reports conflicts; deciding what opening one means is the screen's job, not the panel's.
- `app/admin/locations.tsx` holds the selected id and renders `BookingDetailPopup` at the screen root, the same shape the dashboard uses.
- `onMutated` bumps `scheduleRevision`, so a booking moved or cancelled out of the conflict leaves the list without a manual refresh.

`onOpenBooking` is deliberately **required**, not optional with a default: an Open button wired to nothing is a silent dead control, and a missing prop should fail the build rather than ship a button that does nothing.

The `?query=` deep link into `/admin/bookings` added in #358 is untouched — the sidebar search still uses it. This only changes where the conflicts panel sends you.

## Testing

- [x] Frontend tests pass locally (2736 passed, 190 suites), `npm run check` and `npm run check:doc-links` clean
- [ ] Manually verified the change end-to-end

Covered at both levels, because neither alone catches the wiring: the panel test pins that pressing Open reports the id upward and routes nowhere, and the screen test pins that doing so opens the popup over the form rather than navigating away.

## Migrations

- [ ] This PR includes a database migration

No backend change.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)