### PR TITLE
Fix locale-driven text direction, pin interpolation parity, stop uncoded infra detail reaching clients

### DIFF
--- a/OpenRestoApi.Tests/Infrastructure/GlobalExceptionHandlerTests.cs
+++ b/OpenRestoApi.Tests/Infrastructure/GlobalExceptionHandlerTests.cs
@@ -114,12 +114,73 @@ public class GlobalExceptionHandlerTests
         HttpContext ctx = CreateContext();
 
         bool handled = await handler.TryHandleAsync(
-            ctx, new InfrastructureException("Email is not configured."), default);
+            ctx,
+            new InfrastructureException("Email is not configured.")
+            {
+                Code = ErrorCodes.EmailNotConfigured
+            },
+            default);
 
         Assert.True(handled);
         (int status, string message) = await ReadResponse(ctx);
         Assert.Equal((int)HttpStatusCode.InternalServerError, status);
         Assert.Equal("Email is not configured.", message);
+    }
+
+    [Fact]
+    public async Task InfrastructureException_Production_WithCode_KeepsMessage()
+    {
+        // A Code marks the message as copy the throw site wrote for a client, so it survives
+        // Production — this is what EmailService's "Email is not configured." relies on.
+        GlobalExceptionHandler handler = CreateHandler(isDevelopment: false);
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(
+            ctx,
+            new InfrastructureException("Email is not configured.")
+            {
+                Code = ErrorCodes.EmailNotConfigured
+            },
+            default);
+
+        (int status, string message) = await ReadResponse(ctx);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, status);
+        Assert.Equal("Email is not configured.", message);
+    }
+
+    [Fact]
+    public async Task InfrastructureException_Production_WithoutCode_IsGeneric()
+    {
+        // The other side of that boundary: an uncoded infrastructure failure is whatever the
+        // underlying library said, so its message must not reach the client in Production.
+        GlobalExceptionHandler handler = CreateHandler(isDevelopment: false);
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(
+            ctx,
+            new InfrastructureException("SMTP connect to mail.internal:587 failed for postmaster"),
+            default);
+
+        (int status, string message) = await ReadResponse(ctx);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, status);
+        Assert.Equal("An unexpected error occurred.", message);
+        Assert.DoesNotContain("mail.internal", message);
+    }
+
+    [Fact]
+    public async Task InfrastructureException_Development_WithoutCode_KeepsMessage()
+    {
+        // In Development the same uncoded failure stays legible for debugging.
+        GlobalExceptionHandler handler = CreateHandler(isDevelopment: true);
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(
+            ctx,
+            new InfrastructureException("SMTP connect to mail.internal:587 failed for postmaster"),
+            default);
+
+        (_, string message) = await ReadResponse(ctx);
+        Assert.Contains("mail.internal", message);
     }
 
     [Fact]

--- a/OpenRestoApi/Core/Application/Exceptions/OpenRestoExceptions.cs
+++ b/OpenRestoApi/Core/Application/Exceptions/OpenRestoExceptions.cs
@@ -64,7 +64,9 @@ public sealed class BusinessRuleException : OpenRestoException
 }
 
 // 500 — infrastructure/config failure (email not configured, admin password missing,
-// SMTP). Surfaces to the client as a generic 500 in non-Development environments.
+// SMTP). Outside Development the message reaches the client only when the throw site set a
+// Code, marking it as deliberate client-facing copy; an uncoded one is reported generically
+// so a library's message cannot carry infrastructure detail out with it.
 [Serializable]
 public sealed class InfrastructureException : OpenRestoException
 {

--- a/OpenRestoApi/Infrastructure/Exceptions/GlobalExceptionHandler.cs
+++ b/OpenRestoApi/Infrastructure/Exceptions/GlobalExceptionHandler.cs
@@ -10,11 +10,29 @@ namespace OpenRestoApi.Infrastructure.Exceptions;
 // status discriminator; the handler switch-es on it.
 //
 // Fallback (untyped) exceptions → 500. In Development the underlying message is
-// surfaced for debugging; elsewhere a generic message is returned.
+// surfaced for debugging; elsewhere a generic message is returned. InfrastructureException
+// is held to the same disclosure rule unless it carries an ErrorCodes value — see
+// DiscloseableMessage.
 public sealed class GlobalExceptionHandler(
     ILogger<GlobalExceptionHandler> logger,
     IHostEnvironment env) : IExceptionHandler
 {
+    private const string GenericFailureMessage = "An unexpected error occurred.";
+
+    /// <summary>
+    /// An <see cref="InfrastructureException"/> carrying a <see cref="OpenRestoException.Code"/>
+    /// was shaped for a client by its throw site, so its message is deliberate and safe to return.
+    /// An uncoded one is an unclassified failure whose message is whatever the underlying library
+    /// said — an SMTP host, a connection string, a file path — so outside Development it is
+    /// withheld exactly like an untyped exception's.
+    /// </summary>
+    /// <seealso>GlobalExceptionHandlerTests.InfrastructureException_Production_WithoutCode_IsGeneric</seealso>
+    /// <seealso>GlobalExceptionHandlerTests.InfrastructureException_Production_WithCode_KeepsMessage</seealso>
+    private string DiscloseableMessage(InfrastructureException exception) =>
+        exception.Code is not null || env.IsDevelopment()
+            ? exception.Message
+            : GenericFailureMessage;
+
     public async ValueTask<bool> TryHandleAsync(
         HttpContext httpContext,
         Exception exception,
@@ -26,12 +44,14 @@ public sealed class GlobalExceptionHandler(
             ValidationException => (StatusCodes.Status400BadRequest, exception.Message),
             ConflictException => (StatusCodes.Status409Conflict, exception.Message),
             BusinessRuleException => (StatusCodes.Status400BadRequest, exception.Message),
-            InfrastructureException => (StatusCodes.Status500InternalServerError, exception.Message),
+            InfrastructureException infrastructure => (
+                StatusCodes.Status500InternalServerError,
+                DiscloseableMessage(infrastructure)),
             _ => (
                 StatusCodes.Status500InternalServerError,
                 env.IsDevelopment()
                     ? $"An unexpected error occurred: {exception.Message}"
-                    : "An unexpected error occurred.")
+                    : GenericFailureMessage)
         };
 
         // 5xx are genuine failures worth a stack trace; 4xx are expected domain

--- a/openresto-frontend/components/admin/settings/UsersCard.tsx
+++ b/openresto-frontend/components/admin/settings/UsersCard.tsx
@@ -395,7 +395,7 @@ export function UsersCard({
                       <Input
                         value={newUser.displayName}
                         onChangeText={(displayName) => setNewUser((s) => ({ ...s, displayName }))}
-                        placeholder="Alex Rivera"
+                        placeholder={t("admin.settings.users.displayNamePlaceholder")}
                       />
                     </View>
                   </View>

--- a/openresto-frontend/components/common/LanguageSwitcher.tsx
+++ b/openresto-frontend/components/common/LanguageSwitcher.tsx
@@ -9,8 +9,10 @@ const LANGUAGE_OPTIONS = SUPPORTED_LOCALES.map((locale) => ({
 }));
 
 /**
- * The one language picker in the app — guest footer and admin sidebar footer both render
- * this rather than hand-rolling their own. Writes through `LocaleContext.setLocale`, which
+ * The admin sidebar's language picker. The guest surface reaches the same `setLocale` through
+ * `components/layout/OverflowMenu`'s Language row instead, which lists the locales itself
+ * rather than nesting this `Select`'s `AnchoredPanel` inside a menu item (issue #387).
+ * Writes through `LocaleContext.setLocale`, which
  * persists the pick to `localStorage["openresto.locale"]` and applies it live (i18next +
  * `setActiveLocale`, so date/time formatting follows the switch immediately, not just text).
  */

--- a/openresto-frontend/constants/locales.ts
+++ b/openresto-frontend/constants/locales.ts
@@ -25,3 +25,15 @@ export const LOCALE_LABELS: Record<SupportedLocale, string> = {
 export function isSupportedLocale(value: string | null | undefined): value is SupportedLocale {
   return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value);
 }
+
+/**
+ * Writing direction per supported language. Uniform today because every language shipped is
+ * LTR — it exists so adding an RTL language is the same one-entry change here that adding any
+ * other language is, rather than direction being decided somewhere else.
+ */
+export const LOCALE_DIRECTIONS: Record<SupportedLocale, "ltr" | "rtl"> = {
+  en: "ltr",
+  fr: "ltr",
+  es: "ltr",
+  de: "ltr",
+};

--- a/openresto-frontend/context/LocaleContext.tsx
+++ b/openresto-frontend/context/LocaleContext.tsx
@@ -1,18 +1,22 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
-import { getLocales } from "expo-localization";
 import i18n from "@/i18n";
 import { setActiveLocale } from "@/utils/locale";
 import { StorageService } from "@/services/storage";
 import { useBrand } from "@/context/BrandContext";
-import { DEFAULT_LOCALE, isSupportedLocale, type SupportedLocale } from "@/constants/locales";
+import {
+  DEFAULT_LOCALE,
+  LOCALE_DIRECTIONS,
+  isSupportedLocale,
+  type SupportedLocale,
+} from "@/constants/locales";
 
 const STORAGE_KEY = "openresto.locale";
 
 /**
  * Resolution order, highest priority first:
- *  1. The viewer's own pick, in `localStorage["openresto.locale"]` — nothing writes this key
- *     yet, the switcher that does ships in #373; this layer exists so it activates the moment
- *     that lands, with no further wiring here.
+ *  1. The viewer's own pick, in `localStorage["openresto.locale"]`, written by `setLocale`
+ *     below — the admin sidebar's `LanguageSwitcher` and the guest navbar's overflow menu
+ *     both go through it. A value outside `SUPPORTED_LOCALES` is ignored, not trusted.
  *  2. `brand.defaultLocale`, the self-hoster's `Locale:Default` / `OPENRESTO_DEFAULT_LOCALE`.
  *  3. `DEFAULT_LOCALE` ("en"), hardcoded.
  *
@@ -56,7 +60,7 @@ function applyLocale(locale: SupportedLocale): void {
   /* istanbul ignore else -- native has no `document`; every test runs under jsdom */
   if (typeof document !== "undefined") {
     document.documentElement.lang = locale;
-    document.documentElement.dir = getLocales()[0]?.textDirection ?? "ltr";
+    document.documentElement.dir = LOCALE_DIRECTIONS[locale];
   }
 }
 

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -1414,6 +1414,7 @@
         "setPassword": "Passwort festlegen",
         "emailLabel": "E-Mail",
         "displayNameLabel": "Anzeigename (optional)",
+        "displayNamePlaceholder": "Alex Rivera",
         "temporaryPasswordLabel": "Temporäres Passwort",
         "newUserRoleLabel": "Rolle des neuen Benutzers {{role}}",
         "addThisUserLabel": "Diesen Benutzer hinzufügen",

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -1414,6 +1414,7 @@
         "setPassword": "Set password",
         "emailLabel": "Email",
         "displayNameLabel": "Display name (optional)",
+        "displayNamePlaceholder": "Alex Rivera",
         "temporaryPasswordLabel": "Temporary password",
         "newUserRoleLabel": "New user role {{role}}",
         "addThisUserLabel": "Add this user",

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -1414,6 +1414,7 @@
         "setPassword": "Establecer contraseña",
         "emailLabel": "Correo electrónico",
         "displayNameLabel": "Nombre mostrado (opcional)",
+        "displayNamePlaceholder": "Alex Rivera",
         "temporaryPasswordLabel": "Contraseña temporal",
         "newUserRoleLabel": "Rol del nuevo usuario {{role}}",
         "addThisUserLabel": "Añadir este usuario",

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -1414,6 +1414,7 @@
         "setPassword": "Définir le mot de passe",
         "emailLabel": "E-mail",
         "displayNameLabel": "Nom affiché (facultatif)",
+        "displayNamePlaceholder": "Alex Rivera",
         "temporaryPasswordLabel": "Mot de passe temporaire",
         "newUserRoleLabel": "Rôle du nouvel utilisateur {{role}}",
         "addThisUserLabel": "Ajouter cet utilisateur",

--- a/openresto-frontend/tests/context/LocaleContext.test.tsx
+++ b/openresto-frontend/tests/context/LocaleContext.test.tsx
@@ -7,6 +7,7 @@ import { Platform, Text } from "react-native";
 import { LocaleProvider, useLocale } from "@/context/LocaleContext";
 import i18n from "@/i18n";
 import { setActiveLocale } from "@/utils/locale";
+import { LOCALE_DIRECTIONS } from "@/constants/locales";
 
 // StorageService (and therefore localStorage["openresto.locale"]) only reads on web.
 Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
@@ -113,8 +114,7 @@ describe("LocaleContext", () => {
     await waitFor(() => expect(screen.getByTestId("locale").props.children).toBe("en"));
   });
 
-  it("sets document.documentElement.lang and dir from expo-localization on web", async () => {
-    mockGetLocales.mockReturnValue([{ textDirection: "ltr" }]);
+  it("sets document.documentElement.lang and dir from the active locale on web", async () => {
     mockBrand = { defaultLocale: "fr" };
 
     render(
@@ -124,11 +124,12 @@ describe("LocaleContext", () => {
     );
 
     await waitFor(() => expect(document.documentElement.lang).toBe("fr"));
-    expect(document.documentElement.dir).toBe("ltr");
+    expect(document.documentElement.dir).toBe(LOCALE_DIRECTIONS.fr);
   });
 
-  it("defaults dir to ltr when expo-localization reports no locales", async () => {
-    mockGetLocales.mockReturnValue([]);
+  it("takes dir from the chosen locale, not from an RTL device", async () => {
+    mockGetLocales.mockReturnValue([{ textDirection: "rtl" }]);
+    mockBrand = { defaultLocale: "de" };
 
     render(
       <LocaleProvider>
@@ -136,7 +137,7 @@ describe("LocaleContext", () => {
       </LocaleProvider>
     );
 
-    await waitFor(() => expect(document.documentElement.lang).toBe("en"));
+    await waitFor(() => expect(document.documentElement.lang).toBe("de"));
     expect(document.documentElement.dir).toBe("ltr");
   });
 

--- a/openresto-frontend/tests/i18n/parity.test.ts
+++ b/openresto-frontend/tests/i18n/parity.test.ts
@@ -21,6 +21,24 @@ function leafKeyPaths(node: Json, prefix = ""): string[] {
     });
 }
 
+/**
+ * The interpolation variables a string references, e.g. "{{count}} of {{max}}" -> ["count", "max"].
+ * i18next allows a format suffix ("{{count, number}}"), so only the name before the comma counts.
+ */
+function placeholders(value: string): string[] {
+  return [...value.matchAll(/\{\{\s*([^}]+?)\s*\}\}/g)]
+    .map((match) => match[1].split(",")[0].trim())
+    .sort();
+}
+
+function leafEntries(node: Json, prefix = ""): [string, string][] {
+  return Object.keys(node).flatMap((key): [string, string][] => {
+    const value = node[key];
+    const path = prefix ? `${prefix}.${key}` : key;
+    return typeof value === "string" ? [[path, value]] : leafEntries(value, path);
+  });
+}
+
 const LOCALE_FILES: Record<string, Json> = { en, fr, es, de };
 
 describe("i18n locale key parity", () => {
@@ -38,6 +56,52 @@ describe("i18n locale key parity", () => {
     "%s.json has the exact same leaf key paths as en.json",
     (locale) => {
       expect(leafKeyPaths(LOCALE_FILES[locale])).toEqual(englishKeys);
+    }
+  );
+
+  /**
+   * A placeholder a translation invents is never anything but a bug: nothing supplies it, so
+   * i18next renders the braces literally and the viewer reads "{{naem}}". Key parity cannot
+   * see this — the key is present and the value is a plausible sentence.
+   */
+  it.each(SUPPORTED_LOCALES.filter((locale) => locale !== "en"))(
+    "%s.json references no interpolation variable en.json does not supply",
+    (locale) => {
+      const english = new Map(leafEntries(en));
+      const unknown = leafEntries(LOCALE_FILES[locale])
+        .map(([path, value]) => ({
+          path,
+          extra: placeholders(value).filter(
+            (name) => !placeholders(english.get(path) ?? "").includes(name)
+          ),
+        }))
+        .filter(({ extra }) => extra.length > 0);
+
+      expect(unknown).toEqual([]);
+    }
+  );
+
+  /**
+   * The mirror case: a dropped placeholder silently loses the value from the sentence. The one
+   * principled exception is `count` on a singular variant — "the following booking" is idiomatic
+   * where "the following 1 booking" is not, in every language whose `_one` form means exactly one.
+   */
+  it.each(SUPPORTED_LOCALES.filter((locale) => locale !== "en"))(
+    "%s.json keeps every interpolation variable en.json supplies",
+    (locale) => {
+      const translated = new Map(leafEntries(LOCALE_FILES[locale]));
+      const dropped = leafEntries(en)
+        .map(([path, value]) => ({
+          path,
+          missing: placeholders(value).filter(
+            (name) =>
+              !placeholders(translated.get(path) ?? "").includes(name) &&
+              !(name === "count" && path.endsWith("_one"))
+          ),
+        }))
+        .filter(({ missing }) => missing.length > 0);
+
+      expect(dropped).toEqual([]);
     }
   );
 


### PR DESCRIPTION
## Summary

A review of everything on `main` since v1.8.0 — the i18next rollout (bundles B–G, F1–F5), the language switchers, and the backend error-code work — with fixes for what it turned up. Three substantive findings, one of them security-relevant, plus two doc corrections.

Everything the locale review found is either fixed here or listed under **Not addressed** below, with reasoning.

## Related issue

Closes #

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

**Writing direction followed the device, not the chosen language.** `LocaleContext.applyLocale` set `document.documentElement.dir` from `expo-localization`'s device locale. A viewer on an RTL device got the whole UI mirrored regardless of which language they picked — and every language the app ships is LTR, so that was never the direction any of them wanted. Direction now comes from a `LOCALE_DIRECTIONS` map beside `LOCALE_LABELS`, which also keeps "adding a language is one entry in `constants/locales.ts`" true for an RTL one. `LocaleContext` no longer depends on `expo-localization`.

**Interpolation parity was unenforced.** `parity.test.ts` compared key paths only, so a translation that typos `{{naem}}` or drops `{{email}}` passed: the key is present and the value is a plausible sentence, while the viewer reads the braces literally. All four files are consistent today; nothing kept them that way. Two assertions now pin it in both directions — no translation may reference a variable `en.json` does not supply, and none may drop one. `count` on a `_one` variant is the single tolerated omission, since "the following booking" is idiomatic where "the following 1 booking" is not.

**Uncoded infrastructure detail reached production clients.** `InfrastructureException`'s own contract said it "surfaces to the client as a generic 500 in non-Development environments", but `GlobalExceptionHandler` returned `exception.Message` for it in every environment. Nothing leaks today — both throw sites pass hand-written constants — but the type exists for precisely the failures whose message is not ours to publish; it is documented as covering SMTP, and the first `catch (SmtpException ex) => throw new InfrastructureException(ex.Message, ex)` would put a mail host and account on the wire. Genericising the type wholesale would have cost the admin the useful "Email is not configured." while the frontend still renders `message` rather than `code`, so disclosure keys off `Code` instead: a coded exception is copy its throw site wrote for a client and survives production, an uncoded one is whatever the underlying library said and is reported generically. Development is unchanged.

**Smaller fixes.** The users-card display-name placeholder was hardcoded `"Alex Rivera"` while every sibling placeholder is keyed — now routed through `t()`. Two docstrings still described the locale work mid-flight: `LocaleContext` said nothing writes `localStorage["openresto.locale"]` "yet", and `LanguageSwitcher` claimed a guest-footer mount it does not have since the picker moved into `OverflowMenu` (#387).

## Not addressed

**Server rejection messages are still English in every locale.** `BookingDrawer` renders `err.message` straight from the API, so a French guest hitting a paused restaurant or a table conflict reads English; only the fallback copy is translated. The `Code` field added in #375 is the fix, but nothing consumes it yet — no `errors.*` keys exist beyond `generic`/`genericMessage`/`title`. Wiring ~150 codes to keys across four locales is a feature, not a review fix, so it is flagged rather than half-built. This is the largest remaining gap in the i18n story.

`expo-localization` is now unused in application code (only `jest.setup.ts` mocks it). Left in place — it is an Expo module and removing it is a config question, not a locale one.

The `Unreleased` CHANGELOG section is empty despite a large i18n feature set landing, and all four version fields still read `1.8.0`. Left alone: the bump is a semver judgement call, and `scripts/check-release-version.sh` gates it at tag time.

## Testing

- [x] `OpenRestoApi.Tests` pass locally — 1782 passed, 99.12% line coverage
- [x] Frontend tests/build pass locally — 200 suites / 2889 tests passed, `npm run check` and `tsc --noEmit` clean, `npm run check:doc-links` resolves the new `<seealso>` tags
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — each new test was run against the pre-fix code to confirm it fails there rather than passing vacuously: the RTL-device test goes red on the old `getLocales()` line, and the placeholder assertions go red on an injected `{{emial}}` typo and an injected dropped `{{email}}`, naming the offending key

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed — `InfrastructureException`'s contract comment now matches the handler's behaviour

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKSfj9nPxRWkNav3xe32oC)_