### PR TITLE
Collapse the duplicated saving/adding status strings

### DIFF
--- a/openresto-frontend/app/admin/locations.tsx
+++ b/openresto-frontend/app/admin/locations.tsx
@@ -292,7 +292,7 @@ export default function AdminLocationsScreen() {
               }}
             >
               {pausing
-                ? t("admin.locations.pauseButton.saving")
+                ? t("common.status.saving")
                 : isPaused
                   ? t("admin.locations.pauseButton.resumeUntil", { time: pausedUntilText })
                   : t("admin.locations.pauseButton.pauseFor60")}

--- a/openresto-frontend/components/admin/bookings/BookingDetailPopup.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingDetailPopup.tsx
@@ -428,7 +428,7 @@ export function BookingDetailPopup({
                     accessibilityLabel={t("admin.bookings.detail.saveChangesLabel")}
                   >
                     {editLoading
-                      ? t("admin.bookings.detail.saving")
+                      ? t("common.status.saving")
                       : t("admin.bookings.detail.saveChanges")}
                   </Button>
                 </>

--- a/openresto-frontend/components/admin/locations/AddLocationForm.tsx
+++ b/openresto-frontend/components/admin/locations/AddLocationForm.tsx
@@ -73,7 +73,7 @@ export function AddLocationForm({
         onPress={onSubmit}
         accessibilityLabel={t("admin.locations.addLocation")}
       >
-        {saving ? t("admin.locations.addForm.adding") : t("admin.locations.addForm.add")}
+        {saving ? t("common.status.adding") : t("admin.locations.addForm.add")}
       </Button>
     </View>
   );

--- a/openresto-frontend/components/admin/settings/AddRow.tsx
+++ b/openresto-frontend/components/admin/settings/AddRow.tsx
@@ -104,7 +104,7 @@ export function AddRow({
             setOpen(false);
           }}
         >
-          {saving ? t("admin.settings.addRow.adding") : t("admin.settings.addRow.add")}
+          {saving ? t("common.status.adding") : t("admin.settings.addRow.add")}
         </Button>
       </ButtonRow>
     </View>

--- a/openresto-frontend/components/admin/settings/EmailSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/EmailSettingsCard.tsx
@@ -404,9 +404,7 @@ export function EmailSettingsCard({
                 disabled={saving || !host || !username}
                 loading={saving}
               >
-                {saving
-                  ? t("admin.settings.emailSettings.saving")
-                  : t("admin.settings.emailSettings.saveButton")}
+                {saving ? t("common.status.saving") : t("admin.settings.emailSettings.saveButton")}
               </Button>
             </ButtonRow>
           </View>

--- a/openresto-frontend/components/admin/settings/HighlightsCard.tsx
+++ b/openresto-frontend/components/admin/settings/HighlightsCard.tsx
@@ -544,10 +544,10 @@ function HighlightEditForm({
         >
           {isNew
             ? saving
-              ? t("admin.settings.highlights.adding")
+              ? t("common.status.adding")
               : t("admin.settings.highlights.add")
             : saving
-              ? t("admin.settings.highlights.saving")
+              ? t("common.status.saving")
               : t("admin.settings.highlights.save")}
         </Button>
       </ButtonRow>

--- a/openresto-frontend/components/admin/settings/SaveStatus.tsx
+++ b/openresto-frontend/components/admin/settings/SaveStatus.tsx
@@ -59,7 +59,7 @@ export function SaveStatus({
         <>
           <ActivityIndicator size="small" color={mutedColor} />
           <ThemedText style={[styles.text, { color: mutedColor }]}>
-            {t("admin.settings.saveStatus.saving")}
+            {t("common.status.saving")}
           </ThemedText>
         </>
       )}

--- a/openresto-frontend/components/admin/settings/SecurityCard.tsx
+++ b/openresto-frontend/components/admin/settings/SecurityCard.tsx
@@ -182,9 +182,7 @@ export function SecurityCard({
                   onPress={handleChangeEmail}
                   disabled={saving || !newEmail.trim() || !currentPwForEmail}
                 >
-                  {saving
-                    ? t("admin.settings.security.saving")
-                    : t("admin.settings.security.updateEmail")}
+                  {saving ? t("common.status.saving") : t("admin.settings.security.updateEmail")}
                 </Button>
               </ButtonRow>
             </View>
@@ -264,9 +262,7 @@ export function SecurityCard({
                   onPress={handleSavePvq}
                   disabled={saving || !pvqQuestion.trim() || !pvqAnswer.trim()}
                 >
-                  {saving
-                    ? t("admin.settings.security.saving")
-                    : t("admin.settings.security.saveQuestion")}
+                  {saving ? t("common.status.saving") : t("admin.settings.security.saveQuestion")}
                 </Button>
               </ButtonRow>
             </View>
@@ -354,9 +350,7 @@ export function SecurityCard({
                   onPress={handleChangePw}
                   disabled={saving || !currentPw || newPw.length < 6}
                 >
-                  {saving
-                    ? t("admin.settings.security.saving")
-                    : t("admin.settings.security.updatePassword")}
+                  {saving ? t("common.status.saving") : t("admin.settings.security.updatePassword")}
                 </Button>
               </ButtonRow>
             </View>

--- a/openresto-frontend/components/admin/settings/SocialLinkEditForm.tsx
+++ b/openresto-frontend/components/admin/settings/SocialLinkEditForm.tsx
@@ -171,10 +171,10 @@ export function SocialLinkEditForm({
         >
           {isNew
             ? saving
-              ? t("admin.settings.socialLinkEditForm.adding")
+              ? t("common.status.adding")
               : t("admin.settings.socialLinkEditForm.add")
             : saving
-              ? t("admin.settings.socialLinkEditForm.saving")
+              ? t("common.status.saving")
               : t("admin.settings.socialLinkEditForm.save")}
         </Button>
       </ButtonRow>

--- a/openresto-frontend/components/admin/settings/TableRow.tsx
+++ b/openresto-frontend/components/admin/settings/TableRow.tsx
@@ -378,7 +378,7 @@ export function TableRow({
             }
           }}
         >
-          {saving ? t("admin.settings.tableRow.saving") : t("admin.settings.tableRow.save")}
+          {saving ? t("common.status.saving") : t("admin.settings.tableRow.save")}
         </Button>
       </ButtonRow>
     </View>

--- a/openresto-frontend/components/admin/settings/UsersCard.tsx
+++ b/openresto-frontend/components/admin/settings/UsersCard.tsx
@@ -464,7 +464,7 @@ export function UsersCard({
                       loading={busy}
                       accessibilityLabel={t("admin.settings.users.addThisUserLabel")}
                     >
-                      {busy ? t("admin.settings.users.adding") : t("admin.settings.users.add")}
+                      {busy ? t("common.status.adding") : t("admin.settings.users.add")}
                     </Button>
                   </ButtonRow>
                 </View>

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -221,7 +221,9 @@
       "closeLabel": "{{label}} schließen"
     },
     "status": {
-      "loading": "Wird geladen…"
+      "loading": "Wird geladen…",
+      "saving": "Wird gespeichert…",
+      "adding": "Wird hinzugefügt…"
     },
     "timePicker": {
       "accessibilityLabel": "Uhrzeit",
@@ -587,7 +589,6 @@
         "editLabel": "Buchung bearbeiten",
         "discardChangesLabel": "Änderungen verwerfen",
         "saveChanges": "Änderungen speichern",
-        "saving": "Wird gespeichert…",
         "saveChangesLabel": "Änderungen speichern",
         "notFound": "Buchung nicht gefunden.",
         "invalidSeats": "Ungültige Personenzahl",
@@ -750,7 +751,6 @@
         "subtitle": "Fügen Sie Ihren ersten Standort hinzu, um Buchungen entgegenzunehmen."
       },
       "pauseButton": {
-        "saving": "Wird gespeichert…",
         "resumeLabel": "Buchungen für {{name}} fortsetzen",
         "pauseLabel": "Die nächste Stunde Buchungen bei {{name}} pausieren",
         "resumeUntil": "Neue Buchungen jetzt fortsetzen (pausiert bis {{time}})",
@@ -769,8 +769,7 @@
       "addForm": {
         "namePlaceholder": "Name des Standorts (z. B. Innenstadt, Westseite)",
         "cancelLabel": "Hinzufügen eines Standorts abbrechen",
-        "add": "Hinzufügen",
-        "adding": "Wird hinzugefügt…"
+        "add": "Hinzufügen"
       },
       "archiveRow": {
         "title": "Standort archivieren",
@@ -901,7 +900,6 @@
         "hint": "Kurze Bezeichnungen, die auf der öffentlichen Restaurantkarte angezeigt werden (z. B. „Hunde willkommen“, „Terrasse“)."
       },
       "saveStatus": {
-        "saving": "Wird gespeichert…",
         "saved": "Gespeichert",
         "undoLabel": "Letztes Speichern rückgängig machen",
         "undo": "Rückgängig",
@@ -912,7 +910,6 @@
       "addRow": {
         "namePlaceholder": "Name",
         "cancelLabel": "Hinzufügen abbrechen",
-        "adding": "Wird hinzugefügt…",
         "add": "Hinzufügen"
       },
       "socialLinkRow": {
@@ -977,9 +974,7 @@
         "cancelLabel": "Bearbeitung dieses Links abbrechen",
         "addLabel": "Diesen Link hinzufügen",
         "saveLabel": "Diesen Link speichern",
-        "adding": "Wird hinzugefügt…",
         "add": "Hinzufügen",
-        "saving": "Wird gespeichert…",
         "save": "Speichern"
       },
       "headerImage": {
@@ -1086,8 +1081,6 @@
         "cancelLabel": "Bearbeitung dieses Highlights abbrechen",
         "addThisLabel": "Dieses Highlight hinzufügen",
         "saveThisLabel": "Dieses Highlight speichern",
-        "adding": "Wird hinzugefügt…",
-        "saving": "Wird gespeichert…",
         "save": "Speichern",
         "invalidLinkUrl": "Geben Sie eine gültige Link-URL ein (z. B. https://example.com).",
         "serverUnreachable": "Server konnte nicht erreicht werden. Bitte versuchen Sie es erneut."
@@ -1103,7 +1096,6 @@
         "currentPasswordLabel": "Aktuelles Passwort",
         "passwordPlaceholder": "••••••••",
         "cancelEmailLabel": "E-Mail-Änderung abbrechen",
-        "saving": "Wird gespeichert…",
         "updateEmail": "E-Mail aktualisieren",
         "pvqLabel": "Sicherheitsfrage",
         "pvqNotConfigured": "Nicht konfiguriert. Richten Sie eine ein, um die Passwortzurücksetzung zu aktivieren.",
@@ -1185,7 +1177,6 @@
         "seatsPlaceholder": "Sitzplätze",
         "cancelEditLabel": "Bearbeitung von {{name}} abbrechen",
         "saveLabel": "{{name}} speichern",
-        "saving": "Wird gespeichert…",
         "save": "Speichern"
       },
       "sectionBlock": {
@@ -1247,7 +1238,6 @@
         "fromEmailLabel": "Absender-E-Mail",
         "footerHintVerified": "Verbindung geprüft · Bestätigungen bereit",
         "footerHintUnverified": "Testen Sie die Verbindung, bevor Sie Bestätigungen aktivieren",
-        "saving": "Wird gespeichert…",
         "saveButton": "SMTP-Einstellungen speichern"
       },
       "users": {
@@ -1280,7 +1270,6 @@
         "temporaryPasswordLabel": "Temporäres Passwort",
         "newUserRoleLabel": "Rolle des neuen Benutzers {{role}}",
         "addThisUserLabel": "Diesen Benutzer hinzufügen",
-        "adding": "Wird hinzugefügt…",
         "add": "Hinzufügen",
         "addUser": "Benutzer hinzufügen"
       },

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -221,7 +221,9 @@
       "closeLabel": "Close {{label}}"
     },
     "status": {
-      "loading": "Loading…"
+      "loading": "Loading…",
+      "saving": "Saving…",
+      "adding": "Adding…"
     },
     "timePicker": {
       "accessibilityLabel": "Time",
@@ -587,7 +589,6 @@
         "editLabel": "Edit booking",
         "discardChangesLabel": "Discard changes",
         "saveChanges": "Save Changes",
-        "saving": "Saving…",
         "saveChangesLabel": "Save changes",
         "notFound": "Booking not found.",
         "invalidSeats": "Invalid seats value",
@@ -750,7 +751,6 @@
         "subtitle": "Add your first location to start accepting bookings."
       },
       "pauseButton": {
-        "saving": "Saving…",
         "resumeLabel": "Resume bookings for {{name}}",
         "pauseLabel": "Pause the next hour of bookings at {{name}}",
         "resumeUntil": "Resume New Bookings now (paused up to {{time}})",
@@ -769,8 +769,7 @@
       "addForm": {
         "namePlaceholder": "Location name (e.g. Downtown, Westside)",
         "cancelLabel": "Cancel adding a location",
-        "add": "Add",
-        "adding": "Adding…"
+        "add": "Add"
       },
       "archiveRow": {
         "title": "Archive location",
@@ -901,7 +900,6 @@
         "hint": "Short labels shown on the public restaurant card (e.g. \"Dog friendly\", \"Terrace\")."
       },
       "saveStatus": {
-        "saving": "Saving…",
         "saved": "Saved",
         "undoLabel": "Undo the last save",
         "undo": "Undo",
@@ -912,7 +910,6 @@
       "addRow": {
         "namePlaceholder": "Name",
         "cancelLabel": "Cancel add",
-        "adding": "Adding…",
         "add": "Add"
       },
       "socialLinkRow": {
@@ -977,9 +974,7 @@
         "cancelLabel": "Cancel editing this link",
         "addLabel": "Add this link",
         "saveLabel": "Save this link",
-        "adding": "Adding…",
         "add": "Add",
-        "saving": "Saving…",
         "save": "Save"
       },
       "headerImage": {
@@ -1086,8 +1081,6 @@
         "cancelLabel": "Cancel editing this highlight",
         "addThisLabel": "Add this highlight",
         "saveThisLabel": "Save this highlight",
-        "adding": "Adding…",
-        "saving": "Saving…",
         "save": "Save",
         "invalidLinkUrl": "Enter a valid link URL (e.g. https://example.com).",
         "serverUnreachable": "Couldn't reach the server. Please try again."
@@ -1103,7 +1096,6 @@
         "currentPasswordLabel": "Current password",
         "passwordPlaceholder": "••••••••",
         "cancelEmailLabel": "Cancel email change",
-        "saving": "Saving…",
         "updateEmail": "Update Email",
         "pvqLabel": "Security Question",
         "pvqNotConfigured": "Not configured. Set one up to enable password reset.",
@@ -1185,7 +1177,6 @@
         "seatsPlaceholder": "Seats",
         "cancelEditLabel": "Cancel editing {{name}}",
         "saveLabel": "Save {{name}}",
-        "saving": "Saving…",
         "save": "Save"
       },
       "sectionBlock": {
@@ -1247,7 +1238,6 @@
         "fromEmailLabel": "From email",
         "footerHintVerified": "Connection verified · confirmations ready",
         "footerHintUnverified": "Test the connection before enabling confirmations",
-        "saving": "Saving…",
         "saveButton": "Save SMTP settings"
       },
       "users": {
@@ -1280,7 +1270,6 @@
         "temporaryPasswordLabel": "Temporary password",
         "newUserRoleLabel": "New user role {{role}}",
         "addThisUserLabel": "Add this user",
-        "adding": "Adding…",
         "add": "Add",
         "addUser": "Add user"
       },

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -221,7 +221,9 @@
       "closeLabel": "Cerrar {{label}}"
     },
     "status": {
-      "loading": "Cargando…"
+      "loading": "Cargando…",
+      "saving": "Guardando…",
+      "adding": "Añadiendo…"
     },
     "timePicker": {
       "accessibilityLabel": "Hora",
@@ -587,7 +589,6 @@
         "editLabel": "Editar reserva",
         "discardChangesLabel": "Descartar cambios",
         "saveChanges": "Guardar cambios",
-        "saving": "Guardando…",
         "saveChangesLabel": "Guardar cambios",
         "notFound": "Reserva no encontrada.",
         "invalidSeats": "Número de comensales no válido",
@@ -750,7 +751,6 @@
         "subtitle": "Agrega tu primer local para empezar a aceptar reservas."
       },
       "pauseButton": {
-        "saving": "Guardando…",
         "resumeLabel": "Reanudar reservas de {{name}}",
         "pauseLabel": "Pausar la próxima hora de reservas en {{name}}",
         "resumeUntil": "Reanudar nuevas reservas ahora (pausadas hasta las {{time}})",
@@ -769,8 +769,7 @@
       "addForm": {
         "namePlaceholder": "Nombre del local (p. ej. Centro, Zona oeste)",
         "cancelLabel": "Cancelar la creación del local",
-        "add": "Agregar",
-        "adding": "Agregando…"
+        "add": "Añadir"
       },
       "archiveRow": {
         "title": "Archivar local",
@@ -901,7 +900,6 @@
         "hint": "Etiquetas cortas que se muestran en la tarjeta pública del restaurante (por ejemplo, «Admite perros», «Terraza»)."
       },
       "saveStatus": {
-        "saving": "Guardando…",
         "saved": "Guardado",
         "undoLabel": "Deshacer el último guardado",
         "undo": "Deshacer",
@@ -912,7 +910,6 @@
       "addRow": {
         "namePlaceholder": "Nombre",
         "cancelLabel": "Cancelar adición",
-        "adding": "Añadiendo…",
         "add": "Añadir"
       },
       "socialLinkRow": {
@@ -977,9 +974,7 @@
         "cancelLabel": "Cancelar la edición de este enlace",
         "addLabel": "Añadir este enlace",
         "saveLabel": "Guardar este enlace",
-        "adding": "Añadiendo…",
         "add": "Añadir",
-        "saving": "Guardando…",
         "save": "Guardar"
       },
       "headerImage": {
@@ -1086,8 +1081,6 @@
         "cancelLabel": "Cancelar la edición de este destacado",
         "addThisLabel": "Añadir este destacado",
         "saveThisLabel": "Guardar este destacado",
-        "adding": "Añadiendo…",
-        "saving": "Guardando…",
         "save": "Guardar",
         "invalidLinkUrl": "Introduzca una URL de enlace válida (p. ej. https://example.com).",
         "serverUnreachable": "No se pudo contactar con el servidor. Inténtelo de nuevo."
@@ -1103,7 +1096,6 @@
         "currentPasswordLabel": "Contraseña actual",
         "passwordPlaceholder": "••••••••",
         "cancelEmailLabel": "Cancelar cambio de correo",
-        "saving": "Guardando…",
         "updateEmail": "Actualizar correo",
         "pvqLabel": "Pregunta de seguridad",
         "pvqNotConfigured": "No configurada. Configure una para activar el restablecimiento de contraseña.",
@@ -1185,7 +1177,6 @@
         "seatsPlaceholder": "Asientos",
         "cancelEditLabel": "Cancelar la edición de {{name}}",
         "saveLabel": "Guardar {{name}}",
-        "saving": "Guardando…",
         "save": "Guardar"
       },
       "sectionBlock": {
@@ -1247,7 +1238,6 @@
         "fromEmailLabel": "Correo del remitente",
         "footerHintVerified": "Conexión verificada · confirmaciones listas",
         "footerHintUnverified": "Pruebe la conexión antes de activar las confirmaciones",
-        "saving": "Guardando…",
         "saveButton": "Guardar configuración SMTP"
       },
       "users": {
@@ -1280,7 +1270,6 @@
         "temporaryPasswordLabel": "Contraseña temporal",
         "newUserRoleLabel": "Rol del nuevo usuario {{role}}",
         "addThisUserLabel": "Añadir este usuario",
-        "adding": "Añadiendo…",
         "add": "Añadir",
         "addUser": "Añadir usuario"
       },

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -221,7 +221,9 @@
       "closeLabel": "Fermer {{label}}"
     },
     "status": {
-      "loading": "Chargement…"
+      "loading": "Chargement…",
+      "saving": "Enregistrement…",
+      "adding": "Ajout…"
     },
     "timePicker": {
       "accessibilityLabel": "Heure",
@@ -587,7 +589,6 @@
         "editLabel": "Modifier la réservation",
         "discardChangesLabel": "Annuler les modifications",
         "saveChanges": "Enregistrer les modifications",
-        "saving": "Enregistrement…",
         "saveChangesLabel": "Enregistrer les modifications",
         "notFound": "Réservation introuvable.",
         "invalidSeats": "Nombre de couverts invalide",
@@ -750,7 +751,6 @@
         "subtitle": "Ajoutez votre premier établissement pour commencer à accepter des réservations."
       },
       "pauseButton": {
-        "saving": "Enregistrement…",
         "resumeLabel": "Reprendre les réservations de {{name}}",
         "pauseLabel": "Suspendre la prochaine heure de réservations à {{name}}",
         "resumeUntil": "Reprendre les nouvelles réservations maintenant (suspendues jusqu'à {{time}})",
@@ -769,8 +769,7 @@
       "addForm": {
         "namePlaceholder": "Nom de l'établissement (p. ex. Centre-ville, Rive ouest)",
         "cancelLabel": "Annuler l'ajout d'un établissement",
-        "add": "Ajouter",
-        "adding": "Ajout…"
+        "add": "Ajouter"
       },
       "archiveRow": {
         "title": "Archiver l'établissement",
@@ -901,7 +900,6 @@
         "hint": "Libellés courts affichés sur la fiche publique du restaurant (par ex. « Chiens acceptés », « Terrasse »)."
       },
       "saveStatus": {
-        "saving": "Enregistrement…",
         "saved": "Enregistré",
         "undoLabel": "Annuler le dernier enregistrement",
         "undo": "Annuler",
@@ -912,7 +910,6 @@
       "addRow": {
         "namePlaceholder": "Nom",
         "cancelLabel": "Annuler l'ajout",
-        "adding": "Ajout…",
         "add": "Ajouter"
       },
       "socialLinkRow": {
@@ -977,9 +974,7 @@
         "cancelLabel": "Annuler la modification de ce lien",
         "addLabel": "Ajouter ce lien",
         "saveLabel": "Enregistrer ce lien",
-        "adding": "Ajout…",
         "add": "Ajouter",
-        "saving": "Enregistrement…",
         "save": "Enregistrer"
       },
       "headerImage": {
@@ -1086,8 +1081,6 @@
         "cancelLabel": "Annuler la modification de ce point fort",
         "addThisLabel": "Ajouter ce point fort",
         "saveThisLabel": "Enregistrer ce point fort",
-        "adding": "Ajout…",
-        "saving": "Enregistrement…",
         "save": "Enregistrer",
         "invalidLinkUrl": "Saisissez une URL de lien valide (ex. https://example.com).",
         "serverUnreachable": "Impossible de joindre le serveur. Veuillez réessayer."
@@ -1103,7 +1096,6 @@
         "currentPasswordLabel": "Mot de passe actuel",
         "passwordPlaceholder": "••••••••",
         "cancelEmailLabel": "Annuler le changement d'e-mail",
-        "saving": "Enregistrement…",
         "updateEmail": "Mettre à jour l'e-mail",
         "pvqLabel": "Question de sécurité",
         "pvqNotConfigured": "Non configurée. Configurez-en une pour activer la réinitialisation du mot de passe.",
@@ -1185,7 +1177,6 @@
         "seatsPlaceholder": "Places",
         "cancelEditLabel": "Annuler la modification de {{name}}",
         "saveLabel": "Enregistrer {{name}}",
-        "saving": "Enregistrement…",
         "save": "Enregistrer"
       },
       "sectionBlock": {
@@ -1247,7 +1238,6 @@
         "fromEmailLabel": "E-mail de l'expéditeur",
         "footerHintVerified": "Connexion vérifiée · confirmations prêtes",
         "footerHintUnverified": "Testez la connexion avant d'activer les confirmations",
-        "saving": "Enregistrement…",
         "saveButton": "Enregistrer les paramètres SMTP"
       },
       "users": {
@@ -1280,7 +1270,6 @@
         "temporaryPasswordLabel": "Mot de passe temporaire",
         "newUserRoleLabel": "Rôle du nouvel utilisateur {{role}}",
         "addThisUserLabel": "Ajouter cet utilisateur",
-        "adding": "Ajout…",
         "add": "Ajouter",
         "addUser": "Ajouter un utilisateur"
       },


### PR DESCRIPTION
Follow-up from reviewing the merged i18n epic (F1–F4).

## What

`"Saving…"` was defined in eight separate keys and `"Adding…"` in five — one per card that shows a pending state. Nothing distinguishes them contextually. Folded into `common.status`, next to the `loading` string added in #389.

| before | after |
|---|---|
| `admin.bookings.detail.saving` + 7 others | `common.status.saving` |
| `admin.locations.addForm.adding` + 4 others | `common.status.adding` |

Net −11 keys per locale, 1117 → 1106.

## A real drift this surfaced

The collapse asserts all copies are identical before merging them, and Spanish failed that assert: F2's location form used `"Agregar"` / `"Agregando…"` where F1 and F3 used `"Añadir"` / `"Añadiendo…"` (6-to-1 and 4-to-1 respectively). Both are correct Spanish — `añadir` is more common in Spain, `agregar` in Latin America — but one app shouldn't use both. Normalised the outlier to the majority form.

This is the failure mode the consolidation prevents going forward: five independently-translated copies of one word, with only a key-parity test watching them, which checks that keys match and says nothing about values.

## What I deliberately did not do

- **Verbs stay per-card.** `Add`, `Edit`, `Delete`, `Save` are also duplicated 4–7×, but over-consolidation is its own i18n bug: a standing "Add X" CTA and a form's commit button can want different words, and one shared key removes the ability to distinguish them. They coincide in these four languages today; that's not a guarantee.
- **Spanish prose is untouched.** `admin.locations.emptyState.subtitle` still reads "Agrega tu primer local…". Normalising button labels is a contained fix; rewriting sentences is not.

## Verification

`npm test` 2876 passed / 200 suites · `npm run check` clean · `npx tsc --noEmit` clean · `npm run check:doc-links` clean

`tsc` is the meaningful check here — `types/i18next.d.ts` derives its key union from `en.json`, so any call site left pointing at a removed key is a compile error rather than a runtime miss.