### PR TITLE
i18n: fix guest strings bypassing t() (footer copyright, popular-times a11y label)

### DIFF
--- a/openresto-frontend/components/admin/settings/BrandPreview.tsx
+++ b/openresto-frontend/components/admin/settings/BrandPreview.tsx
@@ -51,7 +51,7 @@ export function BrandPreview({
     draft.highlightsSubheading.trim() || t("restaurant.home.highlightsSubheading");
   const copyright =
     draft.copyrightText.trim() ||
-    t("admin.settings.footer.copyrightPlaceholder", {
+    t("common.footer.copyrightFallback", {
       year: new Date().getFullYear(),
       appName: draft.appName,
     });

--- a/openresto-frontend/components/admin/settings/FooterSettingsCard.tsx
+++ b/openresto-frontend/components/admin/settings/FooterSettingsCard.tsx
@@ -209,7 +209,7 @@ export function FooterSettingsCard({
             <Input
               value={copyrightText}
               onChangeText={setCopyrightText}
-              placeholder={t("admin.settings.footer.copyrightPlaceholder", {
+              placeholder={t("common.footer.copyrightFallback", {
                 year: new Date().getFullYear(),
                 appName: brand.appName,
               })}

--- a/openresto-frontend/components/booking/PopularTimesPicker.tsx
+++ b/openresto-frontend/components/booking/PopularTimesPicker.tsx
@@ -246,7 +246,11 @@ export default function PopularTimesPicker({
         <View style={styles.tabs} accessibilityRole="tablist">
           {categoryTabs}
         </View>
-        <View style={styles.wrappedSlots} role="radiogroup" accessibilityLabel="Available times">
+        <View
+          style={styles.wrappedSlots}
+          role="radiogroup"
+          accessibilityLabel={t("booking.popularTimes.availableTimesA11y")}
+        >
           {slotChips}
         </View>
       </View>

--- a/openresto-frontend/components/layout/Footer.tsx
+++ b/openresto-frontend/components/layout/Footer.tsx
@@ -33,7 +33,8 @@ export default function Footer({ onLayout }: { onLayout?: (e: LayoutChangeEvent)
 
   const year = new Date().getFullYear();
   const copyright =
-    brand.copyrightText?.trim() || `© ${year} ${brand.appName}. All rights reserved.`;
+    brand.copyrightText?.trim() ||
+    t("common.footer.copyrightFallback", { year, appName: brand.appName });
 
   return (
     <ThemedView

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -168,6 +168,7 @@
     },
     "footer": {
       "adminLinkText": "Admin",
+      "copyrightFallback": "© {{year}} {{appName}}. Alle Rechte vorbehalten.",
       "restaurantAdminLabel": "Restaurant-Verwaltung"
     },
     "datePicker": {
@@ -1043,7 +1044,6 @@
         "linksConfigured_other": "{{count}} Social-Media-Links konfiguriert",
         "noLinksSubtitle": "Copyright-Text und Social-Media-Links",
         "copyrightLabel": "Copyright-Text",
-        "copyrightPlaceholder": "© {{year}} {{appName}}. Alle Rechte vorbehalten.",
         "copyrightHint": "Wird in der Website-Fußzeile angezeigt. Leer lassen, um den Standardtext oben zu verwenden.",
         "socialLinksLabel": "Social-Media-Links",
         "noLinksEmptyState": "Noch keine Links. Tippen Sie auf Hinzufügen, um den ersten zu erstellen.",

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -168,6 +168,7 @@
     },
     "footer": {
       "adminLinkText": "Admin",
+      "copyrightFallback": "© {{year}} {{appName}}. All rights reserved.",
       "restaurantAdminLabel": "Restaurant admin"
     },
     "datePicker": {
@@ -1043,7 +1044,6 @@
         "linksConfigured_other": "{{count}} social links configured",
         "noLinksSubtitle": "Copyright text and social links",
         "copyrightLabel": "Copyright Text",
-        "copyrightPlaceholder": "© {{year}} {{appName}}. All rights reserved.",
         "copyrightHint": "Shown in the site footer. Leave blank to use the default above.",
         "socialLinksLabel": "Social Links",
         "noLinksEmptyState": "No links yet. Press Add to create your first one.",

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -168,6 +168,7 @@
     },
     "footer": {
       "adminLinkText": "Admin",
+      "copyrightFallback": "© {{year}} {{appName}}. Todos los derechos reservados.",
       "restaurantAdminLabel": "Administración del restaurante"
     },
     "datePicker": {
@@ -1043,7 +1044,6 @@
         "linksConfigured_other": "{{count}} enlaces sociales configurados",
         "noLinksSubtitle": "Texto de copyright y enlaces sociales",
         "copyrightLabel": "Texto de copyright",
-        "copyrightPlaceholder": "© {{year}} {{appName}}. Todos los derechos reservados.",
         "copyrightHint": "Se muestra en el pie de página del sitio. Déjelo en blanco para usar el texto predeterminado de arriba.",
         "socialLinksLabel": "Enlaces sociales",
         "noLinksEmptyState": "Aún no hay enlaces. Pulse Añadir para crear el primero.",

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -168,6 +168,7 @@
     },
     "footer": {
       "adminLinkText": "Admin",
+      "copyrightFallback": "© {{year}} {{appName}}. Tous droits réservés.",
       "restaurantAdminLabel": "Administration du restaurant"
     },
     "datePicker": {
@@ -1043,7 +1044,6 @@
         "linksConfigured_other": "{{count}} liens sociaux configurés",
         "noLinksSubtitle": "Texte de copyright et liens sociaux",
         "copyrightLabel": "Texte de copyright",
-        "copyrightPlaceholder": "© {{year}} {{appName}}. Tous droits réservés.",
         "copyrightHint": "Affiché dans le pied de page du site. Laissez vide pour utiliser le texte par défaut ci-dessus.",
         "socialLinksLabel": "Liens sociaux",
         "noLinksEmptyState": "Aucun lien pour l'instant. Appuyez sur Ajouter pour créer le premier.",


### PR DESCRIPTION
Closes #386.

Two guest-facing strings from the i18n epic (#368) were missed by the per-area PRs (#373, #374) because neither is a plain JSX text node.

## Fix 1 — Footer copyright fallback

`components/layout/Footer.tsx` built its fallback copyright line as a template literal:

```ts
brand.copyrightText?.trim() || `© ${year} ${brand.appName}. All rights reserved.`;
```

This only renders when `copyrightText` is left blank, so no test with populated brand data ever exercised it — a French visitor to a default/unconfigured install saw English. Meanwhile `components/admin/settings/BrandPreview.tsx` had the *identical* English sentence under `admin.settings.footer.copyrightPlaceholder`, correctly translated, so the admin preview and the real guest footer disagreed — exactly the "two files hand-copied the string" failure the shared-key convention exists to prevent.

**Fix:** promoted to a single shared key `common.footer.copyrightFallback` (`"© {{year}} {{appName}}. All rights reserved."`, i18next interpolation) in all four locales. `Footer.tsx` and `BrandPreview.tsx` now both use it. Also found a third caller of the retired key — `FooterSettingsCard.tsx` used it as the copyright field's placeholder text — and repointed that too. Deleted `admin.settings.footer.copyrightPlaceholder` from all four locale files; `tests/i18n/parity.test.ts` stays green since the key was removed uniformly.

## Fix 2 — PopularTimesPicker a11y label

`components/booking/PopularTimesPicker.tsx` already routes its non-wrap layout's radiogroup label through `t("booking.popularTimes.availableTimesA11y")`, but the `wrap` layout (used in the narrower booking drawer) still had a hardcoded `accessibilityLabel="Available times"` — screen-reader only, so no sighted QA or visual snapshot test ever caught it. Now both layouts use the same existing key.

## Widened sweep

Per the issue, swept `app/(user)/**` and `components/{restaurant,booking,layout,common}/**` for the same failure shapes: template literals with embedded English, string concatenation (`+`), `accessibilityLabel`/`accessibilityHint`/`aria-label`/`placeholder`/`title`/`alt` string-literal attributes, and `Alert.alert`/`window.confirm`/`confirm()` dialog copy.

**Result: nothing further found** beyond the two known instances. The one other hit (`window.confirm` in `BookingForm.tsx`) already passes its message through `t()`. The only other hardcoded-attribute hits found (`AdminSidebar.tsx`, under `components/layout/` but entirely admin-facing chrome — nav labels, "Search bookings", "Log out") are out of scope: that whole file is untranslated end to end, which is a different and much larger gap than "missed template literal/a11y", and squarely the concern of the concurrent F5 admin i18n PR (`components/admin/**`/`app/admin/**`) rather than this guest-facing ticket. Left untouched to avoid stepping on that PR.

## Test plan

- [x] `npm test` — 200 suites / 2876 tests pass, including `tests/i18n/parity.test.ts`
- [x] `npm run check` (prettier + oxlint) — passes, no new warnings introduced
- [x] `npx tsc --noEmit` — passes
- [x] Manually verified `common.footer.copyrightFallback` renders correctly interpolated in all four locales and that no reference to the retired `admin.settings.footer.copyrightPlaceholder` remains anywhere in the codebase

Note: a sibling PR for issue #387 also touches `Footer.tsx` (removing the language-switcher line); a minor merge conflict between the two at merge time is expected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VwjMnybqkwSo2jpyvVq8wK)_