### PR TITLE
i18n F1: translate admin bookings and dashboard

### DIFF
--- a/openresto-frontend/app/admin/bookings/index.tsx
+++ b/openresto-frontend/app/admin/bookings/index.tsx
@@ -1,4 +1,5 @@
 import { ThemedText } from "@/components/themed-text";
+import { useTranslation } from "react-i18next";
 import Button from "@/components/common/Button";
 import {
   getAdminBookings,
@@ -48,6 +49,7 @@ import { Icon } from "@/components/common/Icon";
 type ViewMode = "timetable" | "list";
 
 export default function AdminBookingsScreen() {
+  const { t } = useTranslation();
   const [restaurants, setRestaurants] = useState<RestaurantDto[]>([]);
   const [selectedRestaurantId, setSelectedRestaurantId] = useState<number | null>(null);
   const [persistedRestaurantId, setPersistedRestaurantId] = usePersistedState<number | null>(
@@ -295,10 +297,10 @@ export default function AdminBookingsScreen() {
               viewMode === "timetable"
                 ? fmtDate(gridDate)
                 : statusFilter === "past"
-                  ? "Past Bookings"
+                  ? t("admin.bookings.screenTitle.past")
                   : statusFilter === "cancelled"
-                    ? "Cancelled Bookings"
-                    : "Live Bookings",
+                    ? t("admin.bookings.screenTitle.cancelled")
+                    : t("admin.bookings.screenTitle.live"),
           }}
         />
       )}
@@ -306,14 +308,20 @@ export default function AdminBookingsScreen() {
       <View style={styles.pageHeader}>
         <View style={{ flex: 1 }}>
           <ThemedText style={styles.pageTitle}>
-            {searchQuery ? "Search Results" : "Bookings"}
+            {searchQuery ? t("admin.bookings.searchResultsTitle") : t("admin.bookings.pageTitle")}
           </ThemedText>
           <ThemedText style={[styles.pageSub, { color: mutedColor }]}>
             {searchQuery
-              ? `${bookings.length} result${bookings.length !== 1 ? "s" : ""} for "${searchQuery}"`
+              ? t("admin.bookings.searchResultsCount", {
+                  count: bookings.length,
+                  query: searchQuery,
+                })
               : viewMode === "timetable"
                 ? fmtDate(gridDate)
-                : `${bookings.length} total · ${todayCount} today`}
+                : t("admin.bookings.totalTodaySummary", {
+                    total: bookings.length,
+                    today: todayCount,
+                  })}
           </ThemedText>
         </View>
 
@@ -341,18 +349,18 @@ export default function AdminBookingsScreen() {
               size="md"
               icon="close-outline"
               onPress={() => router.replace("/admin/bookings")}
-              accessibilityLabel="Clear search"
+              accessibilityLabel={t("admin.bookings.clearSearchLabel")}
             >
-              Clear
+              {t("admin.bookings.clearSearch")}
             </Button>
           ) : (
             <Button
               size="md"
               icon="add-outline"
               onPress={() => setShowNewModal(true)}
-              accessibilityLabel="New booking"
+              accessibilityLabel={t("admin.bookings.newBookingLabel")}
             >
-              New Booking
+              {t("admin.bookings.newBooking")}
             </Button>
           )}
         </View>
@@ -395,9 +403,13 @@ export default function AdminBookingsScreen() {
           <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
             {(
               [
-                { key: "active", label: "Active", color: PRIMARY },
-                { key: "past", label: "Past", color: "#7c3aed" },
-                { key: "cancelled", label: "Cancelled", color: theme.status.cancelled.text },
+                { key: "active", label: t("admin.bookings.tabs.active"), color: PRIMARY },
+                { key: "past", label: t("admin.bookings.tabs.past"), color: "#7c3aed" },
+                {
+                  key: "cancelled",
+                  label: t("admin.bookings.tabs.cancelled"),
+                  color: theme.status.cancelled.text,
+                },
               ] as const
             ).map(({ key, label, color }) => (
               <Pressable
@@ -405,7 +417,9 @@ export default function AdminBookingsScreen() {
                 style={[styles.modeBtn, statusFilter === key && { backgroundColor: color }]}
                 onPress={() => setStatusFilter(key)}
                 accessibilityRole="radio"
-                accessibilityLabel={`Show ${label.toLowerCase()} bookings`}
+                accessibilityLabel={t("admin.bookings.tabs.showLabel", {
+                  tab: label.toLowerCase(),
+                })}
                 accessibilityState={{ checked: statusFilter === key }}
               >
                 <ThemedText
@@ -427,7 +441,7 @@ export default function AdminBookingsScreen() {
             style={[styles.modeBtn, viewMode === "timetable" && { backgroundColor: PRIMARY }]}
             onPress={switchToTimetable}
             accessibilityRole="radio"
-            accessibilityLabel="Timetable view"
+            accessibilityLabel={t("admin.bookings.viewToggle.timetableLabel")}
             accessibilityState={{ checked: viewMode === "timetable" }}
           >
             <Icon
@@ -442,7 +456,7 @@ export default function AdminBookingsScreen() {
                   { color: viewMode === "timetable" ? "#fff" : mutedColor },
                 ]}
               >
-                Timetable
+                {t("admin.bookings.viewToggle.timetable")}
               </ThemedText>
             )}
           </Pressable>
@@ -451,7 +465,7 @@ export default function AdminBookingsScreen() {
             style={[styles.modeBtn, viewMode === "list" && { backgroundColor: PRIMARY }]}
             onPress={() => setViewMode("list")}
             accessibilityRole="radio"
-            accessibilityLabel="List view"
+            accessibilityLabel={t("admin.bookings.viewToggle.listLabel")}
             accessibilityState={{ checked: viewMode === "list" }}
           >
             <Icon name="list-outline" size={15} color={viewMode === "list" ? "#fff" : mutedColor} />
@@ -459,7 +473,7 @@ export default function AdminBookingsScreen() {
               <ThemedText
                 style={[styles.modeBtnText, { color: viewMode === "list" ? "#fff" : mutedColor }]}
               >
-                List
+                {t("admin.bookings.viewToggle.list")}
               </ThemedText>
             )}
           </Pressable>
@@ -476,7 +490,7 @@ export default function AdminBookingsScreen() {
               style={styles.gridNavBtn}
               onPress={() => handleGridDateChange(-1)}
               accessibilityRole="button"
-              accessibilityLabel="Previous day"
+              accessibilityLabel={t("admin.bookings.timetable.previousDay")}
             >
               <Icon name="chevron-back" size="lg" color={PRIMARY} />
             </Pressable>
@@ -484,12 +498,14 @@ export default function AdminBookingsScreen() {
               onPress={resetToToday}
               style={styles.gridDateLabel}
               accessibilityRole="button"
-              accessibilityLabel={`${fmtDate(gridDate)}, jump to today`}
+              accessibilityLabel={t("admin.bookings.timetable.jumpToTodayLabel", {
+                date: fmtDate(gridDate),
+              })}
             >
               <ThemedText style={styles.gridDateText}>{fmtDate(gridDate)}</ThemedText>
               {gridDate.toDateString() !== new Date().toDateString() && (
                 <ThemedText style={[styles.gridTodayHint, { color: PRIMARY }]}>
-                  tap for today
+                  {t("admin.bookings.timetable.tapForToday")}
                 </ThemedText>
               )}
             </Pressable>
@@ -498,7 +514,7 @@ export default function AdminBookingsScreen() {
               style={styles.gridNavBtn}
               onPress={() => handleGridDateChange(1)}
               accessibilityRole="button"
-              accessibilityLabel="Next day"
+              accessibilityLabel={t("admin.bookings.timetable.nextDay")}
             >
               <Icon name="chevron-forward" size="lg" color={PRIMARY} />
             </Pressable>
@@ -517,7 +533,9 @@ export default function AdminBookingsScreen() {
               ]}
             >
               <View style={[styles.legendDot, { backgroundColor: PRIMARY }]} />
-              <ThemedText style={[styles.legendText, { color: mutedColor }]}>Seated now</ThemedText>
+              <ThemedText style={[styles.legendText, { color: mutedColor }]}>
+                {t("admin.bookings.timetable.legend.seatedNow")}
+              </ThemedText>
             </View>
             <View
               style={[
@@ -526,7 +544,9 @@ export default function AdminBookingsScreen() {
               ]}
             >
               <View style={[styles.legendDot, { backgroundColor: `${PRIMARY}44` }]} />
-              <ThemedText style={[styles.legendText, { color: mutedColor }]}>Booked</ThemedText>
+              <ThemedText style={[styles.legendText, { color: mutedColor }]}>
+                {t("admin.bookings.timetable.legend.booked")}
+              </ThemedText>
             </View>
             <View
               style={[
@@ -540,10 +560,12 @@ export default function AdminBookingsScreen() {
                   { width: 3, backgroundColor: colors.error, borderRadius: 0 },
                 ]}
               />
-              <ThemedText style={[styles.legendText, { color: mutedColor }]}>Now</ThemedText>
+              <ThemedText style={[styles.legendText, { color: mutedColor }]}>
+                {t("admin.bookings.timetable.legend.now")}
+              </ThemedText>
             </View>
             <ThemedText style={[styles.legendText, { color: mutedColor, marginLeft: 4 }]}>
-              Tap a sitting to view details
+              {t("admin.bookings.timetable.legend.tapHint")}
             </ThemedText>
           </View>
 
@@ -569,16 +591,16 @@ export default function AdminBookingsScreen() {
         <View style={styles.emptyState}>
           <Icon name="calendar-outline" size={40} color={mutedColor} />
           <ThemedText style={[styles.emptyText, { color: mutedColor }]}>
-            No bookings found
+            {t("admin.bookings.emptyState")}
           </ThemedText>
           <Button
             size="md"
             icon="add-outline"
             style={styles.emptyStateAction}
             onPress={() => setShowNewModal(true)}
-            accessibilityLabel="New booking"
+            accessibilityLabel={t("admin.bookings.newBookingLabel")}
           >
-            New Booking
+            {t("admin.bookings.newBooking")}
           </Button>
         </View>
       ) : isWide ? (
@@ -632,14 +654,16 @@ export default function AdminBookingsScreen() {
 
       <ConfirmModal
         visible={!!cancelTarget}
-        title="Cancel Booking"
+        title={t("admin.bookings.cancelBookingTitle")}
         message={
           cancelTarget
-            ? `Cancel booking for ${cancelTarget.customerName ?? cancelTarget.customerEmail}?`
+            ? t("admin.bookings.cancelBookingConfirm", {
+                name: cancelTarget.customerName ?? cancelTarget.customerEmail,
+              })
             : ""
         }
-        confirmLabel="Cancel Booking"
-        cancelLabel="Keep"
+        confirmLabel={t("admin.bookings.cancelBookingTitle")}
+        cancelLabel={t("admin.bookings.keep")}
         destructive
         onConfirm={async () => {
           if (!cancelTarget) return;
@@ -657,7 +681,7 @@ export default function AdminBookingsScreen() {
 
       <AlertModal
         visible={errorMessage !== null}
-        title="Error"
+        title={t("errors.title")}
         message={errorMessage ?? ""}
         onClose={clearError}
       />

--- a/openresto-frontend/app/admin/dashboard.tsx
+++ b/openresto-frontend/app/admin/dashboard.tsx
@@ -1,6 +1,7 @@
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   ActivityIndicator,
   Pressable,
@@ -23,6 +24,7 @@ import { ScheduleConflictsBanner } from "@/components/admin/dashboard/ScheduleCo
 import { fmtMonthDay, fmtNumber, fmtTime, fmtWeekday } from "@/utils/formatters";
 
 export default function AdminDashboardScreen() {
+  const { t } = useTranslation();
   const [stats, setStats] = useState<AdminDashboardStats | null>(null);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
@@ -51,26 +53,31 @@ export default function AdminDashboardScreen() {
   const metricCards = stats
     ? [
         {
-          label: "Today's Bookings",
+          label: t("admin.dashboard.metrics.todayBookings.label"),
           value: stats.todayCount,
-          sub: "Total covers for today",
+          sub: t("admin.dashboard.metrics.todayBookings.sub"),
           icon: "calendar-outline" as const,
           accent: "#2563eb",
         },
         {
-          label: "Active Holds",
+          label: t("admin.dashboard.metrics.activeHolds.label"),
           value: stats.activeHoldsCount,
-          sub: "Tables currently being held",
+          sub: t("admin.dashboard.metrics.activeHolds.sub"),
           icon: "book-outline" as const,
           accent: primaryColor,
         },
         {
-          label: "Restaurant Status",
-          value: stats.pausedCount > 0 ? "Paused" : "Active",
+          label: t("admin.dashboard.metrics.restaurantStatus.label"),
+          value:
+            stats.pausedCount > 0
+              ? t("admin.dashboard.metrics.restaurantStatus.paused")
+              : t("admin.dashboard.metrics.restaurantStatus.active"),
           sub:
             stats.pausedCount > 0
-              ? `${stats.pausedCount} venues are currently paused`
-              : "All venues are accepting bookings",
+              ? t("admin.dashboard.metrics.restaurantStatus.subPaused", {
+                  count: stats.pausedCount,
+                })
+              : t("admin.dashboard.metrics.restaurantStatus.subActive"),
           icon:
             stats.pausedCount > 0
               ? ("pause-circle-outline" as const)
@@ -78,9 +85,9 @@ export default function AdminDashboardScreen() {
           accent: stats.pausedCount > 0 ? theme.colors.error : theme.colors.success,
         },
         {
-          label: "Total Covers",
+          label: t("admin.dashboard.metrics.totalCovers.label"),
           value: fmtNumber(stats.totalCovers),
-          sub: "Total guests served (all time)",
+          sub: t("admin.dashboard.metrics.totalCovers.sub"),
           icon: "people-outline" as const,
           accent: "#d97706",
         },
@@ -89,18 +96,18 @@ export default function AdminDashboardScreen() {
 
   const QUICK_ACTIONS = [
     {
-      title: "New Booking",
+      title: t("admin.bookings.newBooking"),
       icon: "person-add-outline" as const,
       onPress: () => router.push({ pathname: "/admin/bookings", params: { create: "1" } }),
       primary: true,
     },
     {
-      title: "View All Bookings",
+      title: t("admin.dashboard.quickActions.viewAllBookings"),
       icon: "list-outline" as const,
       route: "/admin/bookings" as const,
     },
     {
-      title: "Pause Bookings",
+      title: t("admin.bookings.restaurantAction.title.pause"),
       icon: "pause-circle-outline" as const,
       onPress: () => {
         setActionType("pause");
@@ -108,7 +115,7 @@ export default function AdminDashboardScreen() {
       },
     },
     {
-      title: "Extend Bookings",
+      title: t("admin.bookings.restaurantAction.title.extend"),
       icon: "time-outline" as const,
       onPress: () => {
         setActionType("extend");
@@ -116,7 +123,7 @@ export default function AdminDashboardScreen() {
       },
     },
     {
-      title: "Manage Settings",
+      title: t("admin.dashboard.quickActions.manageSettings"),
       icon: "settings-outline" as const,
       route: "/admin/settings/brand" as const,
     },
@@ -124,13 +131,15 @@ export default function AdminDashboardScreen() {
 
   return (
     <ThemedView style={styles.root}>
-      {Platform.OS !== "web" && <Stack.Screen options={{ title: "Admin Dashboard" }} />}
+      {Platform.OS !== "web" && (
+        <Stack.Screen options={{ title: t("admin.dashboard.nativeTitle") }} />
+      )}
       <ScrollView contentContainerStyle={styles.outer} keyboardShouldPersistTaps="handled">
         <View style={styles.header}>
           <View>
-            <ThemedText type="h1">Dashboard</ThemedText>
+            <ThemedText type="h1">{t("admin.dashboard.title")}</ThemedText>
             <ThemedText style={[styles.pageSub, { color: colors.muted }]}>
-              Welcome back. Here is what&apos;s happening today.
+              {t("admin.dashboard.welcomeSubtitle")}
             </ThemedText>
           </View>
         </View>
@@ -163,9 +172,11 @@ export default function AdminDashboardScreen() {
                 ]}
               >
                 <View style={styles.chartHeader}>
-                  <ThemedText style={styles.cardTitle}>Occupancy Overview</ThemedText>
+                  <ThemedText style={styles.cardTitle}>
+                    {t("admin.dashboard.chart.title")}
+                  </ThemedText>
                   <ThemedText style={[styles.chartSub, { color: colors.muted }]}>
-                    Last 7 days
+                    {t("admin.dashboard.chart.last7Days")}
                   </ThemedText>
                 </View>
                 <OccupancyChart
@@ -217,21 +228,23 @@ export default function AdminDashboardScreen() {
               ]}
             >
               <View style={styles.listHeader}>
-                <ThemedText style={styles.cardTitle}>Today&apos;s Bookings</ThemedText>
+                <ThemedText style={styles.cardTitle}>
+                  {t("admin.dashboard.metrics.todayBookings.label")}
+                </ThemedText>
                 <Pressable
                   onPress={() => router.push("/admin/bookings")}
                   accessibilityRole="link"
-                  accessibilityLabel="View all bookings"
+                  accessibilityLabel={t("admin.dashboard.recentBookings.viewAllLabel")}
                 >
                   <ThemedText style={[styles.viewAll, { color: primaryColor }]}>
-                    View all →
+                    {t("admin.dashboard.recentBookings.viewAll")}
                   </ThemedText>
                 </Pressable>
               </View>
               {stats?.recentBookings.length === 0 ? (
                 <View style={styles.emptyRecent}>
                   <ThemedText style={[styles.emptyText, { color: colors.muted }]}>
-                    No upcoming bookings for today.
+                    {t("admin.dashboard.recentBookings.empty")}
                   </ThemedText>
                 </View>
               ) : (
@@ -265,7 +278,7 @@ export default function AdminDashboardScreen() {
 
       <AlertModal
         visible={alertVisible}
-        title="Success"
+        title={t("admin.dashboard.successTitle")}
         message={alertMessage}
         onClose={() => setAlertVisible(false)}
       />
@@ -319,15 +332,24 @@ function OccupancyChart({
   dates?: string[];
   counts?: number[];
 }) {
+  const { t } = useTranslation();
   const chartData = data?.length > 0 ? data : [0, 0, 0, 0, 0, 0, 0];
   const [labelMode, setLabelMode] = useState<"relative" | "calendar">("relative");
 
-  const relativeLabels = ["T-6", "T-5", "T-4", "T-3", "T-2", "T-1", "Today"];
+  const relativeLabels = [
+    t("admin.dashboard.chart.dayLabel.tMinus6"),
+    t("admin.dashboard.chart.dayLabel.tMinus5"),
+    t("admin.dashboard.chart.dayLabel.tMinus4"),
+    t("admin.dashboard.chart.dayLabel.tMinus3"),
+    t("admin.dashboard.chart.dayLabel.tMinus2"),
+    t("admin.dashboard.chart.dayLabel.tMinus1"),
+    t("admin.dashboard.chart.dayLabel.today"),
+  ];
   const formatCalendar = (iso: string) => fmtMonthDay(new Date(iso));
 
   const labelFor = (i: number) => {
     if (labelMode === "calendar" && dates && dates[i]) {
-      return i === 6 ? "Today" : formatCalendar(dates[i]);
+      return i === 6 ? t("admin.dashboard.chart.dayLabel.today") : formatCalendar(dates[i]);
     }
     return relativeLabels[i];
   };
@@ -345,8 +367,12 @@ function OccupancyChart({
 
   const summary =
     totalBookings > 0
-      ? `${totalBookings} bookings · ${(totalBookings / 7).toFixed(1)}/day · peak ${peakWeekday}`
-      : "No bookings in the last 7 days";
+      ? t("admin.dashboard.chart.summary", {
+          count: totalBookings,
+          perDay: (totalBookings / 7).toFixed(1),
+          weekday: peakWeekday,
+        })
+      : t("admin.dashboard.chart.summaryEmpty");
 
   return (
     <View style={styles.chartArea}>
@@ -362,7 +388,7 @@ function OccupancyChart({
             testID="occupancy-toggle-relative"
             onPress={() => setLabelMode("relative")}
             accessibilityRole="radio"
-            accessibilityLabel="Label hours relative to now"
+            accessibilityLabel={t("admin.dashboard.chart.toggle.relativeLabel")}
             accessibilityState={{ checked: labelMode === "relative" }}
             style={[
               styles.toggleSegment,
@@ -377,14 +403,14 @@ function OccupancyChart({
                 { color: labelMode === "relative" ? theme.colors.white : colors.muted },
               ]}
             >
-              T-x
+              {t("admin.dashboard.chart.toggle.relativeText")}
             </ThemedText>
           </Pressable>
           <Pressable
             testID="occupancy-toggle-calendar"
             onPress={() => setLabelMode("calendar")}
             accessibilityRole="radio"
-            accessibilityLabel="Label hours by clock time"
+            accessibilityLabel={t("admin.dashboard.chart.toggle.calendarLabel")}
             accessibilityState={{ checked: labelMode === "calendar" }}
             style={[
               styles.toggleSegment,
@@ -399,7 +425,7 @@ function OccupancyChart({
                 { color: labelMode === "calendar" ? theme.colors.white : colors.muted },
               ]}
             >
-              Dates
+              {t("admin.dashboard.chart.toggle.datesText")}
             </ThemedText>
           </Pressable>
         </View>
@@ -457,6 +483,7 @@ function BookingItem({
   isDark: boolean;
   onPress: () => void;
 }) {
+  const { t } = useTranslation();
   const now = new Date();
   const startTime = new Date(booking.date);
   const endTime = booking.endTime
@@ -482,15 +509,17 @@ function BookingItem({
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={[
-        fmtTime(startTime),
-        booking.customerName ?? booking.customerEmail,
-        `${booking.seats} guests`,
-        booking.restaurantName,
-        isCancelled ? "cancelled" : null,
-      ]
-        .filter(Boolean)
-        .join(", ")}
+      accessibilityLabel={t(
+        isCancelled
+          ? "admin.dashboard.recentBookings.itemLabelCancelled"
+          : "admin.dashboard.recentBookings.itemLabel",
+        {
+          time: fmtTime(startTime),
+          guest: booking.customerName ?? booking.customerEmail,
+          seats: t("booking.form.partySize", { count: booking.seats }),
+          restaurant: booking.restaurantName,
+        }
+      )}
       style={({ hovered }: any) => [
         styles.bookingItem,
         { borderTopColor: colors.border },
@@ -510,7 +539,9 @@ function BookingItem({
           </ThemedText>
           {isCancelled ? (
             <View style={styles.cancelledBadge}>
-              <ThemedText style={styles.cancelledBadgeText}>Cancelled</ThemedText>
+              <ThemedText style={styles.cancelledBadgeText}>
+                {t("admin.bookings.status.cancelled")}
+              </ThemedText>
             </View>
           ) : (
             <StatusBadge date={booking.date} isDark={isDark} />
@@ -522,7 +553,10 @@ function BookingItem({
           </ThemedText>
         )}
         <ThemedText style={[styles.bookingMeta, { color: colors.muted }]}>
-          {booking.seats} guests · {booking.restaurantName}
+          {t("admin.dashboard.recentBookings.meta", {
+            seats: t("booking.form.partySize", { count: booking.seats }),
+            restaurant: booking.restaurantName,
+          })}
         </ThemedText>
       </View>
       <Icon name="chevron-forward" size="md" color={colors.muted} />

--- a/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
+++ b/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ScrollView, View, Pressable } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { getThemeColors } from "@/theme/theme";
 import { SectionWithTables, BookingDetailDto } from "@/api/admin";
@@ -86,6 +87,7 @@ export function AvailabilityGrid({
   /** Human-readable form of the same day, named in the empty state. */
   dateLabel?: string;
 }) {
+  const { t } = useTranslation();
   const tick = useMinuteTick();
   const colors = getThemeColors(isDark);
   const { primaryColor: PRIMARY } = useAppTheme();
@@ -150,7 +152,7 @@ export function AvailabilityGrid({
       <View style={{ padding: 40, alignItems: "center" }}>
         <Icon name="grid-outline" size={32} color={mutedColor} />
         <ThemedText style={[{ color: mutedColor, marginTop: 10, fontSize: 14 }]}>
-          No tables found. Add sections and tables in Location Manager.
+          {t("admin.bookings.timetable.noTablesFound")}
         </ThemedText>
       </View>
     );
@@ -163,7 +165,9 @@ export function AvailabilityGrid({
       <View testID="grid-empty-day" style={{ padding: 40, alignItems: "center" }}>
         <Icon name="calendar-outline" size={32} color={mutedColor} />
         <ThemedText style={[{ color: mutedColor, marginTop: 10, fontSize: 14 }]}>
-          {dateLabel ? `No bookings on ${dateLabel}` : "No bookings on this day"}
+          {dateLabel
+            ? t("admin.bookings.timetable.noBookingsOnDay", { date: dateLabel })
+            : t("admin.bookings.timetable.noBookingsGeneric")}
         </ThemedText>
       </View>
     );
@@ -193,7 +197,9 @@ export function AvailabilityGrid({
               borderRightColor: borderColor,
             }}
           >
-            <ThemedText style={[styles.gridHeaderText, { color: mutedColor }]}>TABLE</ThemedText>
+            <ThemedText style={[styles.gridHeaderText, { color: mutedColor }]}>
+              {t("booking.form.tableLabel").toUpperCase()}
+            </ThemedText>
           </View>
           <View style={{ width: timelineW }}>
             {timeline.ticks.map(({ offset, label }) => (
@@ -265,7 +271,7 @@ export function AvailabilityGrid({
                       </ThemedText>
                       {unit.seats != null && (
                         <ThemedText style={[styles.gridTableSeats, { color: mutedColor }]}>
-                          {unit.seats}p
+                          {t("admin.bookings.timetable.peopleAbbrev", { count: unit.seats })}
                         </ThemedText>
                       )}
                     </View>
@@ -290,7 +296,7 @@ export function AvailabilityGrid({
                         const guest =
                           placement.booking.customerName ||
                           placement.booking.customerEmail?.split("@")[0] ||
-                          "Guest";
+                          t("admin.bookings.timetable.guestFallback");
                         const startLabel = formatClockMinutes(placement.startClockMinutes);
                         const endLabel = formatClockMinutes(
                           placement.startClockMinutes +
@@ -300,6 +306,9 @@ export function AvailabilityGrid({
                           state === "current" && now != null
                             ? formatRemaining(placement.endOffset - now)
                             : null;
+                        const sittingLabelKey = remaining
+                          ? "admin.bookings.timetable.sittingLabelWithRemaining"
+                          : "admin.bookings.timetable.sittingLabel";
 
                         return (
                           <Pressable
@@ -307,7 +316,14 @@ export function AvailabilityGrid({
                             testID={`sitting-${placement.booking.id}`}
                             onPress={() => onBookingPress(placement.booking)}
                             accessibilityRole="button"
-                            accessibilityLabel={`${guest}, ${placement.booking.seats} covers on ${unit.name}, ${startLabel} to ${endLabel}${remaining ? `, ${remaining}` : ""}`}
+                            accessibilityLabel={t(sittingLabelKey, {
+                              guest,
+                              seats: placement.booking.seats,
+                              unit: unit.name,
+                              start: startLabel,
+                              end: endLabel,
+                              remaining,
+                            })}
                             style={{
                               position: "absolute",
                               left: offsetToPx(placement.startOffset),
@@ -330,7 +346,10 @@ export function AvailabilityGrid({
                             }}
                           >
                             <ThemedText style={styles.gridBarGuest} numberOfLines={1}>
-                              {guest} · {placement.booking.seats}p
+                              {guest} ·{" "}
+                              {t("admin.bookings.timetable.peopleAbbrev", {
+                                count: placement.booking.seats,
+                              })}
                             </ThemedText>
                             <ThemedText
                               style={[styles.gridBarTime, { color: mutedColor }]}

--- a/openresto-frontend/components/admin/bookings/BookingActionButtons.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingActionButtons.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import Button from "@/components/common/Button";
 
 interface BookingActionButtonsProps {
@@ -23,6 +24,7 @@ export function BookingActionButtons({
   onCancel,
   onPurge,
 }: BookingActionButtonsProps) {
+  const { t } = useTranslation();
   return (
     <>
       {isCancelled && (
@@ -35,9 +37,9 @@ export function BookingActionButtons({
           onPress={onUncancel}
           disabled={uncancelling}
           loading={uncancelling}
-          accessibilityLabel="Restore booking"
+          accessibilityLabel={t("admin.bookings.restoreBookingLabel")}
         >
-          {uncancelling ? "Restoring…" : "Restore Booking"}
+          {uncancelling ? t("admin.bookings.restoring") : t("admin.bookings.restoreBooking")}
         </Button>
       )}
 
@@ -51,9 +53,9 @@ export function BookingActionButtons({
           onPress={onCancel}
           disabled={deleting}
           loading={deleting}
-          accessibilityLabel="Cancel booking"
+          accessibilityLabel={t("admin.bookings.cancelBookingLabel")}
         >
-          {deleting ? "Cancelling…" : "Cancel Booking"}
+          {deleting ? t("admin.bookings.cancelling") : t("admin.bookings.cancelBookingTitle")}
         </Button>
       )}
 
@@ -66,10 +68,10 @@ export function BookingActionButtons({
         onPress={onPurge}
         disabled={deleting}
         loading={deleting}
-        accessibilityLabel="Permanently delete booking for GDPR"
-        accessibilityHint="This cannot be undone"
+        accessibilityLabel={t("admin.bookings.permanentlyDeleteLabel")}
+        accessibilityHint={t("admin.bookings.permanentlyDeleteHint")}
       >
-        Permanently Delete (GDPR)
+        {t("admin.bookings.permanentlyDeleteGdpr")}
       </Button>
     </>
   );

--- a/openresto-frontend/components/admin/bookings/BookingDetailPopup.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingDetailPopup.tsx
@@ -1,4 +1,5 @@
 import { Modal, Pressable, ScrollView, View, ActivityIndicator } from "react-native";
+import { useTranslation } from "react-i18next";
 import { scrollIntoView } from "@/utils/scrollIntoView";
 import { ThemedText } from "@/components/themed-text";
 import {
@@ -49,6 +50,7 @@ export function BookingDetailPopup({
    * "open" (Enter). */
   initialFocus?: "extend";
 }) {
+  const { t } = useTranslation();
   const [booking, setBooking] = useState<BookingDetailDto | null>(null);
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -204,7 +206,8 @@ export function BookingDetailPopup({
       onMutated?.();
       onClose();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to cancel the booking.";
+      const message =
+        err instanceof Error ? err.message : t("admin.bookings.detail.failedToCancel");
       setDeleting(false);
       setErrorMessage(message);
     }
@@ -231,7 +234,8 @@ export function BookingDetailPopup({
       setBooking(updated);
       onMutated?.();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to restore booking.";
+      const message =
+        err instanceof Error ? err.message : t("admin.bookings.detail.failedToRestore");
       setErrorMessage(message);
     }
     setUncancelling(false);
@@ -241,11 +245,11 @@ export function BookingDetailPopup({
     if (!booking) return;
     const seats = parseInt(editSeats, 10);
     if (isNaN(seats) || seats < 1) {
-      setErrorMessage("Invalid seats value");
+      setErrorMessage(t("admin.bookings.detail.invalidSeats"));
       return;
     }
     if (!editDate || !editTime) {
-      setErrorMessage("Date and time are required");
+      setErrorMessage(t("admin.bookings.detail.dateTimeRequired"));
       return;
     }
     setEditLoading(true);
@@ -257,7 +261,10 @@ export function BookingDetailPopup({
 
       if (currentTable && seats > currentTable.seats) {
         const confirmed = window.confirm(
-          `Warning: This table only has ${currentTable.seats} seats, but you are booking for ${seats} guests. Do you want to continue?`
+          t("booking.form.oversizeConfirm", {
+            tableSeats: t("booking.form.seatsCount", { count: currentTable.seats }),
+            guests: t("booking.form.partySize", { count: seats }),
+          })
         );
         if (!confirmed) {
           setEditLoading(false);
@@ -303,7 +310,8 @@ export function BookingDetailPopup({
         setMoveNoticeReady(true);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to update booking.";
+      const message =
+        err instanceof Error ? err.message : t("admin.bookings.detail.failedToUpdate");
       setErrorMessage(message);
     }
     setEditLoading(false);
@@ -342,12 +350,15 @@ export function BookingDetailPopup({
 
   const restaurantOptions = restaurants.map((r) => ({ label: r.name, value: r.id }));
   const sectionOptions = sections.map((s) => ({ label: s.name, value: s.id }));
-  const tableOptions = tables.map((t) => ({
-    label: `${t.name ?? `Table ${t.id}`} (${t.seats} seats)`,
-    value: t.id,
+  const tableOptions = tables.map((tbl) => ({
+    label: t("admin.bookings.form.tableOptionLabel", {
+      name: tbl.name ?? t("admin.bookings.form.tableFallbackName", { id: tbl.id }),
+      seats: t("booking.form.seatsCount", { count: tbl.seats }),
+    }),
+    value: tbl.id,
   }));
   const seatOptions = [...Array(10).keys()].map((i) => ({
-    label: `${i + 1} guest${i > 0 ? "s" : ""}`,
+    label: t("booking.form.partySize", { count: i + 1 }),
     value: i + 1,
   }));
 
@@ -362,14 +373,14 @@ export function BookingDetailPopup({
         }}
         onPress={onClose}
         accessibilityRole="button"
-        accessibilityLabel="Close booking details"
+        accessibilityLabel={t("admin.bookings.detail.closeLabel")}
       >
         <Pressable
           onPress={/* istanbul ignore next */ (e) => e.stopPropagation?.()}
           role="dialog"
           aria-modal
           accessibilityViewIsModal
-          accessibilityLabel="Booking details"
+          accessibilityLabel={t("admin.bookings.detail.dialogLabel")}
           style={{
             width: "92%",
             maxWidth: 960,
@@ -394,7 +405,7 @@ export function BookingDetailPopup({
             }}
           >
             <ThemedText style={{ fontSize: 18, fontWeight: "700", letterSpacing: -0.3 }}>
-              Booking Details
+              {t("admin.bookings.detail.heading")}
             </ThemedText>
             <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
               {editing ? (
@@ -405,18 +416,20 @@ export function BookingDetailPopup({
                     size="md"
                     onPress={handleCancelEdit}
                     disabled={editLoading}
-                    accessibilityLabel="Discard changes"
+                    accessibilityLabel={t("admin.bookings.detail.discardChangesLabel")}
                   >
-                    Cancel
+                    {t("common.actions.cancel")}
                   </Button>
                   <Button
                     size="md"
                     onPress={handleSaveEdit}
                     disabled={editLoading}
                     loading={editLoading}
-                    accessibilityLabel="Save changes"
+                    accessibilityLabel={t("admin.bookings.detail.saveChangesLabel")}
                   >
-                    {editLoading ? "Saving…" : "Save Changes"}
+                    {editLoading
+                      ? t("admin.bookings.detail.saving")
+                      : t("admin.bookings.detail.saveChanges")}
                   </Button>
                 </>
               ) : (
@@ -427,9 +440,9 @@ export function BookingDetailPopup({
                     size="md"
                     icon="create-outline"
                     onPress={() => setEditing(true)}
-                    accessibilityLabel="Edit booking"
+                    accessibilityLabel={t("admin.bookings.detail.editLabel")}
                   >
-                    Edit
+                    {t("admin.bookings.detail.edit")}
                   </Button>
                 )
               )}
@@ -437,7 +450,7 @@ export function BookingDetailPopup({
                 onPress={onClose}
                 style={{ padding: 6 }}
                 accessibilityRole="button"
-                accessibilityLabel="Close"
+                accessibilityLabel={t("common.actions.close")}
                 hitSlop={{ top: 11, bottom: 11, left: 11, right: 11 }}
               >
                 <Icon name="close" size={22} color={mutedColor} />
@@ -450,7 +463,7 @@ export function BookingDetailPopup({
               <ActivityIndicator size="large" color={PRIMARY} style={{ marginVertical: 40 }} />
             ) : !booking ? (
               <ThemedText style={{ textAlign: "center", color: mutedColor, marginVertical: 40 }}>
-                Booking not found.
+                {t("admin.bookings.detail.notFound")}
               </ThemedText>
             ) : (
               <>
@@ -542,10 +555,10 @@ export function BookingDetailPopup({
 
       <ConfirmModal
         visible={showDeleteConfirm}
-        title="Cancel Booking"
-        message="Are you sure you want to cancel this booking? This cannot be undone."
-        confirmLabel="Cancel Booking"
-        cancelLabel="Keep"
+        title={t("admin.bookings.cancelBookingTitle")}
+        message={t("admin.bookings.detail.cancelBookingConfirmMessage")}
+        confirmLabel={t("admin.bookings.cancelBookingTitle")}
+        cancelLabel={t("admin.bookings.keep")}
         destructive
         onConfirm={handleDeleteConfirmed}
         onCancel={() => setShowDeleteConfirm(false)}
@@ -553,20 +566,20 @@ export function BookingDetailPopup({
 
       <ConfirmModal
         visible={showUncancelConfirm}
-        title="Restore Booking"
-        message="Are you sure you want to restore this cancelled booking?"
-        confirmLabel="Restore"
-        cancelLabel="Go Back"
+        title={t("admin.bookings.detail.restoreBookingTitle")}
+        message={t("admin.bookings.detail.restoreBookingConfirm")}
+        confirmLabel={t("admin.bookings.detail.restore")}
+        cancelLabel={t("admin.bookings.goBack")}
         onConfirm={handleUncancel}
         onCancel={() => setShowUncancelConfirm(false)}
       />
 
       <ConfirmModal
         visible={showPurgeConfirm}
-        title="Permanently Delete"
-        message="This will permanently erase all data for this booking including the guest's email and personal details. This action cannot be reversed."
-        confirmLabel="Delete Forever"
-        cancelLabel="Go Back"
+        title={t("admin.bookings.detail.permanentlyDeleteTitle")}
+        message={t("admin.bookings.detail.permanentlyDeleteMessage")}
+        confirmLabel={t("admin.bookings.detail.deleteForever")}
+        cancelLabel={t("admin.bookings.goBack")}
         destructive
         onConfirm={async () => {
           if (!booking) return;
@@ -578,7 +591,7 @@ export function BookingDetailPopup({
             onClose();
           } else {
             setDeleting(false);
-            setErrorMessage("Failed to permanently delete the booking.");
+            setErrorMessage(t("admin.bookings.detail.failedToPermanentlyDelete"));
           }
         }}
         onCancel={() => setShowPurgeConfirm(false)}
@@ -586,7 +599,7 @@ export function BookingDetailPopup({
 
       <AlertModal
         visible={!!errorMessage}
-        title="Error"
+        title={t("errors.title")}
         message={errorMessage ?? ""}
         onClose={() => setErrorMessage(null)}
       />

--- a/openresto-frontend/components/admin/bookings/BookingDetailsCard.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingDetailsCard.tsx
@@ -1,4 +1,5 @@
 import { View, ViewStyle } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { theme } from "@/theme/theme";
 import { fmtLongDate, fmtMonthDay, fmtTime } from "@/utils/formatters";
@@ -32,6 +33,7 @@ export function BookingDetailsCard({
   cardColor,
   style,
 }: BookingDetailsCardProps) {
+  const { t } = useTranslation();
   const startTime = new Date(booking.date);
   const endTime = booking.endTime
     ? new Date(booking.endTime)
@@ -51,41 +53,85 @@ export function BookingDetailsCard({
   // Field order mirrors EditBookingForm/NewBookingModal (restaurant → section → table →
   // date → time → guests → email → name → requests) so the read-only card and the edit
   // form stay visually aligned when both are shown side by side.
-  const rows: { label: string; value: string }[] = [
-    { label: "Ref", value: booking.bookingRef ?? `#${booking.id}` },
-    { label: "Restaurant", value: booking.restaurantName },
-    ...(booking.sectionName ? [{ label: "Section", value: booking.sectionName }] : []),
-    { label: "Table", value: booking.tableName ?? "Table" },
+  /**
+   * `key` (rather than the localized `label`) drives the "Status" highlight style below,
+   * since a translated label can't be compared against an English literal.
+   * @see [BookingDetailsCard.test.tsx](../../../tests/components/BookingDetailsCard.test.tsx)
+   * — pins that the cancelled-row highlight still applies once the label is translated.
+   */
+  const rows: { key: string; label: string; value: string }[] = [
     {
-      label: "Date",
+      key: "ref",
+      label: t("admin.bookings.detail.fields.ref"),
+      value: booking.bookingRef ?? `#${booking.id}`,
+    },
+    {
+      key: "restaurant",
+      label: t("admin.bookings.form.restaurant"),
+      value: booking.restaurantName,
+    },
+    ...(booking.sectionName
+      ? [{ key: "section", label: t("booking.form.sectionLabel"), value: booking.sectionName }]
+      : []),
+    {
+      key: "table",
+      label: t("booking.form.tableLabel"),
+      value: booking.tableName ?? t("booking.form.tableLabel"),
+    },
+    {
+      key: "date",
+      label: t("booking.form.dateLabel"),
       value: fmtLongDate(startTime),
     },
     {
-      label: "Time",
-      value: `${timeRangeDisplay} (${durationMins} min)`,
+      key: "time",
+      label: t("booking.form.timeLabel"),
+      value: t("admin.bookings.detail.timeRangeWithDuration", {
+        range: timeRangeDisplay,
+        mins: durationMins,
+      }),
     },
-    { label: "Party", value: `${booking.seats} guest${booking.seats !== 1 ? "s" : ""}` },
-    { label: "Email", value: booking.customerEmail },
-    ...(booking.customerName ? [{ label: "Name", value: booking.customerName }] : []),
-    { label: "Requests", value: booking.specialRequests || "None" },
+    {
+      key: "party",
+      label: t("admin.bookings.detail.fields.party"),
+      value: t("booking.form.partySize", { count: booking.seats }),
+    },
+    { key: "email", label: t("booking.form.emailLabel"), value: booking.customerEmail },
+    ...(booking.customerName
+      ? [
+          {
+            key: "name",
+            label: t("admin.bookings.detail.fields.name"),
+            value: booking.customerName,
+          },
+        ]
+      : []),
+    {
+      key: "requests",
+      label: t("admin.bookings.detail.fields.requests"),
+      value: booking.specialRequests || t("admin.bookings.detail.noRequests"),
+    },
   ];
 
   if (booking.isCancelled) {
-    rows.push({ label: "Status", value: "CANCELLED" });
+    rows.push({
+      key: "status",
+      label: t("admin.bookings.sort.status"),
+      value: t("admin.bookings.status.cancelled").toUpperCase(),
+    });
   }
 
   return (
     <View style={[styles.card, { backgroundColor: cardColor, borderColor }, style]}>
-      {rows.map(({ label, value }, i) => (
-        <View key={label}>
+      {rows.map(({ key, label, value }, i) => (
+        <View key={key}>
           {i > 0 && <View style={[styles.divider, { backgroundColor: borderColor }]} />}
           <View style={styles.row}>
             <ThemedText style={[styles.rowLabel, { color: mutedColor }]}>{label}</ThemedText>
             <ThemedText
               style={[
                 styles.rowValue,
-                label === "Status" &&
-                  value === "CANCELLED" && { color: theme.colors.error, fontWeight: "700" },
+                key === "status" && { color: theme.colors.error, fontWeight: "700" },
               ]}
             >
               {value}

--- a/openresto-frontend/components/admin/bookings/BookingLookupBar.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingLookupBar.tsx
@@ -1,4 +1,5 @@
 import { TextInput, View } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import Button from "@/components/common/Button";
 import { theme } from "@/theme/theme";
@@ -33,6 +34,7 @@ export function BookingLookupBar({
   placeholderColor,
   primaryColor,
 }: BookingLookupBarProps) {
+  const { t } = useTranslation();
   return (
     <>
       <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
@@ -50,7 +52,7 @@ export function BookingLookupBar({
               minWidth: 180,
             },
           ]}
-          placeholder="Name, email or reference…"
+          placeholder={t("admin.bookings.lookup.placeholder")}
           placeholderTextColor={placeholderColor}
           value={query}
           onChangeText={onQueryChange}
@@ -64,20 +66,20 @@ export function BookingLookupBar({
           onPress={onSubmit}
           disabled={loading || !query.trim()}
           loading={loading}
-          accessibilityLabel="Find booking"
+          accessibilityLabel={t("admin.bookings.lookup.findLabel")}
         >
-          Find
+          {t("admin.bookings.lookup.find")}
         </Button>
       </View>
 
       {status === "not_found" && (
         <ThemedText style={{ fontSize: 12, color: theme.colors.error, marginTop: -4 }}>
-          No booking found.
+          {t("admin.bookings.lookup.notFound")}
         </ThemedText>
       )}
       {status === "multiple" && (
         <ThemedText style={{ fontSize: 12, color: primaryColor, marginTop: -4 }}>
-          Showing all matches…
+          {t("admin.bookings.lookup.showingAllMatches")}
         </ThemedText>
       )}
     </>

--- a/openresto-frontend/components/admin/bookings/BookingsCardList.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsCardList.tsx
@@ -1,4 +1,5 @@
 import { Pressable, View } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { BookingDetailDto } from "@/api/admin";
 import { theme } from "@/theme/theme";
@@ -45,6 +46,7 @@ export function BookingsCardList({
   isDark,
   primaryColor,
 }: BookingsCardListProps) {
+  const { t } = useTranslation();
   return (
     <View style={styles.cardListWrap}>
       <BookingsSortControl
@@ -59,7 +61,7 @@ export function BookingsCardList({
         {bookings.map((b) => (
           <Pressable
             key={b.id}
-            {...rowA11yProps(b.id, focusedRowId, describeBookingRow(b))}
+            {...rowA11yProps(b.id, focusedRowId, describeBookingRow(b, t))}
             style={[
               styles.listCard,
               { backgroundColor: cardBg, borderColor },
@@ -97,7 +99,7 @@ export function BookingsCardList({
                 <View style={styles.partyPill}>
                   <Icon name="people-outline" size="xs" color={mutedColor} />
                   <ThemedText style={[styles.tdDate, { color: mutedColor }]}>
-                    {b.seats} guests · {b.tableName}
+                    {t("booking.form.partySize", { count: b.seats })} · {b.tableName}
                   </ThemedText>
                 </View>
               </View>
@@ -112,7 +114,7 @@ export function BookingsCardList({
                     ]}
                   >
                     <ThemedText style={[styles.badgeText, { color: theme.status.cancelled.text }]}>
-                      Cancelled
+                      {t("admin.bookings.status.cancelled")}
                     </ThemedText>
                   </View>
                 ) : (

--- a/openresto-frontend/components/admin/bookings/BookingsSortControl.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsSortControl.tsx
@@ -1,4 +1,6 @@
 import { Pressable, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { ThemedText } from "@/components/themed-text";
 import { styles } from "@/components/admin/bookings/bookings.styles";
 import type { SortKey, SortState } from "@/components/admin/bookings/sorting";
@@ -14,13 +16,15 @@ export interface BookingsSortControlProps {
   primaryColor: string;
 }
 
-const COLUMNS: { key: SortKey; label: string }[] = [
-  { key: "date", label: "Time" },
-  { key: "guest", label: "Guest" },
-  { key: "seats", label: "Party" },
-  { key: "table", label: "Table" },
-  { key: "status", label: "Status" },
-];
+function columnsFor(t: TFunction): { key: SortKey; label: string }[] {
+  return [
+    { key: "date", label: t("admin.bookings.sort.time") },
+    { key: "guest", label: t("admin.bookings.sort.guest") },
+    { key: "seats", label: t("admin.bookings.sort.party") },
+    { key: "table", label: t("booking.form.tableLabel") },
+    { key: "status", label: t("admin.bookings.sort.status") },
+  ];
+}
 
 /**
  * Sort affordance for the mobile card list — column headers don't apply to a
@@ -36,23 +40,30 @@ export function BookingsSortControl({
   mutedColor,
   primaryColor,
 }: BookingsSortControlProps) {
+  const { t } = useTranslation();
+  const columns = columnsFor(t);
   return (
     <View style={[styles.sortControl, { borderColor, backgroundColor: cardBg }]}>
-      <ThemedText style={[styles.sortControlLabel, { color: mutedColor }]}>Sort</ThemedText>
+      <ThemedText style={[styles.sortControlLabel, { color: mutedColor }]}>
+        {t("admin.bookings.sort.sortLabel")}
+      </ThemedText>
       <View style={styles.sortControlChips}>
-        {COLUMNS.map(({ key, label }) => {
+        {columns.map(({ key, label }) => {
           const isActive = sort.key === key;
           const dirLabel = isActive
             ? sort.dir === "asc"
-              ? "ascending"
-              : "descending"
-            : "not sorted";
+              ? t("admin.bookings.sort.ascending")
+              : t("admin.bookings.sort.descending")
+            : t("admin.bookings.sort.notSorted");
           return (
             <Pressable
               key={key}
               testID={`sort-chip-${key}`}
               accessibilityRole="button"
-              accessibilityLabel={`Sort by ${label}, ${dirLabel}`}
+              accessibilityLabel={t("admin.bookings.sort.ariaLabel", {
+                column: label,
+                direction: dirLabel,
+              })}
               style={[
                 styles.sortChip,
                 { borderColor: isActive ? primaryColor : borderColor },

--- a/openresto-frontend/components/admin/bookings/BookingsWideTable.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingsWideTable.tsx
@@ -1,4 +1,5 @@
 import { Pressable, View, type ViewStyle } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { BookingDetailDto } from "@/api/admin";
 import { theme } from "@/theme/theme";
@@ -49,6 +50,7 @@ export function BookingsWideTable({
   isDark,
   primaryColor,
 }: BookingsWideTableProps) {
+  const { t } = useTranslation();
   const headerBg = isDark ? "#28292b" : "#f8f8f9";
   // Subtle alternating row tint for scannability. Translucent so the focused-
   // row highlight (`primaryColor` tint) still reads on top of it.
@@ -56,7 +58,11 @@ export function BookingsWideTable({
 
   const renderSortHeader = (key: SortKey, label: string, columnStyle: ViewStyle) => {
     const isActive = sort.key === key;
-    const dirLabel = isActive ? (sort.dir === "asc" ? "ascending" : "descending") : "not sorted";
+    const dirLabel = isActive
+      ? sort.dir === "asc"
+        ? t("admin.bookings.sort.ascending")
+        : t("admin.bookings.sort.descending")
+      : t("admin.bookings.sort.notSorted");
     const icon = !isActive
       ? "swap-vertical-outline"
       : sort.dir === "asc"
@@ -66,7 +72,10 @@ export function BookingsWideTable({
       <Pressable
         testID={`sort-header-${key}`}
         accessibilityRole="button"
-        accessibilityLabel={`Sort by ${label}, ${dirLabel}`}
+        accessibilityLabel={t("admin.bookings.sort.ariaLabel", {
+          column: label,
+          direction: dirLabel,
+        })}
         style={[styles.thSortBtn, columnStyle, { alignItems: "center" }]}
         onPress={() => onSortChange(key)}
       >
@@ -92,18 +101,22 @@ export function BookingsWideTable({
           { backgroundColor: headerBg, borderBottomWidth: 1, borderBottomColor: borderColor },
         ]}
       >
-        {renderSortHeader("date", "TIME", styles.colTime)}
-        {renderSortHeader("guest", "GUEST", styles.colGuest)}
-        {renderSortHeader("seats", "PARTY", styles.colParty)}
-        {renderSortHeader("table", "TABLE", styles.colTable)}
-        {renderSortHeader("status", "STATUS", styles.colStatus)}
+        {renderSortHeader("date", t("admin.bookings.sort.time").toUpperCase(), styles.colTime)}
+        {renderSortHeader("guest", t("admin.bookings.sort.guest").toUpperCase(), styles.colGuest)}
+        {renderSortHeader("seats", t("admin.bookings.sort.party").toUpperCase(), styles.colParty)}
+        {renderSortHeader("table", t("booking.form.tableLabel").toUpperCase(), styles.colTable)}
+        {renderSortHeader(
+          "status",
+          t("admin.bookings.sort.status").toUpperCase(),
+          styles.colStatus
+        )}
         <View style={styles.colAction} />
       </View>
 
       {bookings.map((b, i) => (
         <Pressable
           key={b.id}
-          {...rowA11yProps(b.id, focusedRowId, describeBookingRow(b))}
+          {...rowA11yProps(b.id, focusedRowId, describeBookingRow(b, t))}
           style={[
             styles.tableRow,
             i > 0 && { borderTopWidth: 1, borderTopColor: borderColor },
@@ -174,7 +187,7 @@ export function BookingsWideTable({
                 ]}
               >
                 <ThemedText style={[styles.badgeText, { color: theme.status.cancelled.text }]}>
-                  Cancelled
+                  {t("admin.bookings.status.cancelled")}
                 </ThemedText>
               </View>
             ) : (
@@ -185,10 +198,12 @@ export function BookingsWideTable({
           <View style={styles.colAction}>
             {!b.isCancelled && !isPast(b.date) && (
               <RowTextButton
-                label="Cancel"
+                label={t("common.actions.cancel")}
                 icon="close-outline"
                 color={theme.status.cancelled.text}
-                accessibilityLabel={`Cancel booking for ${b.customerName ?? b.customerEmail}`}
+                accessibilityLabel={t("admin.bookings.cancelBookingForLabel", {
+                  name: b.customerName ?? b.customerEmail,
+                })}
                 onPress={(e) => {
                   // stopPropagation is present on web mouse events but not RN's
                   // GestureResponderEvent — guard both the event and the method.

--- a/openresto-frontend/components/admin/bookings/EditBookingForm.tsx
+++ b/openresto-frontend/components/admin/bookings/EditBookingForm.tsx
@@ -1,4 +1,5 @@
 import { View, ActivityIndicator } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { theme } from "@/theme/theme";
 import Input from "@/components/common/Input";
@@ -69,13 +70,14 @@ export function EditBookingForm({
   handleRestaurantChange,
   handleSectionChange,
 }: EditBookingFormProps) {
+  const { t } = useTranslation();
   return (
     <View style={[styles.section, { borderColor }]}>
       {loadingRestaurants ? (
         <ActivityIndicator size="small" color={theme.colors.primary} />
       ) : (
         <>
-          <ThemedText style={styles.label}>Restaurant</ThemedText>
+          <ThemedText style={styles.label}>{t("admin.bookings.form.restaurant")}</ThemedText>
           <Select
             selectedValue={editRestaurantId ?? undefined}
             onSelect={handleRestaurantChange}
@@ -84,7 +86,7 @@ export function EditBookingForm({
 
           <View style={styles.fieldRow}>
             <View style={styles.fieldHalf}>
-              <ThemedText style={styles.label}>Section</ThemedText>
+              <ThemedText style={styles.label}>{t("booking.form.sectionLabel")}</ThemedText>
               <Select
                 selectedValue={editSectionId ?? undefined}
                 onSelect={handleSectionChange}
@@ -92,7 +94,7 @@ export function EditBookingForm({
               />
             </View>
             <View style={styles.fieldHalf}>
-              <ThemedText style={styles.label}>Table</ThemedText>
+              <ThemedText style={styles.label}>{t("booking.form.tableLabel")}</ThemedText>
               <Select
                 selectedValue={editTableId ?? undefined}
                 onSelect={(v) => setEditTableId(v as number)}
@@ -103,11 +105,11 @@ export function EditBookingForm({
 
           <View style={styles.fieldRow}>
             <View style={styles.fieldHalf}>
-              <ThemedText style={styles.label}>Date</ThemedText>
+              <ThemedText style={styles.label}>{t("booking.form.dateLabel")}</ThemedText>
               <DatePicker selectedDate={editDate} onSelect={setEditDate} />
             </View>
             <View style={styles.fieldHalf}>
-              <ThemedText style={styles.label}>Time</ThemedText>
+              <ThemedText style={styles.label}>{t("booking.form.timeLabel")}</ThemedText>
               <TimePicker
                 selectedTime={editTime}
                 onSelect={setEditTime}
@@ -119,7 +121,7 @@ export function EditBookingForm({
 
           <View style={styles.fieldRow}>
             <View style={styles.fieldHalf}>
-              <ThemedText style={styles.label}>Guests</ThemedText>
+              <ThemedText style={styles.label}>{t("booking.form.guestsLabel")}</ThemedText>
               <Select
                 selectedValue={Number(editSeats)}
                 onSelect={(v) => setEditSeats(String(v))}
@@ -127,9 +129,9 @@ export function EditBookingForm({
               />
             </View>
             <View style={styles.fieldHalf}>
-              <ThemedText style={styles.label}>Guest email</ThemedText>
+              <ThemedText style={styles.label}>{t("admin.bookings.form.guestEmail")}</ThemedText>
               <Input
-                placeholder="guest@example.com"
+                placeholder={t("admin.bookings.form.emailPlaceholder")}
                 value={editEmail}
                 onChangeText={setEditEmail}
                 keyboardType="email-address"
@@ -140,9 +142,9 @@ export function EditBookingForm({
 
           <View style={styles.fieldRow}>
             <View style={styles.fieldHalf}>
-              <ThemedText style={styles.label}>Guest name</ThemedText>
+              <ThemedText style={styles.label}>{t("admin.bookings.form.guestName")}</ThemedText>
               <Input
-                placeholder="Full name"
+                placeholder={t("admin.bookings.form.namePlaceholder")}
                 value={editCustomerName}
                 onChangeText={setEditCustomerName}
                 autoCapitalize="words"
@@ -150,9 +152,9 @@ export function EditBookingForm({
             </View>
           </View>
 
-          <ThemedText style={styles.label}>Special requests</ThemedText>
+          <ThemedText style={styles.label}>{t("admin.bookings.form.specialRequests")}</ThemedText>
           <Input
-            placeholder="Dietary needs, occasion, notes"
+            placeholder={t("admin.bookings.form.specialRequestsPlaceholder")}
             value={editSpecialRequests}
             onChangeText={setEditSpecialRequests}
           />

--- a/openresto-frontend/components/admin/bookings/EmailGuestForm.tsx
+++ b/openresto-frontend/components/admin/bookings/EmailGuestForm.tsx
@@ -1,4 +1,5 @@
 import { View } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { theme } from "@/theme/theme";
 import { bookingDetailStyles as styles } from "./booking-detail.styles";
@@ -43,25 +44,29 @@ export function EmailGuestForm({
   setEmailBody,
   onSendEmail,
 }: EmailGuestFormProps) {
+  const { t } = useTranslation();
   return (
     <View style={[styles.section, { borderColor }]}>
       <View style={styles.sectionHeader}>
         <Icon name="mail-outline" size="md" color={mutedColor} />
-        <ThemedText style={[styles.sectionTitle, { color: mutedColor }]}>Email guest</ThemedText>
+        <ThemedText style={[styles.sectionTitle, { color: mutedColor }]}>
+          {t("admin.bookings.detail.emailGuest")}
+        </ThemedText>
       </View>
-      <ThemedText style={[styles.emailTo, { color: mutedColor }]}>To: {customerEmail}</ThemedText>
+      <ThemedText style={[styles.emailTo, { color: mutedColor }]}>
+        {t("admin.bookings.detail.emailTo", { email: customerEmail })}
+      </ThemedText>
       {moveNoticeReady && (
         <ThemedText
           testID="move-notice-ready"
           style={[styles.emailTo, { color: theme.colors.warning }]}
         >
-          The sitting moved. A notice is written below and has not been sent: edit it, or send it as
-          it stands.
+          {t("admin.bookings.detail.moveNotice")}
         </ThemedText>
       )}
       <input
         type="text"
-        placeholder="Subject"
+        placeholder={t("admin.bookings.detail.subjectPlaceholder")}
         value={emailSubject}
         onChange={/* istanbul ignore next */ (e) => setEmailSubject(e.target.value)}
         style={
@@ -82,7 +87,7 @@ export function EmailGuestForm({
         }
       />
       <textarea
-        placeholder="Message body (HTML supported)"
+        placeholder={t("admin.bookings.detail.bodyPlaceholder")}
         value={emailBody}
         onChange={/* istanbul ignore next */ (e) => setEmailBody(e.target.value)}
         rows={4}
@@ -108,11 +113,11 @@ export function EmailGuestForm({
           size="md"
           icon="send-outline"
           onPress={onSendEmail}
-          accessibilityLabel="Send email to guest"
+          accessibilityLabel={t("admin.bookings.detail.sendEmailLabel")}
           disabled={!emailSubject.trim() || !emailBody.trim() || emailSending}
           loading={emailSending}
         >
-          {emailSending ? "Sending…" : "Send Email"}
+          {emailSending ? t("admin.bookings.detail.sending") : t("admin.bookings.detail.sendEmail")}
         </Button>
         {emailResult && (
           <ThemedText

--- a/openresto-frontend/components/admin/bookings/ExtendBookingActions.tsx
+++ b/openresto-frontend/components/admin/bookings/ExtendBookingActions.tsx
@@ -1,4 +1,5 @@
 import { View } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import Button from "@/components/common/Button";
 import { bookingDetailStyles as styles } from "./booking-detail.styles";
@@ -17,11 +18,14 @@ export function ExtendBookingActions({
   extending,
   onExtend,
 }: ExtendBookingActionsProps) {
+  const { t } = useTranslation();
   return (
     <View style={[styles.section, { borderColor }]}>
       <View style={styles.sectionHeader}>
         <Icon name="time-outline" size="md" color={mutedColor} />
-        <ThemedText style={[styles.sectionTitle, { color: mutedColor }]}>Extend booking</ThemedText>
+        <ThemedText style={[styles.sectionTitle, { color: mutedColor }]}>
+          {t("admin.bookings.detail.extendSection")}
+        </ThemedText>
       </View>
       <View style={styles.extendBtns}>
         {[30, 60, 90].map((mins) => (
@@ -31,9 +35,9 @@ export function ExtendBookingActions({
             style={styles.extendBtn}
             onPress={() => onExtend(mins)}
             disabled={extending}
-            accessibilityLabel={`Extend booking by ${mins} minutes`}
+            accessibilityLabel={t("admin.bookings.detail.extendByMinutesLabel", { mins })}
           >
-            {`+${mins} min`}
+            {t("admin.bookings.detail.extendByMinutes", { mins })}
           </Button>
         ))}
       </View>

--- a/openresto-frontend/components/admin/bookings/NewBookingModal.tsx
+++ b/openresto-frontend/components/admin/bookings/NewBookingModal.tsx
@@ -7,6 +7,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import Input from "@/components/common/Input";
 import Select from "@/components/common/Select";
@@ -45,6 +46,7 @@ interface NewBookingModalProps {
 }
 
 export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModalProps) {
+  const { t } = useTranslation();
   const { colors, primaryColor: PRIMARY } = useAppTheme();
   const borderColor = colors.border;
   const mutedColor = colors.muted;
@@ -150,17 +152,22 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
         onClose();
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create booking.");
+      setError(
+        err instanceof Error ? err.message : t("admin.bookings.newBookingModal.createError")
+      );
       setSubmitting(false);
     }
   };
 
   const handleSubmit = () => {
     if (!isValid) return;
-    const table = tables.find((t) => t.id === tableId);
+    const table = tables.find((tbl) => tbl.id === tableId);
     if (table && seats > table.seats) {
       setCapacityWarning(
-        `This table only seats ${table.seats} but you're booking for ${seats} guests. Continue anyway?`
+        t("admin.bookings.newBookingModal.overCapacityMessage", {
+          tableSeats: table.seats,
+          guests: t("booking.form.partySize", { count: seats }),
+        })
       );
       return;
     }
@@ -169,12 +176,15 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
 
   const restaurantOptions = restaurants.map((r) => ({ label: r.name, value: r.id }));
   const sectionOptions = sections.map((s) => ({ label: s.name, value: s.id }));
-  const tableOptions = tables.map((t) => ({
-    label: `${t.name ?? `Table ${t.id}`} (${t.seats} seats)`,
-    value: t.id,
+  const tableOptions = tables.map((tbl) => ({
+    label: t("admin.bookings.form.tableOptionLabel", {
+      name: tbl.name ?? t("admin.bookings.form.tableFallbackName", { id: tbl.id }),
+      seats: t("booking.form.seatsCount", { count: tbl.seats }),
+    }),
+    value: tbl.id,
   }));
   const seatOptions = [...Array(10).keys()].map((i) => ({
-    label: `${i + 1} guest${i > 0 ? "s" : ""}`,
+    label: t("booking.form.partySize", { count: i + 1 }),
     value: i + 1,
   }));
 
@@ -185,25 +195,25 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
           style={styles.backdrop}
           onPress={onClose}
           accessibilityRole="button"
-          accessibilityLabel="Close the new booking form"
+          accessibilityLabel={t("admin.bookings.newBookingModal.closeFormLabel")}
         >
           <TouchableWithoutFeedback>
             <View
               role="dialog"
               aria-modal
               accessibilityViewIsModal
-              accessibilityLabel="New booking"
+              accessibilityLabel={t("admin.bookings.newBookingModal.dialogLabel")}
               style={[styles.sheet, { backgroundColor: colors.card, borderColor }]}
             >
               <View style={[styles.header, { borderBottomColor: borderColor }]}>
                 <ThemedText style={styles.title} accessibilityRole="header">
-                  New Booking
+                  {t("admin.bookings.newBooking")}
                 </ThemedText>
                 <Pressable
                   onPress={onClose}
                   style={styles.closeBtn}
                   accessibilityRole="button"
-                  accessibilityLabel="Close"
+                  accessibilityLabel={t("common.actions.close")}
                   hitSlop={{ top: 11, bottom: 11, left: 11, right: 11 }}
                 >
                   <Icon name="close" size={22} color={mutedColor} />
@@ -215,7 +225,7 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
                   <ActivityIndicator
                     size="large"
                     color={PRIMARY}
-                    accessibilityLabel="Loading booking form"
+                    accessibilityLabel={t("admin.bookings.newBookingModal.loadingForm")}
                   />
                 </View>
               ) : (
@@ -231,7 +241,9 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
                   )}
 
                   <View style={styles.field}>
-                    <ThemedText style={styles.label}>Restaurant</ThemedText>
+                    <ThemedText style={styles.label}>
+                      {t("admin.bookings.form.restaurant")}
+                    </ThemedText>
                     <Select
                       selectedValue={restaurantId}
                       onSelect={handleRestaurantChange}
@@ -241,7 +253,7 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
 
                   <View style={styles.fieldRow}>
                     <View style={[styles.fieldHalf, styles.field]}>
-                      <ThemedText style={styles.label}>Section</ThemedText>
+                      <ThemedText style={styles.label}>{t("booking.form.sectionLabel")}</ThemedText>
                       <Select
                         selectedValue={sectionId}
                         onSelect={handleSectionChange}
@@ -249,7 +261,7 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
                       />
                     </View>
                     <View style={[styles.fieldHalf, styles.field]}>
-                      <ThemedText style={styles.label}>Table</ThemedText>
+                      <ThemedText style={styles.label}>{t("booking.form.tableLabel")}</ThemedText>
                       <Select
                         selectedValue={tableId}
                         onSelect={(v) => setTableId(v as number)}
@@ -260,11 +272,11 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
 
                   <View style={styles.fieldRow}>
                     <View style={[styles.fieldHalf, styles.field]}>
-                      <ThemedText style={styles.label}>Date</ThemedText>
+                      <ThemedText style={styles.label}>{t("booking.form.dateLabel")}</ThemedText>
                       <DatePicker selectedDate={date} onSelect={handleDateSelect} allowPast />
                     </View>
                     <View style={[styles.fieldHalf, styles.field]}>
-                      <ThemedText style={styles.label}>Time</ThemedText>
+                      <ThemedText style={styles.label}>{t("booking.form.timeLabel")}</ThemedText>
                       <TimePicker
                         selectedTime={time}
                         onSelect={setTime}
@@ -276,7 +288,7 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
 
                   <View style={styles.fieldRow}>
                     <View style={[styles.fieldHalf, styles.field]}>
-                      <ThemedText style={styles.label}>Guests</ThemedText>
+                      <ThemedText style={styles.label}>{t("booking.form.guestsLabel")}</ThemedText>
                       <Select
                         selectedValue={seats}
                         onSelect={(v) => setSeats(v as number)}
@@ -284,9 +296,11 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
                       />
                     </View>
                     <View style={styles.fieldHalf}>
-                      <ThemedText style={styles.label}>Guest name (optional)</ThemedText>
+                      <ThemedText style={styles.label}>
+                        {t("admin.bookings.form.guestNameOptional")}
+                      </ThemedText>
                       <Input
-                        placeholder="Full name"
+                        placeholder={t("admin.bookings.form.namePlaceholder")}
                         value={guestName}
                         onChangeText={setGuestName}
                         autoCapitalize="words"
@@ -295,9 +309,11 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
                   </View>
 
                   <View style={styles.field}>
-                    <ThemedText style={styles.label}>Guest email</ThemedText>
+                    <ThemedText style={styles.label}>
+                      {t("admin.bookings.form.guestEmail")}
+                    </ThemedText>
                     <Input
-                      placeholder="guest@example.com"
+                      placeholder={t("admin.bookings.form.emailPlaceholder")}
                       value={email}
                       onChangeText={setEmail}
                       keyboardType="email-address"
@@ -313,7 +329,9 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
                     disabled={!isValid || submitting}
                     loading={submitting}
                   >
-                    {submitting ? "Creating…" : "Create Booking"}
+                    {submitting
+                      ? t("admin.bookings.newBookingModal.creating")
+                      : t("admin.bookings.newBookingModal.submit")}
                   </Button>
                 </ScrollView>
               )}
@@ -324,10 +342,10 @@ export function NewBookingModal({ visible, onClose, onCreated }: NewBookingModal
 
       <ConfirmModal
         visible={!!capacityWarning}
-        title="Over Capacity"
+        title={t("admin.bookings.newBookingModal.overCapacityTitle")}
         message={capacityWarning ?? ""}
-        confirmLabel="Book Anyway"
-        cancelLabel="Go Back"
+        confirmLabel={t("admin.bookings.newBookingModal.bookAnyway")}
+        cancelLabel={t("admin.bookings.goBack")}
         onConfirm={() => {
           setCapacityWarning(null);
           doSubmit();

--- a/openresto-frontend/components/admin/bookings/RestaurantActionModal.tsx
+++ b/openresto-frontend/components/admin/bookings/RestaurantActionModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Modal, Pressable, View, ScrollView, ActivityIndicator } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import Button from "@/components/common/Button";
 import { ButtonRow } from "@/components/common/ButtonRow";
@@ -29,6 +30,7 @@ export default function RestaurantActionModal({
   actionType,
   onSuccess,
 }: RestaurantActionModalProps) {
+  const { t } = useTranslation();
   const { colors, primaryColor } = useAppTheme();
   const [restaurants, setRestaurants] = useState<
     { id: number; name: string; bookingsPausedUntil?: string; activeBookingsCount?: number }[]
@@ -74,18 +76,25 @@ export default function RestaurantActionModal({
           if (result.extendedBookings.length > 0) {
             setExtendedBookings(result.extendedBookings);
           } else {
-            onSuccess?.(`No active bookings found to extend for ${restaurantName}.`);
+            onSuccess?.(
+              t("admin.bookings.restaurantAction.noActiveToExtend", { name: restaurantName })
+            );
             onClose();
           }
         }
       } else {
         if (isCurrentlyPaused) {
           await unpauseRestaurantBookings(restaurantId);
-          onSuccess?.(`Bookings for ${restaurantName} have been resumed.`);
+          onSuccess?.(
+            t("admin.bookings.restaurantAction.resumedSuccess", { name: restaurantName })
+          );
         } else {
           await pauseRestaurantBookings(restaurantId, 60);
           onSuccess?.(
-            `Bookings for ${restaurantName} up to ${willPauseUntil} are paused. Later times stay open.`
+            t("admin.bookings.restaurantAction.pausedSuccess", {
+              name: restaurantName,
+              time: willPauseUntil,
+            })
           );
         }
         onClose();
@@ -106,27 +115,27 @@ export default function RestaurantActionModal({
           accessibilityViewIsModal
           accessibilityLabel={
             extendedBookings
-              ? "Bookings extended"
+              ? t("admin.bookings.restaurantAction.a11y.extended")
               : actionType === "pause"
-                ? "Pause bookings"
-                : "Extend bookings"
+                ? t("admin.bookings.restaurantAction.a11y.pause")
+                : t("admin.bookings.restaurantAction.a11y.extend")
           }
           style={[styles.content, { backgroundColor: colors.card, borderColor: colors.border }]}
         >
           <View style={styles.header}>
             <ThemedText style={styles.title} accessibilityRole="header">
               {extendedBookings
-                ? "Bookings Extended"
+                ? t("admin.bookings.restaurantAction.title.extended")
                 : actionType === "pause"
-                  ? "Pause Bookings"
-                  : "Extend Bookings"}
+                  ? t("admin.bookings.restaurantAction.title.pause")
+                  : t("admin.bookings.restaurantAction.title.extend")}
             </ThemedText>
             <Pressable
               onPress={onClose}
               style={styles.closeBtn}
               testID="close-modal-button"
               accessibilityRole="button"
-              accessibilityLabel="Close"
+              accessibilityLabel={t("common.actions.close")}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             >
               <Icon name="close" size="xxl" color={colors.muted} />
@@ -135,10 +144,12 @@ export default function RestaurantActionModal({
 
           <ThemedText style={[styles.subtitle, { color: colors.muted }]}>
             {extendedBookings
-              ? `The following ${extendedBookings.length} bookings have been extended by 1 hour:`
+              ? t("admin.bookings.restaurantAction.extendedSubtitle", {
+                  count: extendedBookings.length,
+                })
               : actionType === "pause"
-                ? "Pausing turns away new bookings for the next hour of service. Later times stay bookable."
-                : "Select a restaurant to extend all active bookings by 1 hour."}
+                ? t("admin.bookings.restaurantAction.pauseSubtitle")
+                : t("admin.bookings.restaurantAction.extendSubtitle")}
           </ThemedText>
 
           {loading ? (
@@ -146,7 +157,7 @@ export default function RestaurantActionModal({
               style={styles.spinner}
               color={primaryColor}
               testID="loading-indicator"
-              accessibilityLabel="Loading restaurants"
+              accessibilityLabel={t("admin.bookings.restaurantAction.loadingRestaurants")}
             />
           ) : extendedBookings ? (
             <>
@@ -158,8 +169,10 @@ export default function RestaurantActionModal({
                       <ThemedText style={[styles.itemMeta, { color: colors.muted }]}>
                         {fmtTime(new Date(b.date))}
                         {" → "}
-                        {b.endTime ? fmtTime(new Date(b.endTime)) : "Extended"}
-                        {` · ${b.seats} guests`}
+                        {b.endTime
+                          ? fmtTime(new Date(b.endTime))
+                          : t("admin.bookings.restaurantAction.extendedFallback")}
+                        {` · ${t("booking.form.partySize", { count: b.seats })}`}
                       </ThemedText>
                     </View>
                   </View>
@@ -167,13 +180,15 @@ export default function RestaurantActionModal({
               </ScrollView>
               <ButtonRow style={styles.footer}>
                 <Button size="md" onPress={onClose}>
-                  Done
+                  {t("admin.bookings.restaurantAction.doneAction")}
                 </Button>
               </ButtonRow>
             </>
           ) : restaurants.length === 0 ? (
             <View style={styles.empty}>
-              <ThemedText style={{ color: colors.muted }}>No restaurants found.</ThemedText>
+              <ThemedText style={{ color: colors.muted }}>
+                {t("admin.bookings.restaurantAction.noRestaurants")}
+              </ThemedText>
             </View>
           ) : (
             <ScrollView style={styles.list}>
@@ -188,7 +203,12 @@ export default function RestaurantActionModal({
                     onPress={() => handleAction(r.id, r.name, isPaused)}
                     disabled={submitting !== null}
                     accessibilityRole="button"
-                    accessibilityLabel={`${isPaused ? "Resume" : "Pause"} bookings for ${r.name}`}
+                    accessibilityLabel={t(
+                      isPaused
+                        ? "admin.bookings.restaurantAction.resumeLabel"
+                        : "admin.bookings.restaurantAction.pauseLabel",
+                      { name: r.name }
+                    )}
                     accessibilityState={{ disabled: submitting !== null }}
                     style={({ pressed }) => [
                       styles.item,
@@ -211,17 +231,23 @@ export default function RestaurantActionModal({
                             <ThemedText
                               style={{ color: theme.colors.error, fontSize: 10, fontWeight: "700" }}
                             >
-                              PAUSED
+                              {t("admin.bookings.restaurantAction.pausedBadge")}
                             </ThemedText>
                           </View>
                         )}
                       </View>
                       <ThemedText style={[styles.itemMeta, { color: colors.muted }]}>
                         {isPaused
-                          ? `Bookings up to ${fmtTime(new Date(r.bookingsPausedUntil!))} are paused`
+                          ? t("admin.bookings.restaurantAction.pausedUntil", {
+                              time: fmtTime(new Date(r.bookingsPausedUntil!)),
+                            })
                           : actionType === "pause"
-                            ? `Will pause bookings up to ${willPauseUntil}`
-                            : `${r.activeBookingsCount ?? 0} active bookings`}
+                            ? t("admin.bookings.restaurantAction.willPauseUntil", {
+                                time: willPauseUntil,
+                              })
+                            : t("admin.bookings.restaurantAction.activeBookingsCount", {
+                                count: r.activeBookingsCount ?? 0,
+                              })}
                       </ThemedText>
                     </View>
                     {submitting === r.id ? (

--- a/openresto-frontend/components/admin/bookings/StatusBadge.tsx
+++ b/openresto-frontend/components/admin/bookings/StatusBadge.tsx
@@ -1,4 +1,6 @@
 import { View } from "react-native";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { ThemedText } from "@/components/themed-text";
 import { theme } from "@/theme/theme";
 import { styles } from "./bookings.styles";
@@ -12,22 +14,46 @@ export type BadgeVariant = "arrived" | "seated" | "upcoming" | "scheduled" | "co
 // and booking-confirmation screens don't have to reach into components/admin.
 export { isPast };
 
-export function getStatus(date: string): { label: string; variant: BadgeVariant } {
+/**
+ * `variant` is the sorting/styling key (STATUS_RANK, BADGE_STYLES below) and is never
+ * rendered on its own — `getStatus` below resolves it to a localized `label` through `t`.
+ * Keeping `variant` untranslated is what lets `statusRankFor` sort correctly regardless
+ * of UI language.
+ * @see [StatusBadge.test.tsx](../../../tests/components/StatusBadge.test.tsx)
+ * — pins that the label localizes while the variant/rank stay locale-independent.
+ */
+export function statusVariantFor(date: string): BadgeVariant {
   const d = new Date(date);
   const now = new Date();
   const diffMins = (d.getTime() - now.getTime()) / 60000;
-  if (diffMins < -90) return { label: "Completed", variant: "completed" };
-  if (diffMins < -15) return { label: "Seated", variant: "seated" };
-  if (diffMins < 5) return { label: "Arrived", variant: "arrived" };
-  if (diffMins < 60) return { label: "Upcoming", variant: "upcoming" };
-  return { label: "Scheduled", variant: "scheduled" };
+  if (diffMins < -90) return "completed";
+  if (diffMins < -15) return "seated";
+  if (diffMins < 5) return "arrived";
+  if (diffMins < 60) return "upcoming";
+  return "scheduled";
+}
+
+export function getStatus(date: string, t: TFunction): { label: string; variant: BadgeVariant } {
+  const variant = statusVariantFor(date);
+  switch (variant) {
+    case "arrived":
+      return { label: t("admin.bookings.status.arrived"), variant };
+    case "seated":
+      return { label: t("admin.bookings.status.seated"), variant };
+    case "upcoming":
+      return { label: t("admin.bookings.status.upcoming"), variant };
+    case "scheduled":
+      return { label: t("admin.bookings.status.scheduled"), variant };
+    case "completed":
+      return { label: t("admin.bookings.status.completed"), variant };
+  }
 }
 
 // Lifecycle rank for status-based sorting (issue #208). Higher rank surfaces
 // earlier in the default (ascending) sort, so the most attention-worthy rows
 // land at the top: in-progress first, then upcoming/future, then historical,
-// with cancelled last. Reuses getStatus so the time thresholds stay defined
-// in exactly one place (see the keep-in-sync note on isPast above).
+// with cancelled last. Reuses statusVariantFor so the time thresholds stay
+// defined in exactly one place (see the keep-in-sync note on isPast above).
 const STATUS_RANK: Record<BadgeVariant, number> = {
   arrived: 5, // in-progress: sitting down now
   seated: 4, // in-progress: recently seated
@@ -39,7 +65,7 @@ const STATUS_RANK: Record<BadgeVariant, number> = {
 /** Numeric status rank for sorting; cancelled bookings sort last (rank 0). */
 export function statusRankFor(b: BookingDetailDto): number {
   if (b.isCancelled) return 0;
-  return STATUS_RANK[getStatus(b.date).variant];
+  return STATUS_RANK[statusVariantFor(b.date)];
 }
 
 const BADGE_STYLES: Record<
@@ -69,7 +95,8 @@ const BADGE_STYLES: Record<
 };
 
 export function StatusBadge({ date, isDark }: { date: string; isDark: boolean }) {
-  const { label, variant } = getStatus(date);
+  const { t } = useTranslation();
+  const { label, variant } = getStatus(date, t);
   const s = BADGE_STYLES[variant];
 
   const bg = isDark && s.bg.dark ? s.bg.dark : s.bg.light;

--- a/openresto-frontend/components/admin/bookings/bookingRowProps.ts
+++ b/openresto-frontend/components/admin/bookings/bookingRowProps.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from "i18next";
 import { fmtDateTime } from "@/utils/formatters";
 
 /**
@@ -25,16 +26,22 @@ export function rowA11yProps(id: number, focusedRowId: number | null, label?: st
 }
 
 /** One-line spoken summary of a booking row. */
-export function describeBookingRow(b: {
-  customerName?: string | null;
-  customerEmail: string;
-  date: string;
-  seats: number;
-  tableName?: string | null;
-}): string {
+export function describeBookingRow(
+  b: {
+    customerName?: string | null;
+    customerEmail: string;
+    date: string;
+    seats: number;
+    tableName?: string | null;
+  },
+  t: TFunction
+): string {
+  const name = b.customerName ?? b.customerEmail;
   const when = fmtDateTime(new Date(b.date));
-  const where = b.tableName ? `, ${b.tableName}` : "";
-  return `${b.customerName ?? b.customerEmail}, ${when}, ${b.seats} guests${where}`;
+  const seats = t("booking.form.partySize", { count: b.seats });
+  return b.tableName
+    ? t("admin.bookings.rowSummaryWithTable", { name, when, seats, table: b.tableName })
+    : t("admin.bookings.rowSummary", { name, when, seats });
 }
 
 /**

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -376,5 +376,255 @@
       "moreTagsLabel_one": "{{count}} weiteres Tag: {{list}}",
       "moreTagsLabel_other": "{{count}} weitere Tags: {{list}}"
     }
+  },
+  "admin": {
+    "bookings": {
+      "pageTitle": "Buchungen",
+      "searchResultsTitle": "Suchergebnisse",
+      "searchResultsCount_one": "{{count}} Ergebnis für „{{query}}“",
+      "searchResultsCount_other": "{{count}} Ergebnisse für „{{query}}“",
+      "totalTodaySummary": "{{total}} insgesamt · {{today}} heute",
+      "clearSearch": "Löschen",
+      "clearSearchLabel": "Suche löschen",
+      "newBooking": "Neue Buchung",
+      "newBookingLabel": "Neue Buchung",
+      "screenTitle": {
+        "live": "Aktuelle Buchungen",
+        "past": "Vergangene Buchungen",
+        "cancelled": "Stornierte Buchungen"
+      },
+      "tabs": {
+        "active": "Aktiv",
+        "past": "Vergangen",
+        "cancelled": "Storniert",
+        "showLabel": "{{tab}} Buchungen anzeigen"
+      },
+      "viewToggle": {
+        "timetable": "Zeitplan",
+        "list": "Liste",
+        "timetableLabel": "Zeitplanansicht",
+        "listLabel": "Listenansicht"
+      },
+      "timetable": {
+        "previousDay": "Vorheriger Tag",
+        "nextDay": "Nächster Tag",
+        "jumpToTodayLabel": "{{date}}, zu heute springen",
+        "tapForToday": "für heute tippen",
+        "legend": {
+          "seatedNow": "Jetzt platziert",
+          "booked": "Gebucht",
+          "now": "Jetzt",
+          "tapHint": "Tippen Sie auf eine Sitzung für Details"
+        },
+        "noTablesFound": "Keine Tische gefunden. Fügen Sie Bereiche und Tische im Standortmanager hinzu.",
+        "noBookingsOnDay": "Keine Buchungen am {{date}}",
+        "noBookingsGeneric": "Keine Buchungen an diesem Tag",
+        "guestFallback": "Gast",
+        "peopleAbbrev": "{{count}}P",
+        "sittingLabel": "{{guest}}, {{seats}} Gedecke an {{unit}}, {{start}} bis {{end}}",
+        "sittingLabelWithRemaining": "{{guest}}, {{seats}} Gedecke an {{unit}}, {{start}} bis {{end}}, {{remaining}}"
+      },
+      "sort": {
+        "time": "Uhrzeit",
+        "guest": "Gast",
+        "party": "Personen",
+        "status": "Status",
+        "sortLabel": "Sortieren",
+        "ariaLabel": "Sortieren nach {{column}}, {{direction}}",
+        "ascending": "aufsteigend",
+        "descending": "absteigend",
+        "notSorted": "nicht sortiert"
+      },
+      "status": {
+        "completed": "Abgeschlossen",
+        "seated": "Platziert",
+        "arrived": "Angekommen",
+        "upcoming": "Bevorstehend",
+        "scheduled": "Geplant",
+        "cancelled": "Storniert"
+      },
+      "rowSummary": "{{name}}, {{when}}, {{seats}}",
+      "rowSummaryWithTable": "{{name}}, {{when}}, {{seats}}, {{table}}",
+      "cancelBookingTitle": "Buchung stornieren",
+      "cancelBookingConfirm": "Buchung für {{name}} stornieren?",
+      "keep": "Behalten",
+      "goBack": "Zurück",
+      "emptyState": "Keine Buchungen gefunden",
+      "cancelBookingLabel": "Buchung stornieren",
+      "cancelBookingForLabel": "Buchung für {{name}} stornieren",
+      "restoring": "Wird wiederhergestellt…",
+      "restoreBooking": "Buchung wiederherstellen",
+      "restoreBookingLabel": "Buchung wiederherstellen",
+      "cancelling": "Wird storniert…",
+      "permanentlyDeleteGdpr": "Endgültig löschen (DSGVO)",
+      "permanentlyDeleteLabel": "Buchung endgültig löschen (DSGVO)",
+      "permanentlyDeleteHint": "Dies kann nicht rückgängig gemacht werden",
+      "form": {
+        "restaurant": "Restaurant",
+        "guestEmail": "E-Mail des Gasts",
+        "guestName": "Name des Gasts",
+        "guestNameOptional": "Name des Gasts (optional)",
+        "specialRequests": "Besondere Wünsche",
+        "emailPlaceholder": "gast@beispiel.com",
+        "namePlaceholder": "Vollständiger Name",
+        "specialRequestsPlaceholder": "Ernährungsbedürfnisse, Anlass, Notizen",
+        "tableOptionLabel": "{{name}} ({{seats}})",
+        "tableFallbackName": "Tisch {{id}}"
+      },
+      "detail": {
+        "heading": "Buchungsdetails",
+        "dialogLabel": "Buchungsdetails",
+        "closeLabel": "Buchungsdetails schließen",
+        "edit": "Bearbeiten",
+        "editLabel": "Buchung bearbeiten",
+        "discardChangesLabel": "Änderungen verwerfen",
+        "saveChanges": "Änderungen speichern",
+        "saving": "Wird gespeichert…",
+        "saveChangesLabel": "Änderungen speichern",
+        "notFound": "Buchung nicht gefunden.",
+        "invalidSeats": "Ungültige Personenzahl",
+        "dateTimeRequired": "Datum und Uhrzeit sind erforderlich",
+        "fields": {
+          "ref": "Ref.",
+          "party": "Personen",
+          "name": "Name",
+          "requests": "Wünsche"
+        },
+        "noRequests": "Keine",
+        "timeRangeWithDuration": "{{range}} ({{mins}} Min.)",
+        "extendSection": "Buchung verlängern",
+        "extendByMinutes": "+{{mins}} Min.",
+        "extendByMinutesLabel": "Buchung um {{mins}} Minuten verlängern",
+        "emailGuest": "E-Mail an Gast",
+        "emailTo": "An: {{email}}",
+        "moveNotice": "Die Sitzung wurde verschoben. Unten steht ein noch nicht gesendeter Hinweis: bearbeiten Sie ihn oder senden Sie ihn so, wie er ist.",
+        "subjectPlaceholder": "Betreff",
+        "bodyPlaceholder": "Nachrichtentext (HTML wird unterstützt)",
+        "sendEmail": "E-Mail senden",
+        "sending": "Wird gesendet…",
+        "sendEmailLabel": "E-Mail an Gast senden",
+        "restoreBookingTitle": "Buchung wiederherstellen",
+        "restoreBookingConfirm": "Möchten Sie diese stornierte Buchung wirklich wiederherstellen?",
+        "restore": "Wiederherstellen",
+        "cancelBookingConfirmMessage": "Möchten Sie diese Buchung wirklich stornieren? Dies kann nicht rückgängig gemacht werden.",
+        "permanentlyDeleteTitle": "Endgültig löschen",
+        "permanentlyDeleteMessage": "Dadurch werden alle Daten dieser Buchung, einschließlich der E-Mail-Adresse und persönlichen Daten des Gasts, endgültig gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "deleteForever": "Endgültig löschen",
+        "failedToCancel": "Die Buchung konnte nicht storniert werden.",
+        "failedToRestore": "Die Buchung konnte nicht wiederhergestellt werden.",
+        "failedToUpdate": "Die Buchung konnte nicht aktualisiert werden.",
+        "failedToPermanentlyDelete": "Die Buchung konnte nicht endgültig gelöscht werden."
+      },
+      "newBookingModal": {
+        "closeFormLabel": "Formular für neue Buchung schließen",
+        "dialogLabel": "Neue Buchung",
+        "loadingForm": "Buchungsformular wird geladen",
+        "creating": "Wird erstellt…",
+        "submit": "Buchung erstellen",
+        "overCapacityTitle": "Kapazität überschritten",
+        "overCapacityMessage": "Dieser Tisch bietet nur Platz für {{tableSeats}}, Sie buchen jedoch für {{guests}}. Trotzdem fortfahren?",
+        "bookAnyway": "Trotzdem buchen",
+        "createError": "Die Buchung konnte nicht erstellt werden."
+      },
+      "restaurantAction": {
+        "title": {
+          "extended": "Buchungen verlängert",
+          "pause": "Buchungen pausieren",
+          "extend": "Buchungen verlängern"
+        },
+        "a11y": {
+          "extended": "Buchungen verlängert",
+          "pause": "Buchungen pausieren",
+          "extend": "Buchungen verlängern"
+        },
+        "pauseSubtitle": "Beim Pausieren werden neue Buchungen für die nächste Servicestunde abgelehnt. Spätere Zeiten bleiben buchbar.",
+        "extendSubtitle": "Wählen Sie ein Restaurant, um alle aktiven Buchungen um 1 Stunde zu verlängern.",
+        "extendedSubtitle_one": "Die folgende Buchung wurde um 1 Stunde verlängert:",
+        "extendedSubtitle_other": "Die folgenden {{count}} Buchungen wurden um 1 Stunde verlängert:",
+        "loadingRestaurants": "Restaurants werden geladen",
+        "noRestaurants": "Keine Restaurants gefunden.",
+        "pausedBadge": "PAUSIERT",
+        "resumeLabel": "Buchungen für {{name}} fortsetzen",
+        "pauseLabel": "Buchungen für {{name}} pausieren",
+        "pausedUntil": "Buchungen bis {{time}} sind pausiert",
+        "willPauseUntil": "Pausiert Buchungen bis {{time}}",
+        "activeBookingsCount_one": "{{count}} aktive Buchung",
+        "activeBookingsCount_other": "{{count}} aktive Buchungen",
+        "extendedFallback": "Verlängert",
+        "noActiveToExtend": "Keine aktiven Buchungen zum Verlängern für {{name}} gefunden.",
+        "resumedSuccess": "Buchungen für {{name}} wurden fortgesetzt.",
+        "pausedSuccess": "Buchungen für {{name}} bis {{time}} sind pausiert. Spätere Zeiten bleiben offen.",
+        "doneAction": "Fertig"
+      },
+      "lookup": {
+        "placeholder": "Name, E-Mail oder Referenz…",
+        "find": "Suchen",
+        "findLabel": "Buchung suchen",
+        "notFound": "Keine Buchung gefunden.",
+        "showingAllMatches": "Alle Treffer werden angezeigt…"
+      }
+    },
+    "dashboard": {
+      "nativeTitle": "Admin-Dashboard",
+      "title": "Dashboard",
+      "welcomeSubtitle": "Willkommen zurück. Das passiert heute.",
+      "successTitle": "Erfolg",
+      "metrics": {
+        "todayBookings": {
+          "label": "Heutige Buchungen",
+          "sub": "Gedecke insgesamt heute"
+        },
+        "activeHolds": {
+          "label": "Aktive Reservierungen",
+          "sub": "Derzeit vorgemerkte Tische"
+        },
+        "restaurantStatus": {
+          "label": "Restaurantstatus",
+          "active": "Aktiv",
+          "paused": "Pausiert",
+          "subActive": "Alle Standorte nehmen Buchungen an",
+          "subPaused_one": "{{count}} Standort ist derzeit pausiert",
+          "subPaused_other": "{{count}} Standorte sind derzeit pausiert"
+        },
+        "totalCovers": {
+          "label": "Gedecke insgesamt",
+          "sub": "Insgesamt bediente Gäste (gesamter Zeitraum)"
+        }
+      },
+      "quickActions": {
+        "viewAllBookings": "Alle Buchungen anzeigen",
+        "manageSettings": "Einstellungen verwalten"
+      },
+      "chart": {
+        "title": "Auslastungsübersicht",
+        "last7Days": "Letzte 7 Tage",
+        "dayLabel": {
+          "tMinus6": "T-6",
+          "tMinus5": "T-5",
+          "tMinus4": "T-4",
+          "tMinus3": "T-3",
+          "tMinus2": "T-2",
+          "tMinus1": "T-1",
+          "today": "Heute"
+        },
+        "toggle": {
+          "relativeLabel": "Stunden relativ zu jetzt anzeigen",
+          "calendarLabel": "Stunden nach Uhrzeit anzeigen",
+          "relativeText": "T-x",
+          "datesText": "Daten"
+        },
+        "summary_one": "{{count}} Buchung · {{perDay}}/Tag · Spitze {{weekday}}",
+        "summary_other": "{{count}} Buchungen · {{perDay}}/Tag · Spitze {{weekday}}",
+        "summaryEmpty": "Keine Buchungen in den letzten 7 Tagen"
+      },
+      "recentBookings": {
+        "viewAll": "Alle anzeigen →",
+        "viewAllLabel": "Alle Buchungen anzeigen",
+        "empty": "Keine bevorstehenden Buchungen für heute.",
+        "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
+        "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, storniert",
+        "meta": "{{seats}} · {{restaurant}}"
+      }
+    }
   }
 }

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -376,5 +376,255 @@
       "moreTagsLabel_one": "{{count}} more tag: {{list}}",
       "moreTagsLabel_other": "{{count}} more tags: {{list}}"
     }
+  },
+  "admin": {
+    "bookings": {
+      "pageTitle": "Bookings",
+      "searchResultsTitle": "Search Results",
+      "searchResultsCount_one": "{{count}} result for \"{{query}}\"",
+      "searchResultsCount_other": "{{count}} results for \"{{query}}\"",
+      "totalTodaySummary": "{{total}} total · {{today}} today",
+      "clearSearch": "Clear",
+      "clearSearchLabel": "Clear search",
+      "newBooking": "New Booking",
+      "newBookingLabel": "New booking",
+      "screenTitle": {
+        "live": "Live Bookings",
+        "past": "Past Bookings",
+        "cancelled": "Cancelled Bookings"
+      },
+      "tabs": {
+        "active": "Active",
+        "past": "Past",
+        "cancelled": "Cancelled",
+        "showLabel": "Show {{tab}} bookings"
+      },
+      "viewToggle": {
+        "timetable": "Timetable",
+        "list": "List",
+        "timetableLabel": "Timetable view",
+        "listLabel": "List view"
+      },
+      "timetable": {
+        "previousDay": "Previous day",
+        "nextDay": "Next day",
+        "jumpToTodayLabel": "{{date}}, jump to today",
+        "tapForToday": "tap for today",
+        "legend": {
+          "seatedNow": "Seated now",
+          "booked": "Booked",
+          "now": "Now",
+          "tapHint": "Tap a sitting to view details"
+        },
+        "noTablesFound": "No tables found. Add sections and tables in Location Manager.",
+        "noBookingsOnDay": "No bookings on {{date}}",
+        "noBookingsGeneric": "No bookings on this day",
+        "guestFallback": "Guest",
+        "peopleAbbrev": "{{count}}p",
+        "sittingLabel": "{{guest}}, {{seats}} covers on {{unit}}, {{start}} to {{end}}",
+        "sittingLabelWithRemaining": "{{guest}}, {{seats}} covers on {{unit}}, {{start}} to {{end}}, {{remaining}}"
+      },
+      "sort": {
+        "time": "Time",
+        "guest": "Guest",
+        "party": "Party",
+        "status": "Status",
+        "sortLabel": "Sort",
+        "ariaLabel": "Sort by {{column}}, {{direction}}",
+        "ascending": "ascending",
+        "descending": "descending",
+        "notSorted": "not sorted"
+      },
+      "status": {
+        "completed": "Completed",
+        "seated": "Seated",
+        "arrived": "Arrived",
+        "upcoming": "Upcoming",
+        "scheduled": "Scheduled",
+        "cancelled": "Cancelled"
+      },
+      "rowSummary": "{{name}}, {{when}}, {{seats}}",
+      "rowSummaryWithTable": "{{name}}, {{when}}, {{seats}}, {{table}}",
+      "cancelBookingTitle": "Cancel Booking",
+      "cancelBookingConfirm": "Cancel booking for {{name}}?",
+      "keep": "Keep",
+      "goBack": "Go Back",
+      "emptyState": "No bookings found",
+      "cancelBookingLabel": "Cancel booking",
+      "cancelBookingForLabel": "Cancel booking for {{name}}",
+      "restoring": "Restoring…",
+      "restoreBooking": "Restore Booking",
+      "restoreBookingLabel": "Restore booking",
+      "cancelling": "Cancelling…",
+      "permanentlyDeleteGdpr": "Permanently Delete (GDPR)",
+      "permanentlyDeleteLabel": "Permanently delete booking for GDPR",
+      "permanentlyDeleteHint": "This cannot be undone",
+      "form": {
+        "restaurant": "Restaurant",
+        "guestEmail": "Guest email",
+        "guestName": "Guest name",
+        "guestNameOptional": "Guest name (optional)",
+        "specialRequests": "Special requests",
+        "emailPlaceholder": "guest@example.com",
+        "namePlaceholder": "Full name",
+        "specialRequestsPlaceholder": "Dietary needs, occasion, notes",
+        "tableOptionLabel": "{{name}} ({{seats}})",
+        "tableFallbackName": "Table {{id}}"
+      },
+      "detail": {
+        "heading": "Booking Details",
+        "dialogLabel": "Booking details",
+        "closeLabel": "Close booking details",
+        "edit": "Edit",
+        "editLabel": "Edit booking",
+        "discardChangesLabel": "Discard changes",
+        "saveChanges": "Save Changes",
+        "saving": "Saving…",
+        "saveChangesLabel": "Save changes",
+        "notFound": "Booking not found.",
+        "invalidSeats": "Invalid seats value",
+        "dateTimeRequired": "Date and time are required",
+        "fields": {
+          "ref": "Ref",
+          "party": "Party",
+          "name": "Name",
+          "requests": "Requests"
+        },
+        "noRequests": "None",
+        "timeRangeWithDuration": "{{range}} ({{mins}} min)",
+        "extendSection": "Extend booking",
+        "extendByMinutes": "+{{mins}} min",
+        "extendByMinutesLabel": "Extend booking by {{mins}} minutes",
+        "emailGuest": "Email guest",
+        "emailTo": "To: {{email}}",
+        "moveNotice": "The sitting moved. A notice is written below and has not been sent: edit it, or send it as it stands.",
+        "subjectPlaceholder": "Subject",
+        "bodyPlaceholder": "Message body (HTML supported)",
+        "sendEmail": "Send Email",
+        "sending": "Sending…",
+        "sendEmailLabel": "Send email to guest",
+        "restoreBookingTitle": "Restore Booking",
+        "restoreBookingConfirm": "Are you sure you want to restore this cancelled booking?",
+        "restore": "Restore",
+        "cancelBookingConfirmMessage": "Are you sure you want to cancel this booking? This cannot be undone.",
+        "permanentlyDeleteTitle": "Permanently Delete",
+        "permanentlyDeleteMessage": "This will permanently erase all data for this booking including the guest's email and personal details. This action cannot be reversed.",
+        "deleteForever": "Delete Forever",
+        "failedToCancel": "Failed to cancel the booking.",
+        "failedToRestore": "Failed to restore booking.",
+        "failedToUpdate": "Failed to update booking.",
+        "failedToPermanentlyDelete": "Failed to permanently delete the booking."
+      },
+      "newBookingModal": {
+        "closeFormLabel": "Close the new booking form",
+        "dialogLabel": "New booking",
+        "loadingForm": "Loading booking form",
+        "creating": "Creating…",
+        "submit": "Create Booking",
+        "overCapacityTitle": "Over Capacity",
+        "overCapacityMessage": "This table only seats {{tableSeats}} but you're booking for {{guests}}. Continue anyway?",
+        "bookAnyway": "Book Anyway",
+        "createError": "Failed to create booking."
+      },
+      "restaurantAction": {
+        "title": {
+          "extended": "Bookings Extended",
+          "pause": "Pause Bookings",
+          "extend": "Extend Bookings"
+        },
+        "a11y": {
+          "extended": "Bookings extended",
+          "pause": "Pause bookings",
+          "extend": "Extend bookings"
+        },
+        "pauseSubtitle": "Pausing turns away new bookings for the next hour of service. Later times stay bookable.",
+        "extendSubtitle": "Select a restaurant to extend all active bookings by 1 hour.",
+        "extendedSubtitle_one": "The following {{count}} booking has been extended by 1 hour:",
+        "extendedSubtitle_other": "The following {{count}} bookings have been extended by 1 hour:",
+        "loadingRestaurants": "Loading restaurants",
+        "noRestaurants": "No restaurants found.",
+        "pausedBadge": "PAUSED",
+        "resumeLabel": "Resume bookings for {{name}}",
+        "pauseLabel": "Pause bookings for {{name}}",
+        "pausedUntil": "Bookings up to {{time}} are paused",
+        "willPauseUntil": "Will pause bookings up to {{time}}",
+        "activeBookingsCount_one": "{{count}} active booking",
+        "activeBookingsCount_other": "{{count}} active bookings",
+        "extendedFallback": "Extended",
+        "noActiveToExtend": "No active bookings found to extend for {{name}}.",
+        "resumedSuccess": "Bookings for {{name}} have been resumed.",
+        "pausedSuccess": "Bookings for {{name}} up to {{time}} are paused. Later times stay open.",
+        "doneAction": "Done"
+      },
+      "lookup": {
+        "placeholder": "Name, email or reference…",
+        "find": "Find",
+        "findLabel": "Find booking",
+        "notFound": "No booking found.",
+        "showingAllMatches": "Showing all matches…"
+      }
+    },
+    "dashboard": {
+      "nativeTitle": "Admin Dashboard",
+      "title": "Dashboard",
+      "welcomeSubtitle": "Welcome back. Here is what's happening today.",
+      "successTitle": "Success",
+      "metrics": {
+        "todayBookings": {
+          "label": "Today's Bookings",
+          "sub": "Total covers for today"
+        },
+        "activeHolds": {
+          "label": "Active Holds",
+          "sub": "Tables currently being held"
+        },
+        "restaurantStatus": {
+          "label": "Restaurant Status",
+          "active": "Active",
+          "paused": "Paused",
+          "subActive": "All venues are accepting bookings",
+          "subPaused_one": "{{count}} venue is currently paused",
+          "subPaused_other": "{{count}} venues are currently paused"
+        },
+        "totalCovers": {
+          "label": "Total Covers",
+          "sub": "Total guests served (all time)"
+        }
+      },
+      "quickActions": {
+        "viewAllBookings": "View All Bookings",
+        "manageSettings": "Manage Settings"
+      },
+      "chart": {
+        "title": "Occupancy Overview",
+        "last7Days": "Last 7 days",
+        "dayLabel": {
+          "tMinus6": "T-6",
+          "tMinus5": "T-5",
+          "tMinus4": "T-4",
+          "tMinus3": "T-3",
+          "tMinus2": "T-2",
+          "tMinus1": "T-1",
+          "today": "Today"
+        },
+        "toggle": {
+          "relativeLabel": "Label hours relative to now",
+          "calendarLabel": "Label hours by clock time",
+          "relativeText": "T-x",
+          "datesText": "Dates"
+        },
+        "summary_one": "{{count}} booking · {{perDay}}/day · peak {{weekday}}",
+        "summary_other": "{{count}} bookings · {{perDay}}/day · peak {{weekday}}",
+        "summaryEmpty": "No bookings in the last 7 days"
+      },
+      "recentBookings": {
+        "viewAll": "View all →",
+        "viewAllLabel": "View all bookings",
+        "empty": "No upcoming bookings for today.",
+        "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
+        "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, cancelled",
+        "meta": "{{seats}} · {{restaurant}}"
+      }
+    }
   }
 }

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -376,5 +376,255 @@
       "moreTagsLabel_one": "{{count}} etiqueta más: {{list}}",
       "moreTagsLabel_other": "{{count}} etiquetas más: {{list}}"
     }
+  },
+  "admin": {
+    "bookings": {
+      "pageTitle": "Reservas",
+      "searchResultsTitle": "Resultados de búsqueda",
+      "searchResultsCount_one": "{{count}} resultado para «{{query}}»",
+      "searchResultsCount_other": "{{count}} resultados para «{{query}}»",
+      "totalTodaySummary": "{{total}} en total · {{today}} hoy",
+      "clearSearch": "Borrar",
+      "clearSearchLabel": "Borrar búsqueda",
+      "newBooking": "Nueva reserva",
+      "newBookingLabel": "Nueva reserva",
+      "screenTitle": {
+        "live": "Reservas activas",
+        "past": "Reservas pasadas",
+        "cancelled": "Reservas canceladas"
+      },
+      "tabs": {
+        "active": "Activas",
+        "past": "Pasadas",
+        "cancelled": "Canceladas",
+        "showLabel": "Mostrar reservas {{tab}}"
+      },
+      "viewToggle": {
+        "timetable": "Horario",
+        "list": "Lista",
+        "timetableLabel": "Vista de horario",
+        "listLabel": "Vista de lista"
+      },
+      "timetable": {
+        "previousDay": "Día anterior",
+        "nextDay": "Día siguiente",
+        "jumpToTodayLabel": "{{date}}, ir a hoy",
+        "tapForToday": "toca para ir a hoy",
+        "legend": {
+          "seatedNow": "Sentados ahora",
+          "booked": "Reservado",
+          "now": "Ahora",
+          "tapHint": "Toca un turno para ver los detalles"
+        },
+        "noTablesFound": "No se encontraron mesas. Agrega secciones y mesas en el gestor de establecimientos.",
+        "noBookingsOnDay": "No hay reservas el {{date}}",
+        "noBookingsGeneric": "No hay reservas este día",
+        "guestFallback": "Cliente",
+        "peopleAbbrev": "{{count}}p",
+        "sittingLabel": "{{guest}}, {{seats}} cubiertos en {{unit}}, de {{start}} a {{end}}",
+        "sittingLabelWithRemaining": "{{guest}}, {{seats}} cubiertos en {{unit}}, de {{start}} a {{end}}, {{remaining}}"
+      },
+      "sort": {
+        "time": "Hora",
+        "guest": "Cliente",
+        "party": "Comensales",
+        "status": "Estado",
+        "sortLabel": "Ordenar",
+        "ariaLabel": "Ordenar por {{column}}, {{direction}}",
+        "ascending": "ascendente",
+        "descending": "descendente",
+        "notSorted": "sin ordenar"
+      },
+      "status": {
+        "completed": "Completada",
+        "seated": "Sentados",
+        "arrived": "Llegaron",
+        "upcoming": "Próxima",
+        "scheduled": "Programada",
+        "cancelled": "Cancelada"
+      },
+      "rowSummary": "{{name}}, {{when}}, {{seats}}",
+      "rowSummaryWithTable": "{{name}}, {{when}}, {{seats}}, {{table}}",
+      "cancelBookingTitle": "Cancelar reserva",
+      "cancelBookingConfirm": "¿Cancelar la reserva de {{name}}?",
+      "keep": "Conservar",
+      "goBack": "Volver",
+      "emptyState": "No se encontraron reservas",
+      "cancelBookingLabel": "Cancelar reserva",
+      "cancelBookingForLabel": "Cancelar la reserva de {{name}}",
+      "restoring": "Restaurando…",
+      "restoreBooking": "Restaurar reserva",
+      "restoreBookingLabel": "Restaurar reserva",
+      "cancelling": "Cancelando…",
+      "permanentlyDeleteGdpr": "Eliminar permanentemente (RGPD)",
+      "permanentlyDeleteLabel": "Eliminar permanentemente la reserva por el RGPD",
+      "permanentlyDeleteHint": "Esta acción no se puede deshacer",
+      "form": {
+        "restaurant": "Restaurante",
+        "guestEmail": "Correo del cliente",
+        "guestName": "Nombre del cliente",
+        "guestNameOptional": "Nombre del cliente (opcional)",
+        "specialRequests": "Solicitudes especiales",
+        "emailPlaceholder": "cliente@ejemplo.com",
+        "namePlaceholder": "Nombre completo",
+        "specialRequestsPlaceholder": "Necesidades dietéticas, ocasión, notas",
+        "tableOptionLabel": "{{name}} ({{seats}})",
+        "tableFallbackName": "Mesa {{id}}"
+      },
+      "detail": {
+        "heading": "Detalles de la reserva",
+        "dialogLabel": "Detalles de la reserva",
+        "closeLabel": "Cerrar detalles de la reserva",
+        "edit": "Editar",
+        "editLabel": "Editar reserva",
+        "discardChangesLabel": "Descartar cambios",
+        "saveChanges": "Guardar cambios",
+        "saving": "Guardando…",
+        "saveChangesLabel": "Guardar cambios",
+        "notFound": "Reserva no encontrada.",
+        "invalidSeats": "Número de comensales no válido",
+        "dateTimeRequired": "La fecha y la hora son obligatorias",
+        "fields": {
+          "ref": "Ref.",
+          "party": "Comensales",
+          "name": "Nombre",
+          "requests": "Solicitudes"
+        },
+        "noRequests": "Ninguna",
+        "timeRangeWithDuration": "{{range}} ({{mins}} min)",
+        "extendSection": "Ampliar reserva",
+        "extendByMinutes": "+{{mins}} min",
+        "extendByMinutesLabel": "Ampliar la reserva {{mins}} minutos",
+        "emailGuest": "Enviar correo al cliente",
+        "emailTo": "Para: {{email}}",
+        "moveNotice": "El turno cambió. Se ha redactado un aviso a continuación y aún no se ha enviado: editálo o envíalo tal cual.",
+        "subjectPlaceholder": "Asunto",
+        "bodyPlaceholder": "Cuerpo del mensaje (se admite HTML)",
+        "sendEmail": "Enviar correo",
+        "sending": "Enviando…",
+        "sendEmailLabel": "Enviar correo al cliente",
+        "restoreBookingTitle": "Restaurar reserva",
+        "restoreBookingConfirm": "¿Seguro que quieres restaurar esta reserva cancelada?",
+        "restore": "Restaurar",
+        "cancelBookingConfirmMessage": "¿Seguro que quieres cancelar esta reserva? Esta acción no se puede deshacer.",
+        "permanentlyDeleteTitle": "Eliminar permanentemente",
+        "permanentlyDeleteMessage": "Esto borrará permanentemente todos los datos de esta reserva, incluidos el correo y los datos personales del cliente. Esta acción no se puede revertir.",
+        "deleteForever": "Eliminar para siempre",
+        "failedToCancel": "No se pudo cancelar la reserva.",
+        "failedToRestore": "No se pudo restaurar la reserva.",
+        "failedToUpdate": "No se pudo actualizar la reserva.",
+        "failedToPermanentlyDelete": "No se pudo eliminar permanentemente la reserva."
+      },
+      "newBookingModal": {
+        "closeFormLabel": "Cerrar el formulario de nueva reserva",
+        "dialogLabel": "Nueva reserva",
+        "loadingForm": "Cargando formulario de reserva",
+        "creating": "Creando…",
+        "submit": "Crear reserva",
+        "overCapacityTitle": "Capacidad excedida",
+        "overCapacityMessage": "Esta mesa solo tiene capacidad para {{tableSeats}}, pero estás reservando para {{guests}}. ¿Continuar de todos modos?",
+        "bookAnyway": "Reservar de todos modos",
+        "createError": "No se pudo crear la reserva."
+      },
+      "restaurantAction": {
+        "title": {
+          "extended": "Reservas ampliadas",
+          "pause": "Pausar reservas",
+          "extend": "Ampliar reservas"
+        },
+        "a11y": {
+          "extended": "Reservas ampliadas",
+          "pause": "Pausar reservas",
+          "extend": "Ampliar reservas"
+        },
+        "pauseSubtitle": "Pausar rechaza nuevas reservas durante la próxima hora de servicio. Los horarios posteriores siguen disponibles.",
+        "extendSubtitle": "Selecciona un restaurante para ampliar todas las reservas activas una hora.",
+        "extendedSubtitle_one": "Se ha ampliado la siguiente reserva una hora:",
+        "extendedSubtitle_other": "Se han ampliado las siguientes {{count}} reservas una hora:",
+        "loadingRestaurants": "Cargando restaurantes",
+        "noRestaurants": "No se encontraron restaurantes.",
+        "pausedBadge": "PAUSADO",
+        "resumeLabel": "Reanudar reservas de {{name}}",
+        "pauseLabel": "Pausar reservas de {{name}}",
+        "pausedUntil": "Las reservas hasta las {{time}} están pausadas",
+        "willPauseUntil": "Pausará las reservas hasta las {{time}}",
+        "activeBookingsCount_one": "{{count}} reserva activa",
+        "activeBookingsCount_other": "{{count}} reservas activas",
+        "extendedFallback": "Ampliada",
+        "noActiveToExtend": "No se encontraron reservas activas para ampliar de {{name}}.",
+        "resumedSuccess": "Se han reanudado las reservas de {{name}}.",
+        "pausedSuccess": "Las reservas de {{name}} hasta las {{time}} están pausadas. Los horarios posteriores siguen abiertos.",
+        "doneAction": "Listo"
+      },
+      "lookup": {
+        "placeholder": "Nombre, correo o referencia…",
+        "find": "Buscar",
+        "findLabel": "Buscar reserva",
+        "notFound": "No se encontró ninguna reserva.",
+        "showingAllMatches": "Mostrando todas las coincidencias…"
+      }
+    },
+    "dashboard": {
+      "nativeTitle": "Panel de administración",
+      "title": "Panel",
+      "welcomeSubtitle": "Bienvenido de nuevo. Esto es lo que pasa hoy.",
+      "successTitle": "Éxito",
+      "metrics": {
+        "todayBookings": {
+          "label": "Reservas de hoy",
+          "sub": "Total de comensales para hoy"
+        },
+        "activeHolds": {
+          "label": "Retenciones activas",
+          "sub": "Mesas retenidas actualmente"
+        },
+        "restaurantStatus": {
+          "label": "Estado del restaurante",
+          "active": "Activo",
+          "paused": "Pausado",
+          "subActive": "Todos los locales aceptan reservas",
+          "subPaused_one": "{{count}} local está pausado actualmente",
+          "subPaused_other": "{{count}} locales están pausados actualmente"
+        },
+        "totalCovers": {
+          "label": "Total de comensales",
+          "sub": "Total de clientes atendidos (desde siempre)"
+        }
+      },
+      "quickActions": {
+        "viewAllBookings": "Ver todas las reservas",
+        "manageSettings": "Gestionar ajustes"
+      },
+      "chart": {
+        "title": "Resumen de ocupación",
+        "last7Days": "Últimos 7 días",
+        "dayLabel": {
+          "tMinus6": "T-6",
+          "tMinus5": "T-5",
+          "tMinus4": "T-4",
+          "tMinus3": "T-3",
+          "tMinus2": "T-2",
+          "tMinus1": "T-1",
+          "today": "Hoy"
+        },
+        "toggle": {
+          "relativeLabel": "Mostrar horas en relación con ahora",
+          "calendarLabel": "Mostrar horas por fecha",
+          "relativeText": "T-x",
+          "datesText": "Fechas"
+        },
+        "summary_one": "{{count}} reserva · {{perDay}}/día · pico {{weekday}}",
+        "summary_other": "{{count}} reservas · {{perDay}}/día · pico {{weekday}}",
+        "summaryEmpty": "No hay reservas en los últimos 7 días"
+      },
+      "recentBookings": {
+        "viewAll": "Ver todo →",
+        "viewAllLabel": "Ver todas las reservas",
+        "empty": "No hay reservas próximas para hoy.",
+        "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
+        "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, cancelada",
+        "meta": "{{seats}} · {{restaurant}}"
+      }
+    }
   }
 }

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -376,5 +376,255 @@
       "moreTagsLabel_one": "{{count}} tag supplémentaire : {{list}}",
       "moreTagsLabel_other": "{{count}} tags supplémentaires : {{list}}"
     }
+  },
+  "admin": {
+    "bookings": {
+      "pageTitle": "Réservations",
+      "searchResultsTitle": "Résultats de recherche",
+      "searchResultsCount_one": "{{count}} résultat pour « {{query}} »",
+      "searchResultsCount_other": "{{count}} résultats pour « {{query}} »",
+      "totalTodaySummary": "{{total}} au total · {{today}} aujourd'hui",
+      "clearSearch": "Effacer",
+      "clearSearchLabel": "Effacer la recherche",
+      "newBooking": "Nouvelle réservation",
+      "newBookingLabel": "Nouvelle réservation",
+      "screenTitle": {
+        "live": "Réservations en cours",
+        "past": "Réservations passées",
+        "cancelled": "Réservations annulées"
+      },
+      "tabs": {
+        "active": "En cours",
+        "past": "Passées",
+        "cancelled": "Annulées",
+        "showLabel": "Afficher les réservations {{tab}}"
+      },
+      "viewToggle": {
+        "timetable": "Planning",
+        "list": "Liste",
+        "timetableLabel": "Vue planning",
+        "listLabel": "Vue liste"
+      },
+      "timetable": {
+        "previousDay": "Jour précédent",
+        "nextDay": "Jour suivant",
+        "jumpToTodayLabel": "{{date}}, revenir à aujourd'hui",
+        "tapForToday": "toucher pour aujourd'hui",
+        "legend": {
+          "seatedNow": "Installés",
+          "booked": "Réservé",
+          "now": "Maintenant",
+          "tapHint": "Touchez un créneau pour voir les détails"
+        },
+        "noTablesFound": "Aucune table trouvée. Ajoutez des sections et des tables dans le gestionnaire d'établissement.",
+        "noBookingsOnDay": "Aucune réservation le {{date}}",
+        "noBookingsGeneric": "Aucune réservation ce jour-là",
+        "guestFallback": "Client",
+        "peopleAbbrev": "{{count}}p",
+        "sittingLabel": "{{guest}}, {{seats}} couverts à {{unit}}, de {{start}} à {{end}}",
+        "sittingLabelWithRemaining": "{{guest}}, {{seats}} couverts à {{unit}}, de {{start}} à {{end}}, {{remaining}}"
+      },
+      "sort": {
+        "time": "Heure",
+        "guest": "Client",
+        "party": "Convives",
+        "status": "Statut",
+        "sortLabel": "Trier",
+        "ariaLabel": "Trier par {{column}}, {{direction}}",
+        "ascending": "croissant",
+        "descending": "décroissant",
+        "notSorted": "non trié"
+      },
+      "status": {
+        "completed": "Terminé",
+        "seated": "Installé",
+        "arrived": "Arrivé",
+        "upcoming": "À venir",
+        "scheduled": "Planifié",
+        "cancelled": "Annulé"
+      },
+      "rowSummary": "{{name}}, {{when}}, {{seats}}",
+      "rowSummaryWithTable": "{{name}}, {{when}}, {{seats}}, {{table}}",
+      "cancelBookingTitle": "Annuler la réservation",
+      "cancelBookingConfirm": "Annuler la réservation de {{name}} ?",
+      "keep": "Conserver",
+      "goBack": "Retour",
+      "emptyState": "Aucune réservation trouvée",
+      "cancelBookingLabel": "Annuler la réservation",
+      "cancelBookingForLabel": "Annuler la réservation de {{name}}",
+      "restoring": "Restauration…",
+      "restoreBooking": "Restaurer la réservation",
+      "restoreBookingLabel": "Restaurer la réservation",
+      "cancelling": "Annulation…",
+      "permanentlyDeleteGdpr": "Supprimer définitivement (RGPD)",
+      "permanentlyDeleteLabel": "Supprimer définitivement la réservation pour le RGPD",
+      "permanentlyDeleteHint": "Cette action est irréversible",
+      "form": {
+        "restaurant": "Établissement",
+        "guestEmail": "E-mail du client",
+        "guestName": "Nom du client",
+        "guestNameOptional": "Nom du client (facultatif)",
+        "specialRequests": "Demandes particulières",
+        "emailPlaceholder": "client@exemple.com",
+        "namePlaceholder": "Nom complet",
+        "specialRequestsPlaceholder": "Régime alimentaire, occasion, notes",
+        "tableOptionLabel": "{{name}} ({{seats}})",
+        "tableFallbackName": "Table {{id}}"
+      },
+      "detail": {
+        "heading": "Détails de la réservation",
+        "dialogLabel": "Détails de la réservation",
+        "closeLabel": "Fermer les détails de la réservation",
+        "edit": "Modifier",
+        "editLabel": "Modifier la réservation",
+        "discardChangesLabel": "Annuler les modifications",
+        "saveChanges": "Enregistrer les modifications",
+        "saving": "Enregistrement…",
+        "saveChangesLabel": "Enregistrer les modifications",
+        "notFound": "Réservation introuvable.",
+        "invalidSeats": "Nombre de couverts invalide",
+        "dateTimeRequired": "La date et l'heure sont requises",
+        "fields": {
+          "ref": "Réf.",
+          "party": "Convives",
+          "name": "Nom",
+          "requests": "Demandes"
+        },
+        "noRequests": "Aucune",
+        "timeRangeWithDuration": "{{range}} ({{mins}} min)",
+        "extendSection": "Prolonger la réservation",
+        "extendByMinutes": "+{{mins}} min",
+        "extendByMinutesLabel": "Prolonger la réservation de {{mins}} minutes",
+        "emailGuest": "E-mail au client",
+        "emailTo": "À : {{email}}",
+        "moveNotice": "Le créneau a changé. Un message a été préparé ci-dessous et n'a pas été envoyé : modifiez-le ou envoyez-le tel quel.",
+        "subjectPlaceholder": "Objet",
+        "bodyPlaceholder": "Corps du message (HTML pris en charge)",
+        "sendEmail": "Envoyer l'e-mail",
+        "sending": "Envoi…",
+        "sendEmailLabel": "Envoyer un e-mail au client",
+        "restoreBookingTitle": "Restaurer la réservation",
+        "restoreBookingConfirm": "Voulez-vous vraiment restaurer cette réservation annulée ?",
+        "restore": "Restaurer",
+        "cancelBookingConfirmMessage": "Voulez-vous vraiment annuler cette réservation ? Cette action est irréversible.",
+        "permanentlyDeleteTitle": "Supprimer définitivement",
+        "permanentlyDeleteMessage": "Cette action effacera définitivement toutes les données de cette réservation, y compris l'e-mail et les informations personnelles du client. Cette action est irréversible.",
+        "deleteForever": "Supprimer définitivement",
+        "failedToCancel": "Échec de l'annulation de la réservation.",
+        "failedToRestore": "Échec de la restauration de la réservation.",
+        "failedToUpdate": "Échec de la mise à jour de la réservation.",
+        "failedToPermanentlyDelete": "Échec de la suppression définitive de la réservation."
+      },
+      "newBookingModal": {
+        "closeFormLabel": "Fermer le formulaire de nouvelle réservation",
+        "dialogLabel": "Nouvelle réservation",
+        "loadingForm": "Chargement du formulaire de réservation",
+        "creating": "Création…",
+        "submit": "Créer la réservation",
+        "overCapacityTitle": "Capacité dépassée",
+        "overCapacityMessage": "Cette table ne compte que {{tableSeats}} places, mais vous réservez pour {{guests}}. Continuer quand même ?",
+        "bookAnyway": "Réserver quand même",
+        "createError": "Échec de la création de la réservation."
+      },
+      "restaurantAction": {
+        "title": {
+          "extended": "Réservations prolongées",
+          "pause": "Suspendre les réservations",
+          "extend": "Prolonger les réservations"
+        },
+        "a11y": {
+          "extended": "Réservations prolongées",
+          "pause": "Suspendre les réservations",
+          "extend": "Prolonger les réservations"
+        },
+        "pauseSubtitle": "La suspension refuse les nouvelles réservations pour la prochaine heure de service. Les créneaux suivants restent réservables.",
+        "extendSubtitle": "Sélectionnez un établissement pour prolonger toutes les réservations actives d'une heure.",
+        "extendedSubtitle_one": "La réservation suivante a été prolongée d'une heure :",
+        "extendedSubtitle_other": "Les {{count}} réservations suivantes ont été prolongées d'une heure :",
+        "loadingRestaurants": "Chargement des établissements",
+        "noRestaurants": "Aucun établissement trouvé.",
+        "pausedBadge": "SUSPENDU",
+        "resumeLabel": "Reprendre les réservations de {{name}}",
+        "pauseLabel": "Suspendre les réservations de {{name}}",
+        "pausedUntil": "Les réservations jusqu'à {{time}} sont suspendues",
+        "willPauseUntil": "Suspendra les réservations jusqu'à {{time}}",
+        "activeBookingsCount_one": "{{count}} réservation active",
+        "activeBookingsCount_other": "{{count}} réservations actives",
+        "extendedFallback": "Prolongée",
+        "noActiveToExtend": "Aucune réservation active à prolonger pour {{name}}.",
+        "resumedSuccess": "Les réservations de {{name}} ont été reprises.",
+        "pausedSuccess": "Les réservations de {{name}} jusqu'à {{time}} sont suspendues. Les créneaux suivants restent ouverts.",
+        "doneAction": "Terminé"
+      },
+      "lookup": {
+        "placeholder": "Nom, e-mail ou référence…",
+        "find": "Rechercher",
+        "findLabel": "Rechercher une réservation",
+        "notFound": "Aucune réservation trouvée.",
+        "showingAllMatches": "Affichage de toutes les correspondances…"
+      }
+    },
+    "dashboard": {
+      "nativeTitle": "Tableau de bord admin",
+      "title": "Tableau de bord",
+      "welcomeSubtitle": "Bon retour. Voici ce qui se passe aujourd'hui.",
+      "successTitle": "Succès",
+      "metrics": {
+        "todayBookings": {
+          "label": "Réservations du jour",
+          "sub": "Total des couverts pour aujourd'hui"
+        },
+        "activeHolds": {
+          "label": "Réservations temporaires actives",
+          "sub": "Tables actuellement retenues"
+        },
+        "restaurantStatus": {
+          "label": "Statut de l'établissement",
+          "active": "Actif",
+          "paused": "Suspendu",
+          "subActive": "Tous les établissements acceptent les réservations",
+          "subPaused_one": "{{count}} établissement est actuellement suspendu",
+          "subPaused_other": "{{count}} établissements sont actuellement suspendus"
+        },
+        "totalCovers": {
+          "label": "Total des couverts",
+          "sub": "Total des clients servis (depuis toujours)"
+        }
+      },
+      "quickActions": {
+        "viewAllBookings": "Voir toutes les réservations",
+        "manageSettings": "Gérer les paramètres"
+      },
+      "chart": {
+        "title": "Aperçu de l'occupation",
+        "last7Days": "7 derniers jours",
+        "dayLabel": {
+          "tMinus6": "T-6",
+          "tMinus5": "T-5",
+          "tMinus4": "T-4",
+          "tMinus3": "T-3",
+          "tMinus2": "T-2",
+          "tMinus1": "T-1",
+          "today": "Aujourd'hui"
+        },
+        "toggle": {
+          "relativeLabel": "Afficher les heures par rapport à maintenant",
+          "calendarLabel": "Afficher les heures par date",
+          "relativeText": "T-x",
+          "datesText": "Dates"
+        },
+        "summary_one": "{{count}} réservation · {{perDay}}/jour · pic {{weekday}}",
+        "summary_other": "{{count}} réservations · {{perDay}}/jour · pic {{weekday}}",
+        "summaryEmpty": "Aucune réservation ces 7 derniers jours"
+      },
+      "recentBookings": {
+        "viewAll": "Tout voir →",
+        "viewAllLabel": "Voir toutes les réservations",
+        "empty": "Aucune réservation à venir aujourd'hui.",
+        "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
+        "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, annulée",
+        "meta": "{{seats}} · {{restaurant}}"
+      }
+    }
   }
 }

--- a/openresto-frontend/tests/app/admin/dashboard.test.tsx
+++ b/openresto-frontend/tests/app/admin/dashboard.test.tsx
@@ -111,7 +111,9 @@ describe("AdminDashboardScreen", () => {
     // "5" appears both as the Today's Bookings metric and as an occupancy count label,
     // so assert presence (not uniqueness) here.
     expect(screen.getAllByText("5").length).toBeGreaterThan(0);
-    expect(screen.getByText("1 venues are currently paused")).toBeTruthy();
+    // i18next's plural rule correctly resolves the singular form for a pausedCount of 1
+    // ("1 venue", not "1 venues") — see admin.dashboard.metrics.restaurantStatus.subPaused_one.
+    expect(screen.getByText("1 venue is currently paused")).toBeTruthy();
     expect(screen.getByText("100")).toBeTruthy();
   });
 

--- a/openresto-frontend/tests/components/BookingDetailsCard.test.tsx
+++ b/openresto-frontend/tests/components/BookingDetailsCard.test.tsx
@@ -1,6 +1,14 @@
 import React from "react";
-import { render, screen } from "@testing-library/react-native";
+import { render, screen, act } from "@testing-library/react-native";
+import i18n from "@/i18n";
 import { BookingDetailsCard } from "@/components/admin/bookings/BookingDetailsCard";
+
+function flattenStyle(style: unknown): Record<string, unknown>[] {
+  return ([] as unknown[]).concat(style).flat(Infinity).filter(Boolean) as Record<
+    string,
+    unknown
+  >[];
+}
 
 describe("BookingDetailsCard", () => {
   const mockBooking = {
@@ -63,5 +71,59 @@ describe("BookingDetailsCard", () => {
     );
     expect(screen.getByText("1 guest")).toBeTruthy();
     expect(screen.getByText(/150 min/)).toBeTruthy(); // 12:00 to 14:30 is 150 mins
+  });
+});
+
+/**
+ * The cancelled-row highlight used to compare the rendered English label ("Status") to
+ * decide which row to redden. Once the label is translated that comparison silently stops
+ * matching in every non-English locale, so the row-identity check now runs off a `key`
+ * field instead of the localized text.
+ * @see [BookingDetailsCard.test.tsx](BookingDetailsCard.test.tsx) — this file.
+ */
+describe("label/value split — the Status row highlight is keyed, not text-matched", () => {
+  const cancelledBooking = {
+    id: 1,
+    bookingRef: "REF123",
+    customerEmail: "guest@example.com",
+    date: "2026-10-10T12:00:00Z",
+    seats: 2,
+    restaurantName: "Test Resto",
+    sectionName: "Main",
+    tableName: "Table 1",
+    specialRequests: "Window seat",
+    isCancelled: true,
+  };
+  const props = {
+    booking: cancelledBooking,
+    borderColor: "gray",
+    mutedColor: "lightgray",
+    cardColor: "white",
+  };
+
+  afterEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+  });
+
+  it("highlights the cancelled status value in English", () => {
+    render(<BookingDetailsCard {...props} />);
+    const value = screen.getByText("CANCELLED");
+    const flattened = flattenStyle(value.props.style);
+    expect(flattened.some((s) => s.color === "#dc2626")).toBe(true);
+  });
+
+  it("still highlights the cancelled status value once the label text is French, not English", async () => {
+    await act(async () => {
+      await i18n.changeLanguage("fr");
+    });
+    render(<BookingDetailsCard {...props} />);
+    // The French label ("Statut") no longer reads "Status" — proof the highlight isn't
+    // driven by a literal-string comparison against the rendered label.
+    expect(screen.queryByText("Status")).toBeNull();
+    const value = screen.getByText("ANNULÉ");
+    const flattened = flattenStyle(value.props.style);
+    expect(flattened.some((s) => s.color === "#dc2626")).toBe(true);
   });
 });

--- a/openresto-frontend/tests/components/StatusBadge.test.tsx
+++ b/openresto-frontend/tests/components/StatusBadge.test.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
+import i18n from "@/i18n";
 import {
   StatusBadge,
   getStatus,
   isPast,
   statusRankFor,
+  statusVariantFor,
 } from "@/components/admin/bookings/StatusBadge";
+
+const t = i18n.getFixedT("en");
 
 jest.mock("@/hooks/use-color-scheme", () => ({
   useColorScheme: () => "light",
@@ -23,27 +27,45 @@ describe("isPast re-export", () => {
 describe("getStatus", () => {
   it("returns 'Completed' for bookings more than 90 minutes ago", () => {
     const date = new Date(Date.now() - 100 * 60 * 1000).toISOString();
-    expect(getStatus(date)).toEqual({ label: "Completed", variant: "completed" });
+    expect(getStatus(date, t)).toEqual({ label: "Completed", variant: "completed" });
   });
 
   it("returns 'Seated' for bookings 15-90 minutes ago", () => {
     const date = new Date(Date.now() - 30 * 60 * 1000).toISOString();
-    expect(getStatus(date)).toEqual({ label: "Seated", variant: "seated" });
+    expect(getStatus(date, t)).toEqual({ label: "Seated", variant: "seated" });
   });
 
   it("returns 'Arrived' for bookings within 5 minutes of now", () => {
     const date = new Date(Date.now() - 2 * 60 * 1000).toISOString();
-    expect(getStatus(date)).toEqual({ label: "Arrived", variant: "arrived" });
+    expect(getStatus(date, t)).toEqual({ label: "Arrived", variant: "arrived" });
   });
 
   it("returns 'Upcoming' for bookings 5-60 minutes in the future", () => {
     const date = new Date(Date.now() + 30 * 60 * 1000).toISOString();
-    expect(getStatus(date)).toEqual({ label: "Upcoming", variant: "upcoming" });
+    expect(getStatus(date, t)).toEqual({ label: "Upcoming", variant: "upcoming" });
   });
 
   it("returns 'Scheduled' for bookings more than 60 minutes in the future", () => {
     const date = new Date(Date.now() + 120 * 60 * 1000).toISOString();
-    expect(getStatus(date)).toEqual({ label: "Scheduled", variant: "scheduled" });
+    expect(getStatus(date, t)).toEqual({ label: "Scheduled", variant: "scheduled" });
+  });
+});
+
+describe("label/value split — variant stays untranslated so rank/style lookups don't break", () => {
+  it("resolves a localized label whose text differs from the internal variant identifier", () => {
+    const date = new Date(Date.now() - 100 * 60 * 1000).toISOString();
+    const { label, variant } = getStatus(date, t);
+    expect(variant).toBe("completed");
+    expect(label).not.toBe(variant);
+    expect(label).toBe("Completed");
+  });
+
+  it("keeps statusVariantFor's identifier stable regardless of the active translation function", () => {
+    const date = new Date(Date.now() - 100 * 60 * 1000).toISOString();
+    const frT = i18n.getFixedT("fr");
+    expect(statusVariantFor(date)).toBe("completed");
+    expect(getStatus(date, frT).variant).toBe("completed");
+    expect(getStatus(date, frT).label).not.toBe(getStatus(date, t).label);
   });
 });
 

--- a/openresto-frontend/tests/components/admin/bookings/bookingRowProps.test.ts
+++ b/openresto-frontend/tests/components/admin/bookings/bookingRowProps.test.ts
@@ -1,0 +1,31 @@
+import i18n from "@/i18n";
+import { describeBookingRow } from "@/components/admin/bookings/bookingRowProps";
+
+const t = i18n.getFixedT("en");
+
+describe("describeBookingRow", () => {
+  const base = {
+    customerName: "Alice",
+    customerEmail: "alice@example.com",
+    date: "2026-10-10T18:00:00Z",
+    seats: 2,
+  };
+
+  it("includes the table name when the booking has one", () => {
+    const label = describeBookingRow({ ...base, tableName: "T4" }, t);
+    expect(label).toContain("T4");
+    expect(label).toContain("Alice");
+    expect(label).toContain("2 guests");
+  });
+
+  it("omits the table clause when the booking has no table (unassigned)", () => {
+    const label = describeBookingRow({ ...base, tableName: null }, t);
+    expect(label).not.toContain("null");
+    expect(label.endsWith("2 guests")).toBe(true);
+  });
+
+  it("falls back to the customer email when no name is set", () => {
+    const label = describeBookingRow({ ...base, customerName: null, tableName: undefined }, t);
+    expect(label).toContain("alice@example.com");
+  });
+});


### PR DESCRIPTION
## Summary
- First of five PRs for #374 (i18n F: translate the admin surface). Wires the admin bookings list/timetable, booking lookup bar, new-booking modal, booking detail popup (including edit/extend/email-guest sub-forms), restaurant pause/extend modal, and the admin dashboard into i18next.
- Adds a new `admin.bookings.*` / `admin.dashboard.*` key subtree to all four locale files (`en`, `fr`, `es`, `de`), reusing `common.actions.*`, `errors.title`, and `booking.form.*` wherever the English text already matched (e.g. Date/Time/Section/Table labels, `partySize`/`seatsCount` pluralization, `oversizeConfirm`).
- Booking status labels (`StatusBadge`) and the "Status" row highlight in `BookingDetailsCard` keep their internal identifiers/keys untranslated so sorting (`statusRankFor`) and styling stay correct in every locale — this label/value split is pinned by new tests in `StatusBadge.test.tsx` and `BookingDetailsCard.test.tsx`.
- Fixed a pre-existing English grammar bug as a side effect of adding proper i18next pluralization: the "Restaurant Status" paused-venues subtitle now says "1 venue is paused" instead of "1 venues are paused" (dashboard.test.tsx updated to match).
- Left `components/admin/settings/**` and `AdminSidebar.tsx` untouched — those belong to sibling PRs in the same issue.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — full suite: 2862 passed, 6 pre-existing failures (`tests/utils/notifications.test.ts`, `tests/utils/formatters.test.ts`, `tests/app/admin/notifications.test.tsx` — relative-time formatting on Windows, confirmed pre-existing via `git stash` + re-run)
- [x] `npm run check` — prettier + oxlint clean (only pre-existing warnings elsewhere in the repo)
- [x] `npm run check:doc-links` (repo root) — all doc links resolve
- [x] New/updated tests: `bookingRowProps.test.ts` (new — covers the table/no-table branch of `describeBookingRow`), `StatusBadge.test.tsx` (label/value split pair), `BookingDetailsCard.test.tsx` (label/value split pair), `dashboard.test.tsx` (pluralization fix)
- [x] `tests/i18n/parity.test.ts` — all four locale files stay key-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBauSPz51qiGQtzs27nvmr