### PR TITLE
Localize server rejections, and show booking search results in the list

### DIFF
--- a/OpenRestoApi.Tests/Infrastructure/GlobalExceptionHandlerTests.cs
+++ b/OpenRestoApi.Tests/Infrastructure/GlobalExceptionHandlerTests.cs
@@ -46,6 +46,48 @@ public class GlobalExceptionHandlerTests
     }
 
     [Fact]
+    public async Task Args_AreSerializedOntoTheResponse()
+    {
+        // A client renders its own copy per code, so it cannot recover "4" and "6" from the
+        // finished English sentence — the args are the only way its wording names the same two.
+        GlobalExceptionHandler handler = CreateHandler();
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(
+            ctx,
+            new ConflictException("This table only has 4 seats, but 6 guests were requested.")
+            {
+                Code = ErrorCodes.TableSeatsExceeded,
+                Args = new Dictionary<string, object> { ["seats"] = 4, ["requested"] = 6 }
+            },
+            default);
+
+        ctx.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        Assert.Equal(ErrorCodes.TableSeatsExceeded, doc.RootElement.GetProperty("code").GetString());
+        JsonElement args = doc.RootElement.GetProperty("args");
+        Assert.Equal(4, args.GetProperty("seats").GetInt32());
+        Assert.Equal(6, args.GetProperty("requested").GetInt32());
+    }
+
+    [Fact]
+    public async Task Args_AreOmittedWhenTheMessageIsAConstant()
+    {
+        // Additive: a response for a message with nothing to interpolate keeps its old shape.
+        GlobalExceptionHandler handler = CreateHandler();
+        HttpContext ctx = CreateContext();
+
+        await handler.TryHandleAsync(
+            ctx,
+            new ConflictException("Cannot create a booking in the past.") { Code = ErrorCodes.BookingPastDate },
+            default);
+
+        ctx.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(ctx.Response.Body);
+        Assert.False(doc.RootElement.TryGetProperty("args", out _));
+    }
+
+    [Fact]
     public async Task NotFoundException_MapsTo_404()
     {
         GlobalExceptionHandler handler = CreateHandler();

--- a/OpenRestoApi.Tests/Services/PauseHelperTests.cs
+++ b/OpenRestoApi.Tests/Services/PauseHelperTests.cs
@@ -1,4 +1,5 @@
 using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Application.Utilities;
 using OpenRestoApi.Core.Domain;
 
 namespace OpenRestoApi.Tests.Services;
@@ -28,5 +29,35 @@ public class PauseHelperTests
 
         Assert.Equal("Bookings for this restaurant are currently paused. Please try again later.",
             PauseHelper.RejectionMessage(restaurant));
+    }
+
+    [Fact]
+    public void Rejection_WithEndTime_NamesTheTimeAndCarriesItAsAnArg()
+    {
+        var restaurant = new Restaurant
+        {
+            Id = 1,
+            Name = "T",
+            Timezone = "America/New_York",
+            BookingsPausedUntil = new DateTime(2026, 1, 15, 20, 30, 0, DateTimeKind.Utc)
+        };
+
+        PauseHelper.Rejection rejection = PauseHelper.RejectionFor(restaurant);
+
+        Assert.Equal(ErrorCodes.BookingPaused, rejection.Code);
+        Assert.Equal("15:30", rejection.Args!["until"]);
+    }
+
+    [Fact]
+    public void Rejection_WithoutEndTime_UsesTheIndefiniteCode()
+    {
+        // A pause with an end and one without are different sentences, so a client rendering its
+        // own copy needs different codes — it cannot branch on an argument being absent.
+        var restaurant = new Restaurant { Id = 1, Name = "T", Timezone = "UTC" };
+
+        PauseHelper.Rejection rejection = PauseHelper.RejectionFor(restaurant);
+
+        Assert.Equal(ErrorCodes.BookingPausedIndefinitely, rejection.Code);
+        Assert.Null(rejection.Args);
     }
 }

--- a/OpenRestoApi/Controllers/AdminController.cs
+++ b/OpenRestoApi/Controllers/AdminController.cs
@@ -186,7 +186,12 @@ public class AdminController(AdminService adminService) : ControllerBase
         }
         catch (Exception ex)
         {
-            return BadRequest(new MessageResponse { Message = $"Failed to send: {ex.Message}", Code = ErrorCodes.BookingEmailSendFailed });
+            return BadRequest(new MessageResponse
+            {
+                Message = $"Failed to send: {ex.Message}",
+                Code = ErrorCodes.BookingEmailSendFailed,
+                Args = new Dictionary<string, object> { ["detail"] = ex.Message }
+            });
         }
     }
 

--- a/OpenRestoApi/Controllers/EmailSettingsController.cs
+++ b/OpenRestoApi/Controllers/EmailSettingsController.cs
@@ -73,7 +73,12 @@ public class EmailSettingsController(EmailSettingsService emailSettings) : Contr
         }
         catch (Exception ex)
         {
-            return BadRequest(new MessageResponse { Message = $"Connection failed: {ex.Message}", Code = ErrorCodes.EmailConnectionFailed });
+            return BadRequest(new MessageResponse
+            {
+                Message = $"Connection failed: {ex.Message}",
+                Code = ErrorCodes.EmailConnectionFailed,
+                Args = new Dictionary<string, object> { ["detail"] = ex.Message }
+            });
         }
     }
 }

--- a/OpenRestoApi/Controllers/HoldsController.cs
+++ b/OpenRestoApi/Controllers/HoldsController.cs
@@ -71,8 +71,8 @@ public class HoldsController(
         return policy.Status switch
         {
             HoldPolicyStatus.NotFound => NotFound(new MessageResponse { Message = "Restaurant not found.", Code = policy.Code }),
-            HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
-            HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
+            HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code, Args = policy.Args }),
+            HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code, Args = policy.Args }),
             _ => autoAssign
                 ? await PlaceAutoAssignedHold(request, policy)
                 : PlaceEligibleHold(request, policy)
@@ -93,8 +93,8 @@ public class HoldsController(
             return policy.Status switch
             {
                 HoldPolicyStatus.NotFound => NotFound(new MessageResponse { Message = "Restaurant not found.", Code = policy.Code }),
-                HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
-                HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code }),
+                HoldPolicyStatus.Rejected => BadRequest(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code, Args = policy.Args }),
+                HoldPolicyStatus.Booked => Conflict(new MessageResponse { Message = policy.FailureMessage!, Code = policy.Code, Args = policy.Args }),
                 _ => BadRequest(new MessageResponse { Message = "Hold not available.", Code = ErrorCodes.HoldUnavailable })
             };
         }

--- a/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/AdminDto.cs
@@ -211,6 +211,14 @@ public class MessageResponse
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Code { get; set; }
+
+    /// <summary>
+    /// Values <see cref="Message"/> interpolated, keyed by placeholder name, so a client
+    /// rendering its own copy for <see cref="Code"/> can rebuild the same sentence in its own
+    /// language. Additive and omitted when null, like <see cref="Code"/>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, object>? Args { get; set; }
 }
 
 public class PvqStatusDto

--- a/OpenRestoApi/Core/Application/Exceptions/OpenRestoExceptions.cs
+++ b/OpenRestoApi/Core/Application/Exceptions/OpenRestoExceptions.cs
@@ -20,6 +20,15 @@ public abstract class OpenRestoException : Exception
     /// </summary>
     public string? Code { get; init; }
 
+    /// <summary>
+    /// The runtime values <see cref="Exception.Message"/> interpolated, keyed by the placeholder
+    /// name the client's copy for <see cref="Code"/> uses. A client that renders its own wording
+    /// for a code has no way to recover "4" and "6" out of the finished English sentence, so a
+    /// throw site that interpolates anything supplies it here too. Null where the message is a
+    /// constant, which is most of them.
+    /// </summary>
+    public IReadOnlyDictionary<string, object>? Args { get; init; }
+
     protected OpenRestoException() { }
     protected OpenRestoException(string message) : base(message) { }
     protected OpenRestoException(string message, Exception inner) : base(message, inner) { }

--- a/OpenRestoApi/Core/Application/Interfaces/IHoldPolicyService.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IHoldPolicyService.cs
@@ -28,11 +28,14 @@ public record HoldPolicyResult(
     Restaurant? Restaurant = null,
     DateTime BookingDate = default,
     string? FailureMessage = null,
-    string? Code = null)
+    string? Code = null,
+    IReadOnlyDictionary<string, object>? Args = null)
 {
     public static HoldPolicyResult NotFound() => new(HoldPolicyStatus.NotFound, Code: ErrorCodes.RestaurantNotFound);
-    public static HoldPolicyResult Rejected(string message, string? code = null) => new(HoldPolicyStatus.Rejected, FailureMessage: message, Code: code);
-    public static HoldPolicyResult Booked(string message, string? code = null) => new(HoldPolicyStatus.Booked, FailureMessage: message, Code: code);
+    public static HoldPolicyResult Rejected(string message, string? code = null, IReadOnlyDictionary<string, object>? args = null)
+        => new(HoldPolicyStatus.Rejected, FailureMessage: message, Code: code, Args: args);
+    public static HoldPolicyResult Booked(string message, string? code = null, IReadOnlyDictionary<string, object>? args = null)
+        => new(HoldPolicyStatus.Booked, FailureMessage: message, Code: code, Args: args);
     public static HoldPolicyResult Eligible(Restaurant restaurant, DateTime bookingDate)
         => new(HoldPolicyStatus.Eligible, restaurant, bookingDate);
 }

--- a/OpenRestoApi/Core/Application/Services/AdminService.cs
+++ b/OpenRestoApi/Core/Application/Services/AdminService.cs
@@ -208,7 +208,7 @@ public class AdminService(
 
         if (req.Seats > table.Seats)
         {
-            throw new ConflictException($"This table only has {table.Seats} seats, but {req.Seats} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded };
+            throw new ConflictException($"This table only has {table.Seats} seats, but {req.Seats} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded, Args = new Dictionary<string, object> { ["seats"] = table.Seats, ["requested"] = req.Seats } };
         }
 
         var booking = new Booking
@@ -393,7 +393,7 @@ public class AdminService(
                 Table? currentTable = await _tableRepository.FindByIdAsync(resolvedTableId.Value);
                 if (currentTable != null && req.Seats.Value > currentTable.Seats)
                 {
-                    throw new BusinessRuleException($"This table only has {currentTable.Seats} seats, but {req.Seats.Value} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded };
+                    throw new BusinessRuleException($"This table only has {currentTable.Seats} seats, but {req.Seats.Value} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded, Args = new Dictionary<string, object> { ["seats"] = currentTable.Seats, ["requested"] = req.Seats.Value } };
                 }
             }
             booking.Seats = req.Seats.Value;

--- a/OpenRestoApi/Core/Application/Services/BookingService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingService.cs
@@ -120,7 +120,8 @@ public class BookingService(
 
         if (restaurant.IsPausedFor(bookingDate))
         {
-            throw new ConflictException(PauseHelper.RejectionMessage(restaurant)) { Code = ErrorCodes.BookingPaused };
+            PauseHelper.Rejection pause = PauseHelper.RejectionFor(restaurant);
+            throw new ConflictException(pause.Message) { Code = pause.Code, Args = pause.Args };
         }
 
         if (restaurant.IsWalkInOnlyAt(bookingDate))
@@ -142,7 +143,7 @@ public class BookingService(
         {
             throw new ValidationException(
                 $"Party size must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.")
-            { Code = ErrorCodes.BookingPartySizeOutOfRange };
+            { Code = ErrorCodes.BookingPartySizeOutOfRange, Args = new Dictionary<string, object> { ["min"] = BookingLimits.MinSeats, ["max"] = BookingLimits.MaxSeats } };
         }
     }
 
@@ -155,14 +156,14 @@ public class BookingService(
 
         if (seats > table.Seats)
         {
-            throw new ConflictException($"This table only has {table.Seats} seats, but {seats} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded };
+            throw new ConflictException($"This table only has {table.Seats} seats, but {seats} guests were requested.") { Code = ErrorCodes.TableSeatsExceeded, Args = new Dictionary<string, object> { ["seats"] = table.Seats, ["requested"] = seats } };
         }
 
         if (restaurant?.ExceedsOversizeCap(table.Seats, seats) == true)
         {
             throw new ConflictException(
                 $"This table has {table.Seats} seats, which is too large for a party of {seats}.")
-            { Code = ErrorCodes.TableOversizeCap };
+            { Code = ErrorCodes.TableOversizeCap, Args = new Dictionary<string, object> { ["seats"] = table.Seats, ["partySize"] = seats } };
         }
     }
 
@@ -346,14 +347,14 @@ public class BookingService(
         {
             throw new ConflictException(
                 $"This group only has {group.CombinedSeats} combined seats, but {seats} guests were requested.")
-            { Code = ErrorCodes.TableGroupSeatsExceeded };
+            { Code = ErrorCodes.TableGroupSeatsExceeded, Args = new Dictionary<string, object> { ["seats"] = group.CombinedSeats, ["requested"] = seats } };
         }
 
         if (restaurant.ExceedsOversizeCap(group.CombinedSeats, seats))
         {
             throw new ConflictException(
                 $"This group has {group.CombinedSeats} combined seats, which is too large for a party of {seats}.")
-            { Code = ErrorCodes.TableGroupOversizeCap };
+            { Code = ErrorCodes.TableGroupOversizeCap, Args = new Dictionary<string, object> { ["seats"] = group.CombinedSeats, ["partySize"] = seats } };
         }
     }
 

--- a/OpenRestoApi/Core/Application/Services/BrandService.cs
+++ b/OpenRestoApi/Core/Application/Services/BrandService.cs
@@ -144,7 +144,10 @@ public class BrandService(
         {
             throw new ValidationException(
                 $"HeaderImageFit must be one of: {string.Join(", ", AllowedHeaderImageFits.Order())}.")
-            { Code = ErrorCodes.BrandHeaderImageFitInvalid };
+            {
+                Code = ErrorCodes.BrandHeaderImageFitInvalid,
+                Args = new Dictionary<string, object> { ["allowed"] = string.Join(", ", AllowedHeaderImageFits.Order()) }
+            };
         }
 
         BrandSettings? brand = await _brandRepository.GetAsync();

--- a/OpenRestoApi/Core/Application/Services/HighlightService.cs
+++ b/OpenRestoApi/Core/Application/Services/HighlightService.cs
@@ -118,13 +118,13 @@ public class HighlightService(IHighlightRepository highlightRepository, IAuditSc
         }
         if (title.Length > MaxTitleLength)
         {
-            throw new ValidationException($"Highlight title cannot exceed {MaxTitleLength} characters.") { Code = ErrorCodes.HighlightTitleTooLong };
+            throw new ValidationException($"Highlight title cannot exceed {MaxTitleLength} characters.") { Code = ErrorCodes.HighlightTitleTooLong, Args = new Dictionary<string, object> { ["max"] = MaxTitleLength } };
         }
 
         body = (rawBody ?? string.Empty).Trim();
         if (body.Length > MaxBodyLength)
         {
-            throw new ValidationException($"Highlight body cannot exceed {MaxBodyLength} characters.") { Code = ErrorCodes.HighlightBodyTooLong };
+            throw new ValidationException($"Highlight body cannot exceed {MaxBodyLength} characters.") { Code = ErrorCodes.HighlightBodyTooLong, Args = new Dictionary<string, object> { ["max"] = MaxBodyLength } };
         }
 
         iconKey = (rawIconKey ?? string.Empty).Trim();

--- a/OpenRestoApi/Core/Application/Services/HoldPolicyService.cs
+++ b/OpenRestoApi/Core/Application/Services/HoldPolicyService.cs
@@ -75,7 +75,8 @@ public sealed class HoldPolicyService(
         // 4. Pause window — scoped to the sittings inside it, not to every future date.
         if (restaurant.IsPausedFor(bookingDate))
         {
-            return HoldPolicyResult.Rejected(PauseHelper.RejectionMessage(restaurant), ErrorCodes.BookingPaused);
+            PauseHelper.Rejection pause = PauseHelper.RejectionFor(restaurant);
+            return HoldPolicyResult.Rejected(pause.Message, pause.Code, pause.Args);
         }
 
         // 5. Walk-in-only policy (location-wide or per ISO day).

--- a/OpenRestoApi/Core/Application/Services/OpeningHoursHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/OpeningHoursHelper.cs
@@ -82,7 +82,7 @@ public static class OpeningHoursHelper
 
             if (byDay.ContainsKey(entry.Day))
             {
-                throw new ValidationException($"OpenHours contains more than one entry for day {entry.Day}.") { Code = ErrorCodes.RestaurantOpenHoursDuplicateDay };
+                throw new ValidationException($"OpenHours contains more than one entry for day {entry.Day}.") { Code = ErrorCodes.RestaurantOpenHoursDuplicateDay, Args = new Dictionary<string, object> { ["day"] = entry.Day } };
             }
 
             if (!TryParseTime(entry.Open, out int openH, out int openM)

--- a/OpenRestoApi/Core/Application/Services/PauseHelper.cs
+++ b/OpenRestoApi/Core/Application/Services/PauseHelper.cs
@@ -12,14 +12,39 @@ namespace OpenRestoApi.Core.Application.Services;
 /// </summary>
 public static class PauseHelper
 {
-    public static string RejectionMessage(Restaurant restaurant)
+    /// <summary>
+    /// How a paused restaurant turns a booking or hold away: the English wording, the code a
+    /// client renders its own wording from, and the values that wording interpolates. A pause
+    /// with an end and one without are different sentences, so they carry different codes —
+    /// a client cannot branch on the presence of an argument.
+    /// </summary>
+    public readonly record struct Rejection(
+        string Message,
+        string Code,
+        IReadOnlyDictionary<string, object>? Args);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso>PauseHelperTests.Rejection_WithEndTime_NamesTheTimeAndCarriesItAsAnArg</seealso>
+    /// <seealso>PauseHelperTests.Rejection_WithoutEndTime_UsesTheIndefiniteCode</seealso>
+    public static Rejection RejectionFor(Restaurant restaurant)
     {
         if (!restaurant.BookingsPausedUntil.HasValue)
         {
-            return "Bookings for this restaurant are currently paused. Please try again later.";
+            return new Rejection(
+                "Bookings for this restaurant are currently paused. Please try again later.",
+                ErrorCodes.BookingPausedIndefinitely,
+                null);
         }
 
         DateTime localEnd = TimeZoneHelper.ConvertUtcToLocal(restaurant.BookingsPausedUntil.Value, restaurant.Timezone);
-        return $"Bookings are paused until {localEnd.ToString("HH:mm", CultureInfo.InvariantCulture)}. Please choose a later time.";
+        string until = localEnd.ToString("HH:mm", CultureInfo.InvariantCulture);
+        return new Rejection(
+            $"Bookings are paused until {until}. Please choose a later time.",
+            ErrorCodes.BookingPaused,
+            new Dictionary<string, object> { ["until"] = until });
     }
+
+    public static string RejectionMessage(Restaurant restaurant) => RejectionFor(restaurant).Message;
 }

--- a/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
+++ b/OpenRestoApi/Core/Application/Services/RestaurantManagementService.cs
@@ -42,7 +42,10 @@ public class RestaurantManagementService(
         {
             throw new ValidationException(
                 $"BookingRefFormat must be one of: {string.Join(", ", Enum.GetNames<BookingRefFormat>())}.")
-            { Code = ErrorCodes.RestaurantBookingRefFormatInvalid };
+            {
+                Code = ErrorCodes.RestaurantBookingRefFormatInvalid,
+                Args = new Dictionary<string, object> { ["allowed"] = string.Join(", ", Enum.GetNames<BookingRefFormat>()) }
+            };
         }
 
         return parsed;
@@ -186,7 +189,10 @@ public class RestaurantManagementService(
             {
                 throw new ValidationException(
                     $"DefaultBookingDurationMinutes must be one of: {string.Join(", ", _allowedBookingDurationsMinutes.Order())}.")
-                { Code = ErrorCodes.RestaurantDurationInvalid };
+                {
+                    Code = ErrorCodes.RestaurantDurationInvalid,
+                    Args = new Dictionary<string, object> { ["allowed"] = string.Join(", ", _allowedBookingDurationsMinutes.Order()) }
+                };
             }
 
             r.DefaultBookingDurationMinutes = req.DefaultBookingDurationMinutes.Value;
@@ -198,7 +204,10 @@ public class RestaurantManagementService(
             {
                 throw new ValidationException(
                     $"BookingSlotIntervalMinutes must be one of: {string.Join(", ", _allowedBookingSlotIntervalsMinutes.Order())}.")
-                { Code = ErrorCodes.RestaurantSlotIntervalInvalid };
+                {
+                    Code = ErrorCodes.RestaurantSlotIntervalInvalid,
+                    Args = new Dictionary<string, object> { ["allowed"] = string.Join(", ", _allowedBookingSlotIntervalsMinutes.Order()) }
+                };
             }
 
             r.BookingSlotIntervalMinutes = req.BookingSlotIntervalMinutes.Value;
@@ -497,7 +506,7 @@ public class RestaurantManagementService(
         {
             throw new ValidationException(
                 $"Seats must be between {BookingLimits.MinSeats} and {BookingLimits.MaxSeats}.")
-            { Code = ErrorCodes.TableSeatsOutOfRange };
+            { Code = ErrorCodes.TableSeatsOutOfRange, Args = new Dictionary<string, object> { ["min"] = BookingLimits.MinSeats, ["max"] = BookingLimits.MaxSeats } };
         }
     }
 
@@ -518,7 +527,7 @@ public class RestaurantManagementService(
         {
             throw new ValidationException(
                 $"CombinedSeats ({combinedSeats}) cannot exceed the sum of member seats ({memberSeatsSum}).")
-            { Code = ErrorCodes.TableGroupCombinedSeatsExceedsSum };
+            { Code = ErrorCodes.TableGroupCombinedSeatsExceedsSum, Args = new Dictionary<string, object> { ["combined"] = combinedSeats, ["sum"] = memberSeatsSum } };
         }
 
         int largestMemberSeats = members.Max(t => t.Seats);
@@ -527,7 +536,10 @@ public class RestaurantManagementService(
             throw new ValidationException(
                 $"CombinedSeats ({combinedSeats}) must be more than the largest member table ({largestMemberSeats}). "
                 + "combining these tables would not seat a bigger party.")
-            { Code = ErrorCodes.TableGroupCombinedSeatsNotWorthCombining };
+            {
+                Code = ErrorCodes.TableGroupCombinedSeatsNotWorthCombining,
+                Args = new Dictionary<string, object> { ["combined"] = combinedSeats, ["largest"] = largestMemberSeats }
+            };
         }
     }
 
@@ -809,7 +821,7 @@ public class RestaurantManagementService(
             {
                 throw new ValidationException(
                     $"Table {t.Id} already belongs to another combinable group ({ownerGroupId}).")
-                { Code = ErrorCodes.TableGroupMemberAlreadyGrouped };
+                { Code = ErrorCodes.TableGroupMemberAlreadyGrouped, Args = new Dictionary<string, object> { ["tableId"] = t.Id, ["groupId"] = ownerGroupId } };
             }
         }
 

--- a/OpenRestoApi/Core/Application/Services/SocialLinkService.cs
+++ b/OpenRestoApi/Core/Application/Services/SocialLinkService.cs
@@ -105,7 +105,7 @@ public class SocialLinkService(ISocialLinkRepository socialLinkRepository, IAudi
         }
         if (label.Length > MaxLabelLength)
         {
-            throw new ValidationException($"Social link label cannot exceed {MaxLabelLength} characters.") { Code = ErrorCodes.SocialLinkLabelTooLong };
+            throw new ValidationException($"Social link label cannot exceed {MaxLabelLength} characters.") { Code = ErrorCodes.SocialLinkLabelTooLong, Args = new Dictionary<string, object> { ["max"] = MaxLabelLength } };
         }
 
         url = (rawUrl ?? string.Empty).Trim();

--- a/OpenRestoApi/Core/Application/Services/UserService.cs
+++ b/OpenRestoApi/Core/Application/Services/UserService.cs
@@ -74,7 +74,7 @@ public class UserService(
                 throw new BusinessRuleException("You cannot change your own role.") { Code = ErrorCodes.UserCannotChangeOwnRole };
             }
 
-            await EnsureAnotherActiveOwnerRemainsAsync(user, "demote");
+            await EnsureAnotherActiveOwnerRemainsAsync(user, "demote", ErrorCodes.UserLastActiveOwnerDemote);
             string previousRole = user.Role;
             user.Role = role;
             await _credentialRepository.SaveChangesAsync();
@@ -100,7 +100,7 @@ public class UserService(
                     throw new BusinessRuleException("You cannot deactivate your own account.") { Code = ErrorCodes.UserCannotDeactivateSelf };
                 }
 
-                await EnsureAnotherActiveOwnerRemainsAsync(user, "deactivate");
+                await EnsureAnotherActiveOwnerRemainsAsync(user, "deactivate", ErrorCodes.UserLastActiveOwnerDeactivate);
             }
 
             user.IsActive = req.IsActive;
@@ -149,7 +149,7 @@ public class UserService(
 
     private async Task<AdminCredential> RequireUserAsync(int id)
         => await _credentialRepository.GetByIdAsync(id)
-            ?? throw new NotFoundException($"User {id} not found.") { Code = ErrorCodes.UserNotFound };
+            ?? throw new NotFoundException($"User {id} not found.") { Code = ErrorCodes.UserNotFound, Args = new Dictionary<string, object> { ["id"] = id } };
 
     private bool IsSelf(AdminCredential user)
         => _currentUser.UserId == user.Id
@@ -158,7 +158,10 @@ public class UserService(
     // Losing the last active Owner would leave the instance with nobody able to manage users —
     // unrecoverable through the UI. Only an active Owner counts, so deactivating one and then
     // demoting it isn't a way around the rule either.
-    private async Task EnsureAnotherActiveOwnerRemainsAsync(AdminCredential user, string action)
+    // The action is part of the rule rather than a value inside it: a client renders its own
+    // wording per code, and both the verb and the role name are words it would have to translate
+    // out of an English sentence it cannot parse.
+    private async Task EnsureAnotherActiveOwnerRemainsAsync(AdminCredential user, string action, string code)
     {
         if (user.Role != UserRoles.Owner || !user.IsActive)
         {
@@ -170,7 +173,7 @@ public class UserService(
         {
             throw new BusinessRuleException(
                 $"Cannot {action} the last active {UserRoles.Owner}. Promote another user first.")
-            { Code = ErrorCodes.UserLastActiveOwner };
+            { Code = code };
         }
     }
 }

--- a/OpenRestoApi/Core/Application/Utilities/ContactFields.cs
+++ b/OpenRestoApi/Core/Application/Utilities/ContactFields.cs
@@ -29,7 +29,7 @@ public static class ContactFields
         {
             throw new ValidationException(
                 $"Phone number cannot exceed {ContactLimits.MaxPhoneLength} characters.")
-            { Code = ErrorCodes.ContactPhoneTooLong };
+            { Code = ErrorCodes.ContactPhoneTooLong, Args = new Dictionary<string, object> { ["max"] = ContactLimits.MaxPhoneLength } };
         }
 
         return trimmed;
@@ -53,7 +53,7 @@ public static class ContactFields
         {
             throw new ValidationException(
                 $"Email address cannot exceed {ContactLimits.MaxEmailLength} characters.")
-            { Code = ErrorCodes.ContactEmailTooLong };
+            { Code = ErrorCodes.ContactEmailTooLong, Args = new Dictionary<string, object> { ["max"] = ContactLimits.MaxEmailLength } };
         }
 
         if (!EmailValidator.IsValid(trimmed))

--- a/OpenRestoApi/Core/Application/Utilities/ErrorCodes.cs
+++ b/OpenRestoApi/Core/Application/Utilities/ErrorCodes.cs
@@ -18,6 +18,7 @@ public static class ErrorCodes
     // ── Bookings ─────────────────────────────────────────────────────────────
     public const string BookingPastDate = "booking.past_date";
     public const string BookingPaused = "booking.paused";
+    public const string BookingPausedIndefinitely = "booking.paused_indefinitely";
     public const string BookingWalkInOnly = "booking.walk_in_only";
     public const string BookingWalkInOnlyToday = "booking.walk_in_only_today";
     public const string BookingTableConflict = "booking.table_conflict";
@@ -84,7 +85,8 @@ public static class ErrorCodes
     public const string UserEmailAlreadyExists = "user.email_already_exists";
     public const string UserCannotChangeOwnRole = "user.cannot_change_own_role";
     public const string UserCannotDeactivateSelf = "user.cannot_deactivate_self";
-    public const string UserLastActiveOwner = "user.last_active_owner";
+    public const string UserLastActiveOwnerDemote = "user.last_active_owner_demote";
+    public const string UserLastActiveOwnerDeactivate = "user.last_active_owner_deactivate";
     public const string UserNotFound = "user.not_found";
     public const string UserEmailInvalid = "user.email_invalid";
     public const string UserEmailTooLong = "user.email_too_long";

--- a/OpenRestoApi/Core/Application/Utilities/UserFields.cs
+++ b/OpenRestoApi/Core/Application/Utilities/UserFields.cs
@@ -31,7 +31,7 @@ public static class UserFields
         {
             throw new ValidationException(
                 $"Email address cannot exceed {ContactLimits.MaxEmailLength} characters.")
-            { Code = ErrorCodes.UserEmailTooLong };
+            { Code = ErrorCodes.UserEmailTooLong, Args = new Dictionary<string, object> { ["max"] = ContactLimits.MaxEmailLength } };
         }
 
         return normalized;
@@ -54,7 +54,7 @@ public static class UserFields
         {
             throw new ValidationException(
                 $"Display name cannot exceed {MaxDisplayNameLength} characters.")
-            { Code = ErrorCodes.UserDisplayNameTooLong };
+            { Code = ErrorCodes.UserDisplayNameTooLong, Args = new Dictionary<string, object> { ["max"] = MaxDisplayNameLength } };
         }
 
         return trimmed;
@@ -73,7 +73,7 @@ public static class UserFields
     {
         if (string.IsNullOrEmpty(password) || password.Length < MinPasswordLength)
         {
-            throw new ValidationException($"Password must be at least {MinPasswordLength} characters.") { Code = ErrorCodes.UserPasswordTooShort };
+            throw new ValidationException($"Password must be at least {MinPasswordLength} characters.") { Code = ErrorCodes.UserPasswordTooShort, Args = new Dictionary<string, object> { ["min"] = MinPasswordLength } };
         }
     }
 
@@ -83,6 +83,9 @@ public static class UserFields
         return UserRoles.Normalise(role)
             ?? throw new ValidationException(
                 $"Role must be one of: {string.Join(", ", UserRoles.Assignable.Order())}.")
-            { Code = ErrorCodes.UserRoleInvalid };
+            {
+                Code = ErrorCodes.UserRoleInvalid,
+                Args = new Dictionary<string, object> { ["allowed"] = string.Join(", ", UserRoles.Assignable.Order()) }
+            };
     }
 }

--- a/OpenRestoApi/Infrastructure/Exceptions/GlobalExceptionHandler.cs
+++ b/OpenRestoApi/Infrastructure/Exceptions/GlobalExceptionHandler.cs
@@ -68,7 +68,12 @@ public sealed class GlobalExceptionHandler(
 
         httpContext.Response.StatusCode = statusCode;
         await httpContext.Response.WriteAsJsonAsync(
-            new MessageResponse { Message = message, Code = (exception as OpenRestoException)?.Code },
+            new MessageResponse
+            {
+                Message = message,
+                Code = (exception as OpenRestoException)?.Code,
+                Args = (exception as OpenRestoException)?.Args
+            },
             cancellationToken);
 
         return true; // marked handled — default ProblemDetails handler is skipped

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -1,4 +1,5 @@
 import { get, post, patch, del, put, buildUrl } from "./client";
+import { apiErrorMessage } from "@/api/errors";
 
 export interface AdminOverviewDto {
   totalRestaurants: number;
@@ -192,7 +193,7 @@ export async function adminCreateBooking(
 
   if (res.status === 409) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.message ?? "This table is already booked on that date.");
+    throw new Error(apiErrorMessage(body, "This table is already booked on that date."));
   }
 
   if (!res.ok) throw new Error("Failed to create booking");
@@ -218,7 +219,7 @@ export async function adminDeleteBooking(id: number): Promise<true> {
     const res = await post(`/admin/bookings/${id}/cancel`);
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      throw new Error(body.message ?? "Failed to cancel the booking.");
+      throw new Error(apiErrorMessage(body, "Failed to cancel the booking."));
     }
     return true;
   } catch (err) {
@@ -256,7 +257,7 @@ export async function adminRestoreBooking(id: number): Promise<boolean> {
     const res = await post(`/admin/bookings/${id}/restore`);
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      throw new Error(body.message ?? "Failed to restore booking");
+      throw new Error(apiErrorMessage(body, "Failed to restore booking"));
     }
     return true;
   } catch (err) {
@@ -284,7 +285,7 @@ export async function adminUpdateBookingFull(
     const res = await put(`/admin/bookings/${id}`, req);
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      throw new Error(body.message ?? "Failed to update booking");
+      throw new Error(apiErrorMessage(body, "Failed to update booking"));
     }
     return await res.json();
   } catch (err) {
@@ -554,7 +555,7 @@ export async function saveBrandSettings(
     const res = await patch("/brand", data);
     if (!res.ok) {
       const err = await res.json().catch(() => null);
-      return { ok: false, message: err?.message ?? "Failed to save." };
+      return { ok: false, message: apiErrorMessage(err, "Failed to save.") };
     }
     return { ok: true, data: await res.json() };
   } catch {
@@ -642,7 +643,7 @@ export async function adminCreateHighlight(
     const res = await post("/highlights", req);
     if (!res.ok) {
       const err = await res.json().catch(() => null);
-      return { ok: false, message: err?.message ?? "Failed to create highlight." };
+      return { ok: false, message: apiErrorMessage(err, "Failed to create highlight.") };
     }
     return { ok: true, data: await res.json() };
   } catch (err) {
@@ -659,7 +660,7 @@ export async function adminUpdateHighlight(
     const res = await put(`/highlights/${id}`, req);
     if (!res.ok) {
       const err = await res.json().catch(() => null);
-      return { ok: false, message: err?.message ?? "Failed to update highlight." };
+      return { ok: false, message: apiErrorMessage(err, "Failed to update highlight.") };
     }
     return { ok: true, data: await res.json() };
   } catch (err) {
@@ -718,7 +719,7 @@ export async function adminCreateSocialLink(
     const res = await post("/social-links", req);
     if (!res.ok) {
       const err = await res.json().catch(() => null);
-      return { ok: false, message: err?.message ?? "Failed to create social link." };
+      return { ok: false, message: apiErrorMessage(err, "Failed to create social link.") };
     }
     return { ok: true, data: await res.json() };
   } catch (err) {
@@ -735,7 +736,7 @@ export async function adminUpdateSocialLink(
     const res = await put(`/social-links/${id}`, req);
     if (!res.ok) {
       const err = await res.json().catch(() => null);
-      return { ok: false, message: err?.message ?? "Failed to update social link." };
+      return { ok: false, message: apiErrorMessage(err, "Failed to update social link.") };
     }
     return { ok: true, data: await res.json() };
   } catch (err) {

--- a/openresto-frontend/api/auth.ts
+++ b/openresto-frontend/api/auth.ts
@@ -1,4 +1,5 @@
 import { get, post } from "./client";
+import { apiErrorMessage } from "@/api/errors";
 
 export async function login(email: string, password: string): Promise<{ message: string } | null> {
   try {
@@ -48,7 +49,10 @@ export async function changePassword(
   try {
     const res = await post("/admin/auth/change-password", { currentPassword, newPassword });
     const body = await res.json().catch(() => ({}));
-    return { ok: res.ok, message: body.message ?? (res.ok ? "Done." : "Request failed.") };
+    return {
+      ok: res.ok,
+      message: res.ok ? (body.message ?? "Done.") : apiErrorMessage(body, "Request failed."),
+    };
   } catch {
     return { ok: false, message: "Network error." };
   }
@@ -63,7 +67,7 @@ export async function changeEmail(
     const body = await res.json().catch(() => ({}));
     return {
       ok: res.ok,
-      message: body.message ?? (res.ok ? "Done." : "Request failed."),
+      message: res.ok ? (body.message ?? "Done.") : apiErrorMessage(body, "Request failed."),
       email: body.email,
     };
   } catch {
@@ -107,7 +111,10 @@ export async function setupPvq(
   try {
     const res = await post("/admin/auth/pvq/setup", { question, answer });
     const body = await res.json().catch(() => ({}));
-    return { ok: res.ok, message: body.message ?? (res.ok ? "Done." : "Failed.") };
+    return {
+      ok: res.ok,
+      message: res.ok ? (body.message ?? "Done.") : apiErrorMessage(body, "Failed."),
+    };
   } catch {
     return { ok: false, message: "Network error." };
   }
@@ -135,7 +142,10 @@ export async function resetPassword(
   try {
     const res = await post("/admin/auth/reset-password", { resetToken, newPassword });
     const body = await res.json().catch(() => ({}));
-    return { ok: res.ok, message: body.message ?? (res.ok ? "Done." : "Failed.") };
+    return {
+      ok: res.ok,
+      message: res.ok ? (body.message ?? "Done.") : apiErrorMessage(body, "Failed."),
+    };
   } catch {
     return { ok: false, message: "Network error." };
   }

--- a/openresto-frontend/api/bookings.ts
+++ b/openresto-frontend/api/bookings.ts
@@ -1,4 +1,5 @@
 import { get, post, del } from "./client";
+import { apiErrorMessage } from "@/api/errors";
 
 export interface BookingDto {
   id: number;
@@ -72,7 +73,7 @@ export async function createBooking(booking: BookingCreationDto): Promise<Bookin
 
   if (res.status === 409) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.message ?? "This table is no longer available.");
+    throw new Error(apiErrorMessage(body, "This table is no longer available."));
   }
 
   if (!res.ok) throw new Error("Failed to create booking");
@@ -135,7 +136,7 @@ export async function cancelBookingByRef(bookingRef: string, email: string): Pro
     const res = await post(`/bookings/ref/${bookingRef}/cancel`, { email });
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      throw new Error(body.message ?? "Failed to cancel booking.");
+      throw new Error(apiErrorMessage(body, "Failed to cancel booking."));
     }
     return true;
   } catch (err) {

--- a/openresto-frontend/api/errors.ts
+++ b/openresto-frontend/api/errors.ts
@@ -1,0 +1,40 @@
+import i18n from "@/i18n";
+
+/**
+ * The shape every rejected OpenResto request returns. `message` is the backend's English
+ * sentence, `code` the stable `ErrorCodes` identifier for the rule that rejected it, and
+ * `args` the values `message` interpolated, keyed by placeholder name. Only `message` is
+ * guaranteed: `code` is absent on the handful of throw sites that predate it, and `args`
+ * only appears where the message is not a constant.
+ */
+export interface ApiErrorBody {
+  message?: string;
+  code?: string;
+  args?: Record<string, string | number>;
+}
+
+/**
+ * The message to show a viewer for a rejected request, in their language.
+ *
+ * The backend's `message` is always English, so rendering it directly is what left a French
+ * guest reading "This table is no longer available." Translating from `code` instead keeps the
+ * whole rejection in one language, and `args` is what lets the translated sentence name the
+ * same seats, limits and times the English one did.
+ *
+ * Falls back to the server's own wording for a code with no copy yet — and to `fallback` when
+ * the response carried no message at all — so an unlocalized rule degrades to today's English
+ * rather than to a raw key.
+ *
+ * @see [errors.test.ts](../tests/api/errors.test.ts) — pins that a known code translates, that
+ * args interpolate into it, and that an unknown code keeps the server's message.
+ */
+export function apiErrorMessage(body: unknown, fallback: string): string {
+  const { message, code, args } = (body ?? {}) as ApiErrorBody;
+  const serverMessage = message ?? fallback;
+
+  if (!code) return serverMessage;
+
+  // The (key, defaultValue, options) overload takes a plain string key — `t()`'s other
+  // overload is typed against en.json's key union, which a runtime error code cannot satisfy.
+  return i18n.t(`errors.${code}`, serverMessage, { ...args, defaultValue: serverMessage });
+}

--- a/openresto-frontend/api/holds.ts
+++ b/openresto-frontend/api/holds.ts
@@ -1,4 +1,5 @@
 import { post, del } from "./client";
+import { apiErrorMessage } from "@/api/errors";
 
 export interface HoldRequest {
   restaurantId: number;
@@ -49,7 +50,7 @@ export async function createHold(request: HoldRequest): Promise<HoldResult> {
     // both carry a descriptive { message } from the backend — surface it
     // instead of discarding it so the customer sees the real reason.
     const body = await res.json().catch(() => ({}));
-    return { ok: false, message: body?.message ?? GENERIC_UNAVAILABLE };
+    return { ok: false, message: apiErrorMessage(body, GENERIC_UNAVAILABLE) };
   } catch (err) {
     // Network failure or non-JSON body — fall back to a generic message.
     console.error("createHold error:", err);

--- a/openresto-frontend/api/users.ts
+++ b/openresto-frontend/api/users.ts
@@ -1,5 +1,6 @@
 import { get, patch, post } from "./client";
 import type { AssignableRole } from "@/constants/roles";
+import { apiErrorMessage } from "@/api/errors";
 
 /** An admin account as listed by the Owner-only user management API. */
 export interface AdminUserDto {
@@ -24,7 +25,7 @@ export type UserMutationResult = { ok: true; user: AdminUserDto } | { ok: false;
 async function toResult(res: Response): Promise<UserMutationResult> {
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
-    return { ok: false, message: body.message ?? "Request failed." };
+    return { ok: false, message: apiErrorMessage(body, "Request failed.") };
   }
   return { ok: true, user: body as AdminUserDto };
 }

--- a/openresto-frontend/app/admin/bookings/index.tsx
+++ b/openresto-frontend/app/admin/bookings/index.tsx
@@ -95,6 +95,12 @@ export default function AdminBookingsScreen() {
   }>();
   const searchQuery = queryParam || null;
 
+  // A search matches across every location and every date, which is exactly what the timetable
+  // cannot draw — it renders one location on one day. So a search forces the list regardless of
+  // the persisted toggle, and the location chips, status tabs and view toggle come down with it:
+  // the search fetch ignores all three, so leaving them up offers filters that do nothing.
+  const effectiveViewMode: ViewMode = searchQuery ? "list" : viewMode;
+
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     if (create === "1") setShowNewModal(true);
@@ -111,7 +117,7 @@ export default function AdminBookingsScreen() {
     loadGrid,
     handleGridDateChange,
     resetToToday,
-  } = useBookingsGrid({ restaurantId: selectedRestaurantId, viewMode });
+  } = useBookingsGrid({ restaurantId: selectedRestaurantId, viewMode: effectiveViewMode });
 
   const selectedRestaurant = restaurants.find((r) => r.id === selectedRestaurantId);
   const gridIsoDay = gridDate.getDay() === 0 ? 7 : gridDate.getDay();
@@ -209,7 +215,7 @@ export default function AdminBookingsScreen() {
 
   const reconcileAfterBookingMutation = () => {
     setRefreshKey((key) => key + 1);
-    if (selectedRestaurantId && viewMode === "timetable") {
+    if (selectedRestaurantId && effectiveViewMode === "timetable") {
       loadGrid(selectedRestaurantId, gridDate);
     }
   };
@@ -245,7 +251,7 @@ export default function AdminBookingsScreen() {
   const listShortcutsBlocked = selectedBookingId !== null || showNewModal || !!cancelTarget;
 
   useKeyboardShortcuts(
-    viewMode === "list" && sorted.length > 0 && !listShortcutsBlocked
+    effectiveViewMode === "list" && sorted.length > 0 && !listShortcutsBlocked
       ? {
           j: () => moveRowFocus(1),
           ArrowDown: () => moveRowFocus(1),
@@ -294,7 +300,7 @@ export default function AdminBookingsScreen() {
         <Stack.Screen
           options={{
             title:
-              viewMode === "timetable"
+              effectiveViewMode === "timetable"
                 ? fmtDate(gridDate)
                 : statusFilter === "past"
                   ? t("admin.bookings.screenTitle.past")
@@ -366,123 +372,132 @@ export default function AdminBookingsScreen() {
         </View>
       </View>
 
-      <View
-        style={{
-          flexDirection: "row",
-          alignItems: "center",
-          flexWrap: "wrap",
-          gap: 8,
-        }}
-      >
-        {restaurants.length > 1 &&
-          restaurants.map((r) => (
-            <Pressable
-              key={r.id}
-              style={[
-                styles.chip,
-                { borderColor },
-                r.id === selectedRestaurantId && { backgroundColor: PRIMARY, borderColor: PRIMARY },
-              ]}
-              onPress={() => handleSelectRestaurant(r.id)}
-            >
-              <ThemedText
-                style={
-                  r.id === selectedRestaurantId
-                    ? styles.chipTextActive
-                    : [styles.chipText, { color: mutedColor }]
-                }
-              >
-                {r.name}
-              </ThemedText>
-            </Pressable>
-          ))}
-
-        <View style={{ flex: 1 }} />
-
-        {viewMode === "list" && (
-          <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
-            {(
-              [
-                { key: "active", label: t("admin.bookings.tabs.active"), color: PRIMARY },
-                { key: "past", label: t("admin.bookings.tabs.past"), color: "#7c3aed" },
-                {
-                  key: "cancelled",
-                  label: t("admin.bookings.tabs.cancelled"),
-                  color: theme.status.cancelled.text,
-                },
-              ] as const
-            ).map(({ key, label, color }) => (
+      {!searchQuery && (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            flexWrap: "wrap",
+            gap: 8,
+          }}
+        >
+          {restaurants.length > 1 &&
+            restaurants.map((r) => (
               <Pressable
-                key={key}
-                style={[styles.modeBtn, statusFilter === key && { backgroundColor: color }]}
-                onPress={() => setStatusFilter(key)}
-                accessibilityRole="radio"
-                accessibilityLabel={t("admin.bookings.tabs.showLabel", {
-                  tab: label.toLowerCase(),
-                })}
-                accessibilityState={{ checked: statusFilter === key }}
+                key={r.id}
+                style={[
+                  styles.chip,
+                  { borderColor },
+                  r.id === selectedRestaurantId && {
+                    backgroundColor: PRIMARY,
+                    borderColor: PRIMARY,
+                  },
+                ]}
+                onPress={() => handleSelectRestaurant(r.id)}
               >
                 <ThemedText
-                  style={[
-                    styles.modeBtnText,
-                    { color: statusFilter === key ? "#fff" : mutedColor },
-                  ]}
+                  style={
+                    r.id === selectedRestaurantId
+                      ? styles.chipTextActive
+                      : [styles.chipText, { color: mutedColor }]
+                  }
                 >
-                  {label}
+                  {r.name}
                 </ThemedText>
               </Pressable>
             ))}
+
+          <View style={{ flex: 1 }} />
+
+          {viewMode === "list" && (
+            <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
+              {(
+                [
+                  { key: "active", label: t("admin.bookings.tabs.active"), color: PRIMARY },
+                  { key: "past", label: t("admin.bookings.tabs.past"), color: "#7c3aed" },
+                  {
+                    key: "cancelled",
+                    label: t("admin.bookings.tabs.cancelled"),
+                    color: theme.status.cancelled.text,
+                  },
+                ] as const
+              ).map(({ key, label, color }) => (
+                <Pressable
+                  key={key}
+                  style={[styles.modeBtn, statusFilter === key && { backgroundColor: color }]}
+                  onPress={() => setStatusFilter(key)}
+                  accessibilityRole="radio"
+                  accessibilityLabel={t("admin.bookings.tabs.showLabel", {
+                    tab: label.toLowerCase(),
+                  })}
+                  accessibilityState={{ checked: statusFilter === key }}
+                >
+                  <ThemedText
+                    style={[
+                      styles.modeBtnText,
+                      { color: statusFilter === key ? "#fff" : mutedColor },
+                    ]}
+                  >
+                    {label}
+                  </ThemedText>
+                </Pressable>
+              ))}
+            </View>
+          )}
+
+          <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
+            <Pressable
+              testID="view-toggle-timetable"
+              style={[styles.modeBtn, viewMode === "timetable" && { backgroundColor: PRIMARY }]}
+              onPress={switchToTimetable}
+              accessibilityRole="radio"
+              accessibilityLabel={t("admin.bookings.viewToggle.timetableLabel")}
+              accessibilityState={{ checked: viewMode === "timetable" }}
+            >
+              <Icon
+                name="grid-outline"
+                size={15}
+                color={viewMode === "timetable" ? "#fff" : mutedColor}
+              />
+              {isWide && (
+                <ThemedText
+                  style={[
+                    styles.modeBtnText,
+                    { color: viewMode === "timetable" ? "#fff" : mutedColor },
+                  ]}
+                >
+                  {t("admin.bookings.viewToggle.timetable")}
+                </ThemedText>
+              )}
+            </Pressable>
+            <Pressable
+              testID="view-toggle-list"
+              style={[styles.modeBtn, viewMode === "list" && { backgroundColor: PRIMARY }]}
+              onPress={() => setViewMode("list")}
+              accessibilityRole="radio"
+              accessibilityLabel={t("admin.bookings.viewToggle.listLabel")}
+              accessibilityState={{ checked: viewMode === "list" }}
+            >
+              <Icon
+                name="list-outline"
+                size={15}
+                color={viewMode === "list" ? "#fff" : mutedColor}
+              />
+              {isWide && (
+                <ThemedText
+                  style={[styles.modeBtnText, { color: viewMode === "list" ? "#fff" : mutedColor }]}
+                >
+                  {t("admin.bookings.viewToggle.list")}
+                </ThemedText>
+              )}
+            </Pressable>
           </View>
-        )}
-
-        <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
-          <Pressable
-            testID="view-toggle-timetable"
-            style={[styles.modeBtn, viewMode === "timetable" && { backgroundColor: PRIMARY }]}
-            onPress={switchToTimetable}
-            accessibilityRole="radio"
-            accessibilityLabel={t("admin.bookings.viewToggle.timetableLabel")}
-            accessibilityState={{ checked: viewMode === "timetable" }}
-          >
-            <Icon
-              name="grid-outline"
-              size={15}
-              color={viewMode === "timetable" ? "#fff" : mutedColor}
-            />
-            {isWide && (
-              <ThemedText
-                style={[
-                  styles.modeBtnText,
-                  { color: viewMode === "timetable" ? "#fff" : mutedColor },
-                ]}
-              >
-                {t("admin.bookings.viewToggle.timetable")}
-              </ThemedText>
-            )}
-          </Pressable>
-          <Pressable
-            testID="view-toggle-list"
-            style={[styles.modeBtn, viewMode === "list" && { backgroundColor: PRIMARY }]}
-            onPress={() => setViewMode("list")}
-            accessibilityRole="radio"
-            accessibilityLabel={t("admin.bookings.viewToggle.listLabel")}
-            accessibilityState={{ checked: viewMode === "list" }}
-          >
-            <Icon name="list-outline" size={15} color={viewMode === "list" ? "#fff" : mutedColor} />
-            {isWide && (
-              <ThemedText
-                style={[styles.modeBtnText, { color: viewMode === "list" ? "#fff" : mutedColor }]}
-              >
-                {t("admin.bookings.viewToggle.list")}
-              </ThemedText>
-            )}
-          </Pressable>
         </View>
-      </View>
+      )}
 
-      {loading && viewMode === "list" ? (
+      {loading && effectiveViewMode === "list" ? (
         <ActivityIndicator style={styles.spinner} size="large" color={PRIMARY} />
-      ) : viewMode === "timetable" ? (
+      ) : effectiveViewMode === "timetable" ? (
         <View style={[styles.gridCard, { backgroundColor: cardBg, borderColor }]}>
           <View style={[styles.gridDateBar, { borderBottomColor: borderColor }]}>
             <Pressable

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -234,9 +234,144 @@
     }
   },
   "errors": {
+    "admin": {
+      "password_not_configured": "Admin:Password muss vor der ersten Nutzung konfiguriert werden. Legen Sie es über die Umgebungsvariable ADMIN_PASSWORD fest."
+    },
+    "auth": {
+      "email_already_in_use": "Diese E-Mail-Adresse wird bereits verwendet.",
+      "email_unchanged": "Die neue E-Mail-Adresse muss sich von der aktuellen unterscheiden.",
+      "invalid_reset_token": "Ungültiges oder abgelaufenes Zurücksetzungs-Token.",
+      "no_account_for_session": "Kein Konto passt zur angemeldeten Sitzung.",
+      "pvq_fields_required": "Frage und Antwort sind erforderlich.",
+      "pvq_not_configured": "Für dieses Konto ist keine Sicherheitsfrage konfiguriert."
+    },
+    "booking": {
+      "all_tables_held": "Alle passenden Tische sind derzeit von anderen Nutzern reserviert. Bitte versuchen Sie es gleich noch einmal.",
+      "already_active": "Die Buchung ist bereits aktiv.",
+      "already_past": "Eine bereits vergangene Buchung kann nicht storniert werden.",
+      "ambiguous_table_selection": "Geben Sie sowohl TableId als auch SectionId an – oder keines von beiden für die automatische Zuweisung.",
+      "cancel_email_required": "Für die Stornierung einer Buchung ist eine E-Mail-Adresse erforderlich.",
+      "email_fields_required": "Betreff und Nachricht sind erforderlich.",
+      "email_send_failed": "Senden fehlgeschlagen: {{detail}}",
+      "invalid_table_for_restaurant": "Ungültiger Tisch für dieses Restaurant.",
+      "lookup_email_required": "Für die Suche nach einer Buchung ist eine E-Mail-Adresse erforderlich.",
+      "lookup_not_found": "Keine Buchung zu dieser Referenz und E-Mail-Adresse gefunden.",
+      "move_conflict": "Diese Änderung würde mit einer bestehenden Buchung kollidieren.",
+      "no_customer_email": "Die E-Mail-Adresse des Gastes ist nicht verfügbar.",
+      "no_tables_available": "Für die gewünschte Zeit und Personenzahl sind keine Tische verfügbar.",
+      "party_size_out_of_range": "Die Personenzahl muss zwischen {{min}} und {{max}} liegen.",
+      "past_date": "Eine Buchung in der Vergangenheit kann nicht erstellt werden.",
+      "paused": "Buchungen sind bis {{until}} Uhr pausiert. Bitte wählen Sie eine spätere Zeit.",
+      "paused_indefinitely": "Buchungen für dieses Restaurant sind derzeit pausiert. Bitte versuchen Sie es später erneut.",
+      "section_mismatch": "Dieser Bereich gehört nicht zu diesem Restaurant.",
+      "table_conflict": "Für diesen Tisch besteht bereits eine Buchung, die sich mit der gewünschten Zeit überschneidet.",
+      "table_held": "Dieser Tisch ist bereits von einem anderen Nutzer reserviert. Bitte wählen Sie einen anderen Tisch oder versuchen Sie es gleich noch einmal.",
+      "table_id_required_for_section_change": "Geben Sie tableId an, wenn Sie in einen anderen Bereich umbuchen.",
+      "table_not_in_section": "Tisch im angegebenen Bereich nicht gefunden.",
+      "walk_in_only": "Dieser Standort nimmt nur spontane Gäste an und akzeptiert keine Onlinebuchungen.",
+      "walk_in_only_today": "Dieser Standort nimmt am gewählten Tag nur spontane Gäste an. Bitte wählen Sie einen anderen Tag oder kommen Sie einfach vorbei."
+    },
+    "brand": {
+      "accent_color_invalid": "Ungültiger Hexcode für die Akzentfarbe.",
+      "app_name_too_long": "Der App-Name darf höchstens 32 Zeichen lang sein.",
+      "copyright_too_long": "Der Copyright-Text darf höchstens 200 Zeichen lang sein.",
+      "favicon_invalid": "Ungültiges Favicon-Symbol.",
+      "header_image_fit_invalid": "HeaderImageFit muss einer dieser Werte sein: {{allowed}}.",
+      "highlights_heading_too_long": "Die Überschrift der Highlights darf höchstens 60 Zeichen lang sein.",
+      "highlights_subheading_too_long": "Die Unterüberschrift der Highlights darf höchstens 60 Zeichen lang sein.",
+      "primary_color_invalid": "Ungültiger Hexcode für die Primärfarbe.",
+      "subtitle_too_long": "Der Untertitel darf höchstens 160 Zeichen lang sein."
+    },
+    "contact": {
+      "email_invalid": "Die E-Mail-Adresse muss gültig sein.",
+      "email_too_long": "Die E-Mail-Adresse darf höchstens {{max}} Zeichen lang sein.",
+      "phone_too_long": "Die Telefonnummer darf höchstens {{max}} Zeichen lang sein."
+    },
+    "email": {
+      "connection_failed": "Verbindung fehlgeschlagen: {{detail}}",
+      "not_configured": "E-Mail ist nicht konfiguriert."
+    },
     "generic": "Etwas ist schiefgelaufen",
     "genericMessage": "Ein unerwarteter Fehler ist aufgetreten. Versuchen Sie es erneut.",
-    "title": "Fehler"
+    "highlight": {
+      "body_too_long": "Der Text des Highlights darf höchstens {{max}} Zeichen lang sein.",
+      "link_invalid": "Der Link des Highlights muss eine gültige absolute URL sein (http, https, mailto, tel oder sms).",
+      "title_required": "Der Titel des Highlights darf nicht leer sein.",
+      "title_too_long": "Der Titel des Highlights darf höchstens {{max}} Zeichen lang sein."
+    },
+    "hold": {
+      "ambiguous_group_and_table": "Geben Sie entweder TableId oder TableGroupId an, nicht beides.",
+      "auto_assign_seats_required": "Für die automatische Zuweisung ist die Personenzahl erforderlich, damit der Server einen passenden Tisch wählen kann.",
+      "group_seats_required": "Für eine Gruppenreservierung ist die Personenzahl erforderlich, damit der Server die kombinierte Kapazität prüfen kann.",
+      "unavailable": "Reservierung nicht verfügbar."
+    },
+    "icon": {
+      "invalid": "Der Symbolschlüssel muss einem der unterstützten Symbole entsprechen."
+    },
+    "media": {
+      "hero_too_large": "Das Titelbild muss kleiner als 5 MB sein.",
+      "location_image_too_large": "Das Standortbild muss kleiner als 2 MB sein.",
+      "menu_too_large": "Die Menüdatei muss kleiner als 10 MB sein.",
+      "unsupported_image_type": "Es werden nur JPEG-, PNG- und WebP-Bilder akzeptiert.",
+      "unsupported_menu_type": "Es werden nur Menüdateien im PDF-Format akzeptiert."
+    },
+    "restaurant": {
+      "archive_before_delete": "Archivieren Sie diesen Standort, bevor Sie ihn löschen. Das Archivieren nimmt ihn von der öffentlichen Website und lässt sich rückgängig machen – das Löschen nicht.",
+      "booking_ref_format_invalid": "BookingRefFormat muss einer dieser Werte sein: {{allowed}}.",
+      "closed_at_time": "Das Restaurant ist zur gewünschten Zeit geschlossen.",
+      "duration_invalid": "DefaultBookingDurationMinutes muss einer dieser Werte sein: {{allowed}}.",
+      "menu_url_invalid": "Die Menü-URL muss eine gültige absolute http(s)-URL sein.",
+      "name_required": "Der Name ist erforderlich.",
+      "no_sections": "Restaurant nicht gefunden oder ohne Bereiche.",
+      "not_found": "Ungültiges Restaurant.",
+      "open_hours_day_invalid": "OpenHours-Einträge müssen ISO-Tagesnummern von 1 (Montag) bis 7 (Sonntag) verwenden.",
+      "open_hours_duplicate_day": "OpenHours enthält mehr als einen Eintrag für Tag {{day}}.",
+      "open_hours_time_invalid": "OpenHours-Zeiten müssen gültige HH:mm-Werte sein (00:00–23:59).",
+      "oversize_cap_invalid": "MaxTableOversizeSeats muss null oder größer sein – oder null, um die Begrenzung zu deaktivieren.",
+      "section_ids_mismatch": "sectionIds muss genau die aktuellen Bereiche des Restaurants enthalten, ohne Duplikate.",
+      "slot_interval_invalid": "BookingSlotIntervalMinutes muss einer dieser Werte sein: {{allowed}}.",
+      "walk_in_days_invalid": "WalkInDays muss eine durch Kommas getrennte Liste von ISO-Tagesnummern von 1 (Montag) bis 7 (Sonntag) sein."
+    },
+    "social_link": {
+      "label_required": "Die Bezeichnung des Social-Media-Links darf nicht leer sein.",
+      "label_too_long": "Die Bezeichnung des Social-Media-Links darf höchstens {{max}} Zeichen lang sein.",
+      "url_invalid": "Die URL des Social-Media-Links muss eine gültige absolute URL sein (http, https, mailto, tel oder sms).",
+      "url_required": "Die URL des Social-Media-Links darf nicht leer sein."
+    },
+    "table": {
+      "oversize_cap": "Dieser Tisch hat {{seats}} Plätze und ist damit zu groß für eine Gruppe von {{partySize}} Personen.",
+      "seats_exceeded": "Dieser Tisch hat nur {{seats}} Plätze, angefragt wurden aber {{requested}} Gäste.",
+      "seats_out_of_range": "Die Platzzahl muss zwischen {{min}} und {{max}} liegen."
+    },
+    "table_group": {
+      "booking_conflict": "Einer der kombinierten Tische ist zu dieser Zeit bereits gebucht.",
+      "combined_seats_exceeds_sum": "CombinedSeats ({{combined}}) darf die Summe der Plätze der Mitgliedstische ({{sum}}) nicht überschreiten.",
+      "combined_seats_not_worth_combining": "CombinedSeats ({{combined}}) muss größer sein als der größte Mitgliedstisch ({{largest}}). Das Kombinieren dieser Tische würde keiner größeren Gruppe Platz bieten.",
+      "disbanded": "Diese Tische lassen sich nicht mehr kombinieren. Bitte wählen Sie eine andere Zeit oder einen anderen Tisch.",
+      "duplicate_member": "Eine kombinierbare Tischgruppe darf denselben Tisch nicht zweimal enthalten.",
+      "hold_conflict": "Einer der kombinierten Tische ist bereits von einem anderen Nutzer reserviert. Bitte versuchen Sie es gleich noch einmal.",
+      "invalid_members": "Alle Mitgliedstische müssen existieren und zu diesem Restaurant gehören.",
+      "member_already_grouped": "Tisch {{tableId}} gehört bereits zu einer anderen kombinierbaren Gruppe ({{groupId}}).",
+      "min_members": "Eine kombinierbare Tischgruppe muss mindestens zwei Mitglieder haben.",
+      "no_members": "Diese Tischgruppe hat keine Mitglieder.",
+      "not_found": "Tischgruppe nicht gefunden.",
+      "oversize_cap": "Diese Gruppe hat {{seats}} kombinierte Plätze und ist damit zu groß für eine Gruppe von {{partySize}} Personen.",
+      "seats_exceeded": "Diese Gruppe hat nur {{seats}} kombinierte Plätze, angefragt wurden aber {{requested}} Gäste."
+    },
+    "title": "Fehler",
+    "user": {
+      "cannot_change_own_role": "Sie können Ihre eigene Rolle nicht ändern.",
+      "cannot_deactivate_self": "Sie können Ihr eigenes Konto nicht deaktivieren.",
+      "display_name_too_long": "Der Anzeigename darf höchstens {{max}} Zeichen lang sein.",
+      "email_already_exists": "Ein Konto mit dieser E-Mail-Adresse existiert bereits.",
+      "email_invalid": "Eine gültige E-Mail-Adresse ist erforderlich.",
+      "email_too_long": "Die E-Mail-Adresse darf höchstens {{max}} Zeichen lang sein.",
+      "last_active_owner_deactivate": "Der letzte aktive Eigentümer kann nicht deaktiviert werden. Befördern Sie zuerst einen anderen Nutzer.",
+      "last_active_owner_demote": "Der letzte aktive Eigentümer kann nicht herabgestuft werden. Befördern Sie zuerst einen anderen Nutzer.",
+      "not_found": "Benutzer {{id}} nicht gefunden.",
+      "password_too_short": "Das Passwort muss mindestens {{min}} Zeichen lang sein.",
+      "role_invalid": "Die Rolle muss einer dieser Werte sein: {{allowed}}."
+    }
   },
   "lookup": {
     "cancelModal": {

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -234,9 +234,144 @@
     }
   },
   "errors": {
+    "admin": {
+      "password_not_configured": "Admin:Password must be configured before first use. Set it via ADMIN_PASSWORD env var."
+    },
+    "auth": {
+      "email_already_in_use": "That email address is already in use.",
+      "email_unchanged": "New email must be different from the current email.",
+      "invalid_reset_token": "Invalid or expired reset token.",
+      "no_account_for_session": "No account matches the signed-in session.",
+      "pvq_fields_required": "Question and answer are required.",
+      "pvq_not_configured": "Security question not configured for this account."
+    },
+    "booking": {
+      "all_tables_held": "All suitable tables are currently being held by other users. Please try again shortly.",
+      "already_active": "Booking is already active.",
+      "already_past": "Cannot cancel a booking that has already passed.",
+      "ambiguous_table_selection": "Specify both TableId and SectionId, or omit both for auto-assign.",
+      "cancel_email_required": "Email is required to cancel a booking.",
+      "email_fields_required": "Subject and body are required.",
+      "email_send_failed": "Failed to send: {{detail}}",
+      "invalid_table_for_restaurant": "Invalid table for this restaurant.",
+      "lookup_email_required": "Email is required to look up a booking.",
+      "lookup_not_found": "No booking found matching that reference and email.",
+      "move_conflict": "This update would cause a conflict with an existing booking.",
+      "no_customer_email": "Customer email is not available.",
+      "no_tables_available": "No tables are available for the requested time and party size.",
+      "party_size_out_of_range": "Party size must be between {{min}} and {{max}}.",
+      "past_date": "Cannot create a booking in the past.",
+      "paused": "Bookings are paused until {{until}}. Please choose a later time.",
+      "paused_indefinitely": "Bookings for this restaurant are currently paused. Please try again later.",
+      "section_mismatch": "Section does not belong to this restaurant.",
+      "table_conflict": "This table already has a booking that overlaps with the requested time.",
+      "table_held": "This table is already held by another user. Please select a different table or try again shortly.",
+      "table_id_required_for_section_change": "Provide tableId when reassigning to a different section.",
+      "table_not_in_section": "Table not found in the specified section.",
+      "walk_in_only": "This location accepts walk-ins only and does not take online bookings.",
+      "walk_in_only_today": "This location accepts walk-ins only on the selected day. Please choose another day or just come in."
+    },
+    "brand": {
+      "accent_color_invalid": "Invalid accent color hex code.",
+      "app_name_too_long": "App name cannot exceed 32 characters.",
+      "copyright_too_long": "Copyright text cannot exceed 200 characters.",
+      "favicon_invalid": "Invalid favicon icon.",
+      "header_image_fit_invalid": "HeaderImageFit must be one of: {{allowed}}.",
+      "highlights_heading_too_long": "Highlights heading cannot exceed 60 characters.",
+      "highlights_subheading_too_long": "Highlights subheading cannot exceed 60 characters.",
+      "primary_color_invalid": "Invalid primary color hex code.",
+      "subtitle_too_long": "Subtitle cannot exceed 160 characters."
+    },
+    "contact": {
+      "email_invalid": "Email address must be a valid email address.",
+      "email_too_long": "Email address cannot exceed {{max}} characters.",
+      "phone_too_long": "Phone number cannot exceed {{max}} characters."
+    },
+    "email": {
+      "connection_failed": "Connection failed: {{detail}}",
+      "not_configured": "Email is not configured."
+    },
     "generic": "Something went wrong",
     "genericMessage": "An unexpected error occurred. Try again.",
-    "title": "Error"
+    "highlight": {
+      "body_too_long": "Highlight body cannot exceed {{max}} characters.",
+      "link_invalid": "Highlight link must be a valid absolute URL (http, https, mailto, tel, or sms).",
+      "title_required": "Highlight title cannot be empty.",
+      "title_too_long": "Highlight title cannot exceed {{max}} characters."
+    },
+    "hold": {
+      "ambiguous_group_and_table": "Specify either TableId or TableGroupId, not both.",
+      "auto_assign_seats_required": "Seats is required for auto-assign so the server can pick a table that fits your party.",
+      "group_seats_required": "Seats is required for a group hold so the server can validate combined capacity.",
+      "unavailable": "Hold not available."
+    },
+    "icon": {
+      "invalid": "Icon key must be one of the supported icons."
+    },
+    "media": {
+      "hero_too_large": "Hero image must be under 5 MB.",
+      "location_image_too_large": "Location image must be under 2 MB.",
+      "menu_too_large": "Menu file must be under 10 MB.",
+      "unsupported_image_type": "Only JPEG, PNG, and WebP images are accepted.",
+      "unsupported_menu_type": "Only PDF menu files are accepted."
+    },
+    "restaurant": {
+      "archive_before_delete": "Archive this location before deleting it. Archiving takes it off the public site and can be undone; deleting cannot.",
+      "booking_ref_format_invalid": "BookingRefFormat must be one of: {{allowed}}.",
+      "closed_at_time": "The restaurant is closed at the requested time.",
+      "duration_invalid": "DefaultBookingDurationMinutes must be one of: {{allowed}}.",
+      "menu_url_invalid": "Menu URL must be a valid absolute http(s) URL.",
+      "name_required": "Name is required.",
+      "no_sections": "Restaurant not found or has no sections.",
+      "not_found": "Invalid restaurant.",
+      "open_hours_day_invalid": "OpenHours entries must use ISO day numbers 1 (Monday) through 7 (Sunday).",
+      "open_hours_duplicate_day": "OpenHours contains more than one entry for day {{day}}.",
+      "open_hours_time_invalid": "OpenHours times must be valid HH:mm values (00:00–23:59).",
+      "oversize_cap_invalid": "MaxTableOversizeSeats must be zero or greater, or null to disable.",
+      "section_ids_mismatch": "sectionIds must include exactly the restaurant's current sections, with no duplicates.",
+      "slot_interval_invalid": "BookingSlotIntervalMinutes must be one of: {{allowed}}.",
+      "walk_in_days_invalid": "WalkInDays must be a comma-separated list of ISO day numbers 1 (Monday) through 7 (Sunday)."
+    },
+    "social_link": {
+      "label_required": "Social link label cannot be empty.",
+      "label_too_long": "Social link label cannot exceed {{max}} characters.",
+      "url_invalid": "Social link URL must be a valid absolute URL (http, https, mailto, tel, or sms).",
+      "url_required": "Social link URL cannot be empty."
+    },
+    "table": {
+      "oversize_cap": "This table has {{seats}} seats, which is too large for a party of {{partySize}}.",
+      "seats_exceeded": "This table only has {{seats}} seats, but {{requested}} guests were requested.",
+      "seats_out_of_range": "Seats must be between {{min}} and {{max}}."
+    },
+    "table_group": {
+      "booking_conflict": "One of the combined tables is already booked for that time.",
+      "combined_seats_exceeds_sum": "CombinedSeats ({{combined}}) cannot exceed the sum of member seats ({{sum}}).",
+      "combined_seats_not_worth_combining": "CombinedSeats ({{combined}}) must be more than the largest member table ({{largest}}). combining these tables would not seat a bigger party.",
+      "disbanded": "These tables can no longer be combined. Please pick another time or table.",
+      "duplicate_member": "A combinable table group cannot list the same table twice.",
+      "hold_conflict": "One of the combined tables is already held by another user. Please try again shortly.",
+      "invalid_members": "All member tables must exist and belong to this restaurant.",
+      "member_already_grouped": "Table {{tableId}} already belongs to another combinable group ({{groupId}}).",
+      "min_members": "A combinable table group must have at least two members.",
+      "no_members": "This table group has no members.",
+      "not_found": "Table group not found.",
+      "oversize_cap": "This group has {{seats}} combined seats, which is too large for a party of {{partySize}}.",
+      "seats_exceeded": "This group only has {{seats}} combined seats, but {{requested}} guests were requested."
+    },
+    "title": "Error",
+    "user": {
+      "cannot_change_own_role": "You cannot change your own role.",
+      "cannot_deactivate_self": "You cannot deactivate your own account.",
+      "display_name_too_long": "Display name cannot exceed {{max}} characters.",
+      "email_already_exists": "An account with that email address already exists.",
+      "email_invalid": "A valid email address is required.",
+      "email_too_long": "Email address cannot exceed {{max}} characters.",
+      "last_active_owner_deactivate": "Cannot deactivate the last active Owner. Promote another user first.",
+      "last_active_owner_demote": "Cannot demote the last active Owner. Promote another user first.",
+      "not_found": "User {{id}} not found.",
+      "password_too_short": "Password must be at least {{min}} characters.",
+      "role_invalid": "Role must be one of: {{allowed}}."
+    }
   },
   "lookup": {
     "cancelModal": {

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -234,9 +234,144 @@
     }
   },
   "errors": {
+    "admin": {
+      "password_not_configured": "Admin:Password debe configurarse antes del primer uso. Defínelo mediante la variable de entorno ADMIN_PASSWORD."
+    },
+    "auth": {
+      "email_already_in_use": "Esa dirección de correo electrónico ya está en uso.",
+      "email_unchanged": "El nuevo correo electrónico debe ser distinto del actual.",
+      "invalid_reset_token": "Token de restablecimiento no válido o caducado.",
+      "no_account_for_session": "Ninguna cuenta coincide con la sesión iniciada.",
+      "pvq_fields_required": "La pregunta y la respuesta son obligatorias.",
+      "pvq_not_configured": "No hay ninguna pregunta de seguridad configurada para esta cuenta."
+    },
+    "booking": {
+      "all_tables_held": "Todas las mesas adecuadas están retenidas por otros usuarios en este momento. Vuelve a intentarlo en unos instantes.",
+      "already_active": "La reserva ya está activa.",
+      "already_past": "No se puede cancelar una reserva que ya ha pasado.",
+      "ambiguous_table_selection": "Indica tanto TableId como SectionId, u omite ambos para la asignación automática.",
+      "cancel_email_required": "Se necesita un correo electrónico para cancelar una reserva.",
+      "email_fields_required": "El asunto y el mensaje son obligatorios.",
+      "email_send_failed": "Error al enviar: {{detail}}",
+      "invalid_table_for_restaurant": "Mesa no válida para este restaurante.",
+      "lookup_email_required": "Se necesita un correo electrónico para buscar una reserva.",
+      "lookup_not_found": "No se ha encontrado ninguna reserva con esa referencia y ese correo electrónico.",
+      "move_conflict": "Este cambio entraría en conflicto con una reserva existente.",
+      "no_customer_email": "El correo electrónico del cliente no está disponible.",
+      "no_tables_available": "No hay mesas disponibles para la hora y el número de comensales solicitados.",
+      "party_size_out_of_range": "El número de comensales debe estar entre {{min}} y {{max}}.",
+      "past_date": "No se puede crear una reserva en el pasado.",
+      "paused": "Las reservas están pausadas hasta las {{until}}. Elige una hora posterior.",
+      "paused_indefinitely": "Las reservas de este restaurante están pausadas en este momento. Vuelve a intentarlo más tarde.",
+      "section_mismatch": "La sala no pertenece a este restaurante.",
+      "table_conflict": "Esta mesa ya tiene una reserva que se solapa con la hora solicitada.",
+      "table_held": "Otro usuario tiene retenida esta mesa. Elige otra mesa o vuelve a intentarlo en unos instantes.",
+      "table_id_required_for_section_change": "Indica tableId al reasignar a otra sala.",
+      "table_not_in_section": "No se ha encontrado la mesa en la sala indicada.",
+      "walk_in_only": "Este local solo admite visitas sin reserva y no acepta reservas en línea.",
+      "walk_in_only_today": "Este local solo admite visitas sin reserva el día seleccionado. Elige otro día o acércate directamente."
+    },
+    "brand": {
+      "accent_color_invalid": "Código hexadecimal de color de acento no válido.",
+      "app_name_too_long": "El nombre de la aplicación no puede superar los 32 caracteres.",
+      "copyright_too_long": "El texto de copyright no puede superar los 200 caracteres.",
+      "favicon_invalid": "Icono de favicon no válido.",
+      "header_image_fit_invalid": "HeaderImageFit debe ser uno de estos valores: {{allowed}}.",
+      "highlights_heading_too_long": "El título de los destacados no puede superar los 60 caracteres.",
+      "highlights_subheading_too_long": "El subtítulo de los destacados no puede superar los 60 caracteres.",
+      "primary_color_invalid": "Código hexadecimal de color principal no válido.",
+      "subtitle_too_long": "El subtítulo no puede superar los 160 caracteres."
+    },
+    "contact": {
+      "email_invalid": "La dirección de correo electrónico debe ser válida.",
+      "email_too_long": "La dirección de correo electrónico no puede superar los {{max}} caracteres.",
+      "phone_too_long": "El número de teléfono no puede superar los {{max}} caracteres."
+    },
+    "email": {
+      "connection_failed": "Error de conexión: {{detail}}",
+      "not_configured": "El correo electrónico no está configurado."
+    },
     "generic": "Ha ocurrido un error",
     "genericMessage": "Se ha producido un error inesperado. Inténtalo de nuevo.",
-    "title": "Error"
+    "highlight": {
+      "body_too_long": "El texto del destacado no puede superar los {{max}} caracteres.",
+      "link_invalid": "El enlace del destacado debe ser una URL absoluta válida (http, https, mailto, tel o sms).",
+      "title_required": "El título del destacado no puede estar vacío.",
+      "title_too_long": "El título del destacado no puede superar los {{max}} caracteres."
+    },
+    "hold": {
+      "ambiguous_group_and_table": "Indica TableId o TableGroupId, pero no ambos.",
+      "auto_assign_seats_required": "Se necesita el número de comensales para la asignación automática, de modo que el servidor pueda elegir una mesa adecuada.",
+      "group_seats_required": "Se necesita el número de comensales para una retención de grupo, de modo que el servidor pueda validar la capacidad combinada.",
+      "unavailable": "Retención no disponible."
+    },
+    "icon": {
+      "invalid": "La clave del icono debe ser uno de los iconos admitidos."
+    },
+    "media": {
+      "hero_too_large": "La imagen principal debe ocupar menos de 5 MB.",
+      "location_image_too_large": "La imagen del local debe ocupar menos de 2 MB.",
+      "menu_too_large": "El archivo del menú debe ocupar menos de 10 MB.",
+      "unsupported_image_type": "Solo se aceptan imágenes JPEG, PNG y WebP.",
+      "unsupported_menu_type": "Solo se aceptan menús en formato PDF."
+    },
+    "restaurant": {
+      "archive_before_delete": "Archiva este local antes de eliminarlo. Archivarlo lo retira del sitio público y se puede deshacer; eliminarlo no.",
+      "booking_ref_format_invalid": "BookingRefFormat debe ser uno de estos valores: {{allowed}}.",
+      "closed_at_time": "El restaurante está cerrado a la hora solicitada.",
+      "duration_invalid": "DefaultBookingDurationMinutes debe ser uno de estos valores: {{allowed}}.",
+      "menu_url_invalid": "La URL del menú debe ser una URL http(s) absoluta válida.",
+      "name_required": "El nombre es obligatorio.",
+      "no_sections": "Restaurante no encontrado o sin salas.",
+      "not_found": "Restaurante no válido.",
+      "open_hours_day_invalid": "Las entradas de OpenHours deben usar números de día ISO del 1 (lunes) al 7 (domingo).",
+      "open_hours_duplicate_day": "OpenHours contiene más de una entrada para el día {{day}}.",
+      "open_hours_time_invalid": "Las horas de OpenHours deben ser valores HH:mm válidos (00:00–23:59).",
+      "oversize_cap_invalid": "MaxTableOversizeSeats debe ser cero o mayor, o null para desactivarlo.",
+      "section_ids_mismatch": "sectionIds debe incluir exactamente las salas actuales del restaurante, sin duplicados.",
+      "slot_interval_invalid": "BookingSlotIntervalMinutes debe ser uno de estos valores: {{allowed}}.",
+      "walk_in_days_invalid": "WalkInDays debe ser una lista de números de día ISO del 1 (lunes) al 7 (domingo), separados por comas."
+    },
+    "social_link": {
+      "label_required": "La etiqueta del enlace social no puede estar vacía.",
+      "label_too_long": "La etiqueta del enlace social no puede superar los {{max}} caracteres.",
+      "url_invalid": "La URL del enlace social debe ser una URL absoluta válida (http, https, mailto, tel o sms).",
+      "url_required": "La URL del enlace social no puede estar vacía."
+    },
+    "table": {
+      "oversize_cap": "Esta mesa tiene {{seats}} plazas, demasiadas para un grupo de {{partySize}}.",
+      "seats_exceeded": "Esta mesa solo tiene {{seats}} plazas, pero se han solicitado {{requested}} comensales.",
+      "seats_out_of_range": "El número de plazas debe estar entre {{min}} y {{max}}."
+    },
+    "table_group": {
+      "booking_conflict": "Una de las mesas combinadas ya está reservada para esa hora.",
+      "combined_seats_exceeds_sum": "CombinedSeats ({{combined}}) no puede superar la suma de las plazas de las mesas miembro ({{sum}}).",
+      "combined_seats_not_worth_combining": "CombinedSeats ({{combined}}) debe ser mayor que la mesa miembro más grande ({{largest}}). Combinar estas mesas no permitiría sentar a un grupo mayor.",
+      "disbanded": "Estas mesas ya no se pueden combinar. Elige otra hora u otra mesa.",
+      "duplicate_member": "Un grupo de mesas combinables no puede incluir la misma mesa dos veces.",
+      "hold_conflict": "Otro usuario tiene retenida una de las mesas combinadas. Vuelve a intentarlo en unos instantes.",
+      "invalid_members": "Todas las mesas miembro deben existir y pertenecer a este restaurante.",
+      "member_already_grouped": "La mesa {{tableId}} ya pertenece a otro grupo combinable ({{groupId}}).",
+      "min_members": "Un grupo de mesas combinables debe tener al menos dos miembros.",
+      "no_members": "Este grupo de mesas no tiene miembros.",
+      "not_found": "Grupo de mesas no encontrado.",
+      "oversize_cap": "Este grupo tiene {{seats}} plazas combinadas, demasiadas para un grupo de {{partySize}}.",
+      "seats_exceeded": "Este grupo solo tiene {{seats}} plazas combinadas, pero se han solicitado {{requested}} comensales."
+    },
+    "title": "Error",
+    "user": {
+      "cannot_change_own_role": "No puedes cambiar tu propio rol.",
+      "cannot_deactivate_self": "No puedes desactivar tu propia cuenta.",
+      "display_name_too_long": "El nombre visible no puede superar los {{max}} caracteres.",
+      "email_already_exists": "Ya existe una cuenta con esa dirección de correo electrónico.",
+      "email_invalid": "Se requiere una dirección de correo electrónico válida.",
+      "email_too_long": "La dirección de correo electrónico no puede superar los {{max}} caracteres.",
+      "last_active_owner_deactivate": "No se puede desactivar al último propietario activo. Asciende antes a otro usuario.",
+      "last_active_owner_demote": "No se puede degradar al último propietario activo. Asciende antes a otro usuario.",
+      "not_found": "Usuario {{id}} no encontrado.",
+      "password_too_short": "La contraseña debe tener al menos {{min}} caracteres.",
+      "role_invalid": "El rol debe ser uno de estos valores: {{allowed}}."
+    }
   },
   "lookup": {
     "cancelModal": {

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -234,9 +234,144 @@
     }
   },
   "errors": {
+    "admin": {
+      "password_not_configured": "Admin:Password doit être configuré avant la première utilisation. Définissez-le via la variable d'environnement ADMIN_PASSWORD."
+    },
+    "auth": {
+      "email_already_in_use": "Cette adresse e-mail est déjà utilisée.",
+      "email_unchanged": "La nouvelle adresse e-mail doit être différente de l'actuelle.",
+      "invalid_reset_token": "Jeton de réinitialisation invalide ou expiré.",
+      "no_account_for_session": "Aucun compte ne correspond à la session connectée.",
+      "pvq_fields_required": "La question et la réponse sont obligatoires.",
+      "pvq_not_configured": "Aucune question de sécurité n'est configurée pour ce compte."
+    },
+    "booking": {
+      "all_tables_held": "Toutes les tables adaptées sont actuellement réservées par d'autres utilisateurs. Veuillez réessayer dans un instant.",
+      "already_active": "La réservation est déjà active.",
+      "already_past": "Impossible d'annuler une réservation déjà passée.",
+      "ambiguous_table_selection": "Indiquez à la fois TableId et SectionId, ou aucun des deux pour l'attribution automatique.",
+      "cancel_email_required": "Une adresse e-mail est requise pour annuler une réservation.",
+      "email_fields_required": "L'objet et le message sont obligatoires.",
+      "email_send_failed": "Échec de l'envoi : {{detail}}",
+      "invalid_table_for_restaurant": "Table invalide pour ce restaurant.",
+      "lookup_email_required": "Une adresse e-mail est requise pour retrouver une réservation.",
+      "lookup_not_found": "Aucune réservation ne correspond à cette référence et à cette adresse e-mail.",
+      "move_conflict": "Cette modification entrerait en conflit avec une réservation existante.",
+      "no_customer_email": "L'adresse e-mail du client n'est pas disponible.",
+      "no_tables_available": "Aucune table n'est disponible pour l'horaire et le nombre de convives demandés.",
+      "party_size_out_of_range": "Le nombre de convives doit être compris entre {{min}} et {{max}}.",
+      "past_date": "Impossible de créer une réservation dans le passé.",
+      "paused": "Les réservations sont suspendues jusqu'à {{until}}. Veuillez choisir un horaire plus tardif.",
+      "paused_indefinitely": "Les réservations pour ce restaurant sont actuellement suspendues. Veuillez réessayer plus tard.",
+      "section_mismatch": "Cette salle n'appartient pas à ce restaurant.",
+      "table_conflict": "Cette table a déjà une réservation qui chevauche l'horaire demandé.",
+      "table_held": "Cette table est déjà réservée par un autre utilisateur. Veuillez choisir une autre table ou réessayer dans un instant.",
+      "table_id_required_for_section_change": "Indiquez tableId lors d'un changement de salle.",
+      "table_not_in_section": "Table introuvable dans la salle indiquée.",
+      "walk_in_only": "Cet établissement accepte uniquement les visites sans réservation et ne prend pas de réservations en ligne.",
+      "walk_in_only_today": "Cet établissement accepte uniquement les visites sans réservation le jour sélectionné. Choisissez un autre jour ou présentez-vous sur place."
+    },
+    "brand": {
+      "accent_color_invalid": "Code hexadécimal de couleur d'accentuation invalide.",
+      "app_name_too_long": "Le nom de l'application ne peut pas dépasser 32 caractères.",
+      "copyright_too_long": "Le texte de copyright ne peut pas dépasser 200 caractères.",
+      "favicon_invalid": "Icône de favicon invalide.",
+      "header_image_fit_invalid": "HeaderImageFit doit être l'une des valeurs suivantes : {{allowed}}.",
+      "highlights_heading_too_long": "Le titre des points forts ne peut pas dépasser 60 caractères.",
+      "highlights_subheading_too_long": "Le sous-titre des points forts ne peut pas dépasser 60 caractères.",
+      "primary_color_invalid": "Code hexadécimal de couleur principale invalide.",
+      "subtitle_too_long": "Le sous-titre ne peut pas dépasser 160 caractères."
+    },
+    "contact": {
+      "email_invalid": "L'adresse e-mail doit être une adresse valide.",
+      "email_too_long": "L'adresse e-mail ne peut pas dépasser {{max}} caractères.",
+      "phone_too_long": "Le numéro de téléphone ne peut pas dépasser {{max}} caractères."
+    },
+    "email": {
+      "connection_failed": "Échec de la connexion : {{detail}}",
+      "not_configured": "L'e-mail n'est pas configuré."
+    },
     "generic": "Une erreur s'est produite",
     "genericMessage": "Une erreur inattendue s'est produite. Réessayez.",
-    "title": "Erreur"
+    "highlight": {
+      "body_too_long": "Le texte du point fort ne peut pas dépasser {{max}} caractères.",
+      "link_invalid": "Le lien du point fort doit être une URL absolue valide (http, https, mailto, tel ou sms).",
+      "title_required": "Le titre du point fort ne peut pas être vide.",
+      "title_too_long": "Le titre du point fort ne peut pas dépasser {{max}} caractères."
+    },
+    "hold": {
+      "ambiguous_group_and_table": "Indiquez soit TableId, soit TableGroupId, mais pas les deux.",
+      "auto_assign_seats_required": "Le nombre de convives est requis pour l'attribution automatique afin que le serveur choisisse une table adaptée.",
+      "group_seats_required": "Le nombre de convives est requis pour une réservation de groupe afin que le serveur vérifie la capacité combinée.",
+      "unavailable": "Réservation temporaire indisponible."
+    },
+    "icon": {
+      "invalid": "La clé d'icône doit correspondre à l'une des icônes prises en charge."
+    },
+    "media": {
+      "hero_too_large": "L'image principale doit faire moins de 5 Mo.",
+      "location_image_too_large": "L'image de l'établissement doit faire moins de 2 Mo.",
+      "menu_too_large": "Le fichier du menu doit faire moins de 10 Mo.",
+      "unsupported_image_type": "Seules les images JPEG, PNG et WebP sont acceptées.",
+      "unsupported_menu_type": "Seuls les menus au format PDF sont acceptés."
+    },
+    "restaurant": {
+      "archive_before_delete": "Archivez cet établissement avant de le supprimer. L'archivage le retire du site public et peut être annulé ; la suppression non.",
+      "booking_ref_format_invalid": "BookingRefFormat doit être l'une des valeurs suivantes : {{allowed}}.",
+      "closed_at_time": "Le restaurant est fermé à l'horaire demandé.",
+      "duration_invalid": "DefaultBookingDurationMinutes doit être l'une des valeurs suivantes : {{allowed}}.",
+      "menu_url_invalid": "L'URL du menu doit être une URL http(s) absolue valide.",
+      "name_required": "Le nom est obligatoire.",
+      "no_sections": "Restaurant introuvable ou sans salle.",
+      "not_found": "Restaurant invalide.",
+      "open_hours_day_invalid": "Les entrées OpenHours doivent utiliser les numéros de jour ISO de 1 (lundi) à 7 (dimanche).",
+      "open_hours_duplicate_day": "OpenHours contient plusieurs entrées pour le jour {{day}}.",
+      "open_hours_time_invalid": "Les horaires OpenHours doivent être des valeurs HH:mm valides (00:00–23:59).",
+      "oversize_cap_invalid": "MaxTableOversizeSeats doit être supérieur ou égal à zéro, ou null pour désactiver.",
+      "section_ids_mismatch": "sectionIds doit contenir exactement les salles actuelles du restaurant, sans doublon.",
+      "slot_interval_invalid": "BookingSlotIntervalMinutes doit être l'une des valeurs suivantes : {{allowed}}.",
+      "walk_in_days_invalid": "WalkInDays doit être une liste de numéros de jour ISO de 1 (lundi) à 7 (dimanche), séparés par des virgules."
+    },
+    "social_link": {
+      "label_required": "Le libellé du lien social ne peut pas être vide.",
+      "label_too_long": "Le libellé du lien social ne peut pas dépasser {{max}} caractères.",
+      "url_invalid": "L'URL du lien social doit être une URL absolue valide (http, https, mailto, tel ou sms).",
+      "url_required": "L'URL du lien social ne peut pas être vide."
+    },
+    "table": {
+      "oversize_cap": "Cette table compte {{seats}} places, ce qui est trop grand pour un groupe de {{partySize}} personnes.",
+      "seats_exceeded": "Cette table ne compte que {{seats}} places, mais {{requested}} convives ont été demandés.",
+      "seats_out_of_range": "Le nombre de places doit être compris entre {{min}} et {{max}}."
+    },
+    "table_group": {
+      "booking_conflict": "L'une des tables combinées est déjà réservée pour cet horaire.",
+      "combined_seats_exceeds_sum": "CombinedSeats ({{combined}}) ne peut pas dépasser la somme des places des tables membres ({{sum}}).",
+      "combined_seats_not_worth_combining": "CombinedSeats ({{combined}}) doit être supérieur à la plus grande table membre ({{largest}}). Combiner ces tables ne permettrait pas d'accueillir un groupe plus grand.",
+      "disbanded": "Ces tables ne peuvent plus être combinées. Veuillez choisir un autre horaire ou une autre table.",
+      "duplicate_member": "Un groupe de tables combinables ne peut pas contenir deux fois la même table.",
+      "hold_conflict": "L'une des tables combinées est déjà réservée par un autre utilisateur. Veuillez réessayer dans un instant.",
+      "invalid_members": "Toutes les tables membres doivent exister et appartenir à ce restaurant.",
+      "member_already_grouped": "La table {{tableId}} appartient déjà à un autre groupe combinable ({{groupId}}).",
+      "min_members": "Un groupe de tables combinables doit compter au moins deux membres.",
+      "no_members": "Ce groupe de tables n'a aucun membre.",
+      "not_found": "Groupe de tables introuvable.",
+      "oversize_cap": "Ce groupe compte {{seats}} places combinées, ce qui est trop grand pour un groupe de {{partySize}} personnes.",
+      "seats_exceeded": "Ce groupe ne compte que {{seats}} places combinées, mais {{requested}} convives ont été demandés."
+    },
+    "title": "Erreur",
+    "user": {
+      "cannot_change_own_role": "Vous ne pouvez pas modifier votre propre rôle.",
+      "cannot_deactivate_self": "Vous ne pouvez pas désactiver votre propre compte.",
+      "display_name_too_long": "Le nom affiché ne peut pas dépasser {{max}} caractères.",
+      "email_already_exists": "Un compte avec cette adresse e-mail existe déjà.",
+      "email_invalid": "Une adresse e-mail valide est requise.",
+      "email_too_long": "L'adresse e-mail ne peut pas dépasser {{max}} caractères.",
+      "last_active_owner_deactivate": "Impossible de désactiver le dernier propriétaire actif. Promouvez d'abord un autre utilisateur.",
+      "last_active_owner_demote": "Impossible de rétrograder le dernier propriétaire actif. Promouvez d'abord un autre utilisateur.",
+      "not_found": "Utilisateur {{id}} introuvable.",
+      "password_too_short": "Le mot de passe doit comporter au moins {{min}} caractères.",
+      "role_invalid": "Le rôle doit être l'une des valeurs suivantes : {{allowed}}."
+    }
   },
   "lookup": {
     "cancelModal": {

--- a/openresto-frontend/tests/api/errors.test.ts
+++ b/openresto-frontend/tests/api/errors.test.ts
@@ -1,0 +1,65 @@
+import i18n from "@/i18n";
+import { apiErrorMessage } from "@/api/errors";
+
+describe("apiErrorMessage", () => {
+  afterEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  it("translates a known code into the active language", async () => {
+    await i18n.changeLanguage("fr");
+
+    expect(
+      apiErrorMessage(
+        { message: "Cannot create a booking in the past.", code: "booking.past_date" },
+        "fallback"
+      )
+    ).toBe("Impossible de créer une réservation dans le passé.");
+  });
+
+  it("interpolates args into the translated sentence", async () => {
+    await i18n.changeLanguage("fr");
+
+    // The English sentence arrives with the numbers already baked in; args is the only way the
+    // French one can name the same two.
+    expect(
+      apiErrorMessage(
+        {
+          message: "This table only has 4 seats, but 6 guests were requested.",
+          code: "table.seats_exceeded",
+          args: { seats: 4, requested: 6 },
+        },
+        "fallback"
+      )
+    ).toBe("Cette table ne compte que 4 places, mais 6 convives ont été demandés.");
+  });
+
+  it("keeps the server's message for a code with no copy yet", () => {
+    // Degrades to today's English rather than rendering a raw key.
+    expect(
+      apiErrorMessage(
+        { message: "Some new rule rejected this.", code: "booking.not_a_real_code" },
+        "fallback"
+      )
+    ).toBe("Some new rule rejected this.");
+  });
+
+  it("keeps the server's message when the response carries no code", () => {
+    expect(apiErrorMessage({ message: "Legacy rejection." }, "fallback")).toBe("Legacy rejection.");
+  });
+
+  it("falls back when the response carried no message at all", () => {
+    expect(apiErrorMessage({}, "Request failed.")).toBe("Request failed.");
+    expect(apiErrorMessage(null, "Request failed.")).toBe("Request failed.");
+  });
+
+  it("translates the same code differently per language", async () => {
+    const body = { message: "Table group not found.", code: "table_group.not_found" };
+
+    await i18n.changeLanguage("de");
+    expect(apiErrorMessage(body, "fallback")).toBe("Tischgruppe nicht gefunden.");
+
+    await i18n.changeLanguage("es");
+    expect(apiErrorMessage(body, "fallback")).toBe("Grupo de mesas no encontrado.");
+  });
+});

--- a/openresto-frontend/tests/app/admin/bookings-index.test.tsx
+++ b/openresto-frontend/tests/app/admin/bookings-index.test.tsx
@@ -261,6 +261,33 @@ describe("AdminBookingsScreen", () => {
     });
   });
 
+  it("shows search results as a list even when the timetable is the persisted view", async () => {
+    // The timetable draws one location on one day; a search matches across all of both, so it
+    // has nothing to render the matches in. Persist timetable explicitly so the assertion is
+    // about the search overriding it, not about whichever mode a previous test left behind.
+    localStorage.setItem("bookings:viewMode", JSON.stringify("timetable"));
+    mockSearchParams.query = "john@example.com";
+
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByText("Search Results")).toBeTruthy());
+    expect(screen.getByText("john@example.com")).toBeTruthy();
+  });
+
+  it("hides the view toggle and status tabs while a search is active", async () => {
+    // The search fetch ignores location, status and view mode, so a control that appears to
+    // filter it would do nothing at all.
+    localStorage.setItem("bookings:viewMode", JSON.stringify("timetable"));
+    mockSearchParams.query = "john@example.com";
+
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByText("Search Results")).toBeTruthy());
+    expect(screen.queryByTestId("view-toggle-timetable")).toBeNull();
+    expect(screen.queryByTestId("view-toggle-list")).toBeNull();
+    expect(screen.queryByText("Past")).toBeNull();
+  });
+
   it("shows clear button when searchQuery is present", async () => {
     mockSearchParams.query = "john@example.com";
     render(<AdminBookingsScreen />);


### PR DESCRIPTION
## Summary

Closes the largest remaining gap in the i18n story — server rejections were English in every locale — and fixes a booking-search bug found alongside it.

## Related issue

Closes #

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

### Server rejections now render in the viewer's language

Every rejection the API returned was English regardless of the UI language: a French guest hitting a paused restaurant or a table conflict read `Bookings are paused until 19:00.` under an otherwise French page, because the frontend passed `body.message` straight through. The error codes added in #375 were the intended fix and nothing consumed them — `errors.*` held three generic keys.

All 105 codes now have copy in `en`, `fr`, `es` and `de`, resolved at **one seam**. `apiErrorMessage(body, fallback)` turns `{message, code, args}` into `t("errors.<code>")`, and the ~17 `api/*.ts` sites that passed the server's message through call it instead. Display sites are untouched — they still receive a string off `Error.message` or `{ ok, message }` — so nothing above the api layer changed. A code with no copy falls back to the server's own wording, so an unlocalized rule degrades to today's English rather than to a raw key.

**Runtime values travel as `Args`.** A client rendering its own sentence cannot recover `4` and `6` out of the finished English one, so the ~21 throw sites that interpolate anything now supply the values under the placeholder names the copy uses. `Args` is additive, omitted when the message is a constant (most of them), and serialized beside `Code`.

**Two messages turned out to be two rules wearing one code.** A client cannot branch on an argument being absent, nor translate an English verb handed to it mid-sentence, so these split: a pause with an end (`booking.paused`, carrying `until`) versus one without (`booking.paused_indefinitely`); and `demote` versus `deactivate` on the last active Owner, whose message also interpolated the untranslated role name. Both follow the rule `ErrorCodes` already states — one constant per distinct rule. The codes are unreleased (#375 landed after v1.8.0), so this costs no compatibility.

### Booking search went to the timetable instead of the list

Searching from the sidebar or the lookup bar navigates to `/admin/bookings?query=…`, which fetches matches across every location and every date. The body still rendered by the persisted `viewMode`, which defaults to timetable — so the header read "Search Results — N matches for X" above a timetable of one location on one day that had never heard of the search. The matches were fetched, held in state, and never drawn.

The timetable cannot render that result set, so a search now forces the list. The location chips, status tabs and view toggle come down with it: the search fetch takes none of them into account, so leaving them up offered filters that quietly did nothing. Keyboard row navigation and the post-mutation grid reload read the same effective mode, so the search list is navigable and cancelling a booking from it no longer refetches a grid nothing is showing.

## Not addressed

`BookingResultPanel` calls Nominatim with a hardcoded `Accept-Language: en`. It only reads back lat/lng, so nothing user-visible is affected — noting it rather than widening this PR.

## Testing

- [x] `OpenRestoApi.Tests` pass locally — 1786 passed
- [x] Frontend tests/build pass locally — 201 suites / 2897 tests, `npm run check`, `tsc --noEmit` and `check:doc-links` all clean
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — both search tests were run against the pre-fix screen to confirm they go red there rather than passing vacuously; the resolver is pinned on a known code, on args interpolation, on an unknown code falling back to the server's message, and on the same code differing across `fr`/`de`/`es`; `Args` is pinned as present when interpolated and absent when not. The placeholder-parity test added in #397 is what verified all 105 keys × 3 languages line up.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed — `MessageResponse.Args` and `OpenRestoException.Args` document the contract; `PauseHelper` and the `ErrorCodes` split carry their reasoning

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKSfj9nPxRWkNav3xe32oC)_