### PR TITLE
i18n F5: translate the admin remainder (sidebar, notifications, login) + E2E spec

### DIFF
--- a/openresto-frontend/app/admin/_layout.tsx
+++ b/openresto-frontend/app/admin/_layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Platform, useWindowDimensions, View } from "react-native";
 import { Slot, Stack, useRouter, usePathname, useSegments } from "expo-router";
+import { useTranslation } from "react-i18next";
 import { ThemedView } from "@/components/themed-view";
 import { ThemedText } from "@/components/themed-text";
 import AdminSidebar from "@/components/layout/AdminSidebar";
@@ -17,14 +18,12 @@ import { Icon } from "@/components/common/Icon";
 const MIN_WIDTH = 600;
 
 function DesktopOnlyWall() {
+  const { t } = useTranslation();
   return (
     <ThemedView style={styles.wall}>
       <Icon name="desktop-outline" size={48} color={theme.colors.primary} />
-      <ThemedText style={styles.wallTitle}>Screen too small</ThemedText>
-      <ThemedText style={styles.wallBody}>
-        The admin dashboard requires a wider screen.{"\n"}
-        Try rotating your device or using a larger screen.
-      </ThemedText>
+      <ThemedText style={styles.wallTitle}>{t("admin.layout.desktopWall.title")}</ThemedText>
+      <ThemedText style={styles.wallBody}>{t("admin.layout.desktopWall.body")}</ThemedText>
     </ThemedView>
   );
 }

--- a/openresto-frontend/app/admin/login.tsx
+++ b/openresto-frontend/app/admin/login.tsx
@@ -7,6 +7,7 @@ import { login, getPvqStatus, verifyPvq, resetPassword } from "@/api/auth";
 import { useRef, useState } from "react";
 import { Pressable, ScrollView, TextInput, View, Platform } from "react-native";
 import { useRouter, Stack } from "expo-router";
+import { useTranslation } from "react-i18next";
 import { theme } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { useAuth } from "@/context/AuthContext";
@@ -17,6 +18,7 @@ import { Icon } from "@/components/common/Icon";
 type Stage = "login" | "pvq-email" | "pvq-answer" | "reset" | "done";
 
 export default function AdminLoginScreen() {
+  const { t } = useTranslation();
   const [stage, setStage] = useState<Stage>("login");
 
   const [email, setEmail] = useState("");
@@ -51,7 +53,7 @@ export default function AdminLoginScreen() {
       await refresh();
       router.replace("/admin/dashboard");
     } else {
-      setLoginError("Invalid email or password. Please try again.");
+      setLoginError(t("admin.login.signIn.invalidCredentials"));
     }
   };
 
@@ -63,7 +65,7 @@ export default function AdminLoginScreen() {
     const status = await getPvqStatus(fpEmail.trim());
     setFpLoading(false);
     if (!status?.isConfigured || !status.question) {
-      setFpError("No security question has been configured for this account.");
+      setFpError(t("admin.login.pvqEmail.noQuestionConfigured"));
       return;
     }
     setPvqQuestion(status.question);
@@ -76,7 +78,7 @@ export default function AdminLoginScreen() {
     const result = await verifyPvq(fpEmail, pvqAnswer);
     setFpLoading(false);
     if (!result) {
-      setFpError("Incorrect answer. Please try again.");
+      setFpError(t("admin.login.pvqAnswer.incorrectAnswer"));
       return;
     }
     setResetToken(result.resetToken);
@@ -104,16 +106,16 @@ export default function AdminLoginScreen() {
     if (stage === "login") {
       return (
         <>
-          <ThemedText style={styles.title}>Sign in</ThemedText>
+          <ThemedText style={styles.title}>{t("admin.login.signIn.title")}</ThemedText>
           <ThemedText style={[styles.subtitle, { color: mutedColor }]}>
-            Manage your restaurant bookings.
+            {t("admin.login.signIn.subtitle")}
           </ThemedText>
 
           <View style={styles.fields}>
             <View style={styles.field}>
-              <ThemedText style={styles.label}>Email</ThemedText>
+              <ThemedText style={styles.label}>{t("admin.login.signIn.emailLabel")}</ThemedText>
               <Input
-                placeholder="admin@restaurant.com"
+                placeholder={t("admin.login.signIn.emailPlaceholder")}
                 value={email}
                 onChangeText={setEmail}
                 keyboardType="email-address"
@@ -125,7 +127,7 @@ export default function AdminLoginScreen() {
               />
             </View>
             <View style={styles.field}>
-              <ThemedText style={styles.label}>Password</ThemedText>
+              <ThemedText style={styles.label}>{t("admin.login.signIn.passwordLabel")}</ThemedText>
               <Input
                 ref={passwordRef}
                 placeholder="••••••••"
@@ -149,21 +151,21 @@ export default function AdminLoginScreen() {
               disabled={!isValidEmail(email) || password.length === 0 || loginLoading}
               style={styles.submitBtn}
             >
-              {loginLoading ? "Signing in…" : "Sign In"}
+              {loginLoading ? t("admin.login.signIn.submitting") : t("admin.login.signIn.submit")}
             </Button>
 
             <Button
               variant="ghost"
               size="md"
               fullWidth
-              accessibilityLabel="Forgot password?"
+              accessibilityLabel={t("admin.login.signIn.forgotPassword")}
               onPress={() => {
                 setFpEmail(email);
                 setStage("pvq-email");
                 setFpError(null);
               }}
             >
-              Forgot password?
+              {t("admin.login.signIn.forgotPassword")}
             </Button>
           </View>
         </>
@@ -179,16 +181,16 @@ export default function AdminLoginScreen() {
               setFpError(null);
             }}
           />
-          <ThemedText style={styles.title}>Reset password</ThemedText>
+          <ThemedText style={styles.title}>{t("admin.login.pvqEmail.title")}</ThemedText>
           <ThemedText style={[styles.subtitle, { color: mutedColor }]}>
-            We'll verify your identity using your security question.
+            {t("admin.login.pvqEmail.subtitle")}
           </ThemedText>
 
           <View style={styles.fields}>
             <View style={styles.field}>
-              <ThemedText style={styles.label}>Admin email</ThemedText>
+              <ThemedText style={styles.label}>{t("admin.login.pvqEmail.emailLabel")}</ThemedText>
               <Input
-                placeholder="admin@restaurant.com"
+                placeholder={t("admin.login.pvqEmail.emailPlaceholder")}
                 value={fpEmail}
                 onChangeText={setFpEmail}
                 keyboardType="email-address"
@@ -207,7 +209,7 @@ export default function AdminLoginScreen() {
               disabled={!isValidEmail(fpEmail) || fpLoading}
               style={styles.submitBtn}
             >
-              {fpLoading ? "Checking…" : "Continue"}
+              {fpLoading ? t("admin.login.pvqEmail.checking") : t("admin.login.pvqEmail.submit")}
             </Button>
           </View>
         </>
@@ -224,7 +226,7 @@ export default function AdminLoginScreen() {
               setPvqAnswer("");
             }}
           />
-          <ThemedText style={styles.title}>Security question</ThemedText>
+          <ThemedText style={styles.title}>{t("admin.login.pvqAnswer.title")}</ThemedText>
           <View
             style={[
               styles.questionBox,
@@ -239,9 +241,9 @@ export default function AdminLoginScreen() {
 
           <View style={styles.fields}>
             <View style={styles.field}>
-              <ThemedText style={styles.label}>Your answer</ThemedText>
+              <ThemedText style={styles.label}>{t("admin.login.pvqAnswer.answerLabel")}</ThemedText>
               <Input
-                placeholder="Answer (not case sensitive)"
+                placeholder={t("admin.login.pvqAnswer.answerPlaceholder")}
                 value={pvqAnswer}
                 onChangeText={setPvqAnswer}
                 autoCapitalize="none"
@@ -259,7 +261,7 @@ export default function AdminLoginScreen() {
               disabled={pvqAnswer.trim().length === 0 || fpLoading}
               style={styles.submitBtn}
             >
-              {fpLoading ? "Verifying…" : "Verify Answer"}
+              {fpLoading ? t("admin.login.pvqAnswer.verifying") : t("admin.login.pvqAnswer.submit")}
             </Button>
           </View>
         </>
@@ -272,25 +274,29 @@ export default function AdminLoginScreen() {
           <View style={styles.successIcon}>
             <Icon name="checkmark-circle-outline" size={32} color={theme.colors.success} />
           </View>
-          <ThemedText style={styles.title}>Set new password</ThemedText>
+          <ThemedText style={styles.title}>{t("admin.login.reset.title")}</ThemedText>
           <ThemedText style={[styles.subtitle, { color: mutedColor }]}>
-            This link expires in 15 minutes.
+            {t("admin.login.reset.subtitle")}
           </ThemedText>
 
           <View style={styles.fields}>
             <View style={styles.field}>
-              <ThemedText style={styles.label}>New password</ThemedText>
+              <ThemedText style={styles.label}>
+                {t("admin.login.reset.newPasswordLabel")}
+              </ThemedText>
               <Input
-                placeholder="At least 6 characters"
+                placeholder={t("admin.login.reset.newPasswordPlaceholder")}
                 value={newPassword}
                 onChangeText={setNewPassword}
                 secureTextEntry
               />
             </View>
             <View style={styles.field}>
-              <ThemedText style={styles.label}>Confirm password</ThemedText>
+              <ThemedText style={styles.label}>
+                {t("admin.login.reset.confirmPasswordLabel")}
+              </ThemedText>
               <Input
-                placeholder="Repeat password"
+                placeholder={t("admin.login.reset.confirmPasswordPlaceholder")}
                 value={confirmPassword}
                 onChangeText={setConfirmPassword}
                 secureTextEntry
@@ -308,7 +314,7 @@ export default function AdminLoginScreen() {
               disabled={newPassword.length < 6 || fpLoading}
               style={styles.submitBtn}
             >
-              {fpLoading ? "Resetting…" : "Reset Password"}
+              {fpLoading ? t("admin.login.reset.resetting") : t("admin.login.reset.submit")}
             </Button>
           </View>
         </>
@@ -320,9 +326,9 @@ export default function AdminLoginScreen() {
         <View style={styles.successIcon}>
           <Icon name="checkmark-circle" size={40} color={theme.colors.success} />
         </View>
-        <ThemedText style={styles.title}>Password reset!</ThemedText>
+        <ThemedText style={styles.title}>{t("admin.login.done.title")}</ThemedText>
         <ThemedText style={[styles.subtitle, { color: mutedColor }]}>
-          Your password has been updated. Sign in with your new credentials.
+          {t("admin.login.done.subtitle")}
         </ThemedText>
         <Button
           onPress={() => {
@@ -331,7 +337,7 @@ export default function AdminLoginScreen() {
           }}
           style={styles.submitBtn}
         >
-          Back to Sign In
+          {t("admin.login.done.backToSignIn")}
         </Button>
       </>
     );
@@ -339,14 +345,16 @@ export default function AdminLoginScreen() {
 
   return (
     <ThemedView style={styles.root}>
-      {Platform.OS !== "web" && <Stack.Screen options={{ title: "Admin Login" }} />}
+      {Platform.OS !== "web" && <Stack.Screen options={{ title: t("admin.login.nativeTitle") }} />}
       <ScrollView contentContainerStyle={styles.outer} keyboardShouldPersistTaps="handled">
         <View style={styles.container}>
           <View style={styles.brandRow}>
             <ThemedText style={[styles.brand, { color: primaryColor, flex: 1 }]} numberOfLines={1}>
               {brand.appName}
             </ThemedText>
-            <ThemedText style={[styles.brandBadge, { color: mutedColor }]}>Admin</ThemedText>
+            <ThemedText style={[styles.brandBadge, { color: mutedColor }]}>
+              {t("admin.login.badge")}
+            </ThemedText>
           </View>
 
           <ThemedView
@@ -359,11 +367,11 @@ export default function AdminLoginScreen() {
             <Pressable
               onPress={() => router.replace("/")}
               accessibilityRole="link"
-              accessibilityLabel={`Back to ${brand.appName}`}
+              accessibilityLabel={t("admin.login.backToApp", { appName: brand.appName })}
               style={{ cursor: "pointer" } as const}
             >
               <ThemedText style={[styles.backLink, { color: mutedColor }]}>
-                ← Back to {brand.appName}
+                ← {t("admin.login.backToApp", { appName: brand.appName })}
               </ThemedText>
             </Pressable>
           )}
@@ -374,6 +382,7 @@ export default function AdminLoginScreen() {
 }
 
 function BackButton({ onPress }: { onPress: () => void }) {
+  const { t } = useTranslation();
   return (
     <ButtonRow align="start" style={styles.backBtn}>
       <Button
@@ -382,9 +391,9 @@ function BackButton({ onPress }: { onPress: () => void }) {
         size="sm"
         icon="arrow-back"
         onPress={onPress}
-        accessibilityLabel="Back"
+        accessibilityLabel={t("admin.login.backLabel")}
       >
-        Back
+        {t("admin.login.backLabel")}
       </Button>
     </ButtonRow>
   );

--- a/openresto-frontend/app/admin/notifications.tsx
+++ b/openresto-frontend/app/admin/notifications.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import { ActivityIndicator, Pressable, ScrollView, View, Platform } from "react-native";
 import { Stack, useRouter } from "expo-router";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { usePersistedState } from "@/hooks/use-persisted-state";
@@ -20,14 +21,16 @@ import { BookingDetailPopup } from "@/components/admin/bookings/BookingDetailPop
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { PushBanner } from "@/components/admin/notifications/PushBanner";
 import { NotificationRow } from "@/components/admin/notifications/NotificationRow";
-import { PAGE_SIZE, PIN_STORAGE_KEY, TYPE_FILTERS } from "@/utils/notifications";
+import { PAGE_SIZE, PIN_STORAGE_KEY, getTypeFilters } from "@/utils/notifications";
 import { styles } from "@/components/admin/notifications/notifications.styles";
 import HorizontalScroller from "@/components/common/HorizontalScroller";
 import { Icon } from "@/components/common/Icon";
 
 export default function NotificationsScreen() {
+  const { t } = useTranslation();
   const { colors, primaryColor, isDark } = useAppTheme();
   const router = useRouter();
+  const typeFilters = getTypeFilters(t);
 
   const [restaurants, setRestaurants] = useState<{ id: number; name: string }[]>([]);
   const [selectedRestaurantId, setSelectedRestaurantId] = usePersistedState<number | null>(
@@ -217,7 +220,7 @@ export default function NotificationsScreen() {
     setMarkingAll(false);
     setSessionUnreadOverrides(new Set());
     setItems((prev) => prev.map((x) => ({ ...x, isRead: true })));
-    showToast("Marked all as read");
+    showToast(t("admin.notifications.markedAllReadToast"));
   };
 
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
@@ -230,7 +233,7 @@ export default function NotificationsScreen() {
       next.delete(id);
       return next;
     });
-    showToast("Notification deleted");
+    showToast(t("admin.notifications.notificationDeletedToast"));
     await deleteNotification(id);
   };
 
@@ -256,7 +259,7 @@ export default function NotificationsScreen() {
   const deleteAllUnpinnedVisible = async () => {
     const idsToDelete = items.filter((x) => !pinnedIds.has(x.id)).map((x) => x.id);
     if (idsToDelete.length === 0) {
-      showToast("All visible notifications are pinned");
+      showToast(t("admin.notifications.allVisiblePinnedToast"));
       return;
     }
     setDeletingAll(true);
@@ -264,7 +267,7 @@ export default function NotificationsScreen() {
     setItems((prev) => prev.filter((x) => pinnedIds.has(x.id)));
     setTotalCount((prev) => Math.max(0, prev - idsToDelete.length));
     setDeletingAll(false);
-    showToast(`Deleted ${idsToDelete.length} notification${idsToDelete.length !== 1 ? "s" : ""}`);
+    showToast(t("admin.notifications.deletedCountToast", { count: idsToDelete.length }));
   };
 
   // On web, only allow swipe-to-delete for touch pointers (not mouse drags).
@@ -289,7 +292,7 @@ export default function NotificationsScreen() {
     setItems((prev) => prev.filter((x) => !readIds.includes(x.id)));
     setTotalCount((prev) => Math.max(0, prev - readIds.length));
     setClearingRead(false);
-    showToast("Read notifications cleared");
+    showToast(t("admin.notifications.readClearedToast"));
   };
 
   const hasMore = items.length < totalCount;
@@ -336,12 +339,14 @@ export default function NotificationsScreen() {
   return (
     <View style={{ flex: 1 }}>
       <ScrollView contentContainerStyle={styles.container}>
-        {Platform.OS !== "web" && <Stack.Screen options={{ title: "Notifications" }} />}
+        {Platform.OS !== "web" && (
+          <Stack.Screen options={{ title: t("admin.notifications.pageTitle") }} />
+        )}
 
         <View style={styles.pageHeader}>
           <View style={styles.headerRow}>
             <View style={styles.pageTitleRow}>
-              <ThemedText type="h1">Notifications</ThemedText>
+              <ThemedText type="h1">{t("admin.notifications.pageTitle")}</ThemedText>
               {unreadCount > 0 && (
                 <View style={[styles.unreadBadge, { backgroundColor: primaryColor }]}>
                   <ThemedText style={styles.unreadBadgeText}>
@@ -362,10 +367,12 @@ export default function NotificationsScreen() {
                 onPress={() => setConfirmDeleteAll(true)}
                 disabled={deletingAll || items.length === 0}
                 loading={deletingAll}
-                accessibilityLabel="Delete all notifications"
-                accessibilityHint="Keeps pinned notifications"
+                accessibilityLabel={t("admin.notifications.deleteAllLabel")}
+                accessibilityHint={t("admin.notifications.deleteAllHint")}
               >
-                {deletingAll ? "Deleting…" : "Delete all"}
+                {deletingAll
+                  ? t("admin.notifications.deletingAll")
+                  : t("admin.notifications.deleteAll")}
               </Button>
 
               {(() => {
@@ -379,9 +386,11 @@ export default function NotificationsScreen() {
                     onPress={handleClearRead}
                     disabled={clearingRead || !hasRead}
                     loading={clearingRead}
-                    accessibilityLabel="Clear read notifications"
+                    accessibilityLabel={t("admin.notifications.clearReadLabel")}
                   >
-                    {clearingRead ? "Clearing…" : "Clear read"}
+                    {clearingRead
+                      ? t("admin.notifications.clearingRead")
+                      : t("admin.notifications.clearRead")}
                   </Button>
                 );
               })()}
@@ -392,17 +401,19 @@ export default function NotificationsScreen() {
                 onPress={handleMarkAllRead}
                 disabled={markingAll || unreadCount === 0}
                 loading={markingAll}
-                accessibilityLabel="Mark all notifications read"
+                accessibilityLabel={t("admin.notifications.markAllReadLabel")}
               >
-                {markingAll ? "Marking…" : "Mark all read"}
+                {markingAll
+                  ? t("admin.notifications.markingAllRead")
+                  : t("admin.notifications.markAllRead")}
               </Button>
             </ButtonRow>
           </View>
 
           <ThemedText style={[styles.pageSub, { color: mutedColor }]}>
             {loading
-              ? "Loading…"
-              : `${totalCount} total notification${totalCount !== 1 ? "s" : ""}`}
+              ? t("common.status.loading")
+              : t("admin.notifications.totalCount", { count: totalCount })}
           </ThemedText>
         </View>
 
@@ -413,35 +424,43 @@ export default function NotificationsScreen() {
         />
 
         <View style={styles.filtersSection}>
-          <HorizontalScroller label="Locations" contentContainerStyle={styles.pillRow}>
-            {[{ id: null, name: "All locations" }, ...restaurants].map((r) => {
-              const active =
-                r.id === null ? selectedRestaurantId === null : selectedRestaurantId === r.id;
-              return (
-                <Pressable
-                  key={r.id ?? "all"}
-                  onPress={() => setSelectedRestaurantId(r.id)}
-                  accessibilityRole="radio"
-                  accessibilityLabel={r.name}
-                  accessibilityState={{ checked: active }}
-                  style={[
-                    styles.pill,
-                    active
-                      ? { backgroundColor: primaryColor, borderColor: primaryColor }
-                      : { backgroundColor: "transparent", borderColor },
-                  ]}
-                >
-                  <ThemedText style={[styles.pillText, { color: active ? "#fff" : mutedColor }]}>
-                    {r.name}
-                  </ThemedText>
-                </Pressable>
-              );
-            })}
+          <HorizontalScroller
+            label={t("admin.notifications.locationsScrollerLabel")}
+            contentContainerStyle={styles.pillRow}
+          >
+            {[{ id: null, name: t("admin.notifications.allLocations") }, ...restaurants].map(
+              (r) => {
+                const active =
+                  r.id === null ? selectedRestaurantId === null : selectedRestaurantId === r.id;
+                return (
+                  <Pressable
+                    key={r.id ?? "all"}
+                    onPress={() => setSelectedRestaurantId(r.id)}
+                    accessibilityRole="radio"
+                    accessibilityLabel={r.name}
+                    accessibilityState={{ checked: active }}
+                    style={[
+                      styles.pill,
+                      active
+                        ? { backgroundColor: primaryColor, borderColor: primaryColor }
+                        : { backgroundColor: "transparent", borderColor },
+                    ]}
+                  >
+                    <ThemedText style={[styles.pillText, { color: active ? "#fff" : mutedColor }]}>
+                      {r.name}
+                    </ThemedText>
+                  </Pressable>
+                );
+              }
+            )}
           </HorizontalScroller>
 
           <View style={styles.pillRow2}>
-            <HorizontalScroller label="Notification types" contentContainerStyle={styles.pillRow}>
-              {TYPE_FILTERS.map((f) => {
+            <HorizontalScroller
+              label={t("admin.notifications.typesScrollerLabel")}
+              contentContainerStyle={styles.pillRow}
+            >
+              {typeFilters.map((f) => {
                 const active = selectedType === f.value;
                 return (
                   <Pressable
@@ -474,7 +493,7 @@ export default function NotificationsScreen() {
               onPress={() => setUnreadOnly((v) => !v)}
               role="switch"
               aria-checked={unreadOnly}
-              accessibilityLabel="Show unread only"
+              accessibilityLabel={t("admin.notifications.unreadOnlyLabel")}
               accessibilityState={{ checked: unreadOnly }}
               style={[
                 styles.pill,
@@ -494,7 +513,7 @@ export default function NotificationsScreen() {
               <ThemedText
                 style={[styles.pillText, { color: unreadOnly ? primaryColor : mutedColor }]}
               >
-                Filter Unread
+                {t("admin.notifications.filterUnread")}
               </ThemedText>
             </Pressable>
           </View>
@@ -510,10 +529,10 @@ export default function NotificationsScreen() {
               <Icon name="warning-outline" size={28} color={mutedColor} />
             </View>
             <ThemedText style={[styles.emptyTitle, { color: colors.text }]}>
-              Something went wrong
+              {t("errors.generic")}
             </ThemedText>
             <ThemedText style={[styles.emptyBody, { color: mutedColor }]}>
-              Could not load notifications. Check your connection and try again.
+              {t("admin.notifications.errorBody")}
             </ThemedText>
           </View>
         ) : items.length === 0 ? (
@@ -526,12 +545,14 @@ export default function NotificationsScreen() {
               />
             </View>
             <ThemedText style={[styles.emptyTitle, { color: colors.text }]}>
-              {unreadOnly ? "All caught up" : "No notifications yet"}
+              {unreadOnly
+                ? t("admin.notifications.allCaughtUpTitle")
+                : t("admin.notifications.emptyTitle")}
             </ThemedText>
             <ThemedText style={[styles.emptyBody, { color: mutedColor }]}>
               {unreadOnly
-                ? "You've read everything. New alerts will appear here."
-                : "Booking events and capacity alerts will appear here."}
+                ? t("admin.notifications.allCaughtUpBody")
+                : t("admin.notifications.emptyBody")}
             </ThemedText>
           </View>
         ) : (
@@ -541,7 +562,7 @@ export default function NotificationsScreen() {
                 <View style={[styles.sectionDivider, { borderBottomColor: borderColor }]}>
                   <Icon name="bookmark" size={11} color={primaryColor} />
                   <ThemedText style={[styles.sectionLabel, { color: primaryColor }]}>
-                    Pinned
+                    {t("admin.notifications.pinnedLabel")}
                   </ThemedText>
                 </View>
                 {pinnedItems.map((n, i) => renderRow(n, i, pinnedItems, unpinnedItems.length > 0))}
@@ -557,7 +578,7 @@ export default function NotificationsScreen() {
                     ]}
                   >
                     <ThemedText style={[styles.sectionLabel, { color: mutedColor }]}>
-                      All notifications
+                      {t("admin.notifications.allNotificationsLabel")}
                     </ThemedText>
                   </View>
                 )}
@@ -576,9 +597,13 @@ export default function NotificationsScreen() {
                 onPress={handleLoadMore}
                 disabled={loadingMore}
                 loading={loadingMore}
-                accessibilityLabel={`Show ${totalCount - items.length} more notifications`}
+                accessibilityLabel={t("admin.notifications.showMoreLabel", {
+                  count: totalCount - items.length,
+                })}
               >
-                {loadingMore ? "Loading…" : `Show ${totalCount - items.length} more`}
+                {loadingMore
+                  ? t("admin.notifications.loadingMore")
+                  : t("admin.notifications.showMoreButton", { count: totalCount - items.length })}
               </Button>
             )}
           </View>
@@ -596,9 +621,9 @@ export default function NotificationsScreen() {
 
       <ConfirmModal
         visible={confirmDeleteAll}
-        title="Delete all notifications?"
-        message="This will permanently delete all visible unpinned notifications. Pinned notifications will be kept."
-        confirmLabel="Delete all"
+        title={t("admin.notifications.deleteAllModal.title")}
+        message={t("admin.notifications.deleteAllModal.message")}
+        confirmLabel={t("admin.notifications.deleteAllModal.confirmLabel")}
         destructive
         onConfirm={() => {
           setConfirmDeleteAll(false);
@@ -608,9 +633,9 @@ export default function NotificationsScreen() {
       />
       <ConfirmModal
         visible={confirmDeleteId != null}
-        title="Delete pinned notification?"
-        message="This notification is pinned. Are you sure you want to delete it?"
-        confirmLabel="Delete"
+        title={t("admin.notifications.deletePinnedModal.title")}
+        message={t("admin.notifications.deletePinnedModal.message")}
+        confirmLabel={t("admin.notifications.deletePinnedModal.confirmLabel")}
         destructive
         onConfirm={handleConfirmedDelete}
         onCancel={() => setConfirmDeleteId(null)}

--- a/openresto-frontend/components/admin/dashboard/ScheduleConflictsBanner.tsx
+++ b/openresto-frontend/components/admin/dashboard/ScheduleConflictsBanner.tsx
@@ -1,5 +1,6 @@
 import { Pressable, View } from "react-native";
 import { useRouter, type Href } from "expo-router";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { Icon } from "@/components/common/Icon";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -34,10 +35,10 @@ export function ScheduleConflictsBanner({
 }) {
   const { colors } = useAppTheme();
   const router = useRouter();
+  const { t } = useTranslation();
 
   if (count <= 0) return null;
 
-  const bookings = `${count} upcoming booking${count === 1 ? "" : "s"}`;
   const target: Href =
     locationIds.length > 0
       ? { pathname: "/admin/locations", params: { location: String(locationIds[0]) } }
@@ -47,7 +48,7 @@ export function ScheduleConflictsBanner({
     <Pressable
       testID="dashboard-schedule-conflicts"
       accessibilityRole="button"
-      accessibilityLabel={`${bookings} no longer fit their location's schedule. Review locations.`}
+      accessibilityLabel={t("admin.dashboard.scheduleConflicts.accessibilityLabel", { count })}
       onPress={() => router.push(target)}
       style={[styles.banner, { backgroundColor: colors.card, borderColor: colors.warning }]}
     >
@@ -56,11 +57,10 @@ export function ScheduleConflictsBanner({
       </View>
       <View style={styles.copy}>
         <ThemedText style={styles.title}>
-          {bookings} no longer fit their location&apos;s schedule
+          {t("admin.dashboard.scheduleConflicts.title", { count })}
         </ThemedText>
         <ThemedText style={[styles.sub, { color: colors.muted }]}>
-          Taken before the current hours and still on the books. The guests have not been told
-          anything changed. Review locations.
+          {t("admin.dashboard.scheduleConflicts.subtitle")}
         </ThemedText>
       </View>
       <Icon name="chevron-forward" size="md" color={colors.muted} />

--- a/openresto-frontend/components/admin/notifications/NotificationRow.tsx
+++ b/openresto-frontend/components/admin/notifications/NotificationRow.tsx
@@ -1,10 +1,11 @@
 import { Platform, Pressable, View } from "react-native";
 import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import { hexToRgba } from "@/utils/colors";
 import { theme } from "@/theme/theme";
 import type { AdminNotificationDto } from "@/api/notifications";
-import { TYPE_ICONS, TYPE_LABELS, formatBookingDate, relativeTime } from "@/utils/notifications";
+import { TYPE_ICONS, getTypeLabels, formatBookingDate, relativeTime } from "@/utils/notifications";
 import { styles } from "@/components/admin/notifications/notifications.styles";
 import { Icon } from "@/components/common/Icon";
 import { RowTextButton } from "@/components/common/RowTextButton";
@@ -49,10 +50,12 @@ export function NotificationRow({
   onRequestDelete,
   onSwipeDelete,
 }: NotificationRowProps) {
+  const { t } = useTranslation();
+  const typeLabels = getTypeLabels(t);
   const typeIcon = TYPE_ICONS[n.type];
   const meta = [
     n.restaurantName,
-    n.seats > 0 ? `${n.seats} guest${n.seats !== 1 ? "s" : ""}` : null,
+    n.seats > 0 ? t("admin.notifications.row.guestCount", { count: n.seats }) : null,
     n.bookingDate ? formatBookingDate(n.bookingDate) : null,
     relativeTime(n.createdAt),
   ]
@@ -83,10 +86,10 @@ export function NotificationRow({
         onPress={() => onRowTap(n)}
         accessibilityRole="button"
         accessibilityLabel={[
-          n.isRead ? "Read" : "Unread",
-          TYPE_LABELS[n.type],
+          n.isRead ? t("admin.notifications.row.read") : t("admin.notifications.row.unread"),
+          typeLabels[n.type],
           n.customerName,
-          n.bookingRef ? `booking ${n.bookingRef}` : null,
+          n.bookingRef ? t("admin.notifications.row.bookingRefLabel", { ref: n.bookingRef }) : null,
           meta,
         ]
           .filter(Boolean)
@@ -110,7 +113,7 @@ export function NotificationRow({
 
         <View style={styles.notifBody}>
           <View style={styles.notifTitleRow}>
-            <ThemedText style={styles.notifType}>{TYPE_LABELS[n.type]}</ThemedText>
+            <ThemedText style={styles.notifType}>{typeLabels[n.type]}</ThemedText>
             {n.bookingRef ? (
               <ThemedText style={[styles.notifRef, { color: mutedColor }]}>
                 #{n.bookingRef}
@@ -130,37 +133,41 @@ export function NotificationRow({
             Pressable so they act on the notification rather than navigating to it. */}
         <View style={styles.rowActions}>
           <RowTextButton
-            label={isPinned ? "Unpin" : "Pin"}
+            label={isPinned ? t("admin.notifications.row.unpin") : t("admin.notifications.row.pin")}
             icon={isPinned ? "bookmark" : "bookmark-outline"}
             color={primaryColor}
             selected={isPinned}
             onPress={() => onTogglePin(n.id)}
-            accessibilityLabel={isPinned ? "Unpin notification" : "Pin notification"}
+            accessibilityLabel={
+              isPinned
+                ? t("admin.notifications.row.unpinLabel")
+                : t("admin.notifications.row.pinLabel")
+            }
           />
           {n.isRead ? (
             <RowTextButton
-              label="Mark unread"
+              label={t("admin.notifications.row.markUnread")}
               icon="mail-unread-outline"
               color={mutedColor}
               onPress={() => onMarkUnread(n.id)}
-              accessibilityLabel="Mark notification unread"
+              accessibilityLabel={t("admin.notifications.row.markUnreadLabel")}
             />
           ) : (
             <RowTextButton
-              label="Mark read"
+              label={t("admin.notifications.row.markRead")}
               icon="mail-open-outline"
               color={mutedColor}
               onPress={() => onMarkRead(n.id)}
-              accessibilityLabel="Mark notification read"
+              accessibilityLabel={t("admin.notifications.row.markReadLabel")}
             />
           )}
           <RowTextButton
             testID={`delete-notif-${n.id}`}
-            label="Delete"
+            label={t("admin.notifications.row.delete")}
             icon="trash-outline"
             color={theme.colors.error}
             onPress={() => onRequestDelete(n.id)}
-            accessibilityLabel="Delete notification"
+            accessibilityLabel={t("admin.notifications.row.deleteLabel")}
           />
         </View>
 

--- a/openresto-frontend/components/admin/notifications/PushBanner.tsx
+++ b/openresto-frontend/components/admin/notifications/PushBanner.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Platform, View } from "react-native";
+import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
 import Button from "@/components/common/Button";
 import { theme } from "@/theme/theme";
@@ -53,6 +54,7 @@ export interface PushBannerProps {
  * or when push is unsupported/already active.
  */
 export function PushBanner({ restaurantId, primaryColor, isDark }: PushBannerProps) {
+  const { t } = useTranslation();
   const [vapidKey, setVapidKey] = useState<string | null | undefined>(undefined);
   const [pushStatus, setPushStatus] = usePushStatus(vapidKey);
   const [working, setWorking] = useState(false);
@@ -76,7 +78,7 @@ export function PushBanner({ restaurantId, primaryColor, isDark }: PushBannerPro
       const permission = await Notification.requestPermission();
       if (permission === "denied") {
         setPushStatus("denied");
-        setErrorMsg("Blocked by browser - allow notifications in site settings.");
+        setErrorMsg(t("admin.notifications.pushBanner.blockedError"));
         setWorking(false);
         return;
       }
@@ -100,7 +102,7 @@ export function PushBanner({ restaurantId, primaryColor, isDark }: PushBannerPro
       setPushStatus("active");
     } catch (err) {
       console.error("Push subscribe error:", err);
-      setErrorMsg("Failed to enable - try again.");
+      setErrorMsg(t("admin.notifications.pushBanner.enableFailed"));
     }
     setWorking(false);
   };
@@ -118,7 +120,7 @@ export function PushBanner({ restaurantId, primaryColor, isDark }: PushBannerPro
       >
         <Icon name="notifications-off-outline" size="md" color={theme.colors.warning} />
         <ThemedText style={[styles.pushBannerText, { color: theme.colors.warning }]}>
-          Push notifications blocked - enable in browser site settings.
+          {t("admin.notifications.pushBanner.deniedBanner")}
         </ThemedText>
       </View>
     );
@@ -136,7 +138,7 @@ export function PushBanner({ restaurantId, primaryColor, isDark }: PushBannerPro
     >
       <Icon name="notifications-outline" size="md" color={primaryColor} />
       <ThemedText style={[styles.pushBannerText, { color: primaryColor }]}>
-        Enable push notifications to get real-time booking alerts.
+        {t("admin.notifications.pushBanner.promptBanner")}
       </ThemedText>
       {errorMsg && (
         <ThemedText
@@ -153,9 +155,9 @@ export function PushBanner({ restaurantId, primaryColor, isDark }: PushBannerPro
         onPress={handleEnable}
         disabled={working}
         loading={working}
-        accessibilityLabel="Enable push notifications"
+        accessibilityLabel={t("admin.notifications.pushBanner.enableLabel")}
       >
-        Enable
+        {t("admin.notifications.pushBanner.enable")}
       </Button>
     </View>
   );

--- a/openresto-frontend/components/layout/AdminSidebar.tsx
+++ b/openresto-frontend/components/layout/AdminSidebar.tsx
@@ -1,11 +1,13 @@
 import { View, Pressable, Platform, TextInput, type ViewStyle } from "react-native";
 import { usePathname, useRouter, type Href } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { ThemedView } from "@/components/themed-view";
 import { ThemedText } from "@/components/themed-text";
 import { useTheme } from "@/context/ThemeContext";
 import { useAuth } from "@/context/AuthContext";
-import { roleLabel, type Capability } from "@/constants/roles";
+import { roleDisplayLabel, type Capability } from "@/constants/roles";
 import { theme } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
@@ -21,6 +23,7 @@ import { styles } from "./AdminSidebar.styles";
 import { Icon, type IconName } from "@/components/common/Icon";
 
 interface NavItem {
+  id: string;
   label: string;
   icon: IconName;
   href: Href;
@@ -29,82 +32,97 @@ interface NavItem {
   capability?: Capability;
 }
 
-const NAV_SECTIONS: { heading: string; items: NavItem[] }[] = [
-  {
-    heading: "Manage",
-    items: [
-      {
-        label: "Overview",
-        icon: "grid-outline" as const,
-        href: "/admin/dashboard" as const,
-        match: (p: string) => p === "/admin/dashboard",
-      },
-      {
-        label: "Bookings",
-        icon: "calendar-outline" as const,
-        href: "/admin/bookings" as const,
-        match: (p: string) => p === "/admin/bookings" || p.startsWith("/admin/bookings/"),
-      },
-      {
-        label: "Locations",
-        icon: "storefront-outline" as const,
-        href: "/admin/locations" as const,
-        match: (p: string) => p === "/admin/locations",
-      },
-      {
-        label: "Notifications",
-        icon: "notifications-outline" as const,
-        href: "/admin/notifications" as const,
-        match: (p: string) => p === "/admin/notifications",
-      },
-      {
-        label: "Activity",
-        icon: "receipt-outline" as const,
-        href: "/admin/activity" as const,
-        match: (p: string) => p === "/admin/activity",
-        capability: "view:audit" as const,
-      },
-    ],
-  },
-  {
-    heading: "Configure",
-    items: [
-      {
-        label: "Brand",
-        icon: "color-palette-outline" as const,
-        // /admin/settings redirects here, so it owns the bare path's highlight too.
-        href: "/admin/settings/brand" as const,
-        match: (p: string) => p === "/admin/settings/brand" || p === "/admin/settings",
-      },
-      {
-        label: "Email & Push",
-        icon: "mail-outline" as const,
-        href: "/admin/settings/email" as const,
-        match: (p: string) => p === "/admin/settings/email",
-      },
-      {
-        label: "Users",
-        icon: "people-outline" as const,
-        href: "/admin/settings/users" as const,
-        match: (p: string) => p === "/admin/settings/users",
-        capability: "manage:users" as const,
-      },
-      {
-        label: "Account",
-        icon: "person-circle-outline" as const,
-        href: "/admin/settings/account" as const,
-        match: (p: string) => p === "/admin/settings/account",
-      },
-    ],
-  },
-];
+/** Module-scope labels would resolve before `LocaleContext` picks a locale and never
+ * re-render on a language switch, so the nav is built fresh from `t` on every render. */
+function getNavSections(t: TFunction): { heading: string; items: NavItem[] }[] {
+  return [
+    {
+      heading: t("admin.sidebar.nav.sections.manage"),
+      items: [
+        {
+          id: "overview",
+          label: t("admin.sidebar.nav.items.overview"),
+          icon: "grid-outline" as const,
+          href: "/admin/dashboard" as const,
+          match: (p: string) => p === "/admin/dashboard",
+        },
+        {
+          id: "bookings",
+          label: t("admin.sidebar.nav.items.bookings"),
+          icon: "calendar-outline" as const,
+          href: "/admin/bookings" as const,
+          match: (p: string) => p === "/admin/bookings" || p.startsWith("/admin/bookings/"),
+        },
+        {
+          id: "locations",
+          label: t("admin.sidebar.nav.items.locations"),
+          icon: "storefront-outline" as const,
+          href: "/admin/locations" as const,
+          match: (p: string) => p === "/admin/locations",
+        },
+        {
+          id: "notifications",
+          label: t("admin.sidebar.nav.items.notifications"),
+          icon: "notifications-outline" as const,
+          href: "/admin/notifications" as const,
+          match: (p: string) => p === "/admin/notifications",
+        },
+        {
+          id: "activity",
+          label: t("admin.sidebar.nav.items.activity"),
+          icon: "receipt-outline" as const,
+          href: "/admin/activity" as const,
+          match: (p: string) => p === "/admin/activity",
+          capability: "view:audit" as const,
+        },
+      ],
+    },
+    {
+      heading: t("admin.sidebar.nav.sections.configure"),
+      items: [
+        {
+          id: "brand",
+          label: t("admin.sidebar.nav.items.brand"),
+          icon: "color-palette-outline" as const,
+          // /admin/settings redirects here, so it owns the bare path's highlight too.
+          href: "/admin/settings/brand" as const,
+          match: (p: string) => p === "/admin/settings/brand" || p === "/admin/settings",
+        },
+        {
+          id: "emailPush",
+          label: t("admin.sidebar.nav.items.emailPush"),
+          icon: "mail-outline" as const,
+          href: "/admin/settings/email" as const,
+          match: (p: string) => p === "/admin/settings/email",
+        },
+        {
+          id: "users",
+          label: t("admin.sidebar.nav.items.users"),
+          icon: "people-outline" as const,
+          href: "/admin/settings/users" as const,
+          match: (p: string) => p === "/admin/settings/users",
+          capability: "manage:users" as const,
+        },
+        {
+          id: "account",
+          label: t("admin.sidebar.nav.items.account"),
+          icon: "person-circle-outline" as const,
+          href: "/admin/settings/account" as const,
+          match: (p: string) => p === "/admin/settings/account",
+        },
+      ],
+    },
+  ];
+}
 
 export default function AdminSidebar() {
+  const { t } = useTranslation();
   const pathname = usePathname();
   const router = useRouter();
   const { colors, isDark, brand, primaryColor: PRIMARY } = useAppTheme();
   const { toggle } = useTheme();
   const { user, signOut, can } = useAuth();
+  const navSections = getNavSections(t);
   const [locationCount, setLocationCount] = useState(0);
   const [unreadNotifCount, setUnreadNotifCount] = useState(0);
   const insets = useSafeAreaInsets();
@@ -190,8 +208,8 @@ export default function AdminSidebar() {
           </ThemedText>
           <ThemedText style={[styles.brandSub, { color: colors.muted }]} numberOfLines={1}>
             {locationCount > 0
-              ? `Managing ${locationCount} location${locationCount !== 1 ? "s" : ""}`
-              : "Admin Panel"}
+              ? t("admin.sidebar.managingLocations", { count: locationCount })
+              : t("admin.sidebar.adminPanel")}
           </ThemedText>
         </View>
       </View>
@@ -199,22 +217,26 @@ export default function AdminSidebar() {
       <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
       <View style={styles.nav}>
-        {NAV_SECTIONS.map(({ heading, items }) => (
+        {navSections.map(({ heading, items }) => (
           <View key={heading} style={styles.navSection}>
             <ThemedText style={[styles.navHeading, { color: colors.muted }]}>
               {heading.toUpperCase()}
             </ThemedText>
             {items
               .filter((item) => !item.capability || can(item.capability))
-              .map(({ label, icon, href, match }) => {
+              .map(({ id, label, icon, href, match }) => {
                 const active = match(pathname);
-                const showBadge = label === "Notifications" && unreadNotifCount > 0;
+                const showBadge = id === "notifications" && unreadNotifCount > 0;
                 return (
                   <Pressable
-                    key={label}
+                    key={id}
                     onPress={() => router.push(href)}
                     accessibilityRole="link"
-                    accessibilityLabel={showBadge ? `${label}, ${unreadNotifCount} unread` : label}
+                    accessibilityLabel={
+                      showBadge
+                        ? t("admin.sidebar.nav.unreadLabel", { label, count: unreadNotifCount })
+                        : label
+                    }
                     accessibilityState={{ selected: active }}
                     aria-current={active ? "page" : undefined}
                     style={(state) => [
@@ -260,7 +282,7 @@ export default function AdminSidebar() {
 
       <View style={styles.ctaWrapper}>
         <ThemedText style={[styles.lookupLabel, { color: colors.muted }]}>
-          Lookup Booking
+          {t("admin.sidebar.lookup.label")}
         </ThemedText>
         <TextInput
           ref={lookupInputRef}
@@ -272,11 +294,11 @@ export default function AdminSidebar() {
               backgroundColor: colors.input,
             },
           ]}
-          placeholder="Name, email or reference…"
+          placeholder={t("admin.sidebar.lookup.placeholder")}
           placeholderTextColor={colors.muted}
           value={lookupQuery}
-          onChangeText={(t) => {
-            setLookupQuery(t);
+          onChangeText={(text) => {
+            setLookupQuery(text);
             if (lookupStatus !== "idle") setLookupStatus("idle");
           }}
           autoCapitalize="none"
@@ -290,23 +312,23 @@ export default function AdminSidebar() {
           onPress={handleLookup}
           disabled={!lookupQuery.trim()}
           loading={lookupLoading}
-          accessibilityLabel="Search bookings"
+          accessibilityLabel={t("admin.sidebar.lookup.searchLabel")}
         >
-          Search
+          {t("admin.sidebar.lookup.searchButton")}
         </Button>
         {lookupStatus === "not_found" && (
           <ThemedText style={[styles.lookupHint, { color: theme.colors.error }]}>
-            No booking found.
+            {t("admin.sidebar.lookup.notFound")}
           </ThemedText>
         )}
         {lookupStatus === "multiple" && (
           <ThemedText style={[styles.lookupHint, { color: PRIMARY }]}>
-            Showing all matches…
+            {t("admin.sidebar.lookup.showingMatches")}
           </ThemedText>
         )}
         {lookupStatus === "idle" && (
           <ThemedText style={[styles.lookupHint, { color: PRIMARY }]}>
-            Partial matching search is supported
+            {t("admin.sidebar.lookup.partialMatchHint")}
           </ThemedText>
         )}
       </View>
@@ -330,7 +352,7 @@ export default function AdminSidebar() {
             </ThemedText>
             <View style={[styles.roleBadge, { backgroundColor: hexToRgba(PRIMARY, 0.12) }]}>
               <ThemedText style={[styles.roleBadgeText, { color: PRIMARY }]}>
-                {roleLabel(user.role)}
+                {roleDisplayLabel(user.role, t)}
               </ThemedText>
             </View>
           </View>
@@ -338,14 +360,16 @@ export default function AdminSidebar() {
         <Pressable
           onPress={() => router.push("/")}
           accessibilityRole="link"
-          accessibilityLabel="Back to site"
+          accessibilityLabel={t("admin.sidebar.backToSite")}
           style={(state) => [
             styles.footerItem,
             (state as { hovered?: boolean }).hovered && { backgroundColor: hoverBg },
           ]}
         >
           <Icon name="arrow-back-outline" size={15} color={colors.muted} />
-          <ThemedText style={[styles.footerText, { color: colors.muted }]}>Back to site</ThemedText>
+          <ThemedText style={[styles.footerText, { color: colors.muted }]}>
+            {t("admin.sidebar.backToSite")}
+          </ThemedText>
         </Pressable>
         <Pressable
           style={(state) => [
@@ -354,11 +378,17 @@ export default function AdminSidebar() {
           ]}
           onPress={toggle}
           accessibilityRole="button"
-          accessibilityLabel={isDark ? "Switch to light mode" : "Switch to dark mode"}
+          accessibilityLabel={
+            isDark
+              ? t("admin.sidebar.themeToggle.switchToLight")
+              : t("admin.sidebar.themeToggle.switchToDark")
+          }
         >
           <Icon name={isDark ? "sunny-outline" : "moon-outline"} size={15} color={colors.muted} />
           <ThemedText style={[styles.footerText, { color: colors.muted }]}>
-            {isDark ? "Light mode" : "Dark mode"}
+            {isDark
+              ? t("admin.sidebar.themeToggle.lightMode")
+              : t("admin.sidebar.themeToggle.darkMode")}
           </ThemedText>
         </Pressable>
         <Pressable
@@ -368,10 +398,12 @@ export default function AdminSidebar() {
           ]}
           onPress={handleLogout}
           accessibilityRole="button"
-          accessibilityLabel="Log out"
+          accessibilityLabel={t("admin.sidebar.logOut")}
         >
           <Icon name="log-out-outline" size={15} color={colors.muted} />
-          <ThemedText style={[styles.footerText, { color: colors.muted }]}>Log out</ThemedText>
+          <ThemedText style={[styles.footerText, { color: colors.muted }]}>
+            {t("admin.sidebar.logOut")}
+          </ThemedText>
         </Pressable>
       </View>
     </ThemedView>

--- a/openresto-frontend/e2e/admin-locale-fr.spec.ts
+++ b/openresto-frontend/e2e/admin-locale-fr.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Guards the i18n admin surface end to end (issue #374, F5 — the last piece of the
+ * per-area admin translation split): with the viewer's locale resolved to French, the
+ * admin dashboard — sidebar chrome, page heading, metric labels, and quick actions —
+ * renders translated copy rather than silently falling back to English.
+ *
+ * F1 translated `app/admin/dashboard.tsx` but scoped itself to `components/admin/bookings`
+ * plus two screens, so `components/admin/dashboard/ScheduleConflictsBanner.tsx` (rendered
+ * by the dashboard, not under `components/admin/bookings`) fell through the cracks and
+ * shipped with no `useTranslation` at all — one feature half-translated across two files
+ * (its sibling `ScheduleConflictsPanel.tsx` on `/admin/locations` was translated by F2).
+ * This spec exercises the same dashboard shell the banner mounts into, so a future regression
+ * that reintroduces hardcoded English anywhere on this screen shows up as an English string
+ * sitting among French ones rather than silently passing.
+ *
+ * Untagged on purpose (extensive suite, not @smoke): the golden admin-dashboard path
+ * (admin-dashboard.spec.ts) stays on English; this is the one spec that exercises the
+ * translated admin surface, mirroring language-switcher.spec.ts's guest-side coverage.
+ *
+ * Runs under chromium-admin (storageState cookie pre-loaded by global-setup.ts) — no
+ * separate login flow.
+ */
+test.describe("Admin locale (French)", () => {
+  test("renders the admin dashboard and sidebar in French", async ({ page }) => {
+    // LocaleContext resolves localStorage above brand.defaultLocale (see LocaleContext /
+    // language-switcher.spec.ts), so seeding it before the first paint is enough to force
+    // French without touching the backend or a second login flow.
+    await page.goto("/admin/dashboard");
+    await page.evaluate(() => window.localStorage.setItem("openresto.locale", "fr"));
+    await page.reload();
+
+    // Wait on the authenticated shell via a testID rather than the sidebar's lookup
+    // placeholder — that placeholder is itself translated copy now, so it can't double as
+    // a locale-agnostic "the page loaded" signal the way gotoAdminDashboard's English-only
+    // wait does.
+    await expect(page.getByTestId("sidebar-identity")).toBeVisible({ timeout: 20_000 });
+
+    // Sidebar nav renders in French (components/layout/AdminSidebar.tsx).
+    await expect(page.getByRole("link", { name: "Aperçu" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Réservations" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Établissements" })).toBeVisible();
+    // Section headings render uppercased (AdminSidebar.tsx: heading.toUpperCase()).
+    await expect(page.getByText("GÉRER", { exact: true })).toBeVisible();
+    await expect(page.getByText("CONFIGURER", { exact: true })).toBeVisible();
+    await expect(page.getByText("Se déconnecter", { exact: true })).toBeVisible();
+
+    // Dashboard heading, metric cards and chart section render in French
+    // (app/admin/dashboard.tsx).
+    await expect(page.getByText("Tableau de bord", { exact: true })).toBeVisible();
+    await expect(page.getByText("Réservations du jour", { exact: true })).toBeVisible();
+    await expect(page.getByText("Réservations temporaires actives", { exact: true })).toBeVisible();
+    await expect(page.getByText("Statut de l'établissement", { exact: true })).toBeVisible();
+    await expect(page.getByText("Total des couverts", { exact: true })).toBeVisible();
+    await expect(page.getByText("Aperçu de l'occupation")).toBeVisible();
+    await expect(page.getByText("7 derniers jours", { exact: true })).toBeVisible();
+    await expect(page.getByText("Aujourd'hui", { exact: true })).toBeVisible();
+
+    // Quick actions render and navigate in French.
+    await expect(page.getByText("Voir toutes les réservations")).toBeVisible();
+    await page.getByText("Gérer les paramètres").click();
+    await page.waitForURL(/.*\/settings/, { timeout: 15_000 });
+  });
+});

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -733,6 +733,19 @@
         "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
         "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, storniert",
         "meta": "{{seats}} · {{restaurant}}"
+      },
+      "scheduleConflicts": {
+        "title_one": "{{count}} bevorstehende Buchung passt nicht mehr in den Zeitplan ihres Standorts",
+        "title_other": "{{count}} bevorstehende Buchungen passen nicht mehr in den Zeitplan ihres Standorts",
+        "subtitle": "Diese wurden vor den aktuellen Öffnungszeiten vorgenommen und stehen weiterhin im Buch. Die Gäste wurden nicht über die Änderung informiert. Sehen Sie sich die Standorte an.",
+        "accessibilityLabel_one": "{{count}} bevorstehende Buchung passt nicht mehr in den Zeitplan ihres Standorts. Sehen Sie sich die Standorte an.",
+        "accessibilityLabel_other": "{{count}} bevorstehende Buchungen passen nicht mehr in den Zeitplan ihres Standorts. Sehen Sie sich die Standorte an."
+      }
+    },
+    "layout": {
+      "desktopWall": {
+        "title": "Bildschirm zu klein",
+        "body": "Das Admin-Dashboard benötigt einen breiteren Bildschirm.\nDrehen Sie Ihr Gerät oder verwenden Sie einen größeren Bildschirm."
       }
     },
     "locations": {
@@ -837,6 +850,138 @@
         "guestCount_other": "{{count}} Gäste",
         "openLabel": "Öffnen",
         "openBookingLabel": "Buchung {{ref}} öffnen"
+      }
+    },
+    "login": {
+      "nativeTitle": "Admin-Anmeldung",
+      "badge": "Admin",
+      "backToApp": "Zurück zu {{appName}}",
+      "signIn": {
+        "title": "Anmelden",
+        "subtitle": "Verwalten Sie die Buchungen Ihres Restaurants.",
+        "emailLabel": "E-Mail",
+        "emailPlaceholder": "admin@restaurant.com",
+        "passwordLabel": "Passwort",
+        "submit": "Anmelden",
+        "submitting": "Anmeldung läuft…",
+        "forgotPassword": "Passwort vergessen?",
+        "invalidCredentials": "Ungültige E-Mail oder ungültiges Passwort. Bitte versuchen Sie es erneut."
+      },
+      "pvqEmail": {
+        "title": "Passwort zurücksetzen",
+        "subtitle": "Wir überprüfen Ihre Identität anhand Ihrer Sicherheitsfrage.",
+        "emailLabel": "Admin-E-Mail",
+        "emailPlaceholder": "admin@restaurant.com",
+        "submit": "Weiter",
+        "checking": "Wird geprüft…",
+        "noQuestionConfigured": "Für dieses Konto wurde keine Sicherheitsfrage eingerichtet."
+      },
+      "pvqAnswer": {
+        "title": "Sicherheitsfrage",
+        "answerLabel": "Ihre Antwort",
+        "answerPlaceholder": "Antwort (Groß-/Kleinschreibung wird nicht beachtet)",
+        "submit": "Antwort bestätigen",
+        "verifying": "Wird überprüft…",
+        "incorrectAnswer": "Falsche Antwort. Bitte versuchen Sie es erneut."
+      },
+      "reset": {
+        "title": "Neues Passwort festlegen",
+        "subtitle": "Dieser Link läuft in 15 Minuten ab.",
+        "newPasswordLabel": "Neues Passwort",
+        "newPasswordPlaceholder": "Mindestens 6 Zeichen",
+        "confirmPasswordLabel": "Passwort bestätigen",
+        "confirmPasswordPlaceholder": "Passwort wiederholen",
+        "submit": "Passwort zurücksetzen",
+        "resetting": "Wird zurückgesetzt…"
+      },
+      "done": {
+        "title": "Passwort zurückgesetzt!",
+        "subtitle": "Ihr Passwort wurde aktualisiert. Melden Sie sich mit Ihren neuen Anmeldedaten an.",
+        "backToSignIn": "Zurück zur Anmeldung"
+      },
+      "backLabel": "Zurück"
+    },
+    "notifications": {
+      "pageTitle": "Benachrichtigungen",
+      "totalCount_one": "{{count}} Benachrichtigung insgesamt",
+      "totalCount_other": "{{count}} Benachrichtigungen insgesamt",
+      "deleteAll": "Alle löschen",
+      "deletingAll": "Wird gelöscht…",
+      "deleteAllLabel": "Alle Benachrichtigungen löschen",
+      "deleteAllHint": "Angepinnte Benachrichtigungen bleiben erhalten",
+      "clearRead": "Gelesene entfernen",
+      "clearingRead": "Wird entfernt…",
+      "clearReadLabel": "Gelesene Benachrichtigungen entfernen",
+      "markAllRead": "Alle als gelesen markieren",
+      "markingAllRead": "Wird markiert…",
+      "markAllReadLabel": "Alle Benachrichtigungen als gelesen markieren",
+      "markedAllReadToast": "Alle als gelesen markiert",
+      "notificationDeletedToast": "Benachrichtigung gelöscht",
+      "allVisiblePinnedToast": "Alle sichtbaren Benachrichtigungen sind angepinnt",
+      "readClearedToast": "Gelesene Benachrichtigungen entfernt",
+      "deletedCountToast_one": "{{count}} Benachrichtigung gelöscht",
+      "deletedCountToast_other": "{{count}} Benachrichtigungen gelöscht",
+      "allLocations": "Alle Standorte",
+      "locationsScrollerLabel": "Standorte",
+      "typesScrollerLabel": "Benachrichtigungstypen",
+      "filterUnread": "Nur ungelesen",
+      "unreadOnlyLabel": "Nur ungelesene anzeigen",
+      "errorBody": "Benachrichtigungen konnten nicht geladen werden. Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "allCaughtUpTitle": "Alles erledigt",
+      "allCaughtUpBody": "Sie haben alles gelesen. Neue Hinweise erscheinen hier.",
+      "emptyTitle": "Noch keine Benachrichtigungen",
+      "emptyBody": "Buchungsereignisse und Kapazitätswarnungen erscheinen hier.",
+      "pinnedLabel": "Angepinnt",
+      "allNotificationsLabel": "Alle Benachrichtigungen",
+      "showMoreButton": "{{count}} weitere anzeigen",
+      "showMoreLabel_one": "{{count}} weitere Benachrichtigung anzeigen",
+      "showMoreLabel_other": "{{count}} weitere Benachrichtigungen anzeigen",
+      "loadingMore": "Wird geladen…",
+      "deleteAllModal": {
+        "title": "Alle Benachrichtigungen löschen?",
+        "message": "Dadurch werden alle sichtbaren, nicht angepinnten Benachrichtigungen dauerhaft gelöscht. Angepinnte Benachrichtigungen bleiben erhalten.",
+        "confirmLabel": "Alle löschen"
+      },
+      "deletePinnedModal": {
+        "title": "Angepinnte Benachrichtigung löschen?",
+        "message": "Diese Benachrichtigung ist angepinnt. Möchten Sie sie wirklich löschen?",
+        "confirmLabel": "Löschen"
+      },
+      "types": {
+        "bookingCreated": "Neue Buchung",
+        "bookingCancelled": "Buchung storniert",
+        "restaurantNearlyFull": "Fast ausgebucht"
+      },
+      "filters": {
+        "all": "Alle Typen",
+        "bookingCreated": "Neue Buchungen",
+        "bookingCancelled": "Storniert",
+        "restaurantNearlyFull": "Fast ausgebucht"
+      },
+      "row": {
+        "guestCount_one": "{{count}} Gast",
+        "guestCount_other": "{{count}} Gäste",
+        "read": "Gelesen",
+        "unread": "Ungelesen",
+        "bookingRefLabel": "Buchung {{ref}}",
+        "pin": "Anpinnen",
+        "unpin": "Loslösen",
+        "pinLabel": "Benachrichtigung anpinnen",
+        "unpinLabel": "Benachrichtigung loslösen",
+        "markRead": "Als gelesen markieren",
+        "markUnread": "Als ungelesen markieren",
+        "markReadLabel": "Benachrichtigung als gelesen markieren",
+        "markUnreadLabel": "Benachrichtigung als ungelesen markieren",
+        "delete": "Löschen",
+        "deleteLabel": "Benachrichtigung löschen"
+      },
+      "pushBanner": {
+        "blockedError": "Vom Browser blockiert - erlauben Sie Benachrichtigungen in den Website-Einstellungen.",
+        "deniedBanner": "Push-Benachrichtigungen blockiert - aktivieren Sie sie in den Website-Einstellungen Ihres Browsers.",
+        "promptBanner": "Aktivieren Sie Push-Benachrichtigungen, um Echtzeit-Buchungswarnungen zu erhalten.",
+        "enableFailed": "Aktivierung fehlgeschlagen - versuchen Sie es erneut.",
+        "enable": "Aktivieren",
+        "enableLabel": "Push-Benachrichtigungen aktivieren"
       }
     },
     "settings": {
@@ -1361,6 +1506,47 @@
       "brandAutosave": {
         "serverUnreachable": "Server konnte nicht erreicht werden."
       }
+    },
+    "sidebar": {
+      "nav": {
+        "sections": {
+          "manage": "Verwalten",
+          "configure": "Konfigurieren"
+        },
+        "items": {
+          "overview": "Übersicht",
+          "bookings": "Buchungen",
+          "locations": "Standorte",
+          "notifications": "Benachrichtigungen",
+          "activity": "Aktivität",
+          "brand": "Marke",
+          "emailPush": "E-Mail & Push",
+          "users": "Benutzer",
+          "account": "Konto"
+        },
+        "unreadLabel_one": "{{label}}, {{count}} ungelesen",
+        "unreadLabel_other": "{{label}}, {{count}} ungelesen"
+      },
+      "managingLocations_one": "Verwaltung von {{count}} Standort",
+      "managingLocations_other": "Verwaltung von {{count}} Standorten",
+      "adminPanel": "Admin-Bereich",
+      "lookup": {
+        "label": "Buchung suchen",
+        "placeholder": "Name, E-Mail oder Referenz…",
+        "searchLabel": "Buchungen suchen",
+        "searchButton": "Suchen",
+        "notFound": "Keine Buchung gefunden.",
+        "showingMatches": "Alle Treffer werden angezeigt…",
+        "partialMatchHint": "Teilweise Übereinstimmung wird unterstützt"
+      },
+      "backToSite": "Zurück zur Website",
+      "themeToggle": {
+        "switchToLight": "Zu hellem Modus wechseln",
+        "switchToDark": "Zu dunklem Modus wechseln",
+        "lightMode": "Heller Modus",
+        "darkMode": "Dunkler Modus"
+      },
+      "logOut": "Abmelden"
     }
   }
 }

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -733,6 +733,19 @@
         "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
         "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, cancelled",
         "meta": "{{seats}} · {{restaurant}}"
+      },
+      "scheduleConflicts": {
+        "title_one": "{{count}} upcoming booking no longer fits its location's schedule",
+        "title_other": "{{count}} upcoming bookings no longer fit their location's schedule",
+        "subtitle": "Taken before the current hours and still on the books. The guests have not been told anything changed. Review locations.",
+        "accessibilityLabel_one": "{{count}} upcoming booking no longer fits its location's schedule. Review locations.",
+        "accessibilityLabel_other": "{{count}} upcoming bookings no longer fit their location's schedule. Review locations."
+      }
+    },
+    "layout": {
+      "desktopWall": {
+        "title": "Screen too small",
+        "body": "The admin dashboard requires a wider screen.\nTry rotating your device or using a larger screen."
       }
     },
     "locations": {
@@ -837,6 +850,138 @@
         "guestCount_other": "{{count}} guests",
         "openLabel": "Open",
         "openBookingLabel": "Open booking {{ref}}"
+      }
+    },
+    "login": {
+      "nativeTitle": "Admin Login",
+      "badge": "Admin",
+      "backToApp": "Back to {{appName}}",
+      "signIn": {
+        "title": "Sign in",
+        "subtitle": "Manage your restaurant bookings.",
+        "emailLabel": "Email",
+        "emailPlaceholder": "admin@restaurant.com",
+        "passwordLabel": "Password",
+        "submit": "Sign In",
+        "submitting": "Signing in…",
+        "forgotPassword": "Forgot password?",
+        "invalidCredentials": "Invalid email or password. Please try again."
+      },
+      "pvqEmail": {
+        "title": "Reset password",
+        "subtitle": "We'll verify your identity using your security question.",
+        "emailLabel": "Admin email",
+        "emailPlaceholder": "admin@restaurant.com",
+        "submit": "Continue",
+        "checking": "Checking…",
+        "noQuestionConfigured": "No security question has been configured for this account."
+      },
+      "pvqAnswer": {
+        "title": "Security question",
+        "answerLabel": "Your answer",
+        "answerPlaceholder": "Answer (not case sensitive)",
+        "submit": "Verify Answer",
+        "verifying": "Verifying…",
+        "incorrectAnswer": "Incorrect answer. Please try again."
+      },
+      "reset": {
+        "title": "Set new password",
+        "subtitle": "This link expires in 15 minutes.",
+        "newPasswordLabel": "New password",
+        "newPasswordPlaceholder": "At least 6 characters",
+        "confirmPasswordLabel": "Confirm password",
+        "confirmPasswordPlaceholder": "Repeat password",
+        "submit": "Reset Password",
+        "resetting": "Resetting…"
+      },
+      "done": {
+        "title": "Password reset!",
+        "subtitle": "Your password has been updated. Sign in with your new credentials.",
+        "backToSignIn": "Back to Sign In"
+      },
+      "backLabel": "Back"
+    },
+    "notifications": {
+      "pageTitle": "Notifications",
+      "totalCount_one": "{{count}} total notification",
+      "totalCount_other": "{{count}} total notifications",
+      "deleteAll": "Delete all",
+      "deletingAll": "Deleting…",
+      "deleteAllLabel": "Delete all notifications",
+      "deleteAllHint": "Keeps pinned notifications",
+      "clearRead": "Clear read",
+      "clearingRead": "Clearing…",
+      "clearReadLabel": "Clear read notifications",
+      "markAllRead": "Mark all read",
+      "markingAllRead": "Marking…",
+      "markAllReadLabel": "Mark all notifications read",
+      "markedAllReadToast": "Marked all as read",
+      "notificationDeletedToast": "Notification deleted",
+      "allVisiblePinnedToast": "All visible notifications are pinned",
+      "readClearedToast": "Read notifications cleared",
+      "deletedCountToast_one": "Deleted {{count}} notification",
+      "deletedCountToast_other": "Deleted {{count}} notifications",
+      "allLocations": "All locations",
+      "locationsScrollerLabel": "Locations",
+      "typesScrollerLabel": "Notification types",
+      "filterUnread": "Filter Unread",
+      "unreadOnlyLabel": "Show unread only",
+      "errorBody": "Could not load notifications. Check your connection and try again.",
+      "allCaughtUpTitle": "All caught up",
+      "allCaughtUpBody": "You've read everything. New alerts will appear here.",
+      "emptyTitle": "No notifications yet",
+      "emptyBody": "Booking events and capacity alerts will appear here.",
+      "pinnedLabel": "Pinned",
+      "allNotificationsLabel": "All notifications",
+      "showMoreButton": "Show {{count}} more",
+      "showMoreLabel_one": "Show {{count}} more notification",
+      "showMoreLabel_other": "Show {{count}} more notifications",
+      "loadingMore": "Loading…",
+      "deleteAllModal": {
+        "title": "Delete all notifications?",
+        "message": "This will permanently delete all visible unpinned notifications. Pinned notifications will be kept.",
+        "confirmLabel": "Delete all"
+      },
+      "deletePinnedModal": {
+        "title": "Delete pinned notification?",
+        "message": "This notification is pinned. Are you sure you want to delete it?",
+        "confirmLabel": "Delete"
+      },
+      "types": {
+        "bookingCreated": "New Booking",
+        "bookingCancelled": "Booking Cancelled",
+        "restaurantNearlyFull": "Nearly Full"
+      },
+      "filters": {
+        "all": "All Types",
+        "bookingCreated": "New Bookings",
+        "bookingCancelled": "Cancelled",
+        "restaurantNearlyFull": "Nearly Full"
+      },
+      "row": {
+        "guestCount_one": "{{count}} guest",
+        "guestCount_other": "{{count}} guests",
+        "read": "Read",
+        "unread": "Unread",
+        "bookingRefLabel": "booking {{ref}}",
+        "pin": "Pin",
+        "unpin": "Unpin",
+        "pinLabel": "Pin notification",
+        "unpinLabel": "Unpin notification",
+        "markRead": "Mark read",
+        "markUnread": "Mark unread",
+        "markReadLabel": "Mark notification read",
+        "markUnreadLabel": "Mark notification unread",
+        "delete": "Delete",
+        "deleteLabel": "Delete notification"
+      },
+      "pushBanner": {
+        "blockedError": "Blocked by browser - allow notifications in site settings.",
+        "deniedBanner": "Push notifications blocked - enable in browser site settings.",
+        "promptBanner": "Enable push notifications to get real-time booking alerts.",
+        "enableFailed": "Failed to enable - try again.",
+        "enable": "Enable",
+        "enableLabel": "Enable push notifications"
       }
     },
     "settings": {
@@ -1361,6 +1506,47 @@
       "brandAutosave": {
         "serverUnreachable": "Couldn't reach the server."
       }
+    },
+    "sidebar": {
+      "nav": {
+        "sections": {
+          "manage": "Manage",
+          "configure": "Configure"
+        },
+        "items": {
+          "overview": "Overview",
+          "bookings": "Bookings",
+          "locations": "Locations",
+          "notifications": "Notifications",
+          "activity": "Activity",
+          "brand": "Brand",
+          "emailPush": "Email & Push",
+          "users": "Users",
+          "account": "Account"
+        },
+        "unreadLabel_one": "{{label}}, {{count}} unread",
+        "unreadLabel_other": "{{label}}, {{count}} unread"
+      },
+      "managingLocations_one": "Managing {{count}} location",
+      "managingLocations_other": "Managing {{count}} locations",
+      "adminPanel": "Admin Panel",
+      "lookup": {
+        "label": "Lookup Booking",
+        "placeholder": "Name, email or reference…",
+        "searchLabel": "Search bookings",
+        "searchButton": "Search",
+        "notFound": "No booking found.",
+        "showingMatches": "Showing all matches…",
+        "partialMatchHint": "Partial matching search is supported"
+      },
+      "backToSite": "Back to site",
+      "themeToggle": {
+        "switchToLight": "Switch to light mode",
+        "switchToDark": "Switch to dark mode",
+        "lightMode": "Light mode",
+        "darkMode": "Dark mode"
+      },
+      "logOut": "Log out"
     }
   }
 }

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -733,6 +733,19 @@
         "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
         "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, cancelada",
         "meta": "{{seats}} · {{restaurant}}"
+      },
+      "scheduleConflicts": {
+        "title_one": "{{count}} reserva próxima ya no encaja en el horario de su local",
+        "title_other": "{{count}} reservas próximas ya no encajan en el horario de su local",
+        "subtitle": "Se tomaron antes del horario actual y siguen en el libro. A los clientes no se les avisó del cambio. Consulta los locales.",
+        "accessibilityLabel_one": "{{count}} reserva próxima ya no encaja en el horario de su local. Consulta los locales.",
+        "accessibilityLabel_other": "{{count}} reservas próximas ya no encajan en el horario de su local. Consulta los locales."
+      }
+    },
+    "layout": {
+      "desktopWall": {
+        "title": "Pantalla demasiado pequeña",
+        "body": "El panel de administración requiere una pantalla más ancha.\nIntenta girar tu dispositivo o usar una pantalla más grande."
       }
     },
     "locations": {
@@ -837,6 +850,138 @@
         "guestCount_other": "{{count}} comensales",
         "openLabel": "Abrir",
         "openBookingLabel": "Abrir la reserva {{ref}}"
+      }
+    },
+    "login": {
+      "nativeTitle": "Inicio de sesión de administrador",
+      "badge": "Administrador",
+      "backToApp": "Volver a {{appName}}",
+      "signIn": {
+        "title": "Iniciar sesión",
+        "subtitle": "Gestiona las reservas de tu restaurante.",
+        "emailLabel": "Correo electrónico",
+        "emailPlaceholder": "admin@restaurant.com",
+        "passwordLabel": "Contraseña",
+        "submit": "Iniciar sesión",
+        "submitting": "Iniciando sesión…",
+        "forgotPassword": "¿Olvidaste tu contraseña?",
+        "invalidCredentials": "Correo electrónico o contraseña incorrectos. Inténtalo de nuevo."
+      },
+      "pvqEmail": {
+        "title": "Restablecer contraseña",
+        "subtitle": "Verificaremos tu identidad con tu pregunta de seguridad.",
+        "emailLabel": "Correo del administrador",
+        "emailPlaceholder": "admin@restaurant.com",
+        "submit": "Continuar",
+        "checking": "Comprobando…",
+        "noQuestionConfigured": "No se ha configurado ninguna pregunta de seguridad para esta cuenta."
+      },
+      "pvqAnswer": {
+        "title": "Pregunta de seguridad",
+        "answerLabel": "Tu respuesta",
+        "answerPlaceholder": "Respuesta (no distingue mayúsculas)",
+        "submit": "Verificar respuesta",
+        "verifying": "Verificando…",
+        "incorrectAnswer": "Respuesta incorrecta. Inténtalo de nuevo."
+      },
+      "reset": {
+        "title": "Establecer nueva contraseña",
+        "subtitle": "Este enlace caduca en 15 minutos.",
+        "newPasswordLabel": "Nueva contraseña",
+        "newPasswordPlaceholder": "Al menos 6 caracteres",
+        "confirmPasswordLabel": "Confirmar contraseña",
+        "confirmPasswordPlaceholder": "Repite la contraseña",
+        "submit": "Restablecer contraseña",
+        "resetting": "Restableciendo…"
+      },
+      "done": {
+        "title": "¡Contraseña restablecida!",
+        "subtitle": "Tu contraseña se ha actualizado. Inicia sesión con tus nuevas credenciales.",
+        "backToSignIn": "Volver a iniciar sesión"
+      },
+      "backLabel": "Atrás"
+    },
+    "notifications": {
+      "pageTitle": "Notificaciones",
+      "totalCount_one": "{{count}} notificación en total",
+      "totalCount_other": "{{count}} notificaciones en total",
+      "deleteAll": "Eliminar todo",
+      "deletingAll": "Eliminando…",
+      "deleteAllLabel": "Eliminar todas las notificaciones",
+      "deleteAllHint": "Conserva las notificaciones fijadas",
+      "clearRead": "Borrar leídas",
+      "clearingRead": "Borrando…",
+      "clearReadLabel": "Borrar notificaciones leídas",
+      "markAllRead": "Marcar todo como leído",
+      "markingAllRead": "Marcando…",
+      "markAllReadLabel": "Marcar todas las notificaciones como leídas",
+      "markedAllReadToast": "Todo marcado como leído",
+      "notificationDeletedToast": "Notificación eliminada",
+      "allVisiblePinnedToast": "Todas las notificaciones visibles están fijadas",
+      "readClearedToast": "Notificaciones leídas borradas",
+      "deletedCountToast_one": "{{count}} notificación eliminada",
+      "deletedCountToast_other": "{{count}} notificaciones eliminadas",
+      "allLocations": "Todos los locales",
+      "locationsScrollerLabel": "Locales",
+      "typesScrollerLabel": "Tipos de notificación",
+      "filterUnread": "Solo no leídas",
+      "unreadOnlyLabel": "Mostrar solo las no leídas",
+      "errorBody": "No se pudieron cargar las notificaciones. Comprueba tu conexión e inténtalo de nuevo.",
+      "allCaughtUpTitle": "Todo al día",
+      "allCaughtUpBody": "Has leído todo. Las nuevas alertas aparecerán aquí.",
+      "emptyTitle": "Aún no hay notificaciones",
+      "emptyBody": "Los eventos de reserva y las alertas de capacidad aparecerán aquí.",
+      "pinnedLabel": "Fijadas",
+      "allNotificationsLabel": "Todas las notificaciones",
+      "showMoreButton": "Mostrar {{count}} más",
+      "showMoreLabel_one": "Mostrar {{count}} notificación más",
+      "showMoreLabel_other": "Mostrar {{count}} notificaciones más",
+      "loadingMore": "Cargando…",
+      "deleteAllModal": {
+        "title": "¿Eliminar todas las notificaciones?",
+        "message": "Esto eliminará permanentemente todas las notificaciones visibles no fijadas. Las notificaciones fijadas se conservarán.",
+        "confirmLabel": "Eliminar todo"
+      },
+      "deletePinnedModal": {
+        "title": "¿Eliminar la notificación fijada?",
+        "message": "Esta notificación está fijada. ¿Seguro que quieres eliminarla?",
+        "confirmLabel": "Eliminar"
+      },
+      "types": {
+        "bookingCreated": "Nueva reserva",
+        "bookingCancelled": "Reserva cancelada",
+        "restaurantNearlyFull": "Casi lleno"
+      },
+      "filters": {
+        "all": "Todos los tipos",
+        "bookingCreated": "Nuevas reservas",
+        "bookingCancelled": "Canceladas",
+        "restaurantNearlyFull": "Casi lleno"
+      },
+      "row": {
+        "guestCount_one": "{{count}} comensal",
+        "guestCount_other": "{{count}} comensales",
+        "read": "Leída",
+        "unread": "No leída",
+        "bookingRefLabel": "reserva {{ref}}",
+        "pin": "Fijar",
+        "unpin": "Desfijar",
+        "pinLabel": "Fijar notificación",
+        "unpinLabel": "Desfijar notificación",
+        "markRead": "Marcar como leída",
+        "markUnread": "Marcar como no leída",
+        "markReadLabel": "Marcar notificación como leída",
+        "markUnreadLabel": "Marcar notificación como no leída",
+        "delete": "Eliminar",
+        "deleteLabel": "Eliminar notificación"
+      },
+      "pushBanner": {
+        "blockedError": "Bloqueado por el navegador - permite las notificaciones en la configuración del sitio.",
+        "deniedBanner": "Notificaciones push bloqueadas - actívalas en la configuración del sitio de tu navegador.",
+        "promptBanner": "Activa las notificaciones push para recibir alertas de reservas en tiempo real.",
+        "enableFailed": "No se pudo activar - inténtalo de nuevo.",
+        "enable": "Activar",
+        "enableLabel": "Activar notificaciones push"
       }
     },
     "settings": {
@@ -1361,6 +1506,47 @@
       "brandAutosave": {
         "serverUnreachable": "No se pudo contactar con el servidor."
       }
+    },
+    "sidebar": {
+      "nav": {
+        "sections": {
+          "manage": "Gestionar",
+          "configure": "Configurar"
+        },
+        "items": {
+          "overview": "Resumen",
+          "bookings": "Reservas",
+          "locations": "Locales",
+          "notifications": "Notificaciones",
+          "activity": "Actividad",
+          "brand": "Marca",
+          "emailPush": "Correo y push",
+          "users": "Usuarios",
+          "account": "Cuenta"
+        },
+        "unreadLabel_one": "{{label}}, {{count}} no leída",
+        "unreadLabel_other": "{{label}}, {{count}} no leídas"
+      },
+      "managingLocations_one": "Gestionando {{count}} local",
+      "managingLocations_other": "Gestionando {{count}} locales",
+      "adminPanel": "Panel de administración",
+      "lookup": {
+        "label": "Buscar reserva",
+        "placeholder": "Nombre, correo o referencia…",
+        "searchLabel": "Buscar reservas",
+        "searchButton": "Buscar",
+        "notFound": "No se encontró ninguna reserva.",
+        "showingMatches": "Mostrando todas las coincidencias…",
+        "partialMatchHint": "Se admite la búsqueda por coincidencia parcial"
+      },
+      "backToSite": "Volver al sitio",
+      "themeToggle": {
+        "switchToLight": "Cambiar a modo claro",
+        "switchToDark": "Cambiar a modo oscuro",
+        "lightMode": "Modo claro",
+        "darkMode": "Modo oscuro"
+      },
+      "logOut": "Cerrar sesión"
     }
   }
 }

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -733,6 +733,19 @@
         "itemLabel": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}",
         "itemLabelCancelled": "{{time}}, {{guest}}, {{seats}}, {{restaurant}}, annulée",
         "meta": "{{seats}} · {{restaurant}}"
+      },
+      "scheduleConflicts": {
+        "title_one": "{{count}} réservation à venir ne correspond plus à l'horaire de son établissement",
+        "title_other": "{{count}} réservations à venir ne correspondent plus à l'horaire de leur établissement",
+        "subtitle": "Elles ont été prises avant les horaires actuels et sont toujours dans le carnet. Les clients n'ont pas été informés du changement. Consultez les établissements.",
+        "accessibilityLabel_one": "{{count}} réservation à venir ne correspond plus à l'horaire de son établissement. Consultez les établissements.",
+        "accessibilityLabel_other": "{{count}} réservations à venir ne correspondent plus à l'horaire de leur établissement. Consultez les établissements."
+      }
+    },
+    "layout": {
+      "desktopWall": {
+        "title": "Écran trop petit",
+        "body": "Le tableau de bord administrateur nécessite un écran plus large.\nEssayez de faire pivoter votre appareil ou d'utiliser un écran plus grand."
       }
     },
     "locations": {
@@ -837,6 +850,138 @@
         "guestCount_other": "{{count}} convives",
         "openLabel": "Ouvrir",
         "openBookingLabel": "Ouvrir la réservation {{ref}}"
+      }
+    },
+    "login": {
+      "nativeTitle": "Connexion administrateur",
+      "badge": "Administrateur",
+      "backToApp": "Retour à {{appName}}",
+      "signIn": {
+        "title": "Connexion",
+        "subtitle": "Gérez les réservations de votre restaurant.",
+        "emailLabel": "E-mail",
+        "emailPlaceholder": "admin@restaurant.com",
+        "passwordLabel": "Mot de passe",
+        "submit": "Se connecter",
+        "submitting": "Connexion…",
+        "forgotPassword": "Mot de passe oublié ?",
+        "invalidCredentials": "E-mail ou mot de passe incorrect. Veuillez réessayer."
+      },
+      "pvqEmail": {
+        "title": "Réinitialiser le mot de passe",
+        "subtitle": "Nous vérifierons votre identité à l'aide de votre question de sécurité.",
+        "emailLabel": "E-mail administrateur",
+        "emailPlaceholder": "admin@restaurant.com",
+        "submit": "Continuer",
+        "checking": "Vérification…",
+        "noQuestionConfigured": "Aucune question de sécurité n'a été configurée pour ce compte."
+      },
+      "pvqAnswer": {
+        "title": "Question de sécurité",
+        "answerLabel": "Votre réponse",
+        "answerPlaceholder": "Réponse (insensible à la casse)",
+        "submit": "Vérifier la réponse",
+        "verifying": "Vérification…",
+        "incorrectAnswer": "Réponse incorrecte. Veuillez réessayer."
+      },
+      "reset": {
+        "title": "Définir un nouveau mot de passe",
+        "subtitle": "Ce lien expire dans 15 minutes.",
+        "newPasswordLabel": "Nouveau mot de passe",
+        "newPasswordPlaceholder": "Au moins 6 caractères",
+        "confirmPasswordLabel": "Confirmer le mot de passe",
+        "confirmPasswordPlaceholder": "Répétez le mot de passe",
+        "submit": "Réinitialiser le mot de passe",
+        "resetting": "Réinitialisation…"
+      },
+      "done": {
+        "title": "Mot de passe réinitialisé !",
+        "subtitle": "Votre mot de passe a été mis à jour. Connectez-vous avec vos nouveaux identifiants.",
+        "backToSignIn": "Retour à la connexion"
+      },
+      "backLabel": "Retour"
+    },
+    "notifications": {
+      "pageTitle": "Notifications",
+      "totalCount_one": "{{count}} notification au total",
+      "totalCount_other": "{{count}} notifications au total",
+      "deleteAll": "Tout supprimer",
+      "deletingAll": "Suppression…",
+      "deleteAllLabel": "Supprimer toutes les notifications",
+      "deleteAllHint": "Conserve les notifications épinglées",
+      "clearRead": "Effacer les lues",
+      "clearingRead": "Effacement…",
+      "clearReadLabel": "Effacer les notifications lues",
+      "markAllRead": "Tout marquer comme lu",
+      "markingAllRead": "Marquage…",
+      "markAllReadLabel": "Marquer toutes les notifications comme lues",
+      "markedAllReadToast": "Tout marqué comme lu",
+      "notificationDeletedToast": "Notification supprimée",
+      "allVisiblePinnedToast": "Toutes les notifications visibles sont épinglées",
+      "readClearedToast": "Notifications lues effacées",
+      "deletedCountToast_one": "{{count}} notification supprimée",
+      "deletedCountToast_other": "{{count}} notifications supprimées",
+      "allLocations": "Tous les établissements",
+      "locationsScrollerLabel": "Établissements",
+      "typesScrollerLabel": "Types de notification",
+      "filterUnread": "Non lues uniquement",
+      "unreadOnlyLabel": "Afficher uniquement les non lues",
+      "errorBody": "Impossible de charger les notifications. Vérifiez votre connexion et réessayez.",
+      "allCaughtUpTitle": "Tout est à jour",
+      "allCaughtUpBody": "Vous avez tout lu. Les nouvelles alertes apparaîtront ici.",
+      "emptyTitle": "Aucune notification pour le moment",
+      "emptyBody": "Les événements de réservation et les alertes de capacité apparaîtront ici.",
+      "pinnedLabel": "Épinglées",
+      "allNotificationsLabel": "Toutes les notifications",
+      "showMoreButton": "Afficher {{count}} de plus",
+      "showMoreLabel_one": "Afficher {{count}} notification de plus",
+      "showMoreLabel_other": "Afficher {{count}} notifications de plus",
+      "loadingMore": "Chargement…",
+      "deleteAllModal": {
+        "title": "Supprimer toutes les notifications ?",
+        "message": "Cela supprimera définitivement toutes les notifications visibles non épinglées. Les notifications épinglées seront conservées.",
+        "confirmLabel": "Tout supprimer"
+      },
+      "deletePinnedModal": {
+        "title": "Supprimer la notification épinglée ?",
+        "message": "Cette notification est épinglée. Voulez-vous vraiment la supprimer ?",
+        "confirmLabel": "Supprimer"
+      },
+      "types": {
+        "bookingCreated": "Nouvelle réservation",
+        "bookingCancelled": "Réservation annulée",
+        "restaurantNearlyFull": "Presque complet"
+      },
+      "filters": {
+        "all": "Tous les types",
+        "bookingCreated": "Nouvelles réservations",
+        "bookingCancelled": "Annulées",
+        "restaurantNearlyFull": "Presque complet"
+      },
+      "row": {
+        "guestCount_one": "{{count}} convive",
+        "guestCount_other": "{{count}} convives",
+        "read": "Lue",
+        "unread": "Non lue",
+        "bookingRefLabel": "réservation {{ref}}",
+        "pin": "Épingler",
+        "unpin": "Désépingler",
+        "pinLabel": "Épingler la notification",
+        "unpinLabel": "Désépingler la notification",
+        "markRead": "Marquer comme lue",
+        "markUnread": "Marquer comme non lue",
+        "markReadLabel": "Marquer la notification comme lue",
+        "markUnreadLabel": "Marquer la notification comme non lue",
+        "delete": "Supprimer",
+        "deleteLabel": "Supprimer la notification"
+      },
+      "pushBanner": {
+        "blockedError": "Bloqué par le navigateur - autorisez les notifications dans les paramètres du site.",
+        "deniedBanner": "Notifications push bloquées - activez-les dans les paramètres du site de votre navigateur.",
+        "promptBanner": "Activez les notifications push pour recevoir des alertes de réservation en temps réel.",
+        "enableFailed": "Échec de l'activation - réessayez.",
+        "enable": "Activer",
+        "enableLabel": "Activer les notifications push"
       }
     },
     "settings": {
@@ -1361,6 +1506,47 @@
       "brandAutosave": {
         "serverUnreachable": "Impossible de joindre le serveur."
       }
+    },
+    "sidebar": {
+      "nav": {
+        "sections": {
+          "manage": "Gérer",
+          "configure": "Configurer"
+        },
+        "items": {
+          "overview": "Aperçu",
+          "bookings": "Réservations",
+          "locations": "Établissements",
+          "notifications": "Notifications",
+          "activity": "Activité",
+          "brand": "Marque",
+          "emailPush": "E-mail et push",
+          "users": "Utilisateurs",
+          "account": "Compte"
+        },
+        "unreadLabel_one": "{{label}}, {{count}} non lue",
+        "unreadLabel_other": "{{label}}, {{count}} non lues"
+      },
+      "managingLocations_one": "Gestion de {{count}} établissement",
+      "managingLocations_other": "Gestion de {{count}} établissements",
+      "adminPanel": "Panneau d'administration",
+      "lookup": {
+        "label": "Rechercher une réservation",
+        "placeholder": "Nom, e-mail ou référence…",
+        "searchLabel": "Rechercher des réservations",
+        "searchButton": "Rechercher",
+        "notFound": "Aucune réservation trouvée.",
+        "showingMatches": "Affichage de toutes les correspondances…",
+        "partialMatchHint": "La recherche par correspondance partielle est prise en charge"
+      },
+      "backToSite": "Retour au site",
+      "themeToggle": {
+        "switchToLight": "Passer en mode clair",
+        "switchToDark": "Passer en mode sombre",
+        "lightMode": "Mode clair",
+        "darkMode": "Mode sombre"
+      },
+      "logOut": "Se déconnecter"
     }
   }
 }

--- a/openresto-frontend/playwright.config.ts
+++ b/openresto-frontend/playwright.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
         "**/admin-users.spec.ts",
         "**/brand-identity.spec.ts",
         "**/walk-in-days.spec.ts",
+        "**/admin-locale-fr.spec.ts",
       ],
     },
     // ── Admin tests — pre-loaded auth cookie ────────────────────────────────
@@ -89,6 +90,7 @@ export default defineConfig({
         "**/admin-users.spec.ts",
         "**/brand-identity.spec.ts",
         "**/walk-in-days.spec.ts",
+        "**/admin-locale-fr.spec.ts",
       ],
     },
   ],

--- a/openresto-frontend/tests/utils/notifications.test.ts
+++ b/openresto-frontend/tests/utils/notifications.test.ts
@@ -4,10 +4,13 @@ import {
   arrayBufferToBase64,
   PAGE_SIZE,
   PIN_STORAGE_KEY,
-  TYPE_LABELS,
-  TYPE_FILTERS,
+  getTypeLabels,
+  getTypeFilters,
 } from "@/utils/notifications";
 import { setActiveLocale } from "@/utils/locale";
+import i18n from "@/i18n";
+
+const t = i18n.getFixedT("en");
 
 // Re-exported from utils/formatters — see formatters.test.ts for why the locale is pinned
 // rather than left to follow the device.
@@ -66,18 +69,26 @@ describe("constants", () => {
     expect(PIN_STORAGE_KEY).toBe("openresto_pinned_notifs");
   });
 
-  it("TYPE_LABELS covers all three notification types", () => {
-    expect(TYPE_LABELS.BookingCreated).toBe("New Booking");
-    expect(TYPE_LABELS.BookingCancelled).toBe("Booking Cancelled");
-    expect(TYPE_LABELS.RestaurantNearlyFull).toBe("Nearly Full");
+  it("getTypeLabels covers all three notification types", () => {
+    const labels = getTypeLabels(t);
+    expect(labels.BookingCreated).toBe("New Booking");
+    expect(labels.BookingCancelled).toBe("Booking Cancelled");
+    expect(labels.RestaurantNearlyFull).toBe("Nearly Full");
   });
 
-  it("TYPE_FILTERS has an 'All Types' empty-value option plus one per type", () => {
-    expect(TYPE_FILTERS[0]).toEqual({ label: "All Types", value: "" });
-    expect(TYPE_FILTERS).toHaveLength(4);
-    const values = TYPE_FILTERS.map((f) => f.value).filter(Boolean);
+  it("getTypeFilters has an 'All Types' empty-value option plus one per type", () => {
+    const filters = getTypeFilters(t);
+    expect(filters[0]).toEqual({ label: "All Types", value: "" });
+    expect(filters).toHaveLength(4);
+    const values = filters.map((f) => f.value).filter(Boolean);
     expect(values).toEqual(
       expect.arrayContaining(["BookingCreated", "BookingCancelled", "RestaurantNearlyFull"])
     );
+  });
+
+  it("getTypeLabels translates independently of the locale getTypeFilters resolves", () => {
+    const fr = i18n.getFixedT("fr");
+    expect(getTypeLabels(fr).BookingCreated).toBe("Nouvelle réservation");
+    expect(getTypeLabels(t).BookingCreated).toBe("New Booking");
   });
 });

--- a/openresto-frontend/utils/notifications.ts
+++ b/openresto-frontend/utils/notifications.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from "i18next";
 import { theme } from "@/theme/theme";
 import type { NotificationType } from "@/api/notifications";
 import { fmtDateTime } from "@/utils/formatters";
@@ -27,11 +28,18 @@ export function formatBookingDate(iso: string): string {
 export const PAGE_SIZE = 20;
 export const PIN_STORAGE_KEY = "openresto_pinned_notifs";
 
-export const TYPE_LABELS: Record<NotificationType, string> = {
-  BookingCreated: "New Booking",
-  BookingCancelled: "Booking Cancelled",
-  RestaurantNearlyFull: "Nearly Full",
-};
+/**
+ * Called from render rather than kept as a module-level constant — resolving it once at
+ * import time would freeze every label in whatever locale loaded first and never react to
+ * a language switch.
+ */
+export function getTypeLabels(t: TFunction): Record<NotificationType, string> {
+  return {
+    BookingCreated: t("admin.notifications.types.bookingCreated"),
+    BookingCancelled: t("admin.notifications.types.bookingCancelled"),
+    RestaurantNearlyFull: t("admin.notifications.types.restaurantNearlyFull"),
+  };
+}
 
 type TypeIcon = {
   name: "checkmark-circle-outline" | "close-circle-outline" | "warning-outline";
@@ -44,9 +52,19 @@ export const TYPE_ICONS: Record<NotificationType, TypeIcon> = {
   RestaurantNearlyFull: { name: "warning-outline", color: theme.colors.warning },
 };
 
-export const TYPE_FILTERS = [
-  { label: "All Types", value: "" },
-  { label: "New Bookings", value: "BookingCreated" },
-  { label: "Cancelled", value: "BookingCancelled" },
-  { label: "Nearly Full", value: "RestaurantNearlyFull" },
-];
+export interface TypeFilter {
+  label: string;
+  value: "" | NotificationType;
+}
+
+export function getTypeFilters(t: TFunction): TypeFilter[] {
+  return [
+    { label: t("admin.notifications.filters.all"), value: "" },
+    { label: t("admin.notifications.filters.bookingCreated"), value: "BookingCreated" },
+    { label: t("admin.notifications.filters.bookingCancelled"), value: "BookingCancelled" },
+    {
+      label: t("admin.notifications.filters.restaurantNearlyFull"),
+      value: "RestaurantNearlyFull",
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

This is F5 — the last piece of issue #374's per-area admin translation split (F1-F4 already merged). It extracts every remaining hardcoded admin-facing string into i18next, using the established `admin.*` key convention (`area.screenOrComponent.concept`).

**Files translated:**
- `components/admin/dashboard/ScheduleConflictsBanner.tsx` — had **no** `useTranslation` at all (F1 scoped itself to `components/admin/bookings` plus two screens, so this fell through the cracks even though its sibling `ScheduleConflictsPanel.tsx` was translated in F2 — one feature was half-translated across two files). Rewrote the accessibility label as full interpolated `_one`/`_other` sentences per plural form instead of concatenating a pluralized fragment into a bigger sentence, since French/German reorder clauses.
- `app/admin/login.tsx` — sign-in, forgot-password/PVQ, reset, and done stages (new `admin.login.*` namespace).
- `app/admin/notifications.tsx` — page header, filters, empty/error states, toasts, load-more, both confirm modals (new `admin.notifications.*` namespace).
- `components/admin/notifications/NotificationRow.tsx` — type label, accessibility label, row actions.
- `components/admin/notifications/PushBanner.tsx` — all banner/error copy.
- `components/layout/AdminSidebar.tsx` — nav sections/items, lookup, footer (theme toggle, back-to-site, log out); switched the role badge from `roleLabel` to `roleDisplayLabel(user.role, t)` (the F4 helper), reusing it instead of duplicating.
- `app/admin/_layout.tsx` — the `DesktopOnlyWall` copy.

**Pluralizers converted to i18next `_one`/`_other`** (all four hand-rolled `${n} thing${n !== 1 ? "s" : ""}` spots called out in the ticket, confirmed no others remain via `grep -rn '!== 1 ?\|=== 1 ?' app/admin components/admin components/layout`):
1. `ScheduleConflictsBanner`'s title/accessibility label
2. `notifications.tsx`'s total-count subtitle and deleted-count toast
3. `NotificationRow`'s guest count
4. `AdminSidebar`'s "Managing N locations" line

**Module-scope-constant-to-function conversions** (same pattern F4 used for `roleLabel`/`roleDisplayLabel` — a module-level constant freezes at whatever locale loaded first and never reacts to a language switch):
- `utils/notifications.ts`: `TYPE_LABELS`/`TYPE_FILTERS` → `getTypeLabels(t)`/`getTypeFilters(t)`
- `AdminSidebar.tsx`: `NAV_SECTIONS` → `getNavSections(t)` (also fixed a fragility bug in the same pass: the "show unread badge" check compared against the literal English label `"Notifications"`, which would silently break in every other locale — now keyed off a stable `id` field instead)

`en`/`fr`/`es`/`de` all got every new key; Spanish/French/German phrasing was checked against sibling keys already in the file (e.g. `admin.locations.pageTitle`, `admin.settings.security.*`, `admin.settings.pushNotifications.*`) before writing new copy, to keep wording consistent with what's already shipped.

## Test plan

- [x] `npm test` — all 200 suites / 2877 tests pass, including the updated `tests/utils/notifications.test.ts` (updated to call `getTypeLabels(t)`/`getTypeFilters(t)` with `i18n.getFixedT`, since the constants they replace changed shape — not a text-query rewrite)
- [x] `npm run check` (prettier + oxlint) — exits 0, only pre-existing warnings in untouched files
- [x] `npx tsc --noEmit` — exits 0
- [x] `npm run check:doc-links` (repo root) — "All doc links resolve."
- [x] `tests/i18n/parity.test.ts` — en/fr/es/de key sets identical
- [x] Final sweep of `app/admin` and `components/admin` for stray JSX text / string-literal props — clean (a couple of placeholder examples like `colleague@restaurant.com` remain in `components/admin/settings/`, but those are pre-existing from the already-merged F3 and out of this PR's scope)
- [x] New e2e spec `e2e/admin-locale-fr.spec.ts` (untagged → extensive suite) — verified with `npx playwright test --list` that it's picked up only by `chromium-admin` (not the unauthenticated `chromium` project) and lands in `--grep-invert @smoke` but not `--grep @smoke`
- [ ] **Could not run the e2e spec against a live Docker stack.** `docker compose -f docker-compose.yml -f docker-compose.e2e.yml up -d --build` fails in my sandboxed session: the nginx/frontend image builds need `apk add`, and the sandbox's egress proxy returns `403 Forbidden` fetching from `dl-cdn.alpinelinux.org` — an organizational policy block, not a code or config issue (confirmed by re-running with `--network host` and explicit proxy build-args per the sandbox's own proxy docs, which explicitly say not to route around a 403). The spec itself is verified compileable, correctly registered in `playwright.config.ts` (added to both the `chromium` `testIgnore` list and the `chromium-admin` `testMatch` list), and every string it asserts against was cross-checked against the actual `fr.json` values it exercises. It has not been run against a real backend/browser in this session — please run it in CI or a local Docker environment before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VwjMnybqkwSo2jpyvVq8wK)_