### PR TITLE
Draw the admin timetable as sittings, not hour buckets

### DIFF
--- a/OpenRestoApi.Tests/Services/AdminServiceTests.GridPlacement.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.GridPlacement.cs
@@ -1,0 +1,169 @@
+using OpenRestoApi.Core.Application.DTOs;
+using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Application.Utilities;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Tests.Services;
+
+/// <summary>
+/// What the admin timetable needs off a booking to draw it on the floor: which unit it reserves
+/// (a table or a combinable group) and when the sitting actually ends.
+/// </summary>
+public partial class AdminServiceTests
+{
+    private void SeedGroup(int restaurantId, int groupId, string? name = null)
+    {
+        _db.Tables.Add(new Table { Id = 80 + groupId, Name = "T8", Seats = 4, SectionId = restaurantId });
+        _db.Tables.Add(new Table { Id = 90 + groupId, Name = "T9", Seats = 4, SectionId = restaurantId });
+        _db.TableGroups.Add(new TableGroup
+        {
+            Id = groupId,
+            Name = name,
+            RestaurantId = restaurantId,
+            CombinedSeats = 7,
+            Members =
+            [
+                new TableGroupMembership { TableGroupId = groupId, TableId = 80 + groupId },
+                new TableGroupMembership { TableGroupId = groupId, TableId = 90 + groupId },
+            ],
+        });
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_ExposesTableGroupId_SoAGroupBookingCanBePlaced()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        SeedGroup(restaurantId: 1, groupId: 5, name: "Window booths");
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = null,
+            TableGroupId = 5,
+            Seats = 7,
+            Date = DateTime.UtcNow.Date.AddHours(19),
+            BookingRef = "GROUP",
+        });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> bookings = await svc.GetBookingsAsync(1, null, "all");
+
+        BookingDetailDto dto = Assert.Single(bookings);
+        Assert.Null(dto.TableId);
+        Assert.Equal(5, dto.TableGroupId);
+        Assert.Equal("Window booths", dto.TableName);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_LabelsAnUnnamedGroupFromItsMemberTables()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        SeedGroup(restaurantId: 1, groupId: 6);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            SectionId = 1,
+            TableGroupId = 6,
+            Seats = 7,
+            Date = DateTime.UtcNow.Date.AddHours(19),
+            BookingRef = "GROUP",
+        });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> bookings = await svc.GetBookingsAsync(1, null, "all");
+
+        Assert.Equal("Tables T8 + T9", Assert.Single(bookings).TableName);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_KeepsTableIdAndLeavesGroupNull_ForASingleTableBooking()
+    {
+        AdminService svc = CreateService();
+        SeedBase(1);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            Seats = 2,
+            Date = DateTime.UtcNow.Date.AddHours(19),
+            BookingRef = "SINGLE",
+        });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> bookings = await svc.GetBookingsAsync(1, null, "all");
+
+        BookingDetailDto dto = Assert.Single(bookings);
+        Assert.Equal(1, dto.TableId);
+        Assert.Null(dto.TableGroupId);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_ResolvesAStoredlessEndTimeToTheLocationsDefaultDuration()
+    {
+        AdminService svc = CreateService();
+        _db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "Test",
+            Timezone = "UTC",
+            DefaultBookingDurationMinutes = 105,
+        });
+        _db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        _db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        DateTime start = DateTime.UtcNow.Date.AddHours(19);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            Seats = 2,
+            Date = start,
+            EndTime = null,
+            BookingRef = "LEGACY",
+        });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> bookings = await svc.GetBookingsAsync(1, null, "all");
+
+        Assert.Equal(start.AddMinutes(105), Assert.Single(bookings).EndTime);
+    }
+
+    [Fact]
+    public async Task GetBookingsAsync_KeepsAStoredEndTimeRatherThanTheDefaultDuration()
+    {
+        AdminService svc = CreateService();
+        _db.Restaurants.Add(new Restaurant
+        {
+            Id = 1,
+            Name = "Test",
+            Timezone = "UTC",
+            DefaultBookingDurationMinutes = 105,
+        });
+        _db.Sections.Add(new Section { Id = 1, Name = "Main", RestaurantId = 1 });
+        _db.Tables.Add(new Table { Id = 1, Name = "T1", Seats = 4, SectionId = 1 });
+        DateTime start = DateTime.UtcNow.Date.AddHours(19);
+        _db.Bookings.Add(new Booking
+        {
+            Id = 1,
+            RestaurantId = 1,
+            SectionId = 1,
+            TableId = 1,
+            Seats = 2,
+            Date = start,
+            EndTime = start.AddMinutes(180),
+            BookingRef = "EXTENDED",
+        });
+        await _db.SaveChangesAsync();
+
+        List<BookingDetailDto> bookings = await svc.GetBookingsAsync(1, null, "all");
+
+        Assert.Equal(start.AddMinutes(180), Assert.Single(bookings).EndTime);
+    }
+}

--- a/OpenRestoApi.Tests/Services/AdminServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/AdminServiceTests.cs
@@ -11,7 +11,7 @@ using OpenRestoApi.Infrastructure.Persistence.Repositories;
 
 namespace OpenRestoApi.Tests.Services;
 
-public class AdminServiceTests : IDisposable
+public partial class AdminServiceTests : IDisposable
 {
     private readonly SqliteConnection _connection;
     private readonly AppDbContext _db;

--- a/OpenRestoApi.Tests/Utilities/BookingDurationTests.cs
+++ b/OpenRestoApi.Tests/Utilities/BookingDurationTests.cs
@@ -1,0 +1,36 @@
+using OpenRestoApi.Core.Application.Utilities;
+
+namespace OpenRestoApi.Tests.Utilities;
+
+public class BookingDurationTests
+{
+    private static readonly DateTime Start = new(2026, 8, 23, 18, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void ResolveEnd_UsesStoredEndTime()
+    {
+        DateTime stored = Start.AddMinutes(150);
+
+        Assert.Equal(stored, BookingDuration.ResolveEnd(Start, stored, 90));
+    }
+
+    [Fact]
+    public void ResolveEnd_FallsBackToRestaurantDefaultWhenNull()
+    {
+        Assert.Equal(Start.AddMinutes(90), BookingDuration.ResolveEnd(Start, null, 90));
+    }
+
+    [Fact]
+    public void ResolveEnd_FallsBackWhenStoredEndIsNotAfterStart()
+    {
+        Assert.Equal(Start.AddMinutes(90), BookingDuration.ResolveEnd(Start, Start, 90));
+    }
+
+    [Fact]
+    public void ResolveEnd_UsesFallbackMinutesWhenLocationHasNoDefault()
+    {
+        Assert.Equal(
+            Start.AddMinutes(BookingDuration.FallbackMinutes),
+            BookingDuration.ResolveEnd(Start, null, null));
+    }
+}

--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -57,8 +57,21 @@ public class BookingDetailDto
     public int? SectionId { get; set; }
     public string? SectionName { get; set; }
     public int? TableId { get; set; }
+
+    /// <summary>
+    /// Set when the booking reserves a combinable <c>TableGroup</c> rather than a single table, in
+    /// which case <see cref="TableId"/> is null. Both are never set at once, so a consumer placing a
+    /// booking on the floor has to branch on this or it will silently drop every group booking.
+    /// </summary>
+    public int? TableGroupId { get; set; }
+
     public string? TableName { get; set; }
     public DateTime Date { get; set; }
+
+    /// <summary>
+    /// The sitting's end, resolved through <c>BookingDuration.ResolveEnd</c> — a booking stored with
+    /// no end reads as its location's default duration rather than as zero-length.
+    /// </summary>
     public DateTime? EndTime { get; set; }
     public string? CustomerEmail { get; set; }
     public string? CustomerName { get; set; }

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -251,16 +251,11 @@ public class AdminService(
             return null;
         }
 
-        DateTime from;
-        if (booking.EndTime.HasValue && booking.EndTime.Value > booking.Date)
-        {
-            from = booking.EndTime.Value;
-        }
-        else
-        {
-            Restaurant? restaurant = await _restaurantRepository.FindByIdAsync(booking.RestaurantId);
-            from = booking.Date.AddMinutes(restaurant?.DefaultBookingDurationMinutes ?? 60);
-        }
+        Restaurant? restaurant = booking.EndTime.HasValue && booking.EndTime.Value > booking.Date
+            ? null
+            : await _restaurantRepository.FindByIdAsync(booking.RestaurantId);
+        DateTime from = BookingDuration.ResolveEnd(
+            booking.Date, booking.EndTime, restaurant?.DefaultBookingDurationMinutes);
 
         DateTime? previousEnd = booking.EndTime;
         booking.EndTime = from.AddMinutes(minutes);
@@ -810,9 +805,11 @@ public class AdminService(
             SectionId = b.SectionId,
             SectionName = b.Section?.Name ?? (b.SectionId.HasValue ? $"Section {b.SectionId}" : "Section"),
             TableId = tableId,
+            TableGroupId = b.TableGroupId,
             TableName = tableName,
             Date = dateUtc,
-            EndTime = endTimeUtc,
+            EndTime = BookingDuration.ResolveEnd(
+                dateUtc, endTimeUtc, b.Restaurant?.DefaultBookingDurationMinutes),
             CustomerEmail = b.CustomerEmail,
             CustomerName = b.CustomerName,
             Seats = b.Seats,

--- a/OpenRestoApi/Core/Application/Utilities/BookingDuration.cs
+++ b/OpenRestoApi/Core/Application/Utilities/BookingDuration.cs
@@ -1,0 +1,22 @@
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// Resolves when a sitting actually finishes. <see cref="Booking.EndTime"/> is nullable and rows
+/// taken before it existed carry null, so anything that needs the end of a booking has to fall back
+/// to the location's default duration rather than read the booking as zero-length.
+/// </summary>
+/// <seealso>BookingDurationTests.ResolveEnd_UsesStoredEndTime</seealso>
+/// <seealso>BookingDurationTests.ResolveEnd_FallsBackToRestaurantDefaultWhenNull</seealso>
+/// <seealso>BookingDurationTests.ResolveEnd_FallsBackWhenStoredEndIsNotAfterStart</seealso>
+public static class BookingDuration
+{
+    /// <summary>Sitting length assumed when a location carries no configured default.</summary>
+    public const int FallbackMinutes = 60;
+
+    public static DateTime ResolveEnd(DateTime start, DateTime? endTime, int? defaultDurationMinutes)
+        => endTime.HasValue && endTime.Value > start
+            ? endTime.Value
+            : start.AddMinutes(defaultDurationMinutes ?? FallbackMinutes);
+}

--- a/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingFilterRepository.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/Repositories/BookingFilterRepository.cs
@@ -35,6 +35,7 @@ internal class BookingFilterRepository(AppDbContext db) : IBookingFilterReposito
             .Include(b => b.Restaurant)
             .Include(b => b.Section)
             .Include(b => b.Table)
+            .Include(b => b.TableGroup!).ThenInclude(g => g.Members).ThenInclude(m => m.Table)
             .AsQueryable();
 
         DateTime nowUtc = DateTime.UtcNow;

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -94,6 +94,12 @@ export interface BookingDetailDto {
   sectionId: number | null;
   sectionName: string;
   tableId: number | null;
+  /**
+   * Set when the booking reserves a combinable table group rather than a single table, in which
+   * case `tableId` is null. Placing a booking on the floor has to branch on both or every group
+   * booking is silently dropped.
+   */
+  tableGroupId?: number | null;
   tableName: string;
   date: string;
   endTime?: string;

--- a/openresto-frontend/app/admin/bookings/index.tsx
+++ b/openresto-frontend/app/admin/bookings/index.tsx
@@ -42,7 +42,7 @@ import {
 import { styles } from "@/components/admin/bookings/bookings.styles";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useErrorHandler } from "@/hooks/useErrorHandler";
-import { fmtDate } from "@/utils/formatters";
+import { fmtDate, isoDate } from "@/utils/formatters";
 import { Icon } from "@/components/common/Icon";
 
 type ViewMode = "timetable" | "list";
@@ -517,6 +517,15 @@ export default function AdminBookingsScreen() {
               ]}
             >
               <View style={[styles.legendDot, { backgroundColor: PRIMARY }]} />
+              <ThemedText style={[styles.legendText, { color: mutedColor }]}>Seated now</ThemedText>
+            </View>
+            <View
+              style={[
+                styles.legendItem,
+                { borderRadius: 6, paddingHorizontal: 8, paddingVertical: 4 },
+              ]}
+            >
+              <View style={[styles.legendDot, { backgroundColor: `${PRIMARY}44` }]} />
               <ThemedText style={[styles.legendText, { color: mutedColor }]}>Booked</ThemedText>
             </View>
             <View
@@ -528,13 +537,13 @@ export default function AdminBookingsScreen() {
               <View
                 style={[
                   styles.legendDot,
-                  { backgroundColor: isDark ? "rgba(255,255,255,0.06)" : "#e5e7eb" },
+                  { width: 3, backgroundColor: colors.error, borderRadius: 0 },
                 ]}
               />
-              <ThemedText style={[styles.legendText, { color: mutedColor }]}>Available</ThemedText>
+              <ThemedText style={[styles.legendText, { color: mutedColor }]}>Now</ThemedText>
             </View>
             <ThemedText style={[styles.legendText, { color: mutedColor, marginLeft: 4 }]}>
-              Tap a booking to view details
+              Tap a sitting to view details
             </ThemedText>
           </View>
 
@@ -546,9 +555,13 @@ export default function AdminBookingsScreen() {
               bookings={gridBookings}
               isDark={isDark}
               onBookingPress={(b) => openBooking(b.id)}
+              groups={selectedRestaurant?.groups ?? []}
               openTime={openTime}
               closeTime={closeTime}
               timezone={timezone}
+              defaultDurationMinutes={selectedRestaurant?.defaultBookingDurationMinutes ?? 90}
+              gridDateIso={isoDate(gridDate)}
+              dateLabel={fmtDate(gridDate)}
             />
           )}
         </View>

--- a/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
+++ b/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
@@ -1,101 +1,149 @@
+import { useEffect, useMemo, useState } from "react";
 import { ScrollView, View, Pressable } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { getThemeColors } from "@/theme/theme";
 import { SectionWithTables, BookingDetailDto } from "@/api/admin";
+import type { TableGroupDto } from "@/api/restaurants";
 import { styles } from "./bookings.styles";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
 import { Icon } from "@/components/common/Icon";
+import { getNowInTimezone } from "@/utils/date";
+import {
+  buildTimeline,
+  buildUnitRows,
+  formatClockMinutes,
+  formatRemaining,
+  nowOffset,
+  unitKeyFor,
+  UNASSIGNED_KEY,
+  type TimelinePlacement,
+} from "@/utils/bookingTimeline";
 
-/** 12-hour clock labels, indexed by 24-hour hour. Midnight reads 12a, not 0a. */
-const HOUR_LABELS = Array.from({ length: 24 }, (_, h) =>
-  h === 0 ? "12a" : h < 12 ? `${h}a` : h === 12 ? "12p" : `${h - 12}p`
-);
-
-/**
- * The hour columns to draw: the service window, plus an extra column for any hour a booking
- * actually falls on. Editing a location's hours leaves the bookings taken under the old ones
- * where they are, so a window-only grid quietly stops rendering them — the timetable is where
- * staff would notice, which makes it the worst place to hide them.
- *
- * Hours are laid out forward from opening, so an overnight service (18:00–02:00) reads
- * 6p…11p, 12a, 1a rather than collapsing to a single column.
- *
- * @see [AvailabilityGrid.test.tsx](../../../tests/components/AvailabilityGrid.test.tsx)
- * — pins that a booking outside the current hours still gets a column, and that an overnight
- * window spans the night instead of one hour.
- */
-function buildTimeSlots(openTime: string, closeTime: string, bookedHours: number[] = []) {
-  const startHour = parseInt(openTime.split(":")[0], 10);
-  const rawEndHour = parseInt(closeTime.split(":")[0], 10);
-  const span = (rawEndHour - startHour + 24) % 24 || 24;
-
-  const hours = new Set<number>();
-  for (let i = 0; i < span; i++) hours.add((startHour + i) % 24);
-  for (const hour of bookedHours) hours.add(hour);
-
-  const sinceOpening = (hour: number) => (hour - startHour + 24) % 24;
-  return [...hours]
-    .sort((a, b) => sinceOpening(a) - sinceOpening(b))
-    .map((h) => ({ hour: h, label: HOUR_LABELS[h] }));
-}
-
-export const COL_W = 68;
-export const ROW_H = 48;
-export const LABEL_W = 110;
+/** Width of one hour of service. Everything else on the axis derives from it. */
+export const HOUR_W = 76;
+export const LABEL_W = 132;
 export const HEADER_H = 36;
 export const SECTION_H = 26;
+/** Height of one sitting bar. A unit needing N lanes gets N of these. */
+export const LANE_H = 38;
+export const ROW_MIN_H = 48;
+const LANE_GAP = 4;
+const PX_PER_MINUTE = HOUR_W / 60;
+const MINUTE_TICK_MS = 60_000;
 
-function getRestaurantHour(dateStr: string, timezone: string): number {
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      hour: "2-digit",
-      hourCycle: "h23",
-    }).formatToParts(new Date(dateStr));
-    return parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10);
-  } catch {
-    return new Date(dateStr).getHours();
-  }
+function rowHeight(lanes: number): number {
+  return Math.max(ROW_MIN_H, lanes * LANE_H + LANE_GAP * 2);
+}
+
+/**
+ * Re-renders once a minute so the "now" marker and every bar's remaining time track the clock. A
+ * timetable a front-of-house tablet is parked on all service is wrong the moment it stops moving.
+ */
+function useMinuteTick(): number {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), MINUTE_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+  return tick;
+}
+
+type SittingState = "past" | "current" | "upcoming";
+
+function sittingState(placement: TimelinePlacement, now: number | null): SittingState {
+  if (now == null) return "upcoming";
+  if (now >= placement.endOffset) return "past";
+  return now >= placement.startOffset ? "current" : "upcoming";
 }
 
 export function AvailabilityGrid({
   sections,
+  groups = [],
   bookings,
   isDark,
   onBookingPress,
   openTime = "11:00",
   closeTime = "23:00",
   timezone = "UTC",
+  defaultDurationMinutes = 90,
+  gridDateIso,
+  dateLabel,
 }: {
   sections: SectionWithTables[];
+  /** Combinable groups for the location; each becomes a bookable row of its own. */
+  groups?: TableGroupDto[];
   bookings: BookingDetailDto[];
   isDark: boolean;
   onBookingPress: (b: BookingDetailDto) => void;
   openTime?: string;
   closeTime?: string;
   timezone?: string;
+  /** Sitting length assumed for a booking stored without an end time. */
+  defaultDurationMinutes?: number;
+  /** The day being shown ("YYYY-MM-DD"). The now marker only draws on the location's today. */
+  gridDateIso?: string;
+  /** Human-readable form of the same day, named in the empty state. */
+  dateLabel?: string;
 }) {
-  const bookedHours = bookings
-    .filter((b) => b.tableId != null)
-    .map((b) => getRestaurantHour(b.date, timezone));
-  const timeSlots = buildTimeSlots(openTime, closeTime, bookedHours);
+  const tick = useMinuteTick();
   const colors = getThemeColors(isDark);
+  const { primaryColor: PRIMARY } = useAppTheme();
+
   const borderColor = colors.border;
+  const mutedColor = colors.muted;
   const headerBg = isDark ? "#28292b" : "#f4f5f6";
   const sectionBg = isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.03)";
-  const availBg = isDark ? "#18191b" : "#fafafa";
-  const { primaryColor: PRIMARY } = useAppTheme();
-  const bookedBg = isDark ? hexToRgba(PRIMARY, 0.22) : hexToRgba(PRIMARY, 0.1);
-  const mutedColor = colors.muted;
+  const laneBg = isDark ? "#18191b" : "#fafafa";
+  const gridLineColor = isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.05)";
 
-  function bookingForCell(tableId: number, hour: number): BookingDetailDto | undefined {
-    return bookings.find(
-      (b) => b.tableId === tableId && getRestaurantHour(b.date, timezone) === hour
-    );
-  }
+  // `tick` is the dependency: the clock is read fresh each minute so the marker and the
+  // remaining-time labels advance without a refetch.
+  const nowMinutes = useMemo(() => {
+    const local = getNowInTimezone(timezone);
+    if (gridDateIso && gridDateIso !== local.dateStr) return null;
+    return local.hours * 60 + local.minutes;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timezone, gridDateIso, tick]);
 
-  const totalW = LABEL_W + timeSlots.length * COL_W;
+  const timeline = useMemo(
+    () =>
+      buildTimeline({
+        openTime,
+        closeTime,
+        timezone,
+        bookings,
+        defaultDurationMinutes,
+        nowMinutes,
+      }),
+    [openTime, closeTime, timezone, bookings, defaultDurationMinutes, nowMinutes]
+  );
+
+  const hasUnassigned = bookings.some((b) => unitKeyFor(b) === UNASSIGNED_KEY);
+  const rowGroups = useMemo(
+    () => buildUnitRows(sections, groups, { includeUnassigned: hasUnassigned }),
+    [sections, groups, hasUnassigned]
+  );
+
+  const now = nowOffset(timeline, openTime, nowMinutes);
+
+  const placementsByUnit = useMemo(() => {
+    const byUnit: Record<string, TimelinePlacement[]> = {};
+    for (const placement of timeline.placements) {
+      (byUnit[placement.unitKey] ??= []).push(placement);
+    }
+    return byUnit;
+  }, [timeline]);
+
+  const timelineW = (timeline.endOffset - timeline.startOffset) * PX_PER_MINUTE;
+  const totalW = LABEL_W + timelineW;
+  const bodyH = rowGroups.reduce(
+    (sum, group) =>
+      sum +
+      SECTION_H +
+      group.units.reduce((h, unit) => h + rowHeight(timeline.laneCount[unit.key] ?? 1), 0),
+    0
+  );
 
   if (sections.length === 0) {
     return (
@@ -108,60 +156,73 @@ export function AvailabilityGrid({
     );
   }
 
+  // An empty day has nothing to place, and a grid of idle hours says less than one sentence does —
+  // for a location open around the clock it says it across 24 columns.
+  if (bookings.length === 0) {
+    return (
+      <View testID="grid-empty-day" style={{ padding: 40, alignItems: "center" }}>
+        <Icon name="calendar-outline" size={32} color={mutedColor} />
+        <ThemedText style={[{ color: mutedColor, marginTop: 10, fontSize: 14 }]}>
+          {dateLabel ? `No bookings on ${dateLabel}` : "No bookings on this day"}
+        </ThemedText>
+      </View>
+    );
+  }
+
+  const offsetToPx = (offset: number) => (offset - timeline.startOffset) * PX_PER_MINUTE;
+
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator>
       <View style={{ width: totalW }}>
         <View
-          style={[
-            {
-              flexDirection: "row",
-              height: HEADER_H,
-              backgroundColor: headerBg,
-              borderBottomWidth: 1,
-              borderBottomColor: borderColor,
-            },
-          ]}
+          style={{
+            flexDirection: "row",
+            height: HEADER_H,
+            backgroundColor: headerBg,
+            borderBottomWidth: 1,
+            borderBottomColor: borderColor,
+          }}
         >
           <View
-            style={[
-              {
-                width: LABEL_W,
-                height: HEADER_H,
-                justifyContent: "center",
-                paddingHorizontal: 10,
-                borderRightWidth: 1,
-                borderRightColor: borderColor,
-              },
-            ]}
+            style={{
+              width: LABEL_W,
+              height: HEADER_H,
+              justifyContent: "center",
+              paddingHorizontal: 10,
+              borderRightWidth: 1,
+              borderRightColor: borderColor,
+            }}
           >
             <ThemedText style={[styles.gridHeaderText, { color: mutedColor }]}>TABLE</ThemedText>
           </View>
-          {timeSlots.map(({ hour, label }) => (
-            <View
-              key={hour}
-              style={[
-                {
-                  width: COL_W,
+          <View style={{ width: timelineW }}>
+            {timeline.ticks.map(({ offset, label }) => (
+              <View
+                key={offset}
+                style={{
+                  position: "absolute",
+                  left: offsetToPx(offset),
+                  width: HOUR_W,
                   height: HEADER_H,
                   alignItems: "center",
                   justifyContent: "center",
                   borderLeftWidth: 1,
                   borderLeftColor: borderColor,
-                },
-              ]}
-            >
-              <ThemedText style={[styles.gridHeaderText, { color: mutedColor }]}>
-                {label}
-              </ThemedText>
-            </View>
-          ))}
+                }}
+              >
+                <ThemedText style={[styles.gridHeaderText, { color: mutedColor }]}>
+                  {label}
+                </ThemedText>
+              </View>
+            ))}
+          </View>
         </View>
 
-        {sections.map((section) => (
-          <View key={section.id}>
-            <View
-              style={[
-                {
+        <View style={{ height: bodyH }}>
+          {rowGroups.map((group) => (
+            <View key={group.key}>
+              <View
+                style={{
                   height: SECTION_H,
                   flexDirection: "row",
                   backgroundColor: sectionBg,
@@ -169,106 +230,139 @@ export function AvailabilityGrid({
                   borderBottomColor: borderColor,
                   alignItems: "center",
                   paddingHorizontal: 10,
-                },
-              ]}
-            >
-              <ThemedText style={[styles.gridSectionLabel, { color: mutedColor }]}>
-                {section.name.toUpperCase()}
-              </ThemedText>
-            </View>
-
-            {section.tables.map((table) => (
-              <View
-                key={table.id}
-                style={[
-                  {
-                    flexDirection: "row",
-                    height: ROW_H,
-                    borderBottomWidth: 1,
-                    borderBottomColor: borderColor,
-                  },
-                ]}
+                }}
               >
-                <View
-                  style={[
-                    {
-                      width: LABEL_W,
-                      height: ROW_H,
-                      justifyContent: "center",
-                      paddingHorizontal: 10,
-                      borderRightWidth: 1,
-                      borderRightColor: borderColor,
-                    },
-                  ]}
-                >
-                  <ThemedText style={styles.gridTableName} numberOfLines={1}>
-                    {table.name ?? `T${table.id}`}
-                  </ThemedText>
-                  <ThemedText style={[styles.gridTableSeats, { color: mutedColor }]}>
-                    {table.seats}p
-                  </ThemedText>
-                </View>
+                <ThemedText style={[styles.gridSectionLabel, { color: mutedColor }]}>
+                  {group.name.toUpperCase()}
+                </ThemedText>
+              </View>
 
-                {timeSlots.map(({ hour }) => {
-                  const booking = bookingForCell(table.id, hour);
-                  return (
-                    <Pressable
-                      key={hour}
-                      style={[
-                        {
-                          width: COL_W,
-                          height: ROW_H,
-                          alignItems: "center",
-                          justifyContent: "center",
-                          borderLeftWidth: 1,
-                          borderLeftColor: borderColor,
-                          paddingHorizontal: 3,
-                        },
-                        booking
-                          ? {
-                              backgroundColor: bookedBg,
-                              borderLeftColor: PRIMARY,
-                              borderLeftWidth: 2,
-                            }
-                          : { backgroundColor: availBg },
-                      ]}
-                      onPress={() => booking && onBookingPress(booking)}
-                      disabled={!booking}
-                      accessibilityRole="button"
-                      accessibilityLabel={
-                        booking
-                          ? `${hour}, ${table.name}, booked by ${booking.customerEmail} for ${booking.seats}`
-                          : `${hour}, ${table.name}, free`
-                      }
-                      accessibilityState={{ disabled: !booking }}
+              {group.units.map((unit) => {
+                const lanes = timeline.laneCount[unit.key] ?? 1;
+                const height = rowHeight(lanes);
+                return (
+                  <View
+                    key={unit.key}
+                    style={{
+                      flexDirection: "row",
+                      height,
+                      borderBottomWidth: 1,
+                      borderBottomColor: borderColor,
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: LABEL_W,
+                        height,
+                        justifyContent: "center",
+                        paddingHorizontal: 10,
+                        borderRightWidth: 1,
+                        borderRightColor: borderColor,
+                      }}
                     >
-                      {booking ? (
-                        <View style={{ alignItems: "center", gap: 1 }}>
-                          <Icon name="person" size={10} color={PRIMARY} />
-                          <ThemedText style={styles.gridCellEmail} numberOfLines={1}>
-                            {booking.customerEmail?.split("@")[0]}
-                          </ThemedText>
-                          <ThemedText style={[styles.gridCellSeats, { color: mutedColor }]}>
-                            {booking.seats}p
-                          </ThemedText>
-                        </View>
-                      ) : (
+                      <ThemedText style={styles.gridTableName} numberOfLines={1}>
+                        {unit.name}
+                      </ThemedText>
+                      {unit.seats != null && (
+                        <ThemedText style={[styles.gridTableSeats, { color: mutedColor }]}>
+                          {unit.seats}p
+                        </ThemedText>
+                      )}
+                    </View>
+
+                    <View style={{ width: timelineW, height, backgroundColor: laneBg }}>
+                      {timeline.ticks.map(({ offset }) => (
                         <View
+                          key={offset}
                           style={{
-                            width: 6,
-                            height: 6,
-                            borderRadius: 3,
-                            backgroundColor: isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)",
+                            position: "absolute",
+                            left: offsetToPx(offset),
+                            top: 0,
+                            bottom: 0,
+                            width: 1,
+                            backgroundColor: gridLineColor,
                           }}
                         />
-                      )}
-                    </Pressable>
-                  );
-                })}
-              </View>
-            ))}
-          </View>
-        ))}
+                      ))}
+
+                      {(placementsByUnit[unit.key] ?? []).map((placement) => {
+                        const state = sittingState(placement, now);
+                        const guest =
+                          placement.booking.customerName ||
+                          placement.booking.customerEmail?.split("@")[0] ||
+                          "Guest";
+                        const startLabel = formatClockMinutes(placement.startClockMinutes);
+                        const endLabel = formatClockMinutes(
+                          placement.startClockMinutes +
+                            (placement.endOffset - placement.startOffset)
+                        );
+                        const remaining =
+                          state === "current" && now != null
+                            ? formatRemaining(placement.endOffset - now)
+                            : null;
+
+                        return (
+                          <Pressable
+                            key={placement.booking.id}
+                            testID={`sitting-${placement.booking.id}`}
+                            onPress={() => onBookingPress(placement.booking)}
+                            accessibilityRole="button"
+                            accessibilityLabel={`${guest}, ${placement.booking.seats} covers on ${unit.name}, ${startLabel} to ${endLabel}${remaining ? `, ${remaining}` : ""}`}
+                            style={{
+                              position: "absolute",
+                              left: offsetToPx(placement.startOffset),
+                              width: Math.max(
+                                (placement.endOffset - placement.startOffset) * PX_PER_MINUTE,
+                                24
+                              ),
+                              top: LANE_GAP + placement.lane * LANE_H,
+                              height: LANE_H - LANE_GAP,
+                              borderRadius: 6,
+                              borderLeftWidth: 3,
+                              borderLeftColor: state === "past" ? mutedColor : PRIMARY,
+                              backgroundColor: hexToRgba(
+                                PRIMARY,
+                                state === "current" ? 0.32 : state === "past" ? 0.08 : 0.16
+                              ),
+                              paddingHorizontal: 6,
+                              justifyContent: "center",
+                              opacity: state === "past" ? 0.55 : 1,
+                            }}
+                          >
+                            <ThemedText style={styles.gridBarGuest} numberOfLines={1}>
+                              {guest} · {placement.booking.seats}p
+                            </ThemedText>
+                            <ThemedText
+                              style={[styles.gridBarTime, { color: mutedColor }]}
+                              numberOfLines={1}
+                            >
+                              {remaining ?? `${startLabel}–${endLabel}`}
+                            </ThemedText>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+                  </View>
+                );
+              })}
+            </View>
+          ))}
+
+          {now != null && (
+            <View
+              testID="now-marker"
+              pointerEvents="none"
+              style={{
+                position: "absolute",
+                left: LABEL_W + offsetToPx(now),
+                top: 0,
+                bottom: 0,
+                width: 2,
+                backgroundColor: colors.error,
+              }}
+            />
+          )}
+        </View>
       </View>
     </ScrollView>
   );

--- a/openresto-frontend/components/admin/bookings/NewBookingModal.tsx
+++ b/openresto-frontend/components/admin/bookings/NewBookingModal.tsx
@@ -283,25 +283,25 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
                         options={seatOptions}
                       />
                     </View>
-                    <View style={[styles.fieldHalf, styles.field]}>
-                      <ThemedText style={styles.label}>Guest email</ThemedText>
+                    <View style={styles.fieldHalf}>
+                      <ThemedText style={styles.label}>Guest name (optional)</ThemedText>
                       <Input
-                        placeholder="guest@example.com"
-                        value={email}
-                        onChangeText={setEmail}
-                        keyboardType="email-address"
-                        autoCapitalize="none"
+                        placeholder="Full name"
+                        value={guestName}
+                        onChangeText={setGuestName}
+                        autoCapitalize="words"
                       />
                     </View>
                   </View>
 
                   <View style={styles.field}>
-                    <ThemedText style={styles.label}>Guest name (optional)</ThemedText>
+                    <ThemedText style={styles.label}>Guest email</ThemedText>
                     <Input
-                      placeholder="Full name"
-                      value={guestName}
-                      onChangeText={setGuestName}
-                      autoCapitalize="words"
+                      placeholder="guest@example.com"
+                      value={email}
+                      onChangeText={setEmail}
+                      keyboardType="email-address"
+                      autoCapitalize="none"
                     />
                   </View>
 

--- a/openresto-frontend/components/admin/bookings/bookings.styles.ts
+++ b/openresto-frontend/components/admin/bookings/bookings.styles.ts
@@ -84,10 +84,10 @@ export const styles = StyleSheet.create({
   legendText: { ...theme.typography.caption },
   gridHeaderText: { ...theme.typography.labelSmall, letterSpacing: 0.5 },
   gridSectionLabel: { ...theme.typography.labelSmall, letterSpacing: 0.8 },
-  gridCellEmail: { fontSize: 9, fontWeight: "600", color: theme.colors.error, textAlign: "center" },
-  gridCellSeats: { fontSize: 9 },
   gridTableName: { ...theme.typography.caption, fontWeight: "600" },
   gridTableSeats: { fontSize: 10 },
+  gridBarGuest: { fontSize: 11, fontWeight: "600" },
+  gridBarTime: { fontSize: 9 },
 
   tableCard: {
     borderRadius: theme.borderRadius.card,

--- a/openresto-frontend/tests/components/AvailabilityGrid.test.tsx
+++ b/openresto-frontend/tests/components/AvailabilityGrid.test.tsx
@@ -14,54 +14,172 @@ jest.mock("@/utils/colors", () => ({
   hexToRgba: (_h: string, _a: number) => "rgba(0,0,0,0.1)",
 }));
 
+const DAY = "2026-08-23";
+
+/** A booking on `DAY` at `hhmm` UTC, `minutes` long. */
+function booking(
+  id: number,
+  hhmm: string,
+  minutes: number,
+  overrides: Partial<Record<string, unknown>> = {}
+) {
+  const date = `${DAY}T${hhmm}:00.000Z`;
+  return {
+    id,
+    tableId: 101,
+    tableGroupId: null,
+    date,
+    endTime: new Date(new Date(date).getTime() + minutes * 60000).toISOString(),
+    seats: 2,
+    customerEmail: "booked@test.com",
+    ...overrides,
+  };
+}
+
 describe("AvailabilityGrid", () => {
   const mockSections = [
     {
       id: 1,
       name: "Main",
-      tables: [{ id: 101, name: "Table 1", seats: 4, sectionId: 1 }],
-    },
-  ];
-
-  const mockBookings = [
-    {
-      id: 10,
-      tableId: 101,
-      // setUTCHours, not setHours: the grid resolves the hour through the timezone prop, so a
-      // date pinned to the machine's local noon lands on a different column anywhere but UTC.
-      date: new Date(new Date().setUTCHours(12, 0, 0, 0)).toISOString(),
-      seats: 2,
-      customerEmail: "booked@test.com",
+      tables: [{ id: 101, name: "Table 1", seats: 4 }],
     },
   ];
 
   const props = {
     sections: mockSections as any,
-    bookings: mockBookings as any,
+    bookings: [booking(10, "18:00", 90)] as any,
     isDark: false,
     onBookingPress: jest.fn(),
+    openTime: "17:00",
+    closeTime: "23:00",
+    timezone: "UTC",
+    // A day that is never the location's today, so the now marker stays out of these assertions.
+    gridDateIso: DAY,
   };
+
+  beforeEach(() => jest.clearAllMocks());
 
   it("renders empty state when no sections", () => {
     render(<AvailabilityGrid {...props} sections={[]} />);
     expect(screen.getByText(/No tables found/)).toBeTruthy();
   });
 
-  it("renders grid with tables and slots", () => {
+  it("renders the section, its tables and the hours around the day's sittings", () => {
     render(<AvailabilityGrid {...props} />);
     expect(screen.getByText("MAIN")).toBeTruthy();
     expect(screen.getByText("Table 1")).toBeTruthy();
-    expect(screen.getByText("12p")).toBeTruthy();
+    expect(screen.getByText("5p")).toBeTruthy();
+    expect(screen.getByText("8p")).toBeTruthy();
   });
 
-  it("renders booking in cell and handles press", () => {
+  // Service runs to 11p but the only sitting is 6p-7:30p, so the idle hours are trimmed away
+  // rather than burying the sittings off the side of the screen.
+  it("does not draw the service hours the day's sittings do not reach", () => {
     render(<AvailabilityGrid {...props} />);
-    // The cell for 12p should have "booked"
-    const bookingCell = screen.getByText("booked");
-    expect(bookingCell).toBeTruthy();
+    expect(screen.queryByText("10p")).toBeNull();
+  });
 
-    fireEvent.press(bookingCell);
-    expect(props.onBookingPress).toHaveBeenCalledWith(mockBookings[0]);
+  it("says so plainly on a day with no bookings instead of drawing an empty grid", () => {
+    render(<AvailabilityGrid {...props} bookings={[]} dateLabel="Sun 23 Aug" />);
+
+    expect(screen.getByText("No bookings on Sun 23 Aug")).toBeTruthy();
+    expect(screen.queryByText("5p")).toBeNull();
+  });
+
+  it("labels a sitting with its guest, covers and time range", () => {
+    render(<AvailabilityGrid {...props} />);
+    expect(screen.getByText("booked · 2p")).toBeTruthy();
+    expect(screen.getByText("6:00p–7:30p")).toBeTruthy();
+  });
+
+  it("prefers the guest's name over their email when there is one", () => {
+    render(
+      <AvailabilityGrid
+        {...props}
+        bookings={[booking(10, "18:00", 90, { customerName: "Patel" })] as any}
+      />
+    );
+    expect(screen.getByText("Patel · 2p")).toBeTruthy();
+  });
+
+  it("opens the booking when its bar is pressed", () => {
+    render(<AvailabilityGrid {...props} />);
+
+    fireEvent.press(screen.getByTestId("sitting-10"));
+
+    expect(props.onBookingPress).toHaveBeenCalledWith(expect.objectContaining({ id: 10 }));
+  });
+
+  // The grid used to bucket by the hour and render only the first match, so a second sitting in
+  // the same hour on the same table vanished entirely.
+  it("renders both sittings when two start in the same hour on one table", () => {
+    render(
+      <AvailabilityGrid
+        {...props}
+        bookings={[booking(10, "18:00", 30), booking(11, "18:30", 30)] as any}
+      />
+    );
+
+    expect(screen.getByTestId("sitting-10")).toBeTruthy();
+    expect(screen.getByTestId("sitting-11")).toBeTruthy();
+  });
+
+  // A group booking stores TableId = null, so a grid keyed on the table alone drops it silently.
+  it("renders a group booking on its combined-tables row", () => {
+    render(
+      <AvailabilityGrid
+        {...props}
+        groups={[{ id: 5, name: "Window booths", combinedSeats: 7, members: [{ id: 101 }] }] as any}
+        bookings={[booking(12, "19:00", 90, { tableId: null, tableGroupId: 5 })] as any}
+      />
+    );
+
+    expect(screen.getByText("COMBINED TABLES")).toBeTruthy();
+    expect(screen.getByText("Window booths")).toBeTruthy();
+    expect(screen.getByTestId("sitting-12")).toBeTruthy();
+  });
+
+  // Deleting a table nulls its bookings' FK rather than cascading, so these belong to no unit.
+  it("keeps a booking whose table was deleted visible on an unassigned row", () => {
+    render(
+      <AvailabilityGrid
+        {...props}
+        bookings={[booking(13, "19:00", 90, { tableId: null, tableGroupId: null })] as any}
+      />
+    );
+
+    expect(screen.getByText("UNASSIGNED")).toBeTruthy();
+    expect(screen.getByTestId("sitting-13")).toBeTruthy();
+  });
+
+  it("does not draw the unassigned row when every booking has a unit", () => {
+    render(<AvailabilityGrid {...props} />);
+    expect(screen.queryByText("UNASSIGNED")).toBeNull();
+  });
+
+  // Narrowing a location's opening hours does not move the bookings already taken under the old
+  // ones (#359). The timetable is where staff would look for them, so the window has to widen.
+  it("keeps a booking that now falls outside the opening hours visible", () => {
+    render(<AvailabilityGrid {...props} bookings={[booking(10, "12:00", 60)] as any} />);
+
+    expect(screen.getByText("12p")).toBeTruthy();
+    expect(screen.getByTestId("sitting-10")).toBeTruthy();
+  });
+
+  it("carries a sitting across midnight on an overnight service", () => {
+    render(
+      <AvailabilityGrid
+        {...props}
+        bookings={[booking(10, "23:00", 120)] as any}
+        openTime="18:00"
+        closeTime="02:00"
+      />
+    );
+
+    expect(screen.getByText("11p")).toBeTruthy();
+    expect(screen.getByText("12a")).toBeTruthy();
+    expect(screen.getByText("1a")).toBeTruthy();
+    expect(screen.queryByText("2a")).toBeNull();
   });
 
   it("renders correctly in dark mode", () => {
@@ -69,52 +187,35 @@ describe("AvailabilityGrid", () => {
     expect(screen.getByText("Table 1")).toBeTruthy();
   });
 
-  // Narrowing a location's opening hours does not move the bookings already taken under the
-  // old ones (#359). The timetable is where staff would look for them, so it has to widen to
-  // cover a sitting the current window no longer contains.
-  it("keeps a booking that now falls outside the opening hours visible", () => {
-    render(<AvailabilityGrid {...props} openTime="17:00" closeTime="23:00" timezone="UTC" />);
+  describe("the now marker", () => {
+    const REAL_NOW = new Date(`${DAY}T18:30:00.000Z`);
 
-    expect(screen.getByText("12p")).toBeTruthy();
-    expect(screen.getByText("booked")).toBeTruthy();
-  });
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(REAL_NOW);
+    });
+    afterEach(() => jest.useRealTimers());
 
-  it("does not draw a column for an hour with no booking in it", () => {
-    render(<AvailabilityGrid {...props} openTime="17:00" closeTime="23:00" timezone="UTC" />);
+    it("draws on the location's today and counts down the sitting in progress", () => {
+      render(<AvailabilityGrid {...props} />);
 
-    expect(screen.queryByText("1p")).toBeNull();
-  });
+      expect(screen.getByTestId("now-marker")).toBeTruthy();
+      expect(screen.getByText("1h left")).toBeTruthy();
+    });
 
-  it("spans the night for an overnight service rather than collapsing to one column", () => {
-    render(
-      <AvailabilityGrid
-        {...props}
-        bookings={[]}
-        openTime="18:00"
-        closeTime="02:00"
-        timezone="UTC"
-      />
-    );
+    it("stays off any other day, where there is no now to mark", () => {
+      render(<AvailabilityGrid {...props} gridDateIso="2026-08-30" />);
 
-    expect(screen.getByText("6p")).toBeTruthy();
-    expect(screen.getByText("11p")).toBeTruthy();
-    expect(screen.getByText("12a")).toBeTruthy();
-    expect(screen.getByText("1a")).toBeTruthy();
-    expect(screen.queryByText("2a")).toBeNull();
-  });
+      expect(screen.queryByTestId("now-marker")).toBeNull();
+      expect(screen.getByText("6:00p–7:30p")).toBeTruthy();
+    });
 
-  it("draws the full day when opening and closing time match", () => {
-    render(
-      <AvailabilityGrid
-        {...props}
-        bookings={[]}
-        openTime="00:00"
-        closeTime="00:00"
-        timezone="UTC"
-      />
-    );
+    it("stays off when now falls outside the drawn service window", () => {
+      jest.setSystemTime(new Date(`${DAY}T04:00:00.000Z`));
 
-    expect(screen.getByText("12a")).toBeTruthy();
-    expect(screen.getByText("11p")).toBeTruthy();
+      render(<AvailabilityGrid {...props} bookings={[]} />);
+
+      expect(screen.queryByTestId("now-marker")).toBeNull();
+    });
   });
 });

--- a/openresto-frontend/tests/utils/bookingTimeline.test.ts
+++ b/openresto-frontend/tests/utils/bookingTimeline.test.ts
@@ -1,0 +1,354 @@
+import {
+  buildTimeline,
+  buildUnitRows,
+  formatClockMinutes,
+  formatRemaining,
+  nowOffset,
+  unitKeyFor,
+  UNASSIGNED_KEY,
+} from "@/utils/bookingTimeline";
+import type { BookingDetailDto, SectionWithTables } from "@/api/admin";
+
+const DAY = "2026-08-23";
+
+/** A booking starting at `hhmm` UTC, `minutes` long. Seats/ids are noise for placement. */
+function booking(
+  id: number,
+  hhmm: string,
+  minutes: number | null,
+  unit: { tableId?: number | null; tableGroupId?: number | null } = { tableId: 1 }
+): BookingDetailDto {
+  const date = `${DAY}T${hhmm}:00.000Z`;
+  return {
+    id,
+    restaurantId: 1,
+    restaurantName: "Test",
+    timezone: "UTC",
+    sectionId: 1,
+    sectionName: "Main",
+    tableId: unit.tableId ?? null,
+    tableGroupId: unit.tableGroupId ?? null,
+    tableName: "T1",
+    date,
+    endTime:
+      minutes == null
+        ? undefined
+        : new Date(new Date(date).getTime() + minutes * 60000).toISOString(),
+    customerEmail: `guest${id}@test.com`,
+    seats: 2,
+  };
+}
+
+const sections: SectionWithTables[] = [
+  { id: 1, name: "Main", tables: [{ id: 1, name: "T1", seats: 4 }] },
+];
+
+const base = {
+  openTime: "17:00",
+  closeTime: "23:00",
+  timezone: "UTC",
+  defaultDurationMinutes: 90,
+};
+
+describe("unitKeyFor", () => {
+  it("keys a single-table booking on its table", () => {
+    expect(unitKeyFor({ tableId: 7, tableGroupId: null })).toBe("table:7");
+  });
+
+  it("keys a group booking on its group, which carries no table id at all", () => {
+    expect(unitKeyFor({ tableId: null, tableGroupId: 5 })).toBe("group:5");
+  });
+
+  it("falls back to the unassigned row when the table was deleted out from under it", () => {
+    expect(unitKeyFor({ tableId: null, tableGroupId: null })).toBe(UNASSIGNED_KEY);
+  });
+});
+
+describe("buildUnitRows", () => {
+  it("gives a combinable group its own row without removing its member tables", () => {
+    const rows = buildUnitRows(sections, [
+      { id: 5, name: null, combinedSeats: 7, members: [{ id: 1, name: "T1", seats: 4 }] },
+    ]);
+
+    expect(rows.map((r) => r.name)).toEqual(["Main", "Combined tables"]);
+    expect(rows[0].units.map((u) => u.key)).toEqual(["table:1"]);
+    expect(rows[1].units[0]).toMatchObject({ key: "group:5", name: "Tables T1", seats: 7 });
+  });
+
+  it("names a group by its own label when the admin gave it one", () => {
+    const rows = buildUnitRows(sections, [
+      {
+        id: 5,
+        name: "Window booths",
+        combinedSeats: 7,
+        members: [{ id: 1, name: "T1", seats: 4 }],
+      },
+    ]);
+
+    expect(rows[1].units[0].name).toBe("Window booths");
+  });
+
+  it("omits the combined block entirely when the location has no groups", () => {
+    expect(buildUnitRows(sections, []).map((r) => r.key)).toEqual(["section:1"]);
+  });
+
+  it("adds the unassigned row only when asked for it", () => {
+    expect(buildUnitRows(sections, [], { includeUnassigned: true }).at(-1)?.key).toBe("unassigned");
+    expect(buildUnitRows(sections, []).at(-1)?.key).toBe("section:1");
+  });
+});
+
+describe("buildTimeline placement", () => {
+  it("places two sittings half an hour apart on one table rather than collapsing them", () => {
+    const timeline = buildTimeline({
+      ...base,
+      bookings: [booking(1, "18:00", 60), booking(2, "18:30", 60)],
+    });
+
+    expect(timeline.placements).toHaveLength(2);
+    expect(timeline.placements.map((p) => p.startOffset)).toEqual([60, 90]);
+  });
+
+  it("sizes a bar by its stored end time, not by the hour it starts in", () => {
+    const timeline = buildTimeline({ ...base, bookings: [booking(1, "18:00", 150)] });
+
+    const [placement] = timeline.placements;
+    expect(placement.endOffset - placement.startOffset).toBe(150);
+  });
+
+  it("falls back to the location's default duration for a booking stored without an end", () => {
+    const timeline = buildTimeline({ ...base, bookings: [booking(1, "18:00", null)] });
+
+    const [placement] = timeline.placements;
+    expect(placement.endOffset - placement.startOffset).toBe(90);
+  });
+
+  it("places a group booking on its group row, where it carries no table id", () => {
+    const timeline = buildTimeline({
+      ...base,
+      bookings: [booking(1, "18:00", 60, { tableGroupId: 5 })],
+    });
+
+    expect(timeline.placements[0].unitKey).toBe("group:5");
+  });
+
+  it("resolves the start against the restaurant's zone, not the machine's", () => {
+    const utc = buildTimeline({ ...base, bookings: [booking(1, "18:00", 60)] });
+    const newYork = buildTimeline({
+      ...base,
+      timezone: "America/New_York",
+      bookings: [booking(1, "18:00", 60)],
+    });
+
+    // 18:00Z is 14:00 in New York — three hours before a 17:00 open, so it lands off the left.
+    expect(utc.placements[0].startOffset).toBe(60);
+    expect(newYork.placements[0].startOffset).toBe(-180);
+  });
+});
+
+describe("buildTimeline lanes", () => {
+  it("stacks overlapping sittings on one table into separate lanes", () => {
+    const timeline = buildTimeline({
+      ...base,
+      bookings: [booking(1, "18:00", 120), booking(2, "18:30", 60)],
+    });
+
+    expect(timeline.placements.map((p) => p.lane)).toEqual([0, 1]);
+    expect(timeline.laneCount["table:1"]).toBe(2);
+  });
+
+  it("reuses a lane once the earlier sitting has ended", () => {
+    const timeline = buildTimeline({
+      ...base,
+      bookings: [booking(1, "18:00", 60), booking(2, "19:00", 60)],
+    });
+
+    expect(timeline.placements.map((p) => p.lane)).toEqual([0, 0]);
+    expect(timeline.laneCount["table:1"]).toBe(1);
+  });
+
+  it("counts lanes per unit, so a busy table does not stretch a quiet one", () => {
+    const timeline = buildTimeline({
+      ...base,
+      bookings: [
+        booking(1, "18:00", 120, { tableId: 1 }),
+        booking(2, "18:30", 60, { tableId: 1 }),
+        booking(3, "18:00", 60, { tableId: 2 }),
+      ],
+    });
+
+    expect(timeline.laneCount).toEqual({ "table:1": 2, "table:2": 1 });
+  });
+});
+
+describe("buildTimeline window", () => {
+  it("trims the idle service hours away from the day's sittings", () => {
+    // Service runs 5p-11p but the only sitting is 6p-7p, so six columns of nothing become three.
+    const timeline = buildTimeline({ ...base, bookings: [booking(1, "18:00", 60)] });
+
+    expect(timeline.ticks.map((t) => t.label)).toEqual(["5p", "6p", "7p"]);
+  });
+
+  it("keeps an hour of headroom either side of the sittings", () => {
+    // 7p-8p sitting, so the axis runs 6p-9p: three columns, the last of them covering 8p-9p.
+    const timeline = buildTimeline({ ...base, bookings: [booking(1, "19:00", 60)] });
+
+    expect(timeline.ticks.map((t) => t.label)).toEqual(["6p", "7p", "8p"]);
+    expect(timeline.endOffset).toBe(240);
+  });
+
+  it("does not pad into hours the location is shut", () => {
+    // The 5p sitting starts on opening; there is no 4p column to pad into.
+    const timeline = buildTimeline({ ...base, bookings: [booking(1, "17:00", 60)] });
+
+    expect(timeline.startOffset).toBe(0);
+    expect(timeline.ticks[0].label).toBe("5p");
+  });
+
+  it("falls back to the service hours when the day holds no bookings to trim to", () => {
+    const timeline = buildTimeline({ ...base, bookings: [] });
+
+    expect([timeline.startOffset, timeline.endOffset]).toEqual([0, 360]);
+  });
+
+  it("keeps now on the axis when the nearest sitting is hours away", () => {
+    // Two lunchtime sittings on a location open around the clock: the marker still has to land.
+    const timeline = buildTimeline({
+      ...base,
+      openTime: "00:00",
+      closeTime: "23:59",
+      bookings: [booking(1, "14:30", 60)],
+      nowMinutes: 10 * 60,
+    });
+
+    expect(timeline.ticks[0].label).toBe("10a");
+    expect(timeline.ticks.at(-1)?.label).toBe("4p");
+  });
+
+  it("ignores a now that falls outside the service window", () => {
+    const timeline = buildTimeline({
+      ...base,
+      bookings: [booking(1, "18:00", 60)],
+      nowMinutes: 60,
+    });
+
+    expect(timeline.ticks.map((t) => t.label)).toEqual(["5p", "6p", "7p"]);
+  });
+
+  it("widens backwards for a booking taken before the location's current open time", () => {
+    const timeline = buildTimeline({ ...base, bookings: [booking(1, "15:00", 60)] });
+
+    expect(timeline.startOffset).toBe(-120);
+    expect(timeline.ticks[0].label).toBe("3p");
+  });
+
+  it("widens forwards for a sitting running past the close", () => {
+    // 22:30 + 2h runs to 00:30, so the window has to reach the small hours to hold the whole bar.
+    const timeline = buildTimeline({ ...base, bookings: [booking(1, "22:30", 120)] });
+
+    expect(timeline.endOffset).toBe(480);
+    expect(timeline.ticks.at(-1)?.label).toBe("12a");
+  });
+
+  it("spans the night for an overnight service rather than collapsing to one hour", () => {
+    const timeline = buildTimeline({
+      ...base,
+      openTime: "18:00",
+      closeTime: "02:00",
+      bookings: [],
+    });
+
+    expect(timeline.ticks.map((t) => t.label)).toEqual([
+      "6p",
+      "7p",
+      "8p",
+      "9p",
+      "10p",
+      "11p",
+      "12a",
+      "1a",
+    ]);
+  });
+
+  it("draws the whole day when the open and close times match", () => {
+    const timeline = buildTimeline({
+      ...base,
+      openTime: "00:00",
+      closeTime: "00:00",
+      bookings: [],
+    });
+
+    expect(timeline.ticks).toHaveLength(24);
+  });
+
+  it("snaps a half-hour open time outwards, so no minute of service falls off the left", () => {
+    const timeline = buildTimeline({
+      ...base,
+      openTime: "17:30",
+      closeTime: "23:00",
+      bookings: [],
+    });
+
+    expect(timeline.ticks[0].label).toBe("5p");
+    expect(timeline.startOffset).toBe(-30);
+  });
+});
+
+describe("nowOffset", () => {
+  const timeline = buildTimeline({ ...base, bookings: [] });
+
+  it("places now inside the service window", () => {
+    expect(nowOffset(timeline, "17:00", 19 * 60)).toBe(120);
+  });
+
+  it("returns null off the drawn window, so no marker is drawn on a closed hour", () => {
+    expect(nowOffset(timeline, "17:00", 9 * 60)).toBeNull();
+  });
+
+  it("returns null when the caller has no local time, which is any day but today", () => {
+    expect(nowOffset(timeline, "17:00", null)).toBeNull();
+  });
+
+  it("places a pre-opening now to the left of the window it widened", () => {
+    const widened = buildTimeline({ ...base, bookings: [booking(1, "15:00", 60)] });
+
+    expect(nowOffset(widened, "17:00", 16 * 60)).toBe(-60);
+  });
+});
+
+describe("formatRemaining", () => {
+  it("reads in minutes under the hour", () => {
+    expect(formatRemaining(45)).toBe("45m left");
+  });
+
+  it("reads in whole hours on the hour", () => {
+    expect(formatRemaining(120)).toBe("2h left");
+  });
+
+  it("reads in hours and minutes in between", () => {
+    expect(formatRemaining(90)).toBe("1h 30m left");
+  });
+
+  it("says the sitting is ending rather than counting past zero", () => {
+    expect(formatRemaining(0)).toBe("ending");
+    expect(formatRemaining(-10)).toBe("ending");
+  });
+});
+
+describe("formatClockMinutes", () => {
+  it("reads midnight as 12a rather than 0a", () => {
+    expect(formatClockMinutes(0)).toBe("12:00a");
+  });
+
+  it("reads noon as 12p rather than 0p", () => {
+    expect(formatClockMinutes(12 * 60)).toBe("12:00p");
+  });
+
+  it("reads an evening sitting on the 12-hour clock", () => {
+    expect(formatClockMinutes(18 * 60 + 30)).toBe("6:30p");
+  });
+
+  it("wraps a past-midnight offset back onto the clock", () => {
+    expect(formatClockMinutes(25 * 60)).toBe("1:00a");
+  });
+});

--- a/openresto-frontend/utils/bookingTimeline.ts
+++ b/openresto-frontend/utils/bookingTimeline.ts
@@ -1,0 +1,289 @@
+import type { BookingDetailDto, SectionWithTables } from "@/api/admin";
+import type { TableGroupDto } from "@/api/restaurants";
+import { minutesInTimezone } from "@/utils/date";
+import { groupDisplayName } from "@/utils/tableGroups";
+
+const MINUTES_PER_DAY = 24 * 60;
+const MINUTES_PER_HOUR = 60;
+
+/** 12-hour clock labels, indexed by 24-hour hour. Midnight reads 12a, not 0a. */
+const HOUR_LABELS = Array.from({ length: 24 }, (_, h) =>
+  h === 0 ? "12a" : h < 12 ? `${h}a` : h === 12 ? "12p" : `${h - 12}p`
+);
+
+/** A row on the timetable: one bookable unit, or the catch-all for bookings that lost theirs. */
+export interface TimelineUnit {
+  /** Stable row identity. A table and a group can share a numeric id, so the kind is part of it. */
+  key: string;
+  kind: "table" | "group" | "unassigned";
+  name: string;
+  /** Null for the unassigned row, which stands for no physical seating. */
+  seats: number | null;
+}
+
+export interface TimelineRowGroup {
+  key: string;
+  name: string;
+  units: TimelineUnit[];
+}
+
+export interface TimelinePlacement {
+  booking: BookingDetailDto;
+  unitKey: string;
+  /** Minutes from the timeline's left edge. */
+  startOffset: number;
+  endOffset: number;
+  /** Restaurant-local minutes since midnight the sitting starts at, for the bar's own label. */
+  startClockMinutes: number;
+  /** Stacking row within the unit, so two overlapping sittings are both visible. */
+  lane: number;
+}
+
+export interface Timeline {
+  /** Minutes from opening at the left edge; negative when a booking predates the open time. */
+  startOffset: number;
+  endOffset: number;
+  ticks: { offset: number; label: string }[];
+  placements: TimelinePlacement[];
+  /** Lanes each unit needs, so a row can grow to fit overlapping sittings. */
+  laneCount: Record<string, number>;
+}
+
+export const UNASSIGNED_KEY = "unassigned";
+
+/**
+ * The unit a booking occupies. `tableId` and `tableGroupId` are mutually exclusive — a group
+ * booking stores no table — so a placement keyed on the table alone drops every group booking.
+ * Deleting a table nulls the booking's FK rather than cascading, leaving bookings that belong to no
+ * unit at all; those land on the unassigned row rather than disappearing.
+ */
+export function unitKeyFor(booking: Pick<BookingDetailDto, "tableId" | "tableGroupId">): string {
+  if (booking.tableGroupId != null) return `group:${booking.tableGroupId}`;
+  if (booking.tableId != null) return `table:${booking.tableId}`;
+  return UNASSIGNED_KEY;
+}
+
+function parseClockMinutes(value: string): number {
+  const [h, m] = value.split(":");
+  return ((parseInt(h, 10) || 0) % 24) * MINUTES_PER_HOUR + (parseInt(m, 10) || 0);
+}
+
+/**
+ * Rows for the timetable: every table under its section, then combinable groups under a trailing
+ * block of their own. A member table stays individually bookable, so a group is an extra row rather
+ * than a replacement for its members' rows. Groups are restaurant-scoped and may span sections,
+ * which is why they get their own block instead of being filed under one.
+ */
+export function buildUnitRows(
+  sections: SectionWithTables[],
+  groups: TableGroupDto[] = [],
+  options: { includeUnassigned?: boolean } = {}
+): TimelineRowGroup[] {
+  const rows: TimelineRowGroup[] = sections.map((section) => ({
+    key: `section:${section.id}`,
+    name: section.name,
+    units: section.tables.map((table) => ({
+      key: `table:${table.id}`,
+      kind: "table" as const,
+      name: table.name ?? `T${table.id}`,
+      seats: table.seats,
+    })),
+  }));
+
+  if (groups.length > 0) {
+    rows.push({
+      key: "groups",
+      name: "Combined tables",
+      units: groups.map((group) => ({
+        key: `group:${group.id}`,
+        kind: "group" as const,
+        name: groupDisplayName(group),
+        seats: group.combinedSeats,
+      })),
+    });
+  }
+
+  if (options.includeUnassigned) {
+    rows.push({
+      key: "unassigned",
+      name: "Unassigned",
+      units: [{ key: UNASSIGNED_KEY, kind: "unassigned", name: "No table", seats: null }],
+    });
+  }
+
+  return rows;
+}
+
+/** Signed distance from opening, choosing whichever side of the day wrap the booking sits nearer. */
+function unwrap(offsetFromOpen: number, serviceSpan: number): number {
+  if (offsetFromOpen <= serviceSpan) return offsetFromOpen;
+  const forward = offsetFromOpen - serviceSpan;
+  const backward = MINUTES_PER_DAY - offsetFromOpen;
+  return backward < forward ? offsetFromOpen - MINUTES_PER_DAY : offsetFromOpen;
+}
+
+function assignLanes(placements: TimelinePlacement[]): Record<string, number> {
+  const laneEnds: Record<string, number[]> = {};
+
+  for (const placement of [...placements].sort((a, b) => a.startOffset - b.startOffset)) {
+    const ends = (laneEnds[placement.unitKey] ??= []);
+    const free = ends.findIndex((end) => end <= placement.startOffset);
+    const lane = free === -1 ? ends.length : free;
+    ends[lane] = placement.endOffset;
+    placement.lane = lane;
+  }
+
+  return Object.fromEntries(Object.entries(laneEnds).map(([key, ends]) => [key, ends.length]));
+}
+
+/** Headroom drawn either side of the day's sittings, so a bar never butts against the edge. */
+const WINDOW_PAD_MINUTES = 60;
+
+/**
+ * The drawn range, as [start, end] offsets from opening. Trims idle service hours away from the
+ * sittings, but never trims a sitting itself, and never pads into hours the location is shut.
+ */
+function windowFor(
+  placements: TimelinePlacement[],
+  serviceSpan: number,
+  nowMinutes: number | null,
+  openMinutes: number
+): [number, number] {
+  if (placements.length === 0) return [0, serviceSpan];
+
+  const earliest = Math.min(...placements.map((p) => p.startOffset));
+  const latest = Math.max(...placements.map((p) => p.endOffset));
+  // Pad outwards, but no further than the service window — unless a booking is already out there.
+  let start = Math.max(earliest - WINDOW_PAD_MINUTES, Math.min(0, earliest));
+  let end = Math.min(latest + WINDOW_PAD_MINUTES, Math.max(serviceSpan, latest));
+
+  if (nowMinutes != null) {
+    // "Who is sitting where right now" is the question the grid exists to answer, so the marker's
+    // position stays on the axis even when the nearest sitting is hours away — inside service only.
+    const nowOffsetRaw = (nowMinutes - openMinutes + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+    if (nowOffsetRaw <= serviceSpan) {
+      start = Math.min(start, nowOffsetRaw);
+      end = Math.max(end, nowOffsetRaw);
+    }
+  }
+
+  return [start, end];
+}
+
+function durationOf(booking: BookingDetailDto, defaultDurationMinutes: number): number {
+  if (!booking.endTime) return defaultDurationMinutes;
+  const minutes = Math.round(
+    (new Date(booking.endTime).getTime() - new Date(booking.date).getTime()) / 60000
+  );
+  return minutes > 0 ? minutes : defaultDurationMinutes;
+}
+
+/**
+ * Lays the day out in minutes rather than hours, so a sitting is drawn where it actually starts and
+ * for as long as it actually runs. Bucketing by the hour is what collapsed an 18:00 and an 18:30
+ * booking on one table into a single cell and rendered only the first of them.
+ *
+ * The window is the day's sittings plus an hour of headroom either side, and "now" when the caller
+ * passes one. It is not the service hours: a location open around the clock would otherwise spend 24
+ * columns to show two lunchtime bookings, burying them off the right of the screen. The headroom
+ * stops at the service window, so hours the location is shut stay off the axis — but a booking
+ * outside those hours still sets the edge itself, because narrowing a location's hours leaves the
+ * bookings taken under the old ones where they are and the timetable is the worst place to hide them.
+ *
+ * With no bookings at all the window falls back to the service hours; callers render their own empty
+ * state rather than an empty grid.
+ *
+ * @see [bookingTimeline.test.ts](../tests/utils/bookingTimeline.test.ts) — pins that two sittings
+ * half an hour apart on one table both place, that a group booking places on its group row, that the
+ * window trims to the sittings rather than spanning idle service hours, that a booking outside the
+ * service hours still widens it, and that overlapping sittings stack into lanes.
+ */
+export function buildTimeline({
+  openTime,
+  closeTime,
+  timezone,
+  bookings,
+  defaultDurationMinutes,
+  nowMinutes = null,
+}: {
+  openTime: string;
+  closeTime: string;
+  timezone: string;
+  bookings: BookingDetailDto[];
+  defaultDurationMinutes: number;
+  /** Restaurant-local minutes since midnight, or null on any day but the location's today. */
+  nowMinutes?: number | null;
+}): Timeline {
+  const openMinutes = parseClockMinutes(openTime);
+  const closeMinutes = parseClockMinutes(closeTime);
+  const serviceSpan =
+    (closeMinutes - openMinutes + MINUTES_PER_DAY) % MINUTES_PER_DAY || MINUTES_PER_DAY;
+
+  const placements: TimelinePlacement[] = bookings.map((booking) => {
+    const startClockMinutes = minutesInTimezone(booking.date, timezone);
+    const startOffset = unwrap(
+      (startClockMinutes - openMinutes + MINUTES_PER_DAY) % MINUTES_PER_DAY,
+      serviceSpan
+    );
+    return {
+      booking,
+      unitKey: unitKeyFor(booking),
+      startOffset,
+      endOffset: startOffset + durationOf(booking, defaultDurationMinutes),
+      startClockMinutes,
+      lane: 0,
+    };
+  });
+
+  const laneCount = assignLanes(placements);
+
+  const [rawStart, rawEnd] = windowFor(placements, serviceSpan, nowMinutes, openMinutes);
+  // Snap the edges to clock hours so every tick lands on a labelled hour rather than mid-column.
+  const startOffset =
+    Math.floor((openMinutes + rawStart) / MINUTES_PER_HOUR) * MINUTES_PER_HOUR - openMinutes;
+  const endOffset =
+    Math.ceil((openMinutes + rawEnd) / MINUTES_PER_HOUR) * MINUTES_PER_HOUR - openMinutes;
+
+  const ticks: { offset: number; label: string }[] = [];
+  for (let offset = startOffset; offset < endOffset; offset += MINUTES_PER_HOUR) {
+    const clockMinute =
+      (((openMinutes + offset) % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+    ticks.push({ offset, label: HOUR_LABELS[Math.floor(clockMinute / MINUTES_PER_HOUR)] });
+  }
+
+  return { startOffset, endOffset, ticks, placements, laneCount };
+}
+
+/**
+ * Where "now" falls on the timeline, or null when it is off the drawn window. Callers pass null for
+ * `nowMinutes` on any day other than the restaurant's today, where "now" has no place on the grid.
+ */
+export function nowOffset(
+  timeline: Timeline,
+  openTime: string,
+  nowMinutes: number | null
+): number | null {
+  if (nowMinutes == null) return null;
+  const openMinutes = parseClockMinutes(openTime);
+  const raw = (nowMinutes - openMinutes + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+  const offset = raw > timeline.endOffset ? raw - MINUTES_PER_DAY : raw;
+  return offset >= timeline.startOffset && offset <= timeline.endOffset ? offset : null;
+}
+
+/** Compact "1h 30m left" / "45m left" for what is left of a sitting. */
+export function formatRemaining(minutes: number): string {
+  if (minutes <= 0) return "ending";
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR);
+  const mins = minutes % MINUTES_PER_HOUR;
+  if (hours === 0) return `${mins}m left`;
+  return mins === 0 ? `${hours}h left` : `${hours}h ${mins}m left`;
+}
+
+/** Restaurant-local minutes since midnight rendered as a compact "6:30p". */
+export function formatClockMinutes(totalMinutes: number): string {
+  const wrapped = ((totalMinutes % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+  const hour24 = Math.floor(wrapped / MINUTES_PER_HOUR);
+  const minute = wrapped % MINUTES_PER_HOUR;
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return `${hour12}:${String(minute).padStart(2, "0")}${hour24 < 12 ? "a" : "p"}`;
+}

--- a/openresto-frontend/utils/date.ts
+++ b/openresto-frontend/utils/date.ts
@@ -118,3 +118,28 @@ export function isTodayInTimezone(utcDateStr: string, timezone: string): boolean
     return false;
   }
 }
+
+/**
+ * Minutes since local midnight for a UTC instant, expressed in the given IANA timezone. The
+ * counterpart of {@link getNowInTimezone} for an arbitrary instant — a booking's `date` is UTC and
+ * names no wall-clock time until it is resolved against the location it belongs to.
+ *
+ * @see [bookingTimeline.test.ts](../tests/utils/bookingTimeline.test.ts) — pins that a booking is
+ * placed by the restaurant's wall clock rather than the admin browser's.
+ */
+export function minutesInTimezone(iso: string, timezone: string): number {
+  const tz = timezone || "UTC";
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(iso));
+    const get = (type: string) => parseInt(parts.find((p) => p.type === type)?.value ?? "0", 10);
+    return (get("hour") % 24) * 60 + get("minute");
+  } catch {
+    const d = new Date(iso);
+    return d.getHours() * 60 + d.getMinutes();
+  }
+}


### PR DESCRIPTION
## Summary

`/admin/bookings`' timetable was the right shape for "who's sitting where" but answered neither half of the FOH use case reliably. It ignored `endTime` entirely, so "how long does it last" was simply absent; it bucketed bookings by the hour and rendered `bookings.find(...)`, so an 18:00 and an 18:30 booking on one table collapsed into a single cell with only the first surviving; and it matched cells on `tableId`, which a combinable-group booking does not have, so those never appeared at all.

Bookings are now placed on a continuous minute axis — left edge at the real start, width from the resolved end — with a now marker and a per-minute tick so current occupancy and time remaining read at a glance.

## Related issue

Refs #334

Deliberately **not** auto-closing: this is phase 1 (the service view). Phase 2 in the issue — real floor-plan geometry, `PositionX`/`PositionY` on `Table` plus a drag-to-place editor — is not included and was scoped there as a separate ticket. The issue stays open after this merges; phase 2 can be split out separately.

Two things in the issue's spec turned out to be stale and are not in this PR: the past-midnight `buildTimeSlots` bug is **already fixed** on main, and the proposed `GetTablesAsync` change is unnecessary — `RestaurantDto` already carries `groups` and `defaultBookingDurationMinutes`, and the screen already fetches it.

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

**Frontend**

- `utils/bookingTimeline.ts` (new) — the placement, lane-packing and window maths as a pure module, so every rule is pinned by a unit test rather than by a rendered grid.
- `AvailabilityGrid` rewritten from hour cells to absolutely-positioned bars. Overlapping sittings stack into lanes instead of hiding each other; group bookings get their own rows under a *Combined tables* block (member tables keep their individual rows, since a member stays individually bookable); a booking whose table was deleted lands on an *Unassigned* row rather than vanishing.
- The axis spans the day's sittings plus an hour either side, not the whole service window. A location configured `00:00–23:59` otherwise spent 24 columns to show two lunchtime bookings, burying them off the right of the screen. Padding stops at the service window, but a booking outside those hours still sets the edge itself (#359's rule).
- A day with no bookings says so instead of drawing an empty grid.
- `utils/date.ts` — adds `minutesInTimezone`, the arbitrary-instant counterpart of `getNowInTimezone`.
- Unrelated, included as its own commit: the new-booking form now puts the guest name beside the party size and gives the optional email its own row.

**Backend**

- `BookingDetailDto.TableGroupId` — without it the frontend cannot place a group booking at all.
- `BookingFilterRepository.QueryAsync` now includes `TableGroup` + members + their tables, so a group booking labels as its group instead of reading "Table". That was wrong in the list view too, not just the grid.
- `BookingDuration.ResolveEnd` (new) — `EndTime` is nullable and legacy rows carry null, so it resolves to the location's default duration. `ExtendBookingAsync` had been open-coding exactly this rule; both now share it, and `ToDetailDto` applies it so consumers stop reinventing the fallback.

**API contract note for reviewers:** `BookingDetailDto.EndTime` is now always populated rather than sometimes null. That is a behaviour change for every consumer of the admin booking endpoints, not just the timetable.

## Testing

- [x] `OpenRestoApi.Tests` pass locally — 1760 passing. Four unrelated Windows-only failures (`InitializeDatabaseTests` ×2 on file locking, `SqlitePragmaInterceptorTests` ×2 on a non-writable directory) fail identically on `main`; verified by re-running them there.
- [x] Frontend tests/build pass locally — 2803 passing, `tsc` clean, `npm run check` and `check:doc-links` green. 55 new tests across `bookingTimeline.test.ts` and the rewritten `AvailabilityGrid.test.tsx`.
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

No schema change — `Booking.TableGroupId` already exists; this only exposes it on the DTO.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

