### PR TITLE
i18n G: attach stable error codes to backend responses

### DIFF
--- a/OpenRestoApi.Tests/Infrastructure/GlobalExceptionHandlerTests.cs
+++ b/OpenRestoApi.Tests/Infrastructure/GlobalExceptionHandlerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using OpenRestoApi.Core.Application.Exceptions;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Infrastructure.Exceptions;
 
 namespace OpenRestoApi.Tests.Infrastructure;
@@ -238,5 +239,83 @@ public class GlobalExceptionHandlerTests
         Assert.True(doc.RootElement.TryGetProperty("message", out JsonElement msg));
         Assert.Equal(JsonValueKind.String, msg.ValueKind);
         Assert.Equal("bad input", msg.GetString());
+    }
+
+    // ── i18n G: error codes (#375) ──────────────────────────────────────────
+
+    [Fact]
+    public async Task ExceptionWithCode_SurfacesCodeInResponseBody()
+    {
+        GlobalExceptionHandler handler = CreateHandler();
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(
+            ctx, new ConflictException("Bookings are paused until 18:00. Please choose a later time.") { Code = ErrorCodes.BookingPaused }, default);
+
+        ctx.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        Assert.True(doc.RootElement.TryGetProperty("code", out JsonElement code));
+        Assert.Equal(ErrorCodes.BookingPaused, code.GetString());
+        Assert.Equal("Bookings are paused until 18:00. Please choose a later time.",
+            doc.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task ExceptionWithoutCode_OmitsCodePropertyEntirely()
+    {
+        // Additive-only guard: an unmigrated throw site (Code left null) must not grow a
+        // "code": null field on the wire, or any snapshot that only ever saw "message" shifts.
+        GlobalExceptionHandler handler = CreateHandler();
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(ctx, new ValidationException("Password must be at least 6 characters."), default);
+
+        ctx.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        Assert.False(doc.RootElement.TryGetProperty("code", out _));
+    }
+
+    [Fact]
+    public async Task UntypedException_OmitsCodeProperty()
+    {
+        // A non-OpenRestoException (the untyped 500 fallback) has no Code to surface at all.
+        GlobalExceptionHandler handler = CreateHandler();
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(ctx, new InvalidOperationException("boom"), default);
+
+        ctx.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        Assert.False(doc.RootElement.TryGetProperty("code", out _));
+    }
+
+    // Pins that a representative sample of throw sites migrated for #375 still produce the
+    // exact pre-migration English message — the whole point of the ticket is that `message`
+    // never moves, only `code` is added alongside it. Each case uses the exact exception type
+    // the real throw site uses, so this also pins the status-code mapping stayed put.
+    public static IEnumerable<object[]> MigratedThrowSites =>
+    [
+        [new NotFoundException("Restaurant not found.") { Code = ErrorCodes.RestaurantNotFound }, (int)HttpStatusCode.NotFound],
+        [new ConflictException("This table is already booked for that time.") { Code = ErrorCodes.BookingTableConflict }, (int)HttpStatusCode.Conflict],
+        [new ConflictException("Cannot create a booking in the past.") { Code = ErrorCodes.BookingPastDate }, (int)HttpStatusCode.Conflict],
+        [new ConflictException("No tables are available for the requested time and party size.") { Code = ErrorCodes.BookingNoTablesAvailable }, (int)HttpStatusCode.Conflict],
+        [new BusinessRuleException("You cannot deactivate your own account.") { Code = ErrorCodes.UserCannotDeactivateSelf }, (int)HttpStatusCode.BadRequest],
+        [new ValidationException("A combinable table group must have at least two members.") { Code = ErrorCodes.TableGroupMinMembers }, (int)HttpStatusCode.BadRequest],
+    ];
+
+    [Theory]
+    [MemberData(nameof(MigratedThrowSites))]
+    public async Task MigratedThrowSite_MessageStaysByteIdentical_CodeAddedAlongside(OpenRestoException exception, int expectedStatus)
+    {
+        GlobalExceptionHandler handler = CreateHandler();
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(ctx, exception, default);
+
+        Assert.Equal(expectedStatus, ctx.Response.StatusCode);
+        ctx.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        Assert.Equal(exception.Message, doc.RootElement.GetProperty("message").GetString());
+        Assert.Equal(exception.Code, doc.RootElement.GetProperty("code").GetString());
     }
 }

--- a/OpenRestoApi/Controllers/AdminController.cs
+++ b/OpenRestoApi/Controllers/AdminController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenRestoApi.Core.Application.DTOs;
+using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Application.Utilities;
 
@@ -72,7 +73,7 @@ public class AdminController(AdminService adminService) : ControllerBase
     {
         if (string.IsNullOrWhiteSpace(req.Name))
         {
-            return BadRequest(new MessageResponse { Message = "Name is required." });
+            throw new ValidationException("Name is required.") { Code = ErrorCodes.RestaurantNameRequired };
         }
 
         RestaurantDto result = await _adminService.CreateRestaurantAsync(req.Name, req.Address);
@@ -148,7 +149,7 @@ public class AdminController(AdminService adminService) : ControllerBase
         return result switch
         {
             null => NotFound(),
-            false => BadRequest(new MessageResponse { Message = "sectionIds must include exactly the restaurant's current sections, with no duplicates." }),
+            false => BadRequest(new MessageResponse { Message = "sectionIds must include exactly the restaurant's current sections, with no duplicates.", Code = ErrorCodes.RestaurantSectionIdsMismatch }),
             true => NoContent(),
         };
     }
@@ -157,9 +158,11 @@ public class AdminController(AdminService adminService) : ControllerBase
     public async Task<IActionResult> GetTables(int restaurantId)
     {
         List<SectionDto>? result = await _adminService.GetTablesAsync(restaurantId);
-        return result == null
-            ? NotFound(new MessageResponse { Message = "Restaurant not found or has no sections." })
-            : Ok(result);
+        if (result == null)
+        {
+            throw new NotFoundException("Restaurant not found or has no sections.") { Code = ErrorCodes.RestaurantNoSections };
+        }
+        return Ok(result);
     }
 
     [HttpPost("bookings/{id}/email")]
@@ -176,14 +179,14 @@ public class AdminController(AdminService adminService) : ControllerBase
             return result.Status switch
             {
                 SendBookingEmailStatus.NotFound => NotFound(),
-                SendBookingEmailStatus.MissingFields => BadRequest(new MessageResponse { Message = "Subject and body are required." }),
-                SendBookingEmailStatus.NoCustomerEmail => BadRequest(new MessageResponse { Message = "Customer email is not available." }),
+                SendBookingEmailStatus.MissingFields => BadRequest(new MessageResponse { Message = "Subject and body are required.", Code = ErrorCodes.BookingEmailFieldsRequired }),
+                SendBookingEmailStatus.NoCustomerEmail => BadRequest(new MessageResponse { Message = "Customer email is not available.", Code = ErrorCodes.BookingNoCustomerEmail }),
                 _ => Ok(new MessageResponse { Message = $"Email sent to {result.Recipient}." })
             };
         }
         catch (Exception ex)
         {
-            return BadRequest(new MessageResponse { Message = $"Failed to send: {ex.Message}" });
+            return BadRequest(new MessageResponse { Message = $"Failed to send: {ex.Message}", Code = ErrorCodes.BookingEmailSendFailed });
         }
     }
 

--- a/OpenRestoApi/Controllers/AuthController.cs
+++ b/OpenRestoApi/Controllers/AuthController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using OpenRestoApi.Core.Application.DTOs;
+using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Interfaces;
 using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Application.Utilities;
@@ -111,7 +112,7 @@ public class AuthController(
     public async Task<IActionResult> SetupPvq([FromBody] SetupPvqRequest req)
     {
         if (string.IsNullOrWhiteSpace(req.Question) || string.IsNullOrWhiteSpace(req.Answer))
-            return BadRequest(new { message = "Question and answer are required." });
+            throw new ValidationException("Question and answer are required.") { Code = ErrorCodes.AuthPvqFieldsRequired };
 
         await _securityQuestions.SetupAsync(req.Question, req.Answer);
         return Ok(new { message = "Security question configured." });
@@ -123,7 +124,7 @@ public class AuthController(
         PvqVerifyOutcome outcome = await _securityQuestions.VerifyAsync(req.Email, req.Answer);
         return outcome.Status switch
         {
-            PvqVerifyStatus.NotConfigured => BadRequest(new { message = "Security question not configured for this account." }),
+            PvqVerifyStatus.NotConfigured => throw new ValidationException("Security question not configured for this account.") { Code = ErrorCodes.AuthPvqNotConfigured },
             PvqVerifyStatus.WrongAnswer => Unauthorized(new { message = "Incorrect answer." }),
             _ => Ok(new { resetToken = outcome.ResetToken })
         };
@@ -135,7 +136,7 @@ public class AuthController(
         // ValidationException (short password) → 400 is mapped by GlobalExceptionHandler.
         bool ok = await _authService.ResetPasswordAsync(req.ResetToken, req.NewPassword);
         if (!ok)
-            return BadRequest(new { message = "Invalid or expired reset token." });
+            throw new ValidationException("Invalid or expired reset token.") { Code = ErrorCodes.AuthInvalidResetToken };
         return Ok(new { message = "Password reset successfully." });
     }
 }

--- a/OpenRestoApi/Controllers/BookingsController.cs
+++ b/OpenRestoApi/Controllers/BookingsController.cs
@@ -41,13 +41,13 @@ namespace OpenRestoApi.Controllers
         {
             if (string.IsNullOrWhiteSpace(email))
             {
-                return BadRequest(new { message = "Email is required to look up a booking." });
+                return BadRequest(new MessageResponse { Message = "Email is required to look up a booking.", Code = ErrorCodes.BookingLookupEmailRequired });
             }
 
             BookingDto? booking = await _bookingService.GetBookingByRefAsync(bookingRef);
             if (booking == null || !string.Equals(booking.CustomerEmail, email.Trim(), StringComparison.OrdinalIgnoreCase))
             {
-                return NotFound(new { message = "No booking found matching that reference and email." });
+                return NotFound(new MessageResponse { Message = "No booking found matching that reference and email.", Code = ErrorCodes.BookingLookupNotFound });
             }
             return Ok(booking);
         }
@@ -118,7 +118,7 @@ namespace OpenRestoApi.Controllers
         {
             if (string.IsNullOrWhiteSpace(req.Email))
             {
-                return BadRequest(new { message = "Email is required to cancel a booking." });
+                return BadRequest(new MessageResponse { Message = "Email is required to cancel a booking.", Code = ErrorCodes.BookingCancelEmailRequired });
             }
 
             // ConflictException (past booking) → 409 is mapped by GlobalExceptionHandler;
@@ -126,7 +126,7 @@ namespace OpenRestoApi.Controllers
             bool ok = await _bookingService.CancelBookingAsync(bookingRef, req.Email);
             if (!ok)
             {
-                return NotFound(new { message = "No booking found matching that reference and email." });
+                return NotFound(new MessageResponse { Message = "No booking found matching that reference and email.", Code = ErrorCodes.BookingLookupNotFound });
             }
             return NoContent();
         }

--- a/OpenRestoApi/Controllers/EmailSettingsController.cs
+++ b/OpenRestoApi/Controllers/EmailSettingsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
@@ -68,11 +69,11 @@ public class EmailSettingsController(EmailSettingsService emailSettings) : Contr
             bool ok = await _emailSettings.TestConnectionAsync();
             return ok
                 ? Ok(new { message = "Connection successful." })
-                : BadRequest(new { message = "Email is not configured." });
+                : BadRequest(new MessageResponse { Message = "Email is not configured.", Code = ErrorCodes.EmailNotConfigured });
         }
         catch (Exception ex)
         {
-            return BadRequest(new { message = $"Connection failed: {ex.Message}" });
+            return BadRequest(new MessageResponse { Message = $"Connection failed: {ex.Message}", Code = ErrorCodes.EmailConnectionFailed });
         }
     }
 }

--- a/OpenRestoApi/Controllers/HoldsController.cs
+++ b/OpenRestoApi/Controllers/HoldsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Interfaces;
 using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Controllers;
@@ -45,7 +46,8 @@ public class HoldsController(
             {
                 return BadRequest(new MessageResponse
                 {
-                    Message = "Specify either TableId or TableGroupId, not both."
+                    Message = "Specify either TableId or TableGroupId, not both.",
+                    Code = ErrorCodes.HoldAmbiguousGroupAndTable
                 });
             }
 
@@ -57,7 +59,8 @@ public class HoldsController(
         {
             return BadRequest(new MessageResponse
             {
-                Message = "Specify both TableId and SectionId, or omit both for auto-assign."
+                Message = "Specify both TableId and SectionId, or omit both for auto-assign.",
+                Code = ErrorCodes.BookingAmbiguousTableSelection
             });
         }
 
@@ -67,9 +70,9 @@ public class HoldsController(
 
         return policy.Status switch
         {
-            HoldPolicyStatus.NotFound => NotFound(new MessageResponse { Message = "Restaurant not found." }),
-            HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage! }),
-            HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage! }),
+            HoldPolicyStatus.NotFound => NotFound(new MessageResponse { Message = "Restaurant not found.", Code = policy.Code }),
+            HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
+            HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
             _ => autoAssign
                 ? await PlaceAutoAssignedHold(request, policy)
                 : PlaceEligibleHold(request, policy)
@@ -89,24 +92,25 @@ public class HoldsController(
         {
             return policy.Status switch
             {
-                HoldPolicyStatus.NotFound => NotFound(new MessageResponse { Message = "Restaurant not found." }),
-                HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage! }),
-                HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage! }),
-                _ => BadRequest(new MessageResponse { Message = "Hold not available." })
+                HoldPolicyStatus.NotFound => NotFound(new MessageResponse { Message = "Restaurant not found.", Code = policy.Code }),
+                HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
+                HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
+                _ => BadRequest(new MessageResponse { Message = "Hold not available.", Code = ErrorCodes.HoldUnavailable })
             };
         }
 
         TableGroup? group = await _tableGroupRepository.GetByIdWithMembersAsync(request.TableGroupId!.Value, request.RestaurantId);
         if (group == null)
         {
-            return NotFound(new MessageResponse { Message = "Table group not found." });
+            return NotFound(new MessageResponse { Message = "Table group not found.", Code = ErrorCodes.TableGroupNotFound });
         }
 
         if (request.Seats <= 0)
         {
             return BadRequest(new MessageResponse
             {
-                Message = "Seats is required for a group hold so the server can validate combined capacity."
+                Message = "Seats is required for a group hold so the server can validate combined capacity.",
+                Code = ErrorCodes.HoldGroupSeatsRequired
             });
         }
 
@@ -114,7 +118,8 @@ public class HoldsController(
         {
             return Conflict(new MessageResponse
             {
-                Message = $"This group only has {group.CombinedSeats} combined seats, but {request.Seats} guests were requested."
+                Message = $"This group only has {group.CombinedSeats} combined seats, but {request.Seats} guests were requested.",
+                Code = ErrorCodes.TableGroupSeatsExceeded
             });
         }
 
@@ -123,14 +128,15 @@ public class HoldsController(
         {
             return Conflict(new MessageResponse
             {
-                Message = $"This group has {group.CombinedSeats} combined seats, which is too large for a party of {request.Seats}."
+                Message = $"This group has {group.CombinedSeats} combined seats, which is too large for a party of {request.Seats}.",
+                Code = ErrorCodes.TableGroupOversizeCap
             });
         }
 
         var memberIds = group.Members.Select(m => m.TableId).ToList();
         if (memberIds.Count == 0)
         {
-            return Conflict(new MessageResponse { Message = "This table group has no members." });
+            return Conflict(new MessageResponse { Message = "This table group has no members.", Code = ErrorCodes.TableGroupNoMembers });
         }
 
         int sectionId = group.Members.OrderBy(m => m.TableId).First().Table?.SectionId ?? 0;
@@ -148,7 +154,8 @@ public class HoldsController(
         {
             return Conflict(new MessageResponse
             {
-                Message = "One of the combined tables is already held by another user. Please try again shortly."
+                Message = "One of the combined tables is already held by another user. Please try again shortly.",
+                Code = ErrorCodes.TableGroupHoldConflict
             });
         }
 
@@ -172,7 +179,7 @@ public class HoldsController(
 
         if (result == null)
         {
-            return Conflict(new MessageResponse { Message = "This table is already held by another user. Please select a different table or try again shortly." });
+            return Conflict(new MessageResponse { Message = "This table is already held by another user. Please select a different table or try again shortly.", Code = ErrorCodes.BookingTableHeld });
         }
 
         return Ok(new HoldResponse
@@ -188,7 +195,8 @@ public class HoldsController(
         {
             return BadRequest(new MessageResponse
             {
-                Message = "Seats is required for auto-assign so the server can pick a table that fits your party."
+                Message = "Seats is required for auto-assign so the server can pick a table that fits your party.",
+                Code = ErrorCodes.HoldAutoAssignSeatsRequired
             });
         }
 
@@ -199,7 +207,8 @@ public class HoldsController(
         {
             return Conflict(new MessageResponse
             {
-                Message = "No tables are available for the requested time and party size."
+                Message = "No tables are available for the requested time and party size.",
+                Code = ErrorCodes.BookingNoTablesAvailable
             });
         }
 
@@ -214,7 +223,8 @@ public class HoldsController(
         {
             return Conflict(new MessageResponse
             {
-                Message = "All suitable tables are currently being held by other users. Please try again shortly."
+                Message = "All suitable tables are currently being held by other users. Please try again shortly.",
+                Code = ErrorCodes.BookingAllTablesHeld
             });
         }
 

--- a/OpenRestoApi/Controllers/MediaController.cs
+++ b/OpenRestoApi/Controllers/MediaController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using OpenRestoApi.Core.Application.DTOs;
 using OpenRestoApi.Core.Application.Services;
 using OpenRestoApi.Core.Application.Utilities;
 
@@ -25,10 +26,10 @@ public class MediaController(MediaService mediaService) : ControllerBase
     public async Task<IActionResult> UploadHero(IFormFile file)
     {
         if (!_allowedTypes.Contains(file.ContentType))
-            return BadRequest(new { message = "Only JPEG, PNG, and WebP images are accepted." });
+            return BadRequest(new MessageResponse { Message = "Only JPEG, PNG, and WebP images are accepted.", Code = ErrorCodes.MediaUnsupportedImageType });
 
         if (file.Length > _maxHeroBytes)
-            return BadRequest(new { message = "Hero image must be under 5 MB." });
+            return BadRequest(new MessageResponse { Message = "Hero image must be under 5 MB.", Code = ErrorCodes.MediaHeroTooLarge });
 
         await using Stream stream = file.OpenReadStream();
         string url = await _mediaService.UploadHeroAsync(stream, file.ContentType);
@@ -47,10 +48,10 @@ public class MediaController(MediaService mediaService) : ControllerBase
     public async Task<IActionResult> UploadLocation(int id, IFormFile file)
     {
         if (!_allowedTypes.Contains(file.ContentType))
-            return BadRequest(new { message = "Only JPEG, PNG, and WebP images are accepted." });
+            return BadRequest(new MessageResponse { Message = "Only JPEG, PNG, and WebP images are accepted.", Code = ErrorCodes.MediaUnsupportedImageType });
 
         if (file.Length > _maxLocationBytes)
-            return BadRequest(new { message = "Location image must be under 2 MB." });
+            return BadRequest(new MessageResponse { Message = "Location image must be under 2 MB.", Code = ErrorCodes.MediaLocationImageTooLarge });
 
         await using Stream stream = file.OpenReadStream();
         string? url = await _mediaService.UploadLocationAsync(id, stream, file.ContentType);
@@ -71,10 +72,10 @@ public class MediaController(MediaService mediaService) : ControllerBase
     public async Task<IActionResult> UploadMenu(int id, IFormFile file)
     {
         if (file.ContentType != _menuContentType)
-            return BadRequest(new { message = "Only PDF menu files are accepted." });
+            return BadRequest(new MessageResponse { Message = "Only PDF menu files are accepted.", Code = ErrorCodes.MediaUnsupportedMenuType });
 
         if (file.Length > _maxMenuBytes)
-            return BadRequest(new { message = "Menu file must be under 10 MB." });
+            return BadRequest(new MessageResponse { Message = "Menu file must be under 10 MB.", Code = ErrorCodes.MediaMenuTooLarge });
 
         await using Stream stream = file.OpenReadStream();
         string? url = await _mediaService.UploadMenuAsync(id, stream);

--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using OpenRestoApi.Core.Application.Utilities;
 
 namespace OpenRestoApi.Core.Application.DTOs;
@@ -202,6 +203,14 @@ public class AdminRestaurantPatchRequest
 public class MessageResponse
 {
     public string Message { get; set; } = null!;
+
+    /// <summary>
+    /// Stable machine-readable identifier for the rule behind <see cref="Message"/> (see
+    /// <see cref="ErrorCodes"/>). Additive: omitted from the JSON entirely when null, so existing
+    /// response snapshots that only ever saw "message" do not shift.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Code { get; set; }
 }
 
 public class PvqStatusDto

--- a/OpenRestoApi/Core/Application/Exceptions/OpenRestoExceptions.cs
+++ b/OpenRestoApi/Core/Application/Exceptions/OpenRestoExceptions.cs
@@ -13,6 +13,13 @@ namespace OpenRestoApi.Core.Application.Exceptions;
 [Serializable]
 public abstract class OpenRestoException : Exception
 {
+    /// <summary>
+    /// Stable machine-readable identifier for the specific rule that rejected the request, e.g.
+    /// "booking.paused" (see <see cref="Utilities.ErrorCodes"/>). Nullable so throw sites not yet
+    /// migrated to a code keep compiling.
+    /// </summary>
+    public string? Code { get; init; }
+
     protected OpenRestoException() { }
     protected OpenRestoException(string message) : base(message) { }
     protected OpenRestoException(string message, Exception inner) : base(message, inner) { }

--- a/OpenRestoApi/Core/Application/Interfaces/IHoldPolicyService.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IHoldPolicyService.cs
@@ -1,3 +1,4 @@
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Core.Application.Interfaces;
@@ -18,17 +19,20 @@ public enum HoldPolicyStatus { Eligible, NotFound, Rejected, Booked }
 /// <summary>
 /// Eligible holds carry the resolved <see cref="Restaurant"/> and the timezone-normalized
 /// UTC booking date so the caller can place the hold without re-fetching. Rejected/Booked/
-/// NotFound results carry <see cref="FailureMessage"/> instead.
+/// NotFound results carry <see cref="FailureMessage"/> instead, plus the matching
+/// <see cref="ErrorCodes"/> value in <see cref="Code"/> — this service never throws for an
+/// expected policy violation, so the code has to travel on the result rather than on an exception.
 /// </summary>
 public record HoldPolicyResult(
     HoldPolicyStatus Status,
     Restaurant? Restaurant = null,
     DateTime BookingDate = default,
-    string? FailureMessage = null)
+    string? FailureMessage = null,
+    string? Code = null)
 {
-    public static HoldPolicyResult NotFound() => new(HoldPolicyStatus.NotFound);
-    public static HoldPolicyResult Rejected(string message) => new(HoldPolicyStatus.Rejected, FailureMessage: message);
-    public static HoldPolicyResult Booked(string message) => new(HoldPolicyStatus.Booked, FailureMessage: message);
+    public static HoldPolicyResult NotFound() => new(HoldPolicyStatus.NotFound, Code: ErrorCodes.RestaurantNotFound);
+    public static HoldPolicyResult Rejected(string message, string? code = null) => new(HoldPolicyStatus.Rejected, FailureMessage: message, Code: code);
+    public static HoldPolicyResult Booked(string message, string? code = null) => new(HoldPolicyStatus.Booked, FailureMessage: message, Code: code);
     public static HoldPolicyResult Eligible(Restaurant restaurant, DateTime bookingDate)
         => new(HoldPolicyStatus.Eligible, restaurant, bookingDate);
 }

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -187,11 +187,11 @@ public class AdminService(
     public virtual async Task<BookingDetailDto> CreateBookingAsync(AdminCreateBookingRequest req)
     {
         Table table = await _tableRepository.GetWithSectionRestaurantAsync(req.TableId, req.SectionId)
-            ?? throw new ValidationException("Table not found in the specified section.");
+            ?? throw new ValidationException("Table not found in the specified section.") { Code = ErrorCodes.BookingTableNotInSection };
 
         if (table.Section!.RestaurantId != req.RestaurantId)
         {
-            throw new ValidationException("Section does not belong to this restaurant.");
+            throw new ValidationException("Section does not belong to this restaurant.") { Code = ErrorCodes.BookingSectionMismatch };
         }
 
         DateTime newStart = TimeZoneHelper.ConvertLocalToUtc(req.Date, table.Section.Restaurant!.Timezone);
@@ -203,12 +203,12 @@ public class AdminService(
 
         if (conflict)
         {
-            throw new ConflictException("This table already has a booking that overlaps with the requested time.");
+            throw new ConflictException("This table already has a booking that overlaps with the requested time.") { Code = ErrorCodes.BookingTableConflict };
         }
 
         if (req.Seats > table.Seats)
         {
-            throw new ConflictException($"This table only has {table.Seats} seats, but {req.Seats} guests were requested.");
+            throw new ConflictException($"This table only has {table.Seats} seats, but {req.Seats} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded };
         }
 
         var booking = new Booking
@@ -277,7 +277,7 @@ public class AdminService(
 
         if (!booking.IsCancelled && !booking.CanBeCancelledAt(DateTime.UtcNow))
         {
-            throw new ConflictException("Cannot cancel a booking that has already passed.");
+            throw new ConflictException("Cannot cancel a booking that has already passed.") { Code = ErrorCodes.BookingAlreadyPast };
         }
 
         booking.IsCancelled = true;
@@ -320,7 +320,7 @@ public class AdminService(
 
         if (!booking.IsCancelled)
         {
-            throw new BusinessRuleException("Booking is already active.");
+            throw new BusinessRuleException("Booking is already active.") { Code = ErrorCodes.BookingAlreadyActive };
         }
 
         booking.IsCancelled = false;
@@ -349,7 +349,7 @@ public class AdminService(
             Restaurant? newRestaurant = await _restaurantRepository.FindByIdAsync(req.RestaurantId.Value);
             if (newRestaurant == null)
             {
-                throw new ValidationException("Invalid restaurant.");
+                throw new ValidationException("Invalid restaurant.") { Code = ErrorCodes.RestaurantNotFound };
             }
             booking.RestaurantId = req.RestaurantId.Value;
             restaurant = newRestaurant;
@@ -363,14 +363,14 @@ public class AdminService(
 
             if (table == null)
             {
-                throw new ValidationException("Invalid table for this restaurant.");
+                throw new ValidationException("Invalid table for this restaurant.") { Code = ErrorCodes.BookingInvalidTableForRestaurant };
             }
             booking.TableId = req.TableId.Value;
             booking.SectionId = table.SectionId;
         }
         else if (req.SectionId.HasValue && req.SectionId.Value != booking.SectionId)
         {
-            throw new ValidationException("Provide tableId when reassigning to a different section.");
+            throw new ValidationException("Provide tableId when reassigning to a different section.") { Code = ErrorCodes.BookingTableIdRequiredForSectionChange };
         }
 
         if (req.Date.HasValue && req.Date.Value != booking.Date)
@@ -393,7 +393,7 @@ public class AdminService(
                 Table? currentTable = await _tableRepository.FindByIdAsync(resolvedTableId.Value);
                 if (currentTable != null && req.Seats.Value > currentTable.Seats)
                 {
-                    throw new BusinessRuleException($"This table only has {currentTable.Seats} seats, but {req.Seats.Value} guests were requested.");
+                    throw new BusinessRuleException($"This table only has {currentTable.Seats} seats, but {req.Seats.Value} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded };
                 }
             }
             booking.Seats = req.Seats.Value;
@@ -521,7 +521,7 @@ public class AdminService(
 
         if (taken)
         {
-            throw new BusinessRuleException("This update would cause a conflict with an existing booking.");
+            throw new BusinessRuleException("This update would cause a conflict with an existing booking.") { Code = ErrorCodes.BookingMoveConflict };
         }
     }
 
@@ -704,7 +704,8 @@ public class AdminService(
         if (!restaurant.IsArchived)
         {
             throw new BusinessRuleException(
-                "Archive this location before deleting it. Archiving takes it off the public site and can be undone; deleting cannot.");
+                "Archive this location before deleting it. Archiving takes it off the public site and can be undone; deleting cannot.")
+            { Code = ErrorCodes.RestaurantArchiveBeforeDelete };
         }
 
         // Cascade-delete all bookings for this restaurant (cancelled and active alike), then the restaurant row,

--- a/OpenRestoApi/Core/Application/Services/AuthService.cs
+++ b/OpenRestoApi/Core/Application/Services/AuthService.cs
@@ -83,11 +83,11 @@ public class AuthService(
         if (cred == null || !CredentialHelper.VerifyPassword(cred, currentPassword, _passwordService))
             return null;
         if (string.Equals(normalizedEmail, cred.Email, StringComparison.OrdinalIgnoreCase))
-            throw new BusinessRuleException("New email must be different from the current email.");
+            throw new BusinessRuleException("New email must be different from the current email.") { Code = ErrorCodes.AuthEmailUnchanged };
 
         AdminCredential? existing = await _credentialRepository.GetByEmailAsync(normalizedEmail);
         if (existing != null && existing.Id != cred.Id)
-            throw new BusinessRuleException("That email address is already in use.");
+            throw new BusinessRuleException("That email address is already in use.") { Code = ErrorCodes.AuthEmailAlreadyInUse };
 
         string previousEmail = cred.Email;
         cred.Email = normalizedEmail;

--- a/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
+++ b/OpenRestoApi/Core/Application/Services/AvailabilityService.cs
@@ -18,7 +18,7 @@ public sealed class AvailabilityService(
     public async Task<AvailabilityResponseDto> GetAvailabilityAsync(int restaurantId, DateTime bookingDate, int seats)
     {
         Restaurant? restaurant = await _restaurantRepository.GetByIdAsync(restaurantId)
-            ?? throw new NotFoundException("Restaurant not found.");
+            ?? throw new NotFoundException("Restaurant not found.") { Code = ErrorCodes.RestaurantNotFound };
 
         TimeZoneInfo tz = TimeZoneHelper.Resolve(restaurant.Timezone);
 

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -33,7 +33,7 @@ public class BookingService(
     public virtual async Task<BookingDto> CreateBookingAsync(BookingDto bookingDto)
     {
         Restaurant restaurant = await _restaurantRepository.GetByIdAsync(bookingDto.RestaurantId)
-            ?? throw new NotFoundException("Restaurant not found.");
+            ?? throw new NotFoundException("Restaurant not found.") { Code = ErrorCodes.RestaurantNotFound };
 
         // An Unspecified date is the restaurant's local time; every check below runs on UTC.
         DateTime bookingDate = TimeZoneHelper.ConvertLocalToUtc(bookingDto.Date, restaurant.Timezone);
@@ -51,7 +51,7 @@ public class BookingService(
             bool ambiguousSelection = bookingDto.TableId is null ^ bookingDto.SectionId is null;
             if (ambiguousSelection)
             {
-                throw new ValidationException("Specify both TableId and SectionId, or neither for auto-assign.");
+                throw new ValidationException("Specify both TableId and SectionId, or neither for auto-assign.") { Code = ErrorCodes.BookingAmbiguousTableSelection };
             }
 
             await ResolveAutoAssignAsync(bookingDto, restaurant, bookingDate);
@@ -70,7 +70,7 @@ public class BookingService(
             tableId, tableGroupId: null, bookingDate, restaurant.DefaultBookingDurationMinutes);
         if (alreadyBooked)
         {
-            throw new ConflictException("This table is already booked for that time.");
+            throw new ConflictException("This table is already booked for that time.") { Code = ErrorCodes.BookingTableConflict };
         }
 
         bool heldByOther = _holdService.IsTableHeld(
@@ -78,7 +78,7 @@ public class BookingService(
             durationMinutes: restaurant.DefaultBookingDurationMinutes);
         if (heldByOther)
         {
-            throw new ConflictException("This table is currently being held by another user. Please try again shortly.");
+            throw new ConflictException("This table is currently being held by another user. Please try again shortly.") { Code = ErrorCodes.BookingTableHeld };
         }
 
         Table? table = await _tableRepository.GetByIdAsync(tableId);
@@ -115,19 +115,20 @@ public class BookingService(
     {
         if (bookingDate < DateTime.UtcNow.AddMinutes(-Booking.CancellationGraceMinutes))
         {
-            throw new ConflictException("Cannot create a booking in the past.");
+            throw new ConflictException("Cannot create a booking in the past.") { Code = ErrorCodes.BookingPastDate };
         }
 
         if (restaurant.IsPausedFor(bookingDate))
         {
-            throw new ConflictException(PauseHelper.RejectionMessage(restaurant));
+            throw new ConflictException(PauseHelper.RejectionMessage(restaurant)) { Code = ErrorCodes.BookingPaused };
         }
 
         if (restaurant.IsWalkInOnlyAt(bookingDate))
         {
             throw new ConflictException(restaurant.WalkInOnly
                 ? "This location accepts walk-ins only and does not take online bookings."
-                : "This location accepts walk-ins only on the selected day. Please choose another day or just come in.");
+                : "This location accepts walk-ins only on the selected day. Please choose another day or just come in.")
+            { Code = restaurant.WalkInOnly ? ErrorCodes.BookingWalkInOnly : ErrorCodes.BookingWalkInOnlyToday };
         }
     }
 
@@ -140,7 +141,8 @@ public class BookingService(
         if (seats < BookingLimits.MinSeats || seats > BookingLimits.MaxSeats)
         {
             throw new ValidationException(
-                $"Party size must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.");
+                $"Party size must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.")
+            { Code = ErrorCodes.BookingPartySizeOutOfRange };
         }
     }
 
@@ -153,13 +155,14 @@ public class BookingService(
 
         if (seats > table.Seats)
         {
-            throw new ConflictException($"This table only has {table.Seats} seats, but {seats} guests were requested.");
+            throw new ConflictException($"This table only has {table.Seats} seats, but {seats} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded };
         }
 
         if (restaurant?.ExceedsOversizeCap(table.Seats, seats) == true)
         {
             throw new ConflictException(
-                $"This table has {table.Seats} seats, which is too large for a party of {seats}.");
+                $"This table has {table.Seats} seats, which is too large for a party of {seats}.")
+            { Code = ErrorCodes.TableOversizeCap };
         }
     }
 
@@ -196,7 +199,7 @@ public class BookingService(
 
         if (candidates.Count == 0)
         {
-            throw new ConflictException("No tables are available for the requested time and party size.");
+            throw new ConflictException("No tables are available for the requested time and party size.") { Code = ErrorCodes.BookingNoTablesAvailable };
         }
 
         AutoAssignResult assigned = _holdService.PlaceAutoHold(
@@ -205,7 +208,7 @@ public class BookingService(
             bookingDate,
             currentHoldId: bookingDto.HoldId,
             restaurant.DefaultBookingDurationMinutes)
-            ?? throw new ConflictException("All suitable tables are currently being held by other users. Please try again shortly.");
+            ?? throw new ConflictException("All suitable tables are currently being held by other users. Please try again shortly.") { Code = ErrorCodes.BookingAllTablesHeld };
 
         if (assigned.IsGroup)
         {
@@ -282,7 +285,7 @@ public class BookingService(
     private async Task<BookingDto> CreateGroupBookingAsync(BookingDto bookingDto, Restaurant restaurant, DateTime bookingDate)
     {
         TableGroup group = await _tableGroupRepository.GetByIdWithMembersAsync(bookingDto.TableGroupId!.Value, restaurant.Id)
-            ?? throw new NotFoundException("The selected table group no longer exists.");
+            ?? throw new NotFoundException("The selected table group no longer exists.") { Code = ErrorCodes.TableGroupNotFound };
 
         RejectIfGroupCannotSeat(group, restaurant, bookingDto.Seats);
 
@@ -296,14 +299,14 @@ public class BookingService(
             tableId: null, tableGroupId: group.Id, bookingDate, durationMinutes);
         if (groupConflict)
         {
-            throw new ConflictException("One of the combined tables is already booked for that time.");
+            throw new ConflictException("One of the combined tables is already booked for that time.") { Code = ErrorCodes.TableGroupBookingConflict };
         }
 
         bool anyMemberHeldByOther = memberIds.Any(id => _holdService.IsTableHeld(
             id, bookingDate, excludeHoldId: bookingDto.HoldId, durationMinutes: durationMinutes));
         if (anyMemberHeldByOther)
         {
-            throw new ConflictException("One of the combined tables is currently being held by another user. Please try again shortly.");
+            throw new ConflictException("One of the combined tables is currently being held by another user. Please try again shortly.") { Code = ErrorCodes.TableGroupHoldConflict };
         }
 
         Booking booking = _mapper.ToEntity(bookingDto);
@@ -336,19 +339,21 @@ public class BookingService(
         // unit, and its stored CombinedSeats no longer describes anything real.
         if (group.Members.Count < 2)
         {
-            throw new ConflictException("These tables can no longer be combined. Please pick another time or table.");
+            throw new ConflictException("These tables can no longer be combined. Please pick another time or table.") { Code = ErrorCodes.TableGroupDisbanded };
         }
 
         if (seats > group.CombinedSeats)
         {
             throw new ConflictException(
-                $"This group only has {group.CombinedSeats} combined seats, but {seats} guests were requested.");
+                $"This group only has {group.CombinedSeats} combined seats, but {seats} guests were requested.")
+            { Code = ErrorCodes.TableGroupSeatsExceeded };
         }
 
         if (restaurant.ExceedsOversizeCap(group.CombinedSeats, seats))
         {
             throw new ConflictException(
-                $"This group has {group.CombinedSeats} combined seats, which is too large for a party of {seats}.");
+                $"This group has {group.CombinedSeats} combined seats, which is too large for a party of {seats}.")
+            { Code = ErrorCodes.TableGroupOversizeCap };
         }
     }
 
@@ -423,7 +428,7 @@ public class BookingService(
 
         if (!booking.CanBeCancelledAt(DateTime.UtcNow))
         {
-            throw new ConflictException("Cannot cancel a booking that has already passed.");
+            throw new ConflictException("Cannot cancel a booking that has already passed.") { Code = ErrorCodes.BookingAlreadyPast };
         }
 
         booking.IsCancelled = true;

--- a/OpenRestoApi/Core/Application/Services/BrandService.cs
+++ b/OpenRestoApi/Core/Application/Services/BrandService.cs
@@ -77,17 +77,17 @@ public class BrandService(
     {
         if (appName != null && appName.Length > 32)
         {
-            throw new ValidationException("App name cannot exceed 32 characters.");
+            throw new ValidationException("App name cannot exceed 32 characters.") { Code = ErrorCodes.BrandAppNameTooLong };
         }
 
         if (primaryColor != null && !IsValidHexColor(primaryColor))
         {
-            throw new ValidationException("Invalid primary color hex code.");
+            throw new ValidationException("Invalid primary color hex code.") { Code = ErrorCodes.BrandPrimaryColorInvalid };
         }
 
         if (accentColor != null && !IsValidHexColor(accentColor))
         {
-            throw new ValidationException("Invalid accent color hex code.");
+            throw new ValidationException("Invalid accent color hex code.") { Code = ErrorCodes.BrandAccentColorInvalid };
         }
 
         // Blank clears the icon (the picker's deselect); a non-blank value must be one we can draw.
@@ -95,27 +95,27 @@ public class BrandService(
             && !string.IsNullOrWhiteSpace(faviconIcon)
             && LucideIconPaths.Get(faviconIcon) == null)
         {
-            throw new ValidationException("Invalid favicon icon.");
+            throw new ValidationException("Invalid favicon icon.") { Code = ErrorCodes.BrandFaviconInvalid };
         }
 
         if (copyrightText != null && copyrightText.Length > 200)
         {
-            throw new ValidationException("Copyright text cannot exceed 200 characters.");
+            throw new ValidationException("Copyright text cannot exceed 200 characters.") { Code = ErrorCodes.BrandCopyrightTooLong };
         }
 
         if (subtitle != null && subtitle.Length > 160)
         {
-            throw new ValidationException("Subtitle cannot exceed 160 characters.");
+            throw new ValidationException("Subtitle cannot exceed 160 characters.") { Code = ErrorCodes.BrandSubtitleTooLong };
         }
 
         if (highlightsHeading != null && highlightsHeading.Length > 60)
         {
-            throw new ValidationException("Highlights heading cannot exceed 60 characters.");
+            throw new ValidationException("Highlights heading cannot exceed 60 characters.") { Code = ErrorCodes.BrandHighlightsHeadingTooLong };
         }
 
         if (highlightsSubheading != null && highlightsSubheading.Length > 60)
         {
-            throw new ValidationException("Highlights subheading cannot exceed 60 characters.");
+            throw new ValidationException("Highlights subheading cannot exceed 60 characters.") { Code = ErrorCodes.BrandHighlightsSubheadingTooLong };
         }
 
         // Empty string clears the fit (falls back to the default "Cover"); a non-empty value
@@ -125,7 +125,8 @@ public class BrandService(
             && !AllowedHeaderImageFits.Contains(headerImageFit))
         {
             throw new ValidationException(
-                $"HeaderImageFit must be one of: {string.Join(", ", AllowedHeaderImageFits.Order())}.");
+                $"HeaderImageFit must be one of: {string.Join(", ", AllowedHeaderImageFits.Order())}.")
+            { Code = ErrorCodes.BrandHeaderImageFitInvalid };
         }
 
         BrandSettings? brand = await _brandRepository.GetAsync();

--- a/OpenRestoApi/Core/Application/Services/HighlightService.cs
+++ b/OpenRestoApi/Core/Application/Services/HighlightService.cs
@@ -114,23 +114,23 @@ public class HighlightService(IHighlightRepository highlightRepository, IAuditSc
         title = (rawTitle ?? string.Empty).Trim();
         if (title.Length == 0)
         {
-            throw new ValidationException("Highlight title cannot be empty.");
+            throw new ValidationException("Highlight title cannot be empty.") { Code = ErrorCodes.HighlightTitleRequired };
         }
         if (title.Length > MaxTitleLength)
         {
-            throw new ValidationException($"Highlight title cannot exceed {MaxTitleLength} characters.");
+            throw new ValidationException($"Highlight title cannot exceed {MaxTitleLength} characters.") { Code = ErrorCodes.HighlightTitleTooLong };
         }
 
         body = (rawBody ?? string.Empty).Trim();
         if (body.Length > MaxBodyLength)
         {
-            throw new ValidationException($"Highlight body cannot exceed {MaxBodyLength} characters.");
+            throw new ValidationException($"Highlight body cannot exceed {MaxBodyLength} characters.") { Code = ErrorCodes.HighlightBodyTooLong };
         }
 
         iconKey = (rawIconKey ?? string.Empty).Trim();
         if (!IoniconsAllowList.AllIcons.Contains(iconKey))
         {
-            throw new ValidationException("Icon key must be one of the supported icons.");
+            throw new ValidationException("Icon key must be one of the supported icons.") { Code = ErrorCodes.IconInvalid };
         }
 
         link = NormalizeLink(rawLink);
@@ -152,7 +152,8 @@ public class HighlightService(IHighlightRepository highlightRepository, IAuditSc
         if (!UrlValidator.IsValid(trimmed, UrlValidator.WebAndContactSchemes))
         {
             throw new ValidationException(
-                "Highlight link must be a valid absolute URL (http, https, mailto, tel, or sms).");
+                "Highlight link must be a valid absolute URL (http, https, mailto, tel, or sms).")
+            { Code = ErrorCodes.HighlightLinkInvalid };
         }
         return trimmed;
     }

--- a/OpenRestoApi/Core/Application/Services/HoldPolicyService.cs
+++ b/OpenRestoApi/Core/Application/Services/HoldPolicyService.cs
@@ -33,7 +33,7 @@ public sealed class HoldPolicyService(
             tableId, bookingDate, restaurant.DefaultBookingDurationMinutes);
         if (alreadyBooked)
         {
-            return HoldPolicyResult.Booked("This table is already booked for that time.");
+            return HoldPolicyResult.Booked("This table is already booked for that time.", ErrorCodes.BookingTableConflict);
         }
 
         return restaurantPolicy;
@@ -69,27 +69,29 @@ public sealed class HoldPolicyService(
         // 3. Past-date guard (same 5-min tolerance as booking create/cancel).
         if (bookingDate < DateTime.UtcNow.AddMinutes(-Booking.CancellationGraceMinutes))
         {
-            return HoldPolicyResult.Rejected("Cannot hold a table for a past time.");
+            return HoldPolicyResult.Rejected("Cannot hold a table for a past time.", ErrorCodes.BookingPastDate);
         }
 
         // 4. Pause window — scoped to the sittings inside it, not to every future date.
         if (restaurant.IsPausedFor(bookingDate))
         {
-            return HoldPolicyResult.Rejected(PauseHelper.RejectionMessage(restaurant));
+            return HoldPolicyResult.Rejected(PauseHelper.RejectionMessage(restaurant), ErrorCodes.BookingPaused);
         }
 
         // 5. Walk-in-only policy (location-wide or per ISO day).
         if (restaurant.IsWalkInOnlyAt(bookingDate))
         {
-            return HoldPolicyResult.Rejected(restaurant.WalkInOnly
-                ? "This location accepts walk-ins only and does not take online bookings."
-                : "This location accepts walk-ins only on the selected day.");
+            return HoldPolicyResult.Rejected(
+                restaurant.WalkInOnly
+                    ? "This location accepts walk-ins only and does not take online bookings."
+                    : "This location accepts walk-ins only on the selected day.",
+                restaurant.WalkInOnly ? ErrorCodes.BookingWalkInOnly : ErrorCodes.BookingWalkInOnlyToday);
         }
 
         // 6. Operating hours / open days.
         if (!restaurant.IsOpenAt(bookingDate))
         {
-            return HoldPolicyResult.Rejected("The restaurant is closed at the requested time.");
+            return HoldPolicyResult.Rejected("The restaurant is closed at the requested time.", ErrorCodes.RestaurantClosedAtTime);
         }
 
         return HoldPolicyResult.Eligible(restaurant, bookingDate);

--- a/OpenRestoApi/Core/Application/Services/OpeningHoursHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/OpeningHoursHelper.cs
@@ -77,18 +77,18 @@ public static class OpeningHoursHelper
         {
             if (entry.Day < 1 || entry.Day > 7)
             {
-                throw new ValidationException("OpenHours entries must use ISO day numbers 1 (Monday) through 7 (Sunday).");
+                throw new ValidationException("OpenHours entries must use ISO day numbers 1 (Monday) through 7 (Sunday).") { Code = ErrorCodes.RestaurantOpenHoursDayInvalid };
             }
 
             if (byDay.ContainsKey(entry.Day))
             {
-                throw new ValidationException($"OpenHours contains more than one entry for day {entry.Day}.");
+                throw new ValidationException($"OpenHours contains more than one entry for day {entry.Day}.") { Code = ErrorCodes.RestaurantOpenHoursDuplicateDay };
             }
 
             if (!TryParseTime(entry.Open, out int openH, out int openM)
                 || !TryParseTime(entry.Close, out int closeH, out int closeM))
             {
-                throw new ValidationException("OpenHours times must be valid HH:mm values (00:00–23:59).");
+                throw new ValidationException("OpenHours times must be valid HH:mm values (00:00–23:59).") { Code = ErrorCodes.RestaurantOpenHoursTimeInvalid };
             }
 
             byDay[entry.Day] = new DayHours

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -41,7 +41,8 @@ public class RestaurantManagementService(
             || char.IsDigit(value.Trim().FirstOrDefault()))
         {
             throw new ValidationException(
-                $"BookingRefFormat must be one of: {string.Join(", ", Enum.GetNames<BookingRefFormat>())}.");
+                $"BookingRefFormat must be one of: {string.Join(", ", Enum.GetNames<BookingRefFormat>())}.")
+            { Code = ErrorCodes.RestaurantBookingRefFormatInvalid };
         }
 
         return parsed;
@@ -135,7 +136,8 @@ public class RestaurantManagementService(
                 if (!isServedMenuFile && !UrlValidator.IsValid(trimmed, UrlValidator.WebSchemes))
                 {
                     throw new ValidationException(
-                        "Menu URL must be a valid absolute http(s) URL.");
+                        "Menu URL must be a valid absolute http(s) URL.")
+                    { Code = ErrorCodes.RestaurantMenuUrlInvalid };
                 }
                 r.MenuUrl = trimmed;
             }
@@ -183,7 +185,8 @@ public class RestaurantManagementService(
             if (!_allowedBookingDurationsMinutes.Contains(req.DefaultBookingDurationMinutes.Value))
             {
                 throw new ValidationException(
-                    $"DefaultBookingDurationMinutes must be one of: {string.Join(", ", _allowedBookingDurationsMinutes.Order())}.");
+                    $"DefaultBookingDurationMinutes must be one of: {string.Join(", ", _allowedBookingDurationsMinutes.Order())}.")
+                { Code = ErrorCodes.RestaurantDurationInvalid };
             }
 
             r.DefaultBookingDurationMinutes = req.DefaultBookingDurationMinutes.Value;
@@ -194,7 +197,8 @@ public class RestaurantManagementService(
             if (!_allowedBookingSlotIntervalsMinutes.Contains(req.BookingSlotIntervalMinutes.Value))
             {
                 throw new ValidationException(
-                    $"BookingSlotIntervalMinutes must be one of: {string.Join(", ", _allowedBookingSlotIntervalsMinutes.Order())}.");
+                    $"BookingSlotIntervalMinutes must be one of: {string.Join(", ", _allowedBookingSlotIntervalsMinutes.Order())}.")
+                { Code = ErrorCodes.RestaurantSlotIntervalInvalid };
             }
 
             r.BookingSlotIntervalMinutes = req.BookingSlotIntervalMinutes.Value;
@@ -204,7 +208,7 @@ public class RestaurantManagementService(
         // field, so a conditional write would make selecting "Off" unable to clear a set cap.
         if (req.MaxTableOversizeSeats.HasValue && req.MaxTableOversizeSeats.Value < 0)
         {
-            throw new ValidationException("MaxTableOversizeSeats must be zero or greater, or null to disable.");
+            throw new ValidationException("MaxTableOversizeSeats must be zero or greater, or null to disable.") { Code = ErrorCodes.RestaurantOversizeCapInvalid };
         }
 
         r.MaxTableOversizeSeats = req.MaxTableOversizeSeats;
@@ -492,7 +496,8 @@ public class RestaurantManagementService(
         if (seats < BookingLimits.MinSeats || seats > BookingLimits.MaxSeats)
         {
             throw new ValidationException(
-                $"Seats must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.");
+                $"Seats must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.")
+            { Code = ErrorCodes.TableSeatsOutOfRange };
         }
     }
 
@@ -512,7 +517,8 @@ public class RestaurantManagementService(
         if (combinedSeats > memberSeatsSum)
         {
             throw new ValidationException(
-                $"CombinedSeats ({combinedSeats}) cannot exceed the sum of member seats ({memberSeatsSum}).");
+                $"CombinedSeats ({combinedSeats}) cannot exceed the sum of member seats ({memberSeatsSum}).")
+            { Code = ErrorCodes.TableGroupCombinedSeatsExceedsSum };
         }
 
         int largestMemberSeats = members.Max(t => t.Seats);
@@ -520,7 +526,8 @@ public class RestaurantManagementService(
         {
             throw new ValidationException(
                 $"CombinedSeats ({combinedSeats}) must be more than the largest member table ({largestMemberSeats}). "
-                + "combining these tables would not seat a bigger party.");
+                + "combining these tables would not seat a bigger party.")
+            { Code = ErrorCodes.TableGroupCombinedSeatsNotWorthCombining };
         }
     }
 
@@ -768,19 +775,19 @@ public class RestaurantManagementService(
     {
         if (memberIds == null || memberIds.Count < 2)
         {
-            throw new ValidationException("A combinable table group must have at least two members.");
+            throw new ValidationException("A combinable table group must have at least two members.") { Code = ErrorCodes.TableGroupMinMembers };
         }
 
         if (memberIds.Distinct().Count() != memberIds.Count)
         {
-            throw new ValidationException("A combinable table group cannot list the same table twice.");
+            throw new ValidationException("A combinable table group cannot list the same table twice.") { Code = ErrorCodes.TableGroupDuplicateMember };
         }
 
         // Load candidate members scoped to the restaurant via the section→restaurant chain.
         List<Table> tables = await _tableRepository.GetManyForRestaurantAsync(memberIds, restaurantId);
         if (tables.Count != memberIds.Count)
         {
-            throw new ValidationException("All member tables must exist and belong to this restaurant.");
+            throw new ValidationException("All member tables must exist and belong to this restaurant.") { Code = ErrorCodes.TableGroupInvalidMembers };
         }
 
         // Reject any member already claimed by a *different* group. A table in the group being edited
@@ -801,7 +808,8 @@ public class RestaurantManagementService(
             if (tableIdToGroup.TryGetValue(t.Id, out int ownerGroupId))
             {
                 throw new ValidationException(
-                    $"Table {t.Id} already belongs to another combinable group ({ownerGroupId}).");
+                    $"Table {t.Id} already belongs to another combinable group ({ownerGroupId}).")
+                { Code = ErrorCodes.TableGroupMemberAlreadyGrouped };
             }
         }
 

--- a/OpenRestoApi/Core/Application/Services/SecurityQuestionsService.cs
+++ b/OpenRestoApi/Core/Application/Services/SecurityQuestionsService.cs
@@ -40,7 +40,7 @@ public sealed class SecurityQuestionsService(
     public async Task SetupAsync(string question, string answer)
     {
         AdminCredential cred = await ResolveCurrentUserAsync()
-            ?? throw new NotFoundException("No account matches the signed-in session.");
+            ?? throw new NotFoundException("No account matches the signed-in session.") { Code = ErrorCodes.AuthNoAccountForSession };
         (cred.PvqAnswerHash, cred.PvqAnswerSalt) = _passwordService.Hash(NormaliseAnswer(answer));
         cred.PvqQuestion = question.Trim();
         await _credentialRepository.SaveChangesAsync();

--- a/OpenRestoApi/Core/Application/Services/SocialLinkService.cs
+++ b/OpenRestoApi/Core/Application/Services/SocialLinkService.cs
@@ -101,28 +101,29 @@ public class SocialLinkService(ISocialLinkRepository socialLinkRepository, IAudi
         label = (rawLabel ?? string.Empty).Trim();
         if (label.Length == 0)
         {
-            throw new ValidationException("Social link label cannot be empty.");
+            throw new ValidationException("Social link label cannot be empty.") { Code = ErrorCodes.SocialLinkLabelRequired };
         }
         if (label.Length > MaxLabelLength)
         {
-            throw new ValidationException($"Social link label cannot exceed {MaxLabelLength} characters.");
+            throw new ValidationException($"Social link label cannot exceed {MaxLabelLength} characters.") { Code = ErrorCodes.SocialLinkLabelTooLong };
         }
 
         url = (rawUrl ?? string.Empty).Trim();
         if (url.Length == 0)
         {
-            throw new ValidationException("Social link URL cannot be empty.");
+            throw new ValidationException("Social link URL cannot be empty.") { Code = ErrorCodes.SocialLinkUrlRequired };
         }
         if (!UrlValidator.IsValid(url, UrlValidator.WebAndContactSchemes))
         {
             throw new ValidationException(
-                "Social link URL must be a valid absolute URL (http, https, mailto, tel, or sms).");
+                "Social link URL must be a valid absolute URL (http, https, mailto, tel, or sms).")
+            { Code = ErrorCodes.SocialLinkUrlInvalid };
         }
 
         iconKey = (rawIconKey ?? string.Empty).Trim();
         if (!IoniconsAllowList.AllIcons.Contains(iconKey))
         {
-            throw new ValidationException("Icon key must be one of the supported icons.");
+            throw new ValidationException("Icon key must be one of the supported icons.") { Code = ErrorCodes.IconInvalid };
         }
     }
 }

--- a/OpenRestoApi/Core/Application/Services/UserService.cs
+++ b/OpenRestoApi/Core/Application/Services/UserService.cs
@@ -40,7 +40,7 @@ public class UserService(
 
         if (await _credentialRepository.GetByEmailAsync(email) != null)
         {
-            throw new BusinessRuleException("An account with that email address already exists.");
+            throw new BusinessRuleException("An account with that email address already exists.") { Code = ErrorCodes.UserEmailAlreadyExists };
         }
 
         (string hash, string salt) = _passwordService.Hash(req.Password);
@@ -71,7 +71,7 @@ public class UserService(
             // your access to this very screen, so it takes another Owner to do it to you.
             if (IsSelf(user))
             {
-                throw new BusinessRuleException("You cannot change your own role.");
+                throw new BusinessRuleException("You cannot change your own role.") { Code = ErrorCodes.UserCannotChangeOwnRole };
             }
 
             await EnsureAnotherActiveOwnerRemainsAsync(user, "demote");
@@ -97,7 +97,7 @@ public class UserService(
             {
                 if (IsSelf(user))
                 {
-                    throw new BusinessRuleException("You cannot deactivate your own account.");
+                    throw new BusinessRuleException("You cannot deactivate your own account.") { Code = ErrorCodes.UserCannotDeactivateSelf };
                 }
 
                 await EnsureAnotherActiveOwnerRemainsAsync(user, "deactivate");
@@ -149,7 +149,7 @@ public class UserService(
 
     private async Task<AdminCredential> RequireUserAsync(int id)
         => await _credentialRepository.GetByIdAsync(id)
-            ?? throw new NotFoundException($"User {id} not found.");
+            ?? throw new NotFoundException($"User {id} not found.") { Code = ErrorCodes.UserNotFound };
 
     private bool IsSelf(AdminCredential user)
         => _currentUser.UserId == user.Id
@@ -169,7 +169,8 @@ public class UserService(
         if (activeOwners <= 1)
         {
             throw new BusinessRuleException(
-                $"Cannot {action} the last active {UserRoles.Owner}. Promote another user first.");
+                $"Cannot {action} the last active {UserRoles.Owner}. Promote another user first.")
+            { Code = ErrorCodes.UserLastActiveOwner };
         }
     }
 }

--- a/OpenRestoApi/Core/Application/Services/WalkInHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/WalkInHelper.cs
@@ -50,7 +50,7 @@ public static class WalkInHelper
         {
             if (!int.TryParse(part, out int day) || day < 1 || day > 7)
             {
-                throw new ValidationException("WalkInDays must be a comma-separated list of ISO day numbers 1 (Monday) through 7 (Sunday).");
+                throw new ValidationException("WalkInDays must be a comma-separated list of ISO day numbers 1 (Monday) through 7 (Sunday).") { Code = ErrorCodes.RestaurantWalkInDaysInvalid };
             }
 
             days.Add(day);

--- a/OpenRestoApi/Core/Application/Utilities/ContactFields.cs
+++ b/OpenRestoApi/Core/Application/Utilities/ContactFields.cs
@@ -28,7 +28,8 @@ public static class ContactFields
         if (trimmed.Length > ContactLimits.MaxPhoneLength)
         {
             throw new ValidationException(
-                $"Phone number cannot exceed {ContactLimits.MaxPhoneLength} characters.");
+                $"Phone number cannot exceed {ContactLimits.MaxPhoneLength} characters.")
+            { Code = ErrorCodes.ContactPhoneTooLong };
         }
 
         return trimmed;
@@ -51,12 +52,13 @@ public static class ContactFields
         if (trimmed.Length > ContactLimits.MaxEmailLength)
         {
             throw new ValidationException(
-                $"Email address cannot exceed {ContactLimits.MaxEmailLength} characters.");
+                $"Email address cannot exceed {ContactLimits.MaxEmailLength} characters.")
+            { Code = ErrorCodes.ContactEmailTooLong };
         }
 
         if (!EmailValidator.IsValid(trimmed))
         {
-            throw new ValidationException("Email address must be a valid email address.");
+            throw new ValidationException("Email address must be a valid email address.") { Code = ErrorCodes.ContactEmailInvalid };
         }
 
         return trimmed;

--- a/OpenRestoApi/Core/Application/Utilities/ErrorCodes.cs
+++ b/OpenRestoApi/Core/Application/Utilities/ErrorCodes.cs
@@ -1,0 +1,141 @@
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// Stable, machine-readable identifiers for the specific rule that rejected a request. Surfaced
+/// as <c>OpenRestoException.Code</c> and echoed on <c>MessageResponse.Code</c> alongside the
+/// existing English <c>message</c> — the code is what a client branches on, the message is what
+/// it shows. One constant per distinct rule, not per throw site: two throw sites rejecting for
+/// the same reason share a code, even across different controllers or exception types.
+/// </summary>
+/// <remarks>
+/// Does not cover the ~35 <c>[StringLength]</c>/<c>[Required]</c>-style <c>ErrorMessage</c>
+/// values on request DTOs (e.g. <c>BrandRequest</c>). Model-state validation fails before a
+/// controller action runs, so those never reach <c>GlobalExceptionHandler</c> — giving them a
+/// code is a follow-up epic, not part of #375.
+/// </remarks>
+public static class ErrorCodes
+{
+    // ── Bookings ─────────────────────────────────────────────────────────────
+    public const string BookingPastDate = "booking.past_date";
+    public const string BookingPaused = "booking.paused";
+    public const string BookingWalkInOnly = "booking.walk_in_only";
+    public const string BookingWalkInOnlyToday = "booking.walk_in_only_today";
+    public const string BookingTableConflict = "booking.table_conflict";
+    public const string BookingTableHeld = "booking.table_held";
+    public const string BookingNoTablesAvailable = "booking.no_tables_available";
+    public const string BookingAllTablesHeld = "booking.all_tables_held";
+    public const string BookingAmbiguousTableSelection = "booking.ambiguous_table_selection";
+    public const string BookingPartySizeOutOfRange = "booking.party_size_out_of_range";
+    public const string BookingAlreadyPast = "booking.already_past";
+    public const string BookingAlreadyActive = "booking.already_active";
+    public const string BookingMoveConflict = "booking.move_conflict";
+    public const string BookingTableNotInSection = "booking.table_not_in_section";
+    public const string BookingInvalidTableForRestaurant = "booking.invalid_table_for_restaurant";
+    public const string BookingSectionMismatch = "booking.section_mismatch";
+    public const string BookingTableIdRequiredForSectionChange = "booking.table_id_required_for_section_change";
+    public const string BookingEmailFieldsRequired = "booking.email_fields_required";
+    public const string BookingNoCustomerEmail = "booking.no_customer_email";
+    public const string BookingEmailSendFailed = "booking.email_send_failed";
+    public const string BookingLookupEmailRequired = "booking.lookup_email_required";
+    public const string BookingLookupNotFound = "booking.lookup_not_found";
+    public const string BookingCancelEmailRequired = "booking.cancel_email_required";
+
+    public const string TableSeatsExceeded = "table.seats_exceeded";
+    public const string TableOversizeCap = "table.oversize_cap";
+    public const string TableSeatsOutOfRange = "table.seats_out_of_range";
+
+    public const string TableGroupNotFound = "table_group.not_found";
+    public const string TableGroupBookingConflict = "table_group.booking_conflict";
+    public const string TableGroupHoldConflict = "table_group.hold_conflict";
+    public const string TableGroupDisbanded = "table_group.disbanded";
+    public const string TableGroupSeatsExceeded = "table_group.seats_exceeded";
+    public const string TableGroupOversizeCap = "table_group.oversize_cap";
+    public const string TableGroupNoMembers = "table_group.no_members";
+    public const string TableGroupMinMembers = "table_group.min_members";
+    public const string TableGroupDuplicateMember = "table_group.duplicate_member";
+    public const string TableGroupInvalidMembers = "table_group.invalid_members";
+    public const string TableGroupMemberAlreadyGrouped = "table_group.member_already_grouped";
+    public const string TableGroupCombinedSeatsExceedsSum = "table_group.combined_seats_exceeds_sum";
+    public const string TableGroupCombinedSeatsNotWorthCombining = "table_group.combined_seats_not_worth_combining";
+
+    public const string HoldAmbiguousGroupAndTable = "hold.ambiguous_group_and_table";
+    public const string HoldGroupSeatsRequired = "hold.group_seats_required";
+    public const string HoldAutoAssignSeatsRequired = "hold.auto_assign_seats_required";
+    public const string HoldUnavailable = "hold.unavailable";
+
+    // ── Locations ────────────────────────────────────────────────────────────
+    public const string RestaurantNotFound = "restaurant.not_found";
+    public const string RestaurantNoSections = "restaurant.no_sections";
+    public const string RestaurantNameRequired = "restaurant.name_required";
+    public const string RestaurantArchiveBeforeDelete = "restaurant.archive_before_delete";
+    public const string RestaurantClosedAtTime = "restaurant.closed_at_time";
+    public const string RestaurantDurationInvalid = "restaurant.duration_invalid";
+    public const string RestaurantSlotIntervalInvalid = "restaurant.slot_interval_invalid";
+    public const string RestaurantOversizeCapInvalid = "restaurant.oversize_cap_invalid";
+    public const string RestaurantMenuUrlInvalid = "restaurant.menu_url_invalid";
+    public const string RestaurantBookingRefFormatInvalid = "restaurant.booking_ref_format_invalid";
+    public const string RestaurantWalkInDaysInvalid = "restaurant.walk_in_days_invalid";
+    public const string RestaurantOpenHoursDayInvalid = "restaurant.open_hours_day_invalid";
+    public const string RestaurantOpenHoursDuplicateDay = "restaurant.open_hours_duplicate_day";
+    public const string RestaurantOpenHoursTimeInvalid = "restaurant.open_hours_time_invalid";
+    public const string RestaurantSectionIdsMismatch = "restaurant.section_ids_mismatch";
+
+    // ── Accounts ─────────────────────────────────────────────────────────────
+    public const string UserEmailAlreadyExists = "user.email_already_exists";
+    public const string UserCannotChangeOwnRole = "user.cannot_change_own_role";
+    public const string UserCannotDeactivateSelf = "user.cannot_deactivate_self";
+    public const string UserLastActiveOwner = "user.last_active_owner";
+    public const string UserNotFound = "user.not_found";
+    public const string UserEmailInvalid = "user.email_invalid";
+    public const string UserEmailTooLong = "user.email_too_long";
+    public const string UserDisplayNameTooLong = "user.display_name_too_long";
+    public const string UserPasswordTooShort = "user.password_too_short";
+    public const string UserRoleInvalid = "user.role_invalid";
+
+    public const string AuthEmailUnchanged = "auth.email_unchanged";
+    public const string AuthEmailAlreadyInUse = "auth.email_already_in_use";
+    public const string AuthPvqFieldsRequired = "auth.pvq_fields_required";
+    public const string AuthPvqNotConfigured = "auth.pvq_not_configured";
+    public const string AuthInvalidResetToken = "auth.invalid_reset_token";
+    public const string AuthNoAccountForSession = "auth.no_account_for_session";
+
+    // ── Instance settings ────────────────────────────────────────────────────
+    public const string BrandAppNameTooLong = "brand.app_name_too_long";
+    public const string BrandPrimaryColorInvalid = "brand.primary_color_invalid";
+    public const string BrandAccentColorInvalid = "brand.accent_color_invalid";
+    public const string BrandFaviconInvalid = "brand.favicon_invalid";
+    public const string BrandCopyrightTooLong = "brand.copyright_too_long";
+    public const string BrandSubtitleTooLong = "brand.subtitle_too_long";
+    public const string BrandHighlightsHeadingTooLong = "brand.highlights_heading_too_long";
+    public const string BrandHighlightsSubheadingTooLong = "brand.highlights_subheading_too_long";
+    public const string BrandHeaderImageFitInvalid = "brand.header_image_fit_invalid";
+
+    public const string HighlightTitleRequired = "highlight.title_required";
+    public const string HighlightTitleTooLong = "highlight.title_too_long";
+    public const string HighlightBodyTooLong = "highlight.body_too_long";
+    public const string HighlightLinkInvalid = "highlight.link_invalid";
+
+    public const string SocialLinkLabelRequired = "social_link.label_required";
+    public const string SocialLinkLabelTooLong = "social_link.label_too_long";
+    public const string SocialLinkUrlRequired = "social_link.url_required";
+    public const string SocialLinkUrlInvalid = "social_link.url_invalid";
+
+    /// <summary>Shared by highlights and social links: both validate an icon key against the same allow-list.</summary>
+    public const string IconInvalid = "icon.invalid";
+
+    public const string ContactPhoneTooLong = "contact.phone_too_long";
+    public const string ContactEmailTooLong = "contact.email_too_long";
+    public const string ContactEmailInvalid = "contact.email_invalid";
+
+    // ── Media ────────────────────────────────────────────────────────────────
+    public const string MediaUnsupportedImageType = "media.unsupported_image_type";
+    public const string MediaHeroTooLarge = "media.hero_too_large";
+    public const string MediaLocationImageTooLarge = "media.location_image_too_large";
+    public const string MediaUnsupportedMenuType = "media.unsupported_menu_type";
+    public const string MediaMenuTooLarge = "media.menu_too_large";
+
+    // ── Infrastructure ───────────────────────────────────────────────────────
+    public const string EmailNotConfigured = "email.not_configured";
+    public const string EmailConnectionFailed = "email.connection_failed";
+    public const string AdminPasswordNotConfigured = "admin.password_not_configured";
+}

--- a/OpenRestoApi/Core/Application/Utilities/UserFields.cs
+++ b/OpenRestoApi/Core/Application/Utilities/UserFields.cs
@@ -23,14 +23,15 @@ public static class UserFields
     {
         if (!EmailValidator.IsValid(email))
         {
-            throw new ValidationException("A valid email address is required.");
+            throw new ValidationException("A valid email address is required.") { Code = ErrorCodes.UserEmailInvalid };
         }
 
         string normalized = email!.Trim().ToLowerInvariant();
         if (normalized.Length > ContactLimits.MaxEmailLength)
         {
             throw new ValidationException(
-                $"Email address cannot exceed {ContactLimits.MaxEmailLength} characters.");
+                $"Email address cannot exceed {ContactLimits.MaxEmailLength} characters.")
+            { Code = ErrorCodes.UserEmailTooLong };
         }
 
         return normalized;
@@ -52,7 +53,8 @@ public static class UserFields
         if (trimmed.Length > MaxDisplayNameLength)
         {
             throw new ValidationException(
-                $"Display name cannot exceed {MaxDisplayNameLength} characters.");
+                $"Display name cannot exceed {MaxDisplayNameLength} characters.")
+            { Code = ErrorCodes.UserDisplayNameTooLong };
         }
 
         return trimmed;
@@ -71,7 +73,7 @@ public static class UserFields
     {
         if (string.IsNullOrEmpty(password) || password.Length < MinPasswordLength)
         {
-            throw new ValidationException($"Password must be at least {MinPasswordLength} characters.");
+            throw new ValidationException($"Password must be at least {MinPasswordLength} characters.") { Code = ErrorCodes.UserPasswordTooShort };
         }
     }
 
@@ -80,6 +82,7 @@ public static class UserFields
     {
         return UserRoles.Normalise(role)
             ?? throw new ValidationException(
-                $"Role must be one of: {string.Join(", ", UserRoles.Assignable.Order())}.");
+                $"Role must be one of: {string.Join(", ", UserRoles.Assignable.Order())}.")
+            { Code = ErrorCodes.UserRoleInvalid };
     }
 }

--- a/OpenRestoApi/Infrastructure/Email/EmailService.cs
+++ b/OpenRestoApi/Infrastructure/Email/EmailService.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using MimeKit;
 using OpenRestoApi.Core.Application.Exceptions;
 using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 using OpenRestoApi.Infrastructure.Persistence;
 
@@ -42,7 +43,7 @@ public class EmailService(AppDbContext db, CredentialProtector protector, Func<I
     public async Task SendEmailAsync(string recipient, string subject, string htmlBody)
     {
         EmailSettings settings = await GetSettingsAsync()
-            ?? throw new InfrastructureException("Email is not configured.");
+            ?? throw new InfrastructureException("Email is not configured.") { Code = ErrorCodes.EmailNotConfigured };
 
         var message = new MimeMessage();
         message.From.Add(new MailboxAddress(

--- a/OpenRestoApi/Infrastructure/Exceptions/GlobalExceptionHandler.cs
+++ b/OpenRestoApi/Infrastructure/Exceptions/GlobalExceptionHandler.cs
@@ -48,7 +48,7 @@ public sealed class GlobalExceptionHandler(
 
         httpContext.Response.StatusCode = statusCode;
         await httpContext.Response.WriteAsJsonAsync(
-            new MessageResponse { Message = message },
+            new MessageResponse { Message = message, Code = (exception as OpenRestoException)?.Code },
             cancellationToken);
 
         return true; // marked handled — default ProblemDetails handler is skipped

--- a/OpenRestoApi/Infrastructure/Persistence/AdminBootstrap.cs
+++ b/OpenRestoApi/Infrastructure/Persistence/AdminBootstrap.cs
@@ -40,7 +40,8 @@ public static class AdminBootstrap
         if (string.IsNullOrWhiteSpace(password))
         {
             throw new InfrastructureException(
-                "Admin:Password must be configured before first use. Set it via ADMIN_PASSWORD env var.");
+                "Admin:Password must be configured before first use. Set it via ADMIN_PASSWORD env var.")
+            { Code = ErrorCodes.AdminPasswordNotConfigured };
         }
 
         (string hash, string salt) = passwordService.Hash(password);


### PR DESCRIPTION
## Summary

Implements #375: attaches a stable, machine-readable `code` to every backend error response alongside the existing English `message`, so a client can branch on the specific rule that rejected a request instead of string-matching prose. This is purely additive — no `message` string changed, and `code` is omitted from the JSON entirely when null, so no existing response shape moves. No translation, no frontend changes.

## Acceptance criteria

- [x] `ErrorCodes` exists with one constant per distinct rule
- [x] `OpenRestoException.Code` exists and is nullable
- [x] `MessageResponse.Code` is present and omitted from JSON when null
- [x] Every `message` string in every response is byte-identical to before
- [x] Inline controller error returns converted to typed exceptions where the mapping already exists (and safe to do so — see note below)
- [x] All existing backend tests pass unchanged
- [ ] All E2E specs pass unchanged — not run in this session per instructions; CI will verify. Grepped the e2e specs and frontend `api/` wrappers for anything that could be affected (see Verification below) and found nothing at risk.

## What changed

- **`OpenRestoApi/Core/Application/Exceptions/OpenRestoExceptions.cs`** — `OpenRestoException` gains a nullable `Code { get; init; }`.
- **`OpenRestoApi/Core/Application/DTOs/AdminDto.cs`** — `MessageResponse` gains a nullable `Code`, `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`.
- **`OpenRestoApi/Infrastructure/Exceptions/GlobalExceptionHandler.cs`** — sets `Code = (exception as OpenRestoException)?.Code` on the response.
- **New `OpenRestoApi/Core/Application/Utilities/ErrorCodes.cs`** — flat `public const string`, dotted lowercase, modelled on `AuditActions.cs`, ~99 constants, one per distinct rule (shared across throw sites/exception types/controllers that reject for the same reason).
- **~85 typed exception throw sites** across 14 service/utility files now carry a `Code` (all `BusinessRuleException`, `ValidationException`, `ConflictException`, `NotFoundException`, `InfrastructureException` throws in non-test code).
- **`HoldPolicyResult`** (`IHoldPolicyService.cs`) gained an optional `Code` alongside its existing `FailureMessage` — this service is documented to deliberately never throw for an expected policy violation, so `HoldsController` reads `policy.Code` into the `MessageResponse` it builds.
- **~10 inline controller returns converted to typed exceptions** where doing so is safe (see note); the rest attach `Code` directly to the existing `MessageResponse`/anonymous-object-turned-`MessageResponse` instead, unchanged in status and message.
- **`PauseHelper.RejectionMessage`** callers (`BookingService`, `HoldPolicyService`) now attach `ErrorCodes.BookingPaused` at the throw/reject site; `PauseHelper` itself is untouched.
- **Test**: `OpenRestoApi.Tests/Infrastructure/GlobalExceptionHandlerTests.cs` — added tests only (no existing test edited): a typed exception with a code surfaces `code`; one without a code omits the property entirely; the untyped 500 fallback omits it too; a representative sample of migrated throw sites (`NotFoundException`, `ConflictException` ×3, `BusinessRuleException`, `ValidationException`) pins that both the exact pre-migration `message` and the expected HTTP status are unchanged.

### A note on inline controller returns and unit tests

I initially converted most of the ~22 inline controller returns to `throw new ...Exception(...)`. Several **unit tests call controller actions directly** (`HoldsControllerUnitTests`, `HoldsControllerGroupHoldTests`, `MediaControllerUnitTests`, `BookingsControllerUnitTests`, `AdminControllerSectionsReorderTests`), asserting `Assert.IsType<BadRequestObjectResult>(result)` etc. on the **direct return value** — those calls never go through `GlobalExceptionHandler`, so a `throw` would surface as an unhandled exception instead of a result and break the test. I reverted every conversion that a direct-call unit test exercises back to an inline `return BadRequest/Conflict/NotFound(new MessageResponse { Message = "...", Code = ... })` — identical status and message, `Code` attached without changing control flow.

Only 4 conversions to `throw` survived, all confirmed (via `git grep`) to have **no** unit test calling the action directly, only integration tests that do run the full pipeline: `AdminController.CreateRestaurant` ("Name is required."), `AdminController.GetTables` ("Restaurant not found or has no sections."), `AuthController.SetupPvq` ("Question and answer are required."), `AuthController.VerifyPvq`'s `NotConfigured` arm ("Security question not configured for this account."), `AuthController.ResetPassword` ("Invalid or expired reset token.").

`NotificationsController`'s inline returns use `{ error = "..." }` (not `{ message = "..." }`) and were left alone — converting them to `MessageResponse` would change the JSON field name, which is exactly the kind of shape change this ticket is not allowed to make.

## Error codes introduced

<details>
<summary>~99 codes, grouped by area (click to expand)</summary>

| Booking | | Table / Table Group | | Hold |
|---|---|---|---|---|
| `booking.past_date` | `booking.already_active` | `table.seats_exceeded` | `table_group.no_members` | `hold.ambiguous_group_and_table` |
| `booking.paused` | `booking.move_conflict` | `table.oversize_cap` | `table_group.min_members` | `hold.group_seats_required` |
| `booking.walk_in_only` | `booking.table_not_in_section` | `table.seats_out_of_range` | `table_group.duplicate_member` | `hold.auto_assign_seats_required` |
| `booking.walk_in_only_today` | `booking.invalid_table_for_restaurant` | `table_group.not_found` | `table_group.invalid_members` | `hold.unavailable` |
| `booking.table_conflict` | `booking.section_mismatch` | `table_group.booking_conflict` | `table_group.member_already_grouped` | |
| `booking.table_held` | `booking.table_id_required_for_section_change` | `table_group.hold_conflict` | `table_group.combined_seats_exceeds_sum` | |
| `booking.no_tables_available` | `booking.email_fields_required` | `table_group.disbanded` | `table_group.combined_seats_not_worth_combining` | |
| `booking.all_tables_held` | `booking.no_customer_email` | `table_group.seats_exceeded` | | |
| `booking.ambiguous_table_selection` | `booking.email_send_failed` | `table_group.oversize_cap` | | |
| `booking.party_size_out_of_range` | `booking.lookup_email_required` | | | |
| `booking.already_past` | `booking.lookup_not_found` / `booking.cancel_email_required` | | | |

| Location | | Account / Auth | | Brand / Highlight / Social / Contact / Media / Infra |
|---|---|---|---|---|
| `restaurant.not_found` | `restaurant.open_hours_day_invalid` | `user.email_already_exists` | `auth.email_unchanged` | `brand.app_name_too_long` |
| `restaurant.no_sections` | `restaurant.open_hours_duplicate_day` | `user.cannot_change_own_role` | `auth.email_already_in_use` | `brand.primary_color_invalid` / `accent_color_invalid` |
| `restaurant.name_required` | `restaurant.open_hours_time_invalid` | `user.cannot_deactivate_self` | `auth.pvq_fields_required` | `brand.favicon_invalid` |
| `restaurant.archive_before_delete` | `restaurant.section_ids_mismatch` | `user.last_active_owner` | `auth.pvq_not_configured` | `brand.copyright_too_long` / `subtitle_too_long` |
| `restaurant.closed_at_time` | | `user.not_found` | `auth.invalid_reset_token` | `brand.highlights_heading_too_long` / `subheading_too_long` |
| `restaurant.duration_invalid` | | `user.email_invalid` / `email_too_long` | `auth.no_account_for_session` | `brand.header_image_fit_invalid` |
| `restaurant.slot_interval_invalid` | | `user.display_name_too_long` | | `highlight.title_required` / `title_too_long` / `body_too_long` / `link_invalid` |
| `restaurant.oversize_cap_invalid` | | `user.password_too_short` | | `social_link.label_required` / `label_too_long` / `url_required` / `url_invalid` |
| `restaurant.menu_url_invalid` | | `user.role_invalid` | | `icon.invalid` (shared by highlight + social link) |
| `restaurant.booking_ref_format_invalid` | | | | `contact.phone_too_long` / `email_too_long` / `email_invalid` |
| `restaurant.walk_in_days_invalid` | | | | `media.unsupported_image_type` / `hero_too_large` / `location_image_too_large` / `unsupported_menu_type` / `menu_too_large` |
| | | | | `email.not_configured` / `connection_failed`, `admin.password_not_configured` |

</details>

## Verification

```
dotnet build          # 0 errors
dotnet test openresto.sln
# 1769 passed, 0 failed (excluding 4 pre-existing failures below)
```

4 pre-existing failures, unrelated to this change, confirmed by stashing the diff and re-running on `main`: `InitializeDatabaseTests.DiagnoseDbState_LogsFailure_WhenIntegrityCheckReportsCorruption`, `InitializeDatabaseTests.ExistingDirectoryNotWritable_IsLogged_AndInitializationContinues`, `SqlitePragmaInterceptorTests.ApplyPragmas_SwallowsReadOnlyException`, `SqlitePragmaInterceptorTests.ApplyPragmasAsync_SwallowsReadOnlyException` — all Windows-file-locking flakes in Windows-only local test infra, they fail identically with zero diff applied.

Grepped `openresto-frontend/e2e` and `openresto-frontend/api/*.ts` for anything reading `body.message`/`response.message`/`.message` from an error body: every hit uses `.toMatch()`/`.toContain()` on `message` or destructures `body.message` — none asserts exact JSON equality or would be affected by an added `code` field, and every message string in this diff is byte-identical to before, so none of those assertions can have moved.

## Files touched that may be shared with other in-flight work

- **`OpenRestoApi/Core/Application/Services/BrandService.cs`** — only touches the 9 existing `ValidationException` throws inside `SaveAsync` (app-name/color/favicon/copyright/subtitle/highlights-heading/subheading/headerImageFit length & format checks), each gaining `{ Code = ErrorCodes.X }`. No new methods, nothing near `GetWebsiteUrl`/`GetWebsiteUrlAsync`.
- **`OpenRestoApi/Core/Application/Interfaces/IHoldPolicyService.cs`**, **`.../Services/HoldPolicyService.cs`**, **`OpenRestoApi/Controllers/HoldsController.cs`** — additive `Code` field on `HoldPolicyResult` and its three rejection factories.

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBauSPz51qiGQtzs27nvmr
