### PR TITLE
Pin the test locale for relativeTime assertions

### DIFF
--- a/openresto-frontend/tests/app/admin/notifications.test.tsx
+++ b/openresto-frontend/tests/app/admin/notifications.test.tsx
@@ -8,6 +8,7 @@ import NotificationsScreen from "@/app/admin/notifications";
 import * as notificationsApi from "@/api/notifications";
 import * as restaurantsApi from "@/api/restaurants";
 import { PIN_STORAGE_KEY } from "@/utils/notifications";
+import { setActiveLocale } from "@/utils/locale";
 
 // Mock ReanimatedSwipeable — exposes onSwipeableOpen via a testID button so tests can
 // simulate swipe-to-delete without needing real gesture-handler infrastructure.
@@ -141,6 +142,9 @@ const mockNotificationsPage = {
 beforeEach(() => {
   jest.clearAllMocks();
   jest.spyOn(console, "error").mockImplementation(() => {});
+  // Rows render `relativeTime`, which follows the device when no locale is set — see
+  // tests/utils/formatters.test.ts for why an unpinned assertion only holds in en-US.
+  setActiveLocale("en");
 
   Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
 
@@ -181,6 +185,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.restoreAllMocks();
+  setActiveLocale(undefined);
   Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
 });
 

--- a/openresto-frontend/tests/utils/formatters.test.ts
+++ b/openresto-frontend/tests/utils/formatters.test.ts
@@ -150,7 +150,17 @@ describe("formatters - fmtNumber", () => {
   });
 });
 
+/**
+ * `relativeTime` passes `getActiveLocale()` to `Intl.RelativeTimeFormat`, and an unset
+ * locale means "follow the device" — so an assertion left unpinned reads the host's
+ * locale and only holds on a US-locale machine (`en-CA` renders "5 mins ago", `en-GB`
+ * "5 min ago"). Pin the locale the app itself defaults to.
+ */
 describe("formatters - relativeTime", () => {
+  beforeEach(() => {
+    setActiveLocale("en");
+  });
+
   it("returns 'now' for <1 minute", () => {
     const iso = new Date(Date.now() - 30_000).toISOString();
     expect(relativeTime(iso)).toBe("now");

--- a/openresto-frontend/tests/utils/notifications.test.ts
+++ b/openresto-frontend/tests/utils/notifications.test.ts
@@ -7,8 +7,19 @@ import {
   TYPE_LABELS,
   TYPE_FILTERS,
 } from "@/utils/notifications";
+import { setActiveLocale } from "@/utils/locale";
 
+// Re-exported from utils/formatters — see formatters.test.ts for why the locale is pinned
+// rather than left to follow the device.
 describe("relativeTime", () => {
+  beforeEach(() => {
+    setActiveLocale("en");
+  });
+
+  afterEach(() => {
+    setActiveLocale(undefined);
+  });
+
   it("returns 'now' for <1 minute", () => {
     const iso = new Date(Date.now() - 30_000).toISOString();
     expect(relativeTime(iso)).toBe("now");


### PR DESCRIPTION
Six tests fail on a clean checkout for any contributor whose machine is not US-locale. CI never caught it because GitHub's runners are `en-US`.

## Cause

`relativeTime` (`utils/formatters.ts:97`) passes `getActiveLocale()` straight to `Intl.RelativeTimeFormat`:

```ts
const rtf = new Intl.RelativeTimeFormat(getActiveLocale(), { numeric: "auto", style: "narrow" });
```

`getActiveLocale()` returns `undefined` until `setActiveLocale` is called — documented in `utils/locale.ts` as "follow the device". Three suites assert `relativeTime`'s output without setting one, so they were really asserting that the host is US-locale:

| host locale | `-5 minute` | `-3 hour` |
|---|---|---|
| `en` / `en-US` | `5m ago` | `3h ago` |
| `en-CA` | `5 mins ago` | `3 hrs ago` |
| `en-GB` | `5 min ago` | `3 hr ago` |

## Fix

Pin those assertions to `"en"` — the locale the app itself defaults to (`DEFAULT_LOCALE`) — and reset afterwards so `tests/utils/locale.test.ts` still sees the documented `undefined` default. Three files, hooks only; no assertion changed.

## Not an app bug

`LocaleContext` calls `setActiveLocale` on mount, so a real render always has an explicit locale. Device fallback for an unset locale is deliberate. This is purely a test-side host dependency.

## Verification

Run on an `en-CA` machine, which is where it reproduces:

- before: `2870 passed, 6 failed`
- after: `2876 passed, 200 suites` — plus `npm run check` and `npx tsc --noEmit` clean

CI (`en-US`) was green before and should stay green; the point is that it is now green in both.

Found while reviewing #389.