### PR TITLE
i18n A: centralise date/time/number formatting behind utils/formatters.ts

### DIFF
--- a/openresto-frontend/app/admin/dashboard.tsx
+++ b/openresto-frontend/app/admin/dashboard.tsx
@@ -20,6 +20,7 @@ import AlertModal from "@/components/common/AlertModal";
 import { styles } from "@/styles/admin/dashboard.styles";
 import { Icon, type IconName } from "@/components/common/Icon";
 import { ScheduleConflictsBanner } from "@/components/admin/dashboard/ScheduleConflictsBanner";
+import { fmtMonthDay, fmtNumber, fmtTime, fmtWeekday } from "@/utils/formatters";
 
 export default function AdminDashboardScreen() {
   const [stats, setStats] = useState<AdminDashboardStats | null>(null);
@@ -78,7 +79,7 @@ export default function AdminDashboardScreen() {
         },
         {
           label: "Total Covers",
-          value: stats.totalCovers.toLocaleString(),
+          value: fmtNumber(stats.totalCovers),
           sub: "Total guests served (all time)",
           icon: "people-outline" as const,
           accent: "#d97706",
@@ -322,8 +323,7 @@ function OccupancyChart({
   const [labelMode, setLabelMode] = useState<"relative" | "calendar">("relative");
 
   const relativeLabels = ["T-6", "T-5", "T-4", "T-3", "T-2", "T-1", "Today"];
-  const formatCalendar = (iso: string) =>
-    new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  const formatCalendar = (iso: string) => fmtMonthDay(new Date(iso));
 
   const labelFor = (i: number) => {
     if (labelMode === "calendar" && dates && dates[i]) {
@@ -338,7 +338,7 @@ function OccupancyChart({
   const totalBookings = hasCounts ? (counts as number[]).reduce((a, b) => a + b, 0) : 0;
   const peakWeekday =
     peakIndex >= 0 && dates && dates[peakIndex]
-      ? new Date(dates[peakIndex]).toLocaleDateString(undefined, { weekday: "short" })
+      ? fmtWeekday(new Date(dates[peakIndex]))
       : peakIndex >= 0
         ? relativeLabels[peakIndex]
         : "";
@@ -483,7 +483,7 @@ function BookingItem({
       onPress={onPress}
       accessibilityRole="button"
       accessibilityLabel={[
-        startTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+        fmtTime(startTime),
         booking.customerName ?? booking.customerEmail,
         `${booking.seats} guests`,
         booking.restaurantName,
@@ -500,7 +500,7 @@ function BookingItem({
     >
       <View style={[styles.bookingTime, { backgroundColor: bubbleBg }]}>
         <ThemedText style={[styles.bookingTimeText, { color: bubbleTextColor }]}>
-          {startTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+          {fmtTime(startTime)}
         </ThemedText>
       </View>
       <View style={styles.bookingInfo}>

--- a/openresto-frontend/app/admin/locations.tsx
+++ b/openresto-frontend/app/admin/locations.tsx
@@ -27,6 +27,7 @@ import { ScheduleConflictsPanel } from "@/components/admin/locations/ScheduleCon
 import { BookingDetailPopup } from "@/components/admin/bookings/BookingDetailPopup";
 import { styles } from "@/components/admin/settings/settings.styles";
 import { Icon } from "@/components/common/Icon";
+import { fmtTime } from "@/utils/formatters";
 
 function locationCountSummary(activeCount: number, archivedCount: number): string {
   if (activeCount + archivedCount === 0) return "No locations configured";
@@ -117,10 +118,7 @@ export default function AdminLocationsScreen() {
     : false;
   const pausedUntilText =
     isPaused && selectedSummary?.bookingsPausedUntil
-      ? new Date(selectedSummary.bookingsPausedUntil).toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
-        })
+      ? fmtTime(new Date(selectedSummary.bookingsPausedUntil))
       : null;
   const archivedCount = allRestaurants.filter((r) => r.isArchived).length;
 

--- a/openresto-frontend/components/admin/bookings/BookingDetailsCard.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingDetailsCard.tsx
@@ -1,6 +1,7 @@
 import { View, ViewStyle } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { theme } from "@/theme/theme";
+import { fmtLongDate, fmtMonthDay, fmtTime } from "@/utils/formatters";
 import { bookingDetailStyles as styles } from "./booking-detail.styles";
 
 interface BookingDetailsCardProps {
@@ -39,20 +40,8 @@ export function BookingDetailsCard({
   const diffMs = endTime.getTime() - startTime.getTime();
   const durationMins = Math.round(diffMs / 60000);
 
-  const formatTime = (d: Date) => {
-    return d.toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-  };
-
-  const formatDate = (d: Date) => {
-    return d.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
-  };
+  const formatTime = fmtTime;
+  const formatDate = fmtMonthDay;
 
   const timeRangeDisplay =
     startTime.toDateString() === endTime.toDateString()
@@ -69,12 +58,7 @@ export function BookingDetailsCard({
     { label: "Table", value: booking.tableName ?? "Table" },
     {
       label: "Date",
-      value: startTime.toLocaleDateString(undefined, {
-        weekday: "long",
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      }),
+      value: fmtLongDate(startTime),
     },
     {
       label: "Time",

--- a/openresto-frontend/components/admin/bookings/BookingsCardList.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsCardList.tsx
@@ -9,7 +9,7 @@ import {
   focusedRowHighlight,
   rowA11yProps,
 } from "@/components/admin/bookings/bookingRowProps";
-import { initials } from "@/utils/formatters";
+import { fmtDateTime, initials } from "@/utils/formatters";
 import { BookingsSortControl } from "@/components/admin/bookings/BookingsSortControl";
 import type { SortKey, SortState } from "@/components/admin/bookings/sorting";
 import { Icon } from "@/components/common/Icon";
@@ -92,13 +92,7 @@ export function BookingsCardList({
                   </ThemedText>
                 ) : null}
                 <ThemedText style={[styles.tdTime, { fontSize: 13 }]}>
-                  {new Date(b.date).toLocaleString(undefined, {
-                    weekday: "short",
-                    month: "short",
-                    day: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
+                  {fmtDateTime(new Date(b.date))}
                 </ThemedText>
                 <View style={styles.partyPill}>
                   <Icon name="people-outline" size="xs" color={mutedColor} />

--- a/openresto-frontend/components/admin/bookings/BookingsWideTable.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsWideTable.tsx
@@ -2,7 +2,7 @@ import { Pressable, View, type ViewStyle } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { BookingDetailDto } from "@/api/admin";
 import { theme } from "@/theme/theme";
-import { initials } from "@/utils/formatters";
+import { fmtMonthDay, fmtTime, initials } from "@/utils/formatters";
 import { isPast, StatusBadge } from "@/components/admin/bookings/StatusBadge";
 import { styles } from "@/components/admin/bookings/bookings.styles";
 import {
@@ -131,17 +131,9 @@ export function BookingsWideTable({
               </ThemedText>
             </View>
             <View>
-              <ThemedText style={styles.tdTime}>
-                {new Date(b.date).toLocaleTimeString(undefined, {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </ThemedText>
+              <ThemedText style={styles.tdTime}>{fmtTime(new Date(b.date))}</ThemedText>
               <ThemedText style={[styles.tdDate, { color: mutedColor }]}>
-                {new Date(b.date).toLocaleDateString(undefined, {
-                  month: "short",
-                  day: "numeric",
-                })}
+                {fmtMonthDay(new Date(b.date))}
               </ThemedText>
             </View>
           </View>

--- a/openresto-frontend/components/admin/bookings/RestaurantActionModal.tsx
+++ b/openresto-frontend/components/admin/bookings/RestaurantActionModal.tsx
@@ -14,6 +14,7 @@ import {
 import { styles } from "./RestaurantActionModal.styles";
 import { theme } from "@/theme/theme";
 import { Icon } from "@/components/common/Icon";
+import { fmtTime } from "@/utils/formatters";
 
 interface RestaurantActionModalProps {
   visible: boolean;
@@ -39,12 +40,7 @@ export default function RestaurantActionModal({
 
   async function loadRestaurants() {
     setExtendedBookings(null);
-    setWillPauseUntil(
-      new Date(Date.now() + 60 * 60 * 1000).toLocaleTimeString([], {
-        hour: "2-digit",
-        minute: "2-digit",
-      })
-    );
+    setWillPauseUntil(fmtTime(new Date(Date.now() + 60 * 60 * 1000)));
     setLoading(true);
     try {
       const data = await adminGetRestaurants();
@@ -160,17 +156,9 @@ export default function RestaurantActionModal({
                     <View style={styles.itemMain}>
                       <ThemedText style={styles.itemName}>{b.customerEmail}</ThemedText>
                       <ThemedText style={[styles.itemMeta, { color: colors.muted }]}>
-                        {new Date(b.date).toLocaleTimeString([], {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}
+                        {fmtTime(new Date(b.date))}
                         {" → "}
-                        {b.endTime
-                          ? new Date(b.endTime).toLocaleTimeString([], {
-                              hour: "2-digit",
-                              minute: "2-digit",
-                            })
-                          : "Extended"}
+                        {b.endTime ? fmtTime(new Date(b.endTime)) : "Extended"}
                         {` · ${b.seats} guests`}
                       </ThemedText>
                     </View>
@@ -230,7 +218,7 @@ export default function RestaurantActionModal({
                       </View>
                       <ThemedText style={[styles.itemMeta, { color: colors.muted }]}>
                         {isPaused
-                          ? `Bookings up to ${new Date(r.bookingsPausedUntil!).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} are paused`
+                          ? `Bookings up to ${fmtTime(new Date(r.bookingsPausedUntil!))} are paused`
                           : actionType === "pause"
                             ? `Will pause bookings up to ${willPauseUntil}`
                             : `${r.activeBookingsCount ?? 0} active bookings`}

--- a/openresto-frontend/components/admin/bookings/bookingRowProps.ts
+++ b/openresto-frontend/components/admin/bookings/bookingRowProps.ts
@@ -1,3 +1,5 @@
+import { fmtDateTime } from "@/utils/formatters";
+
 /**
  * Shared a11y/highlight helpers for bookings-list rows — kept identical between
  * the wide-table and mobile-card layouts so keyboard-focus state can't silently
@@ -30,12 +32,7 @@ export function describeBookingRow(b: {
   seats: number;
   tableName?: string | null;
 }): string {
-  const when = new Date(b.date).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const when = fmtDateTime(new Date(b.date));
   const where = b.tableName ? `, ${b.tableName}` : "";
   return `${b.customerName ?? b.customerEmail}, ${when}, ${b.seats} guests${where}`;
 }

--- a/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.tsx
+++ b/openresto-frontend/components/admin/locations/ScheduleConflictsPanel.tsx
@@ -9,6 +9,7 @@ import {
   ScheduleConflictDto,
   ScheduleConflictReason,
 } from "@/api/restaurants";
+import { fmtDateTimeInZone } from "@/utils/formatters";
 import { styles } from "./ScheduleConflictsPanel.styles";
 
 const REASON_LABELS: Record<ScheduleConflictReason, string> = {
@@ -17,14 +18,7 @@ const REASON_LABELS: Record<ScheduleConflictReason, string> = {
 };
 
 function formatSitting(dateUtc: string, timezone: string): string {
-  return new Date(dateUtc).toLocaleString(undefined, {
-    timeZone: timezone,
-    weekday: "short",
-    day: "numeric",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return fmtDateTimeInZone(dateUtc, timezone);
 }
 
 /**

--- a/openresto-frontend/components/admin/settings/EmailFailuresList.tsx
+++ b/openresto-frontend/components/admin/settings/EmailFailuresList.tsx
@@ -3,6 +3,7 @@ import { ThemedText } from "@/components/themed-text";
 import { SubLabel } from "./settingsShared";
 import type { EmailFailureDto } from "@/api/admin";
 import { Icon } from "@/components/common/Icon";
+import { fmtDateTime } from "@/utils/formatters";
 import { styles } from "./EmailFailuresList.styles";
 
 export interface EmailFailuresListProps {
@@ -33,12 +34,7 @@ export function EmailFailuresList({
       <View style={[styles.list, { borderColor: dangerBorder, backgroundColor: dangerSoft }]}>
         {failures.map((f, i) => {
           const date = new Date(f.attemptedAt);
-          const dateStr = date.toLocaleDateString(undefined, {
-            month: "short",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          });
+          const dateStr = fmtDateTime(date);
           return (
             <View
               key={f.id}

--- a/openresto-frontend/components/booking/BookingFactsBand.tsx
+++ b/openresto-frontend/components/booking/BookingFactsBand.tsx
@@ -1,6 +1,7 @@
 import { View } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { BookingDto } from "@/api/bookings";
+import { fmtDate, fmtTime, fmtYear } from "@/utils/formatters";
 import { styles } from "./BookingFactsBand.styles";
 
 interface BookingFactsBandProps {
@@ -18,16 +19,12 @@ type Fact = { key: string; value: string; sub?: string };
 const formatTime = (value: string): string | undefined => {
   const d = new Date(value);
   if (Number.isNaN(d.getTime())) return undefined;
-  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  return fmtTime(d);
 };
 
 export function buildFacts(booking: BookingDto, compact: boolean): Fact[] {
   const date = new Date(booking.date);
-  const day = date.toLocaleDateString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
+  const day = fmtDate(date);
   const time = formatTime(booking.date) ?? "";
   const until = booking.endTime ? formatTime(booking.endTime) : undefined;
   const party = {
@@ -41,7 +38,7 @@ export function buildFacts(booking: BookingDto, compact: boolean): Fact[] {
   }
 
   return [
-    { key: "Date", value: day, sub: date.toLocaleDateString(undefined, { year: "numeric" }) },
+    { key: "Date", value: day, sub: fmtYear(date) },
     { key: "Time", value: time, sub: until ? `until ${until}` : undefined },
     party,
   ];

--- a/openresto-frontend/components/booking/RecentBookingsList.tsx
+++ b/openresto-frontend/components/booking/RecentBookingsList.tsx
@@ -6,6 +6,7 @@ import { ThemeColors } from "@/theme/theme";
 import { CachedBooking } from "@/utils/bookingCache";
 import { Icon } from "@/components/common/Icon";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { fmtMonthDay } from "@/utils/formatters";
 import { styles } from "./RecentBookingsList.styles";
 
 /** How many rows show before the list collapses behind a Show all control. */
@@ -65,10 +66,7 @@ export default function RecentBookingsList({
                 <ThemedText style={styles.ref}>{c.bookingRef}</ThemedText>
                 <ThemedText style={[styles.meta, { color: colors.muted }]}>
                   {c.restaurantName ? `${c.restaurantName} · ` : ""}
-                  {new Date(c.date).toLocaleDateString(undefined, {
-                    month: "short",
-                    day: "numeric",
-                  })}
+                  {fmtMonthDay(new Date(c.date))}
                   {" · "}
                   {c.seats} guest{c.seats !== 1 ? "s" : ""}
                 </ThemedText>

--- a/openresto-frontend/components/common/DatePicker.tsx
+++ b/openresto-frontend/components/common/DatePicker.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Icon, type IconName } from "@/components/common/Icon";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { LISTBOX_ROLE } from "@/utils/webProps";
+import { fmtDate } from "@/utils/formatters";
 import { styles } from "./DatePicker.styles";
 
 export function generateDateOptions(options?: {
@@ -18,11 +19,7 @@ export function generateDateOptions(options?: {
   for (let i = startOffset; i <= 29; i++) {
     const d = new Date(today);
     d.setDate(today.getDate() + i);
-    const label = d.toLocaleDateString(undefined, {
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-    });
+    const label = fmtDate(d);
     const year = d.getFullYear();
     const month = String(d.getMonth() + 1).padStart(2, "0");
     const day = String(d.getDate()).padStart(2, "0");

--- a/openresto-frontend/components/common/DatePicker.web.tsx
+++ b/openresto-frontend/components/common/DatePicker.web.tsx
@@ -8,6 +8,7 @@ import { useAppTheme } from "@/hooks/use-app-theme";
 import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { clampToRange, resolveCalendarKey, shiftCalendarMonths } from "@/utils/calendarKeys";
 import { GRIDCELL_ROLE, webProps, type WebKeyEvent } from "@/utils/webProps";
+import { fmtDateString, fmtLongDate } from "@/utils/formatters";
 import { styles } from "./DatePicker.web.styles";
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -223,21 +224,9 @@ export default function DatePicker({
   ];
   while (cells.length % 7 !== 0) cells.push(null);
 
-  const selectedLabel = selectedDate
-    ? new Date(selectedDate + "T12:00:00").toLocaleDateString(undefined, {
-        weekday: "short",
-        month: "short",
-        day: "numeric",
-      })
-    : null;
+  const selectedLabel = selectedDate ? fmtDateString(selectedDate) : null;
 
-  const describeDate = (d: Date) =>
-    d.toLocaleDateString(undefined, {
-      weekday: "long",
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
+  const describeDate = (d: Date) => fmtLongDate(d);
 
   return (
     <View style={styles.wrapper} testID="date-picker-web">

--- a/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
+++ b/openresto-frontend/components/restaurant/LocationsFilterBar.tsx
@@ -3,6 +3,7 @@ import { ThemedText } from "@/components/themed-text";
 import Select from "@/components/common/Select";
 import DatePicker from "@/components/common/DatePicker";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { fmtDateString } from "@/utils/formatters";
 import { styles } from "./LocationsFilterBar.styles";
 
 /**
@@ -38,11 +39,7 @@ export function formatBarDate(date: string, today: string, compact: boolean): st
 }
 
 function shortDate(date: string): string {
-  return new Date(date + "T12:00:00").toLocaleDateString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
+  return fmtDateString(date);
 }
 
 /** Page-level party/date/meal bar for the Locations list. */

--- a/openresto-frontend/tests/app/admin/activity.test.tsx
+++ b/openresto-frontend/tests/app/admin/activity.test.tsx
@@ -141,7 +141,7 @@ describe("ActivityScreen", () => {
   it("leads a row with its summary, actor and status", async () => {
     renderWithProviders(<ActivityScreen />, { withAuth: true });
     await waitFor(() => expect(screen.getByText("Cancelled REF001 at Resto A")).toBeTruthy());
-    expect(screen.getByText(/Dana · Owner · just now/)).toBeTruthy();
+    expect(screen.getByText(/Dana · Owner · now/)).toBeTruthy();
     expect(screen.getByText("200")).toBeTruthy();
   });
 

--- a/openresto-frontend/tests/app/admin/notifications.test.tsx
+++ b/openresto-frontend/tests/app/admin/notifications.test.tsx
@@ -475,14 +475,24 @@ describe("NotificationsScreen", () => {
     await waitFor(() => expect(screen.getByText(/3h ago/)).toBeTruthy());
   });
 
-  it("relativeTime shows 'Xd ago' for notifications created days ago", async () => {
-    const twoDaysAgo = new Date(Date.now() - 25 * 3600000).toISOString();
+  it("relativeTime shows 'yesterday' for notifications created a day ago", async () => {
+    const oneDayAgo = new Date(Date.now() - 25 * 3600000).toISOString();
     mockGetNotifications.mockResolvedValue({
-      items: [{ ...mockNotification, createdAt: twoDaysAgo }],
+      items: [{ ...mockNotification, createdAt: oneDayAgo }],
       totalCount: 1,
     });
     render(<NotificationsScreen />);
-    await waitFor(() => expect(screen.getByText(/1d ago/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/yesterday/)).toBeTruthy());
+  });
+
+  it("relativeTime shows 'Xd ago' for notifications created several days ago", async () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400000).toISOString();
+    mockGetNotifications.mockResolvedValue({
+      items: [{ ...mockNotification, createdAt: threeDaysAgo }],
+      totalCount: 1,
+    });
+    render(<NotificationsScreen />);
+    await waitFor(() => expect(screen.getByText(/3d ago/)).toBeTruthy());
   });
 
   it("pressing Mark all read with a specific restaurant selected calls markAllRead for that restaurant only", async () => {
@@ -503,14 +513,14 @@ describe("NotificationsScreen", () => {
     expect(mockMarkAllRead).not.toHaveBeenCalledWith(1);
   });
 
-  it("relativeTime shows 'just now' for notifications created seconds ago", async () => {
+  it("relativeTime shows 'now' for notifications created seconds ago", async () => {
     const justNow = new Date(Date.now() - 30000).toISOString();
     mockGetNotifications.mockResolvedValue({
       items: [{ ...mockNotification, createdAt: justNow }],
       totalCount: 1,
     });
     render(<NotificationsScreen />);
-    await waitFor(() => expect(screen.getByText(/just now/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/· now$/)).toBeTruthy());
   });
 
   it("swipe to delete removes notification and shows toast", async () => {

--- a/openresto-frontend/tests/utils/date.test.ts
+++ b/openresto-frontend/tests/utils/date.test.ts
@@ -4,7 +4,9 @@ import {
   getNowInTimezone,
   formatCurrentTimeInTimezone,
   isViewerInTimezone,
+  minutesInTimezone,
 } from "@/utils/date";
+import { setActiveLocale } from "@/utils/locale";
 
 describe("date utility - convertLocalToUtc", () => {
   it("converts Toronto local time (EDT, UTC-4) to UTC", () => {
@@ -176,6 +178,47 @@ describe("date utility - isTodayInTimezone", () => {
     const now = new Date().toISOString();
     const result = isTodayInTimezone(now, "");
     expect(typeof result).toBe("boolean");
+  });
+});
+
+describe("date utility - pinned parsers stay correct under a non-English active locale", () => {
+  afterEach(() => {
+    setActiveLocale(undefined);
+  });
+
+  it("convertLocalToUtc is unaffected by the active display locale", () => {
+    setActiveLocale("fr");
+    const result = convertLocalToUtc("2026-04-18", "15:00", "America/Toronto");
+    expect(result).toBe("2026-04-18T19:00:00.000Z");
+  });
+
+  it("isTodayInTimezone is unaffected by the active display locale", () => {
+    setActiveLocale("fr");
+    const now = new Date().toISOString();
+    expect(isTodayInTimezone(now, "America/Toronto")).toBe(true);
+
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(isTodayInTimezone(yesterday.toISOString(), "UTC")).toBe(false);
+  });
+
+  it("getNowInTimezone is unaffected by the active display locale", () => {
+    setActiveLocale("fr");
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-05T10:30:00Z")); // a Monday
+    try {
+      const { dateStr, hours, minutes } = getNowInTimezone("UTC");
+      expect(dateStr).toBe("2026-01-05");
+      expect(hours).toBe(10);
+      expect(minutes).toBe(30);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("minutesInTimezone is unaffected by the active display locale", () => {
+    setActiveLocale("fr");
+    expect(minutesInTimezone("2026-04-18T19:30:00Z", "UTC")).toBe(19 * 60 + 30);
   });
 });
 

--- a/openresto-frontend/tests/utils/formatters.test.ts
+++ b/openresto-frontend/tests/utils/formatters.test.ts
@@ -1,18 +1,44 @@
-import { fmtDate, isoDate, initials } from "@/utils/formatters";
+import {
+  fmtDate,
+  fmtDateString,
+  fmtDateTime,
+  fmtDateTimeInZone,
+  fmtLongDate,
+  fmtMonthDay,
+  fmtNumber,
+  fmtTime,
+  fmtTimestamp,
+  fmtWeekday,
+  fmtYear,
+  initials,
+  isoDate,
+  relativeTime,
+} from "@/utils/formatters";
+import { setActiveLocale } from "@/utils/locale";
+
+afterEach(() => {
+  setActiveLocale(undefined);
+});
 
 describe("formatters - fmtDate", () => {
-  it("formats a date with the toLocaleDateString short weekday/month/day shape", () => {
+  it("formats a date with the short weekday/month/day shape under en-GB", () => {
+    setActiveLocale("en-GB");
     const d = new Date(2026, 3, 18, 12, 0, 0); // Saturday, April 18, 2026
-    // toLocaleDateString with these options returns e.g. "Sat, Apr 18" in en locales.
-    // We assert day-of-month and abbreviated month are present; year is intentionally omitted
-    // by the formatter (matching the original inline behaviour).
     const result = fmtDate(d);
     expect(result).toContain("18");
     expect(result).toMatch(/apr/i);
   });
+
+  it("formats a date under fr", () => {
+    setActiveLocale("fr");
+    const d = new Date(2026, 3, 18, 12, 0, 0);
+    const result = fmtDate(d);
+    expect(result).toContain("18");
+    expect(result.toLowerCase()).toContain("avr");
+  });
 });
 
-describe("formatters - isoDate", () => {
+describe("formatters - fmtDateString / isoDate", () => {
   it("formats a Date as a naive YYYY-MM-DD string", () => {
     const d = new Date(2026, 3, 18, 23, 59, 59); // local Apr 18
     expect(isoDate(d)).toBe("2026-04-18");
@@ -21,6 +47,134 @@ describe("formatters - isoDate", () => {
   it("pads single-digit months and days", () => {
     const d = new Date(2026, 0, 5, 0, 0, 0); // local Jan 5
     expect(isoDate(d)).toBe("2026-01-05");
+  });
+
+  it("formats a YYYY-MM-DD string the same as the equivalent noon Date", () => {
+    setActiveLocale("en-GB");
+    expect(fmtDateString("2026-04-18")).toBe(fmtDate(new Date("2026-04-18T12:00:00")));
+  });
+});
+
+describe("formatters - fmtTime", () => {
+  it("includes the hour and minute", () => {
+    setActiveLocale("en-GB");
+    const d = new Date(2026, 3, 18, 19, 30, 0);
+    expect(fmtTime(d)).toMatch(/19:30|7:30/);
+  });
+
+  it("formats under fr", () => {
+    setActiveLocale("fr");
+    const d = new Date(2026, 3, 18, 19, 30, 0);
+    expect(fmtTime(d)).toContain("19");
+    expect(fmtTime(d)).toContain("30");
+  });
+});
+
+describe("formatters - fmtDateTime", () => {
+  it("combines weekday, month, day and time", () => {
+    setActiveLocale("en-GB");
+    const d = new Date(2026, 3, 18, 19, 30, 0);
+    const result = fmtDateTime(d);
+    expect(result).toMatch(/apr/i);
+    expect(result).toContain("18");
+    expect(result).toMatch(/19:30|7:30/);
+  });
+});
+
+describe("formatters - fmtDateTimeInZone", () => {
+  it("renders the instant in the given IANA timezone rather than the active locale's default", () => {
+    setActiveLocale("en-GB");
+    // 2026-04-18T23:30:00Z is already the 19th in a zone ahead of UTC.
+    const result = fmtDateTimeInZone("2026-04-18T23:30:00Z", "Pacific/Auckland");
+    expect(result).toMatch(/19/);
+  });
+});
+
+describe("formatters - fmtWeekday", () => {
+  it("returns an abbreviated weekday", () => {
+    setActiveLocale("en-GB");
+    const d = new Date(2026, 3, 18); // Saturday
+    expect(fmtWeekday(d)).toMatch(/sat/i);
+  });
+});
+
+describe("formatters - fmtMonthDay", () => {
+  it("returns month + day, no year", () => {
+    setActiveLocale("en-GB");
+    const d = new Date(2026, 3, 18);
+    const result = fmtMonthDay(d);
+    expect(result).toMatch(/apr/i);
+    expect(result).toContain("18");
+    expect(result).not.toContain("2026");
+  });
+});
+
+describe("formatters - fmtLongDate", () => {
+  it("returns a full weekday + long month + day + year", () => {
+    setActiveLocale("en-GB");
+    const d = new Date(2026, 3, 18);
+    const result = fmtLongDate(d);
+    expect(result).toMatch(/saturday/i);
+    expect(result).toMatch(/april/i);
+    expect(result).toContain("18");
+    expect(result).toContain("2026");
+  });
+});
+
+describe("formatters - fmtYear", () => {
+  it("returns only the year", () => {
+    setActiveLocale("en-GB");
+    expect(fmtYear(new Date(2026, 3, 18))).toBe("2026");
+  });
+});
+
+describe("formatters - fmtTimestamp", () => {
+  it("includes both date and time", () => {
+    setActiveLocale("en-GB");
+    const result = fmtTimestamp("2026-04-18T19:30:00Z");
+    expect(result).toMatch(/2026/);
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+  });
+});
+
+describe("formatters - fmtNumber", () => {
+  it("groups thousands under en-GB", () => {
+    setActiveLocale("en-GB");
+    expect(fmtNumber(12345)).toBe("12,345");
+  });
+
+  it("groups thousands under fr", () => {
+    setActiveLocale("fr");
+    // French grouping uses a non-breaking space; just assert the digits survive intact.
+    expect(fmtNumber(12345).replace(/\s/g, "")).toBe("12345");
+  });
+});
+
+describe("formatters - relativeTime", () => {
+  it("returns 'now' for <1 minute", () => {
+    const iso = new Date(Date.now() - 30_000).toISOString();
+    expect(relativeTime(iso)).toBe("now");
+  });
+
+  it("returns minutes for <1 hour", () => {
+    const iso = new Date(Date.now() - 5 * 60_000).toISOString();
+    expect(relativeTime(iso)).toBe("5m ago");
+  });
+
+  it("returns hours for <1 day", () => {
+    const iso = new Date(Date.now() - 3 * 3_600_000).toISOString();
+    expect(relativeTime(iso)).toBe("3h ago");
+  });
+
+  it("returns days for >=1 day", () => {
+    const iso = new Date(Date.now() - 2 * 86_400_000).toISOString();
+    expect(relativeTime(iso)).toBe("2d ago");
+  });
+
+  it("localizes under fr", () => {
+    setActiveLocale("fr");
+    const iso = new Date(Date.now() - 5 * 60_000).toISOString();
+    expect(relativeTime(iso)).toMatch(/min/);
   });
 });
 

--- a/openresto-frontend/tests/utils/locale.test.ts
+++ b/openresto-frontend/tests/utils/locale.test.ts
@@ -1,0 +1,18 @@
+import { getActiveLocale, setActiveLocale } from "@/utils/locale";
+
+afterEach(() => {
+  setActiveLocale(undefined);
+});
+
+describe("locale", () => {
+  it("defaults to undefined (follow the device)", () => {
+    expect(getActiveLocale()).toBeUndefined();
+  });
+
+  it("returns whatever was last set", () => {
+    setActiveLocale("fr");
+    expect(getActiveLocale()).toBe("fr");
+    setActiveLocale("es");
+    expect(getActiveLocale()).toBe("es");
+  });
+});

--- a/openresto-frontend/tests/utils/notifications.test.ts
+++ b/openresto-frontend/tests/utils/notifications.test.ts
@@ -9,9 +9,9 @@ import {
 } from "@/utils/notifications";
 
 describe("relativeTime", () => {
-  it("returns 'just now' for <1 minute", () => {
+  it("returns 'now' for <1 minute", () => {
     const iso = new Date(Date.now() - 30_000).toISOString();
-    expect(relativeTime(iso)).toBe("just now");
+    expect(relativeTime(iso)).toBe("now");
   });
 
   it("returns minutes for <1 hour", () => {

--- a/openresto-frontend/tests/utils/restaurantTime.test.ts
+++ b/openresto-frontend/tests/utils/restaurantTime.test.ts
@@ -4,6 +4,7 @@ import {
   parseDayOfWeek,
   getOpenDaysList,
 } from "@/utils/restaurantTime";
+import { setActiveLocale } from "@/utils/locale";
 
 describe("restaurantTime", () => {
   describe("getRestaurantNow", () => {
@@ -41,6 +42,36 @@ describe("restaurantTime", () => {
     it("falls back gracefully for an invalid timezone", () => {
       const d = getRestaurantDate("Invalid/Zone_XYZ");
       expect(/^\d{4}-\d{2}-\d{2}$/.test(d)).toBe(true);
+    });
+  });
+
+  describe("pinned parsers stay correct under a non-English active locale", () => {
+    afterEach(() => {
+      setActiveLocale(undefined);
+    });
+
+    it("getRestaurantNow is unaffected by the active display locale", () => {
+      setActiveLocale("fr");
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2026-01-05T10:30:00Z")); // a Monday
+      try {
+        const { totalMins, isoDay } = getRestaurantNow("UTC");
+        expect(isoDay).toBe(1);
+        expect(totalMins).toBe(10 * 60 + 30);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("getRestaurantDate is unaffected by the active display locale", () => {
+      setActiveLocale("fr");
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2026-01-05T10:30:00Z"));
+      try {
+        expect(getRestaurantDate("UTC")).toBe("2026-01-05");
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/openresto-frontend/utils/audit.ts
+++ b/openresto-frontend/utils/audit.ts
@@ -1,6 +1,7 @@
 import type { AdminAuditEntryDto } from "@/api/audit";
 import type { IconName } from "@/components/common/Icon";
 import { theme } from "@/theme/theme";
+import { fmtTimestamp } from "@/utils/formatters";
 
 /**
  * What the API sends in place of a protected field's value (credentials, customer identity).
@@ -202,7 +203,7 @@ export function httpLine(
 
 /** Full local timestamp for the expanded detail, where "3h ago" is no longer precise enough. */
 export function formatExactTime(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "medium" });
+  return fmtTimestamp(iso);
 }
 
 /**

--- a/openresto-frontend/utils/bookingMoveNotice.ts
+++ b/openresto-frontend/utils/bookingMoveNotice.ts
@@ -1,3 +1,5 @@
+import { getActiveLocale } from "@/utils/locale";
+
 /**
  * The email an admin sends a guest whose sitting has been moved.
  *
@@ -41,7 +43,7 @@ function formatSitting(iso: string, timezone?: string | null): string {
   };
 
   try {
-    return new Date(iso).toLocaleString(undefined, {
+    return new Date(iso).toLocaleString(getActiveLocale(), {
       ...options,
       ...(timezone ? { timeZone: timezone } : {}),
     });
@@ -49,7 +51,7 @@ function formatSitting(iso: string, timezone?: string | null): string {
     // An unknown IANA id would otherwise throw and take the whole save handler with it. The
     // browser's zone is wrong for a remote location, but it is labelled, and a notice the admin
     // can correct beats no notice at all.
-    return new Date(iso).toLocaleString(undefined, options);
+    return new Date(iso).toLocaleString(getActiveLocale(), options);
   }
 }
 

--- a/openresto-frontend/utils/date.ts
+++ b/openresto-frontend/utils/date.ts
@@ -10,6 +10,8 @@ export function getNowInTimezone(timezone: string): {
   const now = new Date();
   const tz = timezone || "UTC";
   try {
+    // Locale pinned to en-CA (not the active display locale): formatToParts below relies on
+    // en-CA's fixed YYYY-MM-DD part order and 24h hour to parse out date/time components.
     const fmt = new Intl.DateTimeFormat("en-CA", {
       timeZone: tz,
       year: "numeric",
@@ -44,6 +46,9 @@ export function formatCurrentTimeInTimezone(timezone: string): string {
   const now = new Date();
   const tz = timezone || "UTC";
   try {
+    // Locale pinned to en-US: this renders the "currently X there" disambiguation hint next to
+    // a stated IANA zone name (BookingForm), so it stays in one fixed, unambiguous 12h shape
+    // rather than following the viewer's own locale.
     return new Intl.DateTimeFormat("en-US", {
       timeZone: tz,
       hour: "numeric",
@@ -71,6 +76,8 @@ export function convertLocalToUtc(date: string, time: string, timezone: string):
     // Use Intl.DateTimeFormat to find the offset of the target timezone relative to UTC
     // by comparing a "local-looking" parse with its localized output.
     const tempDate = new Date(localStr);
+    // Locale pinned to en-US: the M/D/YYYY, HH:MM:SS shape is re-parsed by `new Date()` below,
+    // so the active display locale can't be used here without breaking that round-trip.
     const targetStr = tempDate.toLocaleString("en-US", { timeZone: tz });
     const targetDate = new Date(targetStr);
     const diff = tempDate.getTime() - targetDate.getTime();
@@ -106,6 +113,8 @@ export function isTodayInTimezone(utcDateStr: string, timezone: string): boolean
     const date = new Date(utcDateStr);
     const tz = timezone || "UTC";
 
+    // Locale pinned to en-US for the same reason as convertLocalToUtc: the output is re-parsed
+    // by `new Date()`, so it must stay in a shape that constructor reliably understands.
     const nowInTz = new Date(new Date().toLocaleString("en-US", { timeZone: tz }));
     const dateInTz = new Date(date.toLocaleString("en-US", { timeZone: tz }));
 
@@ -130,6 +139,9 @@ export function isTodayInTimezone(utcDateStr: string, timezone: string): boolean
 export function minutesInTimezone(iso: string, timezone: string): number {
   const tz = timezone || "UTC";
   try {
+    // Locale pinned to en-US: only `formatToParts`'s "hour"/"minute" part types are read below,
+    // so the locale itself is irrelevant to the result — pinning avoids a locale that renders
+    // the hour/minute parts in an unexpected order or script.
     const parts = new Intl.DateTimeFormat("en-US", {
       timeZone: tz,
       hour: "2-digit",

--- a/openresto-frontend/utils/formatters.ts
+++ b/openresto-frontend/utils/formatters.ts
@@ -1,10 +1,12 @@
-/**
- * Formats a Date as a short locale-aware label, e.g. "Sat, Apr 18".
- * Uses the runtime locale (undefined first arg) intentionally — users see dates in their
- * own locale, not the restaurant's.
- */
+import { getActiveLocale } from "@/utils/locale";
+
+/** Formats a Date as a short label, e.g. "Sat, Apr 18". */
 export function fmtDate(d: Date): string {
-  return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+  return d.toLocaleDateString(getActiveLocale(), {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
 }
 
 /** fmtDate for a YYYY-MM-DD string; noon avoids timezone rollover to an adjacent day. */
@@ -12,10 +14,8 @@ export function fmtDateString(yyyyMmDd: string): string {
   return fmtDate(new Date(yyyyMmDd + "T12:00:00"));
 }
 
-/**
- * Formats a Date as a naive YYYY-MM-DD string (no timezone offset). Used for query params
- * where the backend reinterprets the date in the restaurant's timezone.
- */
+/** Formats a Date as a naive YYYY-MM-DD string (no timezone offset). Used for query params
+ * where the backend reinterprets the date in the restaurant's timezone. */
 export function isoDate(d: Date): string {
   const year = d.getFullYear();
   const month = String(d.getMonth() + 1).padStart(2, "0");
@@ -23,15 +23,83 @@ export function isoDate(d: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-/** Compact relative timestamp: "just now", "5m ago", "3h ago", "2d ago". */
+/** Formats a Date as a time, e.g. "19:30" or "7:30 PM" depending on locale. */
+export function fmtTime(d: Date): string {
+  return d.toLocaleTimeString(getActiveLocale(), { hour: "2-digit", minute: "2-digit" });
+}
+
+/** Compact date + time, e.g. "Sat, Apr 18, 7:30 PM". */
+export function fmtDateTime(d: Date): string {
+  return d.toLocaleString(getActiveLocale(), {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Date + time in a specific IANA timezone rather than the viewer's own, e.g. for a sitting
+ * displayed against the restaurant's clock. */
+export function fmtDateTimeInZone(iso: string, timezone: string): string {
+  return new Date(iso).toLocaleString(getActiveLocale(), {
+    timeZone: timezone,
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Formats a Date as an abbreviated weekday, e.g. "Sat". */
+export function fmtWeekday(d: Date): string {
+  return d.toLocaleDateString(getActiveLocale(), { weekday: "short" });
+}
+
+/** Formats a Date as month + day, e.g. "Apr 18". */
+export function fmtMonthDay(d: Date): string {
+  return d.toLocaleDateString(getActiveLocale(), { month: "short", day: "numeric" });
+}
+
+/** Formats a Date as a full date, e.g. "Saturday, 18 April 2025". */
+export function fmtLongDate(d: Date): string {
+  return d.toLocaleDateString(getActiveLocale(), {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+/** Formats a Date as a bare year, e.g. "2025". */
+export function fmtYear(d: Date): string {
+  return d.toLocaleDateString(getActiveLocale(), { year: "numeric" });
+}
+
+/** Full local timestamp for an ISO instant, e.g. "Apr 18, 2025, 7:30:00 PM". */
+export function fmtTimestamp(iso: string): string {
+  return new Date(iso).toLocaleString(getActiveLocale(), {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  });
+}
+
+/** Formats a number with locale-appropriate thousands grouping. */
+export function fmtNumber(n: number): string {
+  return n.toLocaleString(getActiveLocale());
+}
+
+/** Compact relative timestamp: "now", "5m ago", "3h ago", "2d ago" (localized). */
 export function relativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
   const mins = Math.floor(diff / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
+  const rtf = new Intl.RelativeTimeFormat(getActiveLocale(), { numeric: "auto", style: "narrow" });
+  if (mins < 1) return rtf.format(0, "second");
+  if (mins < 60) return rtf.format(-mins, "minute");
   const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
+  if (hrs < 24) return rtf.format(-hrs, "hour");
+  return rtf.format(-Math.floor(hrs / 24), "day");
 }
 
 /**

--- a/openresto-frontend/utils/locale.ts
+++ b/openresto-frontend/utils/locale.ts
@@ -1,0 +1,10 @@
+let activeLocale: string | undefined;
+
+/** The locale display formatters should use. `undefined` means "follow the device". */
+export function getActiveLocale(): string | undefined {
+  return activeLocale;
+}
+
+export function setActiveLocale(locale: string | undefined): void {
+  activeLocale = locale;
+}

--- a/openresto-frontend/utils/notifications.ts
+++ b/openresto-frontend/utils/notifications.ts
@@ -1,5 +1,6 @@
 import { theme } from "@/theme/theme";
 import type { NotificationType } from "@/api/notifications";
+import { fmtDateTime } from "@/utils/formatters";
 
 /** Decodes a VAPID public key (base64url) into a Uint8Array for PushManager.subscribe. */
 export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
@@ -20,13 +21,7 @@ export { relativeTime } from "@/utils/formatters";
 
 /** Locale-aware booking date for notification meta lines. */
 export function formatBookingDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    weekday: "short",
-    day: "numeric",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return fmtDateTime(new Date(iso));
 }
 
 export const PAGE_SIZE = 20;

--- a/openresto-frontend/utils/restaurantTime.ts
+++ b/openresto-frontend/utils/restaurantTime.ts
@@ -23,6 +23,8 @@ const WEEKDAY_TO_ISO: Record<string, number> = {
 export function getRestaurantNow(timezone: string): { totalMins: number; isoDay: number } {
   try {
     const now = new Date();
+    // Locale pinned to en-US: only the "hour"/"minute"/"weekday" part types are read below, and
+    // WEEKDAY_TO_ISO expects English weekday names, so the locale itself must stay fixed.
     const parts = new Intl.DateTimeFormat("en-US", {
       timeZone: timezone,
       hour: "numeric",
@@ -48,6 +50,8 @@ export function getRestaurantNow(timezone: string): { totalMins: number; isoDay:
 export function getRestaurantDate(timezone: string): string {
   try {
     const now = new Date();
+    // Locale pinned to en-US: only the "year"/"month"/"day" part types are read below, so the
+    // locale itself is irrelevant to the result — pinning keeps the part values numeric.
     const parts = new Intl.DateTimeFormat("en-US", {
       timeZone: timezone,
       year: "numeric",


### PR DESCRIPTION
## Summary

Ticket A of the Translation epic (#368) — a pure refactor with no i18n in it, mergeable on its own and independent of every other ticket in the epic. 32 call sites formatted dates/times inline with `toLocaleDateString(undefined, ...)` / `toLocaleTimeString([], ...)`, which follows the *device* locale. Once the app owns its own language (later tickets), every one of those becomes a bug: a French UI on a US laptop would still print `Mon, Aug 24`.

## Related issue

Closes #369 (part of #368)

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- Adds `utils/locale.ts`: a single `getActiveLocale()`/`setActiveLocale()` seam. Nothing calls `setActiveLocale` yet — a later ticket wires it to i18next. `undefined` means "follow the device", so this ships with zero visual change.
- Expands `utils/formatters.ts` with `fmtTime`, `fmtDateTime`, `fmtDateTimeInZone`, `fmtWeekday`, `fmtMonthDay`, `fmtLongDate`, `fmtYear`, `fmtTimestamp`, `fmtNumber`, consolidating the bespoke `Intl` options objects the 32 call sites used into one shared set. Where two call sites used slightly different options for the same concept (e.g. one screen forcing 24h time, another not), they're now unified on one shared formatter rather than getting a ninth variant.
- Reimplements `relativeTime` on `Intl.RelativeTimeFormat` (`numeric: "auto"`, `style: "narrow"`) instead of hardcoded English strings — output changes from `"just now"` → `"now"`, and `"1d ago"` → `"yesterday"` for exactly one day, since `numeric: "auto"` substitutes the natural word. Updated the handful of tests asserting that literal text.
- Repoints all 32 call sites (`app/admin/dashboard.tsx`, `BookingDetailsCard`, `BookingsCardList`, `BookingsWideTable`, `bookingRowProps`, `RestaurantActionModal`, `EmailFailuresList`, `ScheduleConflictsPanel`, `app/admin/locations.tsx`, `RecentBookingsList`, `BookingFactsBand`, `DatePicker`/`DatePicker.web`, `LocationsFilterBar`, `utils/notifications.ts`, `utils/bookingMoveNotice.ts`, `utils/audit.ts`) to the shared formatters.
- Leaves the genuine parsers in `utils/date.ts` and `utils/restaurantTime.ts` untouched — they pin `en-US`/`en-CA` deliberately because they parse the formatted output (extracting date parts, doing timezone math) rather than display it. Added a short comment on each stating the invariant, and a regression test proving each stays correct with `setActiveLocale("fr")` set.

## Testing

- [x] Frontend tests pass locally (`npm test`: 193 suites / 2830 tests)
- [x] `npm run check` passes (prettier + oxlint; only pre-existing warnings remain, unrelated to this diff)
- [ ] CI passes (build, migration-check)
- [x] Verified `grep -rn 'toLocale' app components utils hooks` returns only the pinned parsers (`utils/date.ts`) plus the new seam itself (`utils/formatters.ts`, `utils/bookingMoveNotice.ts`), all routed through `getActiveLocale()`

## Migrations

- [ ] This PR includes a database migration

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed (not applicable — no API/docs change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaRLJ7wLmg8tX3GzTtKLZd)_