### PR TITLE
Compose the guest notice when an admin moves a booking

### DIFF
--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -41,6 +41,13 @@ public class BookingDetailDto
     public int Id { get; set; }
     public int RestaurantId { get; set; }
     public string? RestaurantName { get; set; }
+
+    /// <summary>
+    /// The location's IANA timezone. <see cref="Date"/> is UTC, so it names no wall-clock time on
+    /// its own — anything shown to or sent to a guest has to resolve it through this rather than
+    /// through whatever zone the admin's browser happens to be in.
+    /// </summary>
+    public string? Timezone { get; set; }
     public int? SectionId { get; set; }
     public string? SectionName { get; set; }
     public int? TableId { get; set; }

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -777,6 +777,7 @@ public class AdminService(
             Id = b.Id,
             RestaurantId = b.RestaurantId,
             RestaurantName = b.Restaurant?.Name,
+            Timezone = b.Restaurant?.Timezone,
             SectionId = b.SectionId,
             SectionName = b.Section?.Name ?? (b.SectionId.HasValue ? $"Section {b.SectionId}" : "Section"),
             TableId = tableId,

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -83,6 +83,11 @@ export interface BookingDetailDto {
   id: number;
   restaurantId: number;
   restaurantName: string;
+  /**
+   * The location's IANA timezone. `date` is UTC and names no wall-clock time on its own, so
+   * anything shown to or sent to a guest resolves through this, not the admin's browser zone.
+   */
+  timezone?: string;
   sectionId: number | null;
   sectionName: string;
   tableId: number | null;

--- a/openresto-frontend/components/admin/bookings/BookingDetailPopup.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingDetailPopup.tsx
@@ -24,6 +24,7 @@ import { BookingDetailsCard } from "./BookingDetailsCard";
 import { EditBookingForm } from "./EditBookingForm";
 import { ExtendBookingActions } from "./ExtendBookingActions";
 import { EmailGuestForm } from "./EmailGuestForm";
+import { composeBookingMoveNotice } from "@/utils/bookingMoveNotice";
 import { BookingActionButtons } from "./BookingActionButtons";
 import { isPast } from "./StatusBadge";
 import Button from "@/components/common/Button";
@@ -54,6 +55,7 @@ export function BookingDetailPopup({
   const [emailBody, setEmailBody] = useState("");
   const [emailSending, setEmailSending] = useState(false);
   const [emailResult, setEmailResult] = useState<{ ok: boolean; message: string } | null>(null);
+  const [moveNoticeReady, setMoveNoticeReady] = useState(false);
   const [uncancelling, setUncancelling] = useState(false);
   const [showUncancelConfirm, setShowUncancelConfirm] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -76,6 +78,18 @@ export function BookingDetailPopup({
 
   const scrollRef = useRef<ScrollView>(null);
   const extendSectionRef = useRef<View>(null);
+  const emailSectionRef = useRef<View>(null);
+
+  // A form that silently fills itself in reads as a glitch. Bringing it into view is what turns
+  // the prefill into an offer the admin can act on or ignore.
+  useEffect(() => {
+    if (!moveNoticeReady) return;
+    const timer = setTimeout(
+      () => scrollIntoView(emailSectionRef, scrollRef, { block: "center" }),
+      150
+    );
+    return () => clearTimeout(timer);
+  }, [moveNoticeReady]);
 
   useEffect(() => {
     if (initialFocus !== "extend" || loading || editing || !booking || booking.isCancelled) return;
@@ -98,6 +112,7 @@ export function BookingDetailPopup({
       setEmailSubject("");
       setEmailBody("");
       setEmailResult(null);
+      setMoveNoticeReady(false);
       return;
     }
     let cancelled = false;
@@ -249,10 +264,31 @@ export function BookingDetailPopup({
         specialRequests: editSpecialRequests.trim() || undefined,
       };
 
+      const movedFrom = booking.date;
       const updated = await adminUpdateBookingFull(booking.id, updateData);
       setBooking(updated);
       setEditing(false);
       onMutated?.();
+
+      // Composing the notice is the step that was missing, not sending it: the admin still reads
+      // and sends. Only offered once the write has landed, so a move the conflict check rejected
+      // never gets announced to a guest it did not happen to.
+      const notice = updated
+        ? composeBookingMoveNotice({
+            restaurantName: updated.restaurantName,
+            bookingRef: updated.bookingRef,
+            customerName: updated.customerName,
+            fromIso: movedFrom,
+            toIso: updated.date,
+            timezone: updated.timezone,
+          })
+        : null;
+      if (notice && updated?.customerEmail) {
+        setEmailSubject(notice.subject);
+        setEmailBody(notice.body);
+        setEmailResult(null);
+        setMoveNoticeReady(true);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to update booking.";
       setErrorMessage(message);
@@ -287,6 +323,7 @@ export function BookingDetailPopup({
     if (result.ok) {
       setEmailSubject("");
       setEmailBody("");
+      setMoveNoticeReady(false);
     }
   };
 
@@ -453,20 +490,23 @@ export function BookingDetailPopup({
                             onExtend={handleExtend}
                           />
                         </View>
-                        <EmailGuestForm
-                          borderColor={borderColor}
-                          mutedColor={mutedColor}
-                          isDark={isDark}
-                          colors={colors}
-                          customerEmail={booking.customerEmail}
-                          emailSubject={emailSubject}
-                          emailBody={emailBody}
-                          emailSending={emailSending}
-                          emailResult={emailResult}
-                          setEmailSubject={setEmailSubject}
-                          setEmailBody={setEmailBody}
-                          onSendEmail={handleSendEmail}
-                        />
+                        <View ref={emailSectionRef} testID="email-section">
+                          <EmailGuestForm
+                            moveNoticeReady={moveNoticeReady}
+                            borderColor={borderColor}
+                            mutedColor={mutedColor}
+                            isDark={isDark}
+                            colors={colors}
+                            customerEmail={booking.customerEmail}
+                            emailSubject={emailSubject}
+                            emailBody={emailBody}
+                            emailSending={emailSending}
+                            emailResult={emailResult}
+                            setEmailSubject={setEmailSubject}
+                            setEmailBody={setEmailBody}
+                            onSendEmail={handleSendEmail}
+                          />
+                        </View>
                       </View>
                     ) : null}
                   </View>

--- a/openresto-frontend/components/admin/bookings/EmailGuestForm.tsx
+++ b/openresto-frontend/components/admin/bookings/EmailGuestForm.tsx
@@ -12,6 +12,8 @@ interface ThemeColors {
 }
 
 interface EmailGuestFormProps {
+  /** The sitting just moved and a notice has been written into the fields below, unsent. */
+  moveNoticeReady?: boolean;
   borderColor: string;
   mutedColor: string;
   isDark: boolean;
@@ -27,6 +29,7 @@ interface EmailGuestFormProps {
 }
 
 export function EmailGuestForm({
+  moveNoticeReady = false,
   borderColor,
   mutedColor,
   isDark,
@@ -47,6 +50,15 @@ export function EmailGuestForm({
         <ThemedText style={[styles.sectionTitle, { color: mutedColor }]}>Email guest</ThemedText>
       </View>
       <ThemedText style={[styles.emailTo, { color: mutedColor }]}>To: {customerEmail}</ThemedText>
+      {moveNoticeReady && (
+        <ThemedText
+          testID="move-notice-ready"
+          style={[styles.emailTo, { color: theme.colors.warning }]}
+        >
+          The sitting moved. A notice is written below and has not been sent: edit it, or send it as
+          it stands.
+        </ThemedText>
+      )}
       <input
         type="text"
         placeholder="Subject"

--- a/openresto-frontend/tests/components/admin/bookings/BookingDetailPopup.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingDetailPopup.test.tsx
@@ -101,14 +101,23 @@ jest.mock("@/components/admin/bookings/EmailGuestForm", () => ({
     onSendEmail,
     setEmailSubject,
     setEmailBody,
+    emailSubject,
+    emailBody,
+    moveNoticeReady,
   }: {
     onSendEmail: () => void;
     setEmailSubject: (s: string) => void;
     setEmailBody: (s: string) => void;
+    emailSubject: string;
+    emailBody: string;
+    moveNoticeReady?: boolean;
   }) => {
     const { View, Text, Pressable } = require("react-native");
     return (
       <View>
+        {moveNoticeReady ? <Text testID="move-notice-ready">notice ready</Text> : null}
+        <Text testID="email-subject">{emailSubject}</Text>
+        <Text testID="email-body">{emailBody}</Text>
         <Pressable testID="send-email-btn" onPress={onSendEmail}>
           <Text>Send Email</Text>
         </Pressable>
@@ -1169,6 +1178,93 @@ describe("BookingDetailPopup", () => {
       await new Promise((resolve) => setTimeout(resolve, 250));
       expect(findNodeHandleSpy).not.toHaveBeenCalled();
       findNodeHandleSpy.mockRestore();
+    });
+  });
+
+  // Moving a booking and telling the guest were two unrelated steps: the admin edited it, then
+  // hand-typed an email, with nothing carrying the old time across. The composing is what the
+  // save now does; sending stays the admin's.
+  describe("notifying the guest when a sitting moves", () => {
+    const moved = {
+      ...mockBooking,
+      date: "2026-12-02T20:30:00Z",
+      timezone: "America/New_York",
+      customerName: "Ada Lovelace",
+    };
+
+    it("writes an unsent notice into the email form naming both sittings", async () => {
+      (adminApi.adminUpdateBookingFull as jest.Mock).mockResolvedValue(moved);
+      render(<BookingDetailPopup {...baseProps} />);
+      await waitFor(() => expect(screen.getByText("Edit")).toBeTruthy());
+      fireEvent.press(screen.getByText("Edit"));
+      await waitFor(() => expect(screen.getByText("Save Changes")).toBeTruthy());
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Save Changes"));
+      });
+
+      await waitFor(() => expect(screen.getByTestId("move-notice-ready")).toBeTruthy());
+      expect(screen.getByTestId("email-subject").props.children).toContain("has moved");
+      expect(screen.getByTestId("email-body").props.children).toContain("Previously:");
+      // Composed, not sent. Sending stays an explicit press.
+      expect(adminApi.sendBookingEmail).not.toHaveBeenCalled();
+    });
+
+    it("offers nothing when the edit left the sitting where it was", async () => {
+      (adminApi.adminUpdateBookingFull as jest.Mock).mockResolvedValue({
+        ...mockBooking,
+        seats: 4,
+      });
+      render(<BookingDetailPopup {...baseProps} />);
+      await waitFor(() => expect(screen.getByText("Edit")).toBeTruthy());
+      fireEvent.press(screen.getByText("Edit"));
+      await waitFor(() => expect(screen.getByText("Save Changes")).toBeTruthy());
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Save Changes"));
+      });
+
+      await waitFor(() => expect(adminApi.adminUpdateBookingFull).toHaveBeenCalled());
+      expect(screen.queryByTestId("move-notice-ready")).toBeNull();
+      expect(screen.getByTestId("email-subject").props.children).toBe("");
+    });
+
+    // A booking with no address on it cannot be told anything, and a notice written into a form
+    // that can never send reads as a step the admin failed to complete.
+    it("offers nothing when the booking carries no customer email", async () => {
+      (adminApi.adminUpdateBookingFull as jest.Mock).mockResolvedValue({
+        ...moved,
+        customerEmail: "",
+      });
+      render(<BookingDetailPopup {...baseProps} />);
+      await waitFor(() => expect(screen.getByText("Edit")).toBeTruthy());
+      fireEvent.press(screen.getByText("Edit"));
+      await waitFor(() => expect(screen.getByText("Save Changes")).toBeTruthy());
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Save Changes"));
+      });
+
+      await waitFor(() => expect(adminApi.adminUpdateBookingFull).toHaveBeenCalled());
+      expect(screen.queryByTestId("move-notice-ready")).toBeNull();
+    });
+
+    // A rejected move must never be announced to a guest it did not happen to.
+    it("offers nothing when the update was rejected", async () => {
+      (adminApi.adminUpdateBookingFull as jest.Mock).mockRejectedValue(
+        new Error("This update would cause a conflict with an existing booking.")
+      );
+      render(<BookingDetailPopup {...baseProps} />);
+      await waitFor(() => expect(screen.getByText("Edit")).toBeTruthy());
+      fireEvent.press(screen.getByText("Edit"));
+      await waitFor(() => expect(screen.getByText("Save Changes")).toBeTruthy());
+
+      await act(async () => {
+        fireEvent.press(screen.getByText("Save Changes"));
+      });
+
+      await waitFor(() => expect(screen.getByTestId("alert-message")).toBeTruthy());
+      expect(screen.queryByTestId("move-notice-ready")).toBeNull();
     });
   });
 });

--- a/openresto-frontend/tests/utils/bookingMoveNotice.test.ts
+++ b/openresto-frontend/tests/utils/bookingMoveNotice.test.ts
@@ -1,0 +1,103 @@
+import { composeBookingMoveNotice } from "@/utils/bookingMoveNotice";
+
+const NY = "America/New_York";
+// 2026-09-02T23:00Z is 19:00 EDT the same day; 2026-09-03T16:30Z is 12:30 EDT the next.
+const FROM = "2026-09-02T23:00:00Z";
+const TO = "2026-09-03T16:30:00Z";
+
+/** Mirrors the composer's own format options, so the assertions pin the zone, not the locale. */
+const inZone = (iso: string, timeZone: string) =>
+  new Date(iso).toLocaleString(undefined, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+    timeZone,
+  });
+
+const details = {
+  restaurantName: "Paddy's Pub",
+  bookingRef: "crispy-basil-truffle",
+  customerName: "Ada Lovelace",
+  fromIso: FROM,
+  toIso: TO,
+  timezone: NY,
+};
+
+describe("composeBookingMoveNotice", () => {
+  // A rename or a seat-count change must never offer the admin an email announcing a change of
+  // time that did not happen.
+  it("composes nothing when the sitting did not move", () => {
+    expect(composeBookingMoveNotice({ ...details, toIso: FROM })).toBeNull();
+  });
+
+  it("composes nothing when the two instants differ only in how they are written", () => {
+    expect(
+      composeBookingMoveNotice({ ...details, fromIso: FROM, toIso: "2026-09-02T19:00:00-04:00" })
+    ).toBeNull();
+  });
+
+  it("composes a notice when the sitting moved", () => {
+    const notice = composeBookingMoveNotice(details)!;
+
+    expect(notice.subject).toBe("Your booking at Paddy's Pub has moved");
+    expect(notice.body).toContain("Hi Ada Lovelace,");
+    expect(notice.body).toContain("crispy-basil-truffle");
+  });
+
+  // The guest turns up at the restaurant's clock, not the admin's. An admin covering a location
+  // in another zone would otherwise send a time nobody is expecting them at.
+  //
+  // Asserted against a locally formatted reference rather than a literal string: the output is
+  // locale-dependent (en-GB gives "Wednesday 2 September at 19:00 GMT-4", en-US gives
+  // "Wednesday, September 2 at 7:00 PM EDT"), so a literal would pass on CI and fail on a
+  // developer's machine. What is being pinned is the zone reaching the formatter, not the format.
+  it("renders both sittings in the restaurant's timezone", () => {
+    const notice = composeBookingMoveNotice({ ...details, timezone: "Asia/Tokyo" })!;
+
+    expect(notice.body).toContain(`Previously: ${inZone(FROM, "Asia/Tokyo")}`);
+    expect(notice.body).toContain(`Now: ${inZone(TO, "Asia/Tokyo")}`);
+  });
+
+  it("renders a different time for a location in a different zone", () => {
+    const tokyo = composeBookingMoveNotice({ ...details, timezone: "Asia/Tokyo" })!;
+    const london = composeBookingMoveNotice({ ...details, timezone: "Europe/London" })!;
+
+    expect(tokyo.body).not.toEqual(london.body);
+  });
+
+  it("still names a zone when the location has none recorded", () => {
+    const notice = composeBookingMoveNotice({ ...details, timezone: null })!;
+
+    expect(notice.body).toMatch(/Previously: .+\d/);
+    expect(notice.body).toContain("Now:");
+  });
+
+  // An unknown IANA id would otherwise throw out of the save handler that composes this.
+  it("falls back rather than throwing on an unusable timezone", () => {
+    const notice = composeBookingMoveNotice({ ...details, timezone: "Not/A/Zone" })!;
+
+    expect(notice.body).toContain("Previously:");
+  });
+
+  it("greets without a name when the booking has none", () => {
+    const notice = composeBookingMoveNotice({ ...details, customerName: null })!;
+
+    expect(notice.body).toContain("Hello,");
+    expect(notice.body).not.toContain("Hi ,");
+  });
+
+  it("omits the reference line when the booking has no reference", () => {
+    const notice = composeBookingMoveNotice({ ...details, bookingRef: "  " })!;
+
+    expect(notice.body).not.toContain("booking reference");
+  });
+
+  it("names the venue generically when the location has no name", () => {
+    const notice = composeBookingMoveNotice({ ...details, restaurantName: null })!;
+
+    expect(notice.subject).toBe("Your booking at the restaurant has moved");
+  });
+});

--- a/openresto-frontend/utils/bookingMoveNotice.ts
+++ b/openresto-frontend/utils/bookingMoveNotice.ts
@@ -1,0 +1,82 @@
+/**
+ * The email an admin sends a guest whose sitting has been moved.
+ *
+ * Moving a booking and telling the guest were two unrelated steps: the admin edited the booking,
+ * then hand-typed an email about it. Nothing carried the old time across, so the message the guest
+ * most needs to be exact about was the one most likely to be wrong. This composes it from what
+ * actually changed, and the admin still reviews and sends it.
+ *
+ * Times resolve through the restaurant's timezone, never the browser's. An admin covering a
+ * location in another zone would otherwise tell the guest a time nobody is expecting them at, so
+ * the zone is named in the text as well: a guest reading "7:00 PM EDT" can act on it, where a bare
+ * "7:00 PM" is only as good as an assumption they cannot check.
+ *
+ * @see [bookingMoveNotice.test.ts](../tests/utils/bookingMoveNotice.test.ts) — pins that the
+ * sitting is rendered in the restaurant's zone and that an unchanged sitting composes nothing.
+ */
+export interface BookingMoveNotice {
+  subject: string;
+  body: string;
+}
+
+export interface BookingMoveDetails {
+  restaurantName?: string | null;
+  bookingRef?: string | null;
+  customerName?: string | null;
+  /** ISO instants. The booking's UTC start before and after the edit. */
+  fromIso: string;
+  toIso: string;
+  /** IANA id. Falls back to the browser's zone, which is still labelled in the output. */
+  timezone?: string | null;
+}
+
+function formatSitting(iso: string, timezone?: string | null): string {
+  const options: Intl.DateTimeFormatOptions = {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  };
+
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      ...options,
+      ...(timezone ? { timeZone: timezone } : {}),
+    });
+  } catch {
+    // An unknown IANA id would otherwise throw and take the whole save handler with it. The
+    // browser's zone is wrong for a remote location, but it is labelled, and a notice the admin
+    // can correct beats no notice at all.
+    return new Date(iso).toLocaleString(undefined, options);
+  }
+}
+
+/**
+ * Null when the sitting did not move, so a rename or a seat-count change never offers the admin
+ * an email announcing a change of time that did not happen.
+ */
+export function composeBookingMoveNotice(details: BookingMoveDetails): BookingMoveNotice | null {
+  const from = new Date(details.fromIso);
+  const to = new Date(details.toIso);
+  if (from.getTime() === to.getTime()) return null;
+
+  const venue = details.restaurantName?.trim() || "the restaurant";
+  const greeting = details.customerName?.trim() ? `Hi ${details.customerName.trim()},` : "Hello,";
+  const reference = details.bookingRef?.trim()
+    ? `\n\nYour booking reference is unchanged: ${details.bookingRef.trim()}.`
+    : "";
+
+  return {
+    subject: `Your booking at ${venue} has moved`,
+    body:
+      `${greeting}\n\n` +
+      `We have moved your booking at ${venue}.\n\n` +
+      `Previously: ${formatSitting(details.fromIso, details.timezone)}\n` +
+      `Now: ${formatSitting(details.toIso, details.timezone)}\n\n` +
+      `Everything else about the booking stays the same.` +
+      reference +
+      `\n\nIf the new time does not work for you, reply to this email and we will sort it out.`,
+  };
+}


### PR DESCRIPTION
## Summary

The last gap from the #359 spike: *"There is currently no way to move a booking and notify the guest in one action, which is what the admin actually needs next."*

Both halves already existed in `BookingDetailPopup` and had nothing to do with each other. The admin edited the booking, then hand-typed an email about it. Nothing carried the old time across, so the message the guest most needs to be exact about was the one most likely to be wrong, and the one most likely to be skipped.

A save that changes the sitting now writes the notice into the email form, naming both the old time and the new, and scrolls it into view.

## Composing is the missing step, not sending

The admin still reads it, edits it if they want, and presses Send. An email that leaves without anyone reading it is worse than the manual version it replaces: the admin knows things the composer does not (why it moved, what was agreed on the phone, whether this guest has already been called).

Two cases deliberately offer nothing:

- **The update was rejected.** The notice is composed after the write lands, so a move the conflict check refuses is never announced to a guest it did not happen to. That check only started working in #365.
- **The booking carries no address.** A notice written into a form that can never send reads as a step the admin failed to finish.

An edit that leaves the sitting alone (a rename, a seat-count change) composes nothing, so the offer never appears for a change of time that did not happen.

## Times resolve through the restaurant's zone

`BookingDetailDto` now carries `Timezone`. `Date` is UTC and names no wall-clock time on its own, so an admin covering a location in another zone would otherwise send a time nobody is expecting the guest at. The demo has locations in New York and Toronto, so this is not hypothetical.

The zone is named in the text as well: a guest reading "7:00 PM EDT" can act on it, where a bare "7:00 PM" is only as good as an assumption they cannot check.

Worth flagging separately: `BookingDetailsCard` still renders the booking's own times in the **admin's browser zone** with no `timeZone` passed. That is pre-existing, invisible for a single-location operator, and wrong for a multi-zone one. Not fixed here because it is a visible change to admin display rather than to what a guest receives; it now has the field it needs whenever you want it.

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `BookingDetailDto.Timezone`, mapped from `b.Restaurant?.Timezone` in `ToDetailDto`.
- `utils/bookingMoveNotice.ts` composes subject and body from what actually changed. Pure, so the wording is pinned by tests rather than by clicking through, and returns `null` when the sitting did not move.
- `BookingDetailPopup` prefills the email form after a successful move and scrolls it into view; `EmailGuestForm` says the notice is written and unsent, so a form that filled itself in does not read as a glitch.

## Testing

- [x] `OpenRestoApi.Tests` pass locally (1751 passed)
- [x] Frontend tests pass locally (2750 passed, 191 suites), `npm run check` and `npm run check:doc-links` clean
- [ ] Manually verified the change end-to-end

The composer's timezone tests assert against a locally formatted reference rather than a literal string. The output is locale-dependent (`en-GB` gives "Wednesday 2 September at 19:00 GMT-4", `en-US` gives "Wednesday, September 2 at 7:00 PM EDT"), so a literal would pass on CI and fail on a developer's machine. That is the exact failure mode fixed in an `AvailabilityGrid` test earlier today, so it seemed worth not reintroducing.

## Migrations

- [ ] This PR includes a database migration

`Timezone` is read from the existing `Restaurants` column. No schema change.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)