### PR TITLE
Show front of house who is sitting where, right now

### DIFF
--- a/openresto-frontend/app/admin/bookings/index.tsx
+++ b/openresto-frontend/app/admin/bookings/index.tsx
@@ -29,6 +29,8 @@ import { theme } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 
 import { AvailabilityGrid } from "@/components/admin/bookings/AvailabilityGrid";
+import { ServiceView } from "@/components/admin/bookings/ServiceView";
+import { GridDateBar } from "@/components/admin/bookings/GridDateBar";
 import { BookingDetailPopup } from "@/components/admin/bookings/BookingDetailPopup";
 import { BookingsWideTable } from "@/components/admin/bookings/BookingsWideTable";
 import { BookingsCardList } from "@/components/admin/bookings/BookingsCardList";
@@ -46,7 +48,17 @@ import { useErrorHandler } from "@/hooks/useErrorHandler";
 import { fmtDate, isoDate } from "@/utils/formatters";
 import { Icon } from "@/components/common/Icon";
 
-type ViewMode = "timetable" | "list";
+type ViewMode = "timetable" | "service" | "list";
+
+/**
+ * Modes drawn from the grid fetch (sections + that day's bookings) rather than the list fetch, so
+ * both have to load the grid on entry, on a location switch and after a mutation.
+ */
+const GRID_MODES: readonly ViewMode[] = ["timetable", "service"];
+
+function usesGrid(mode: ViewMode): boolean {
+  return GRID_MODES.includes(mode);
+}
 
 export default function AdminBookingsScreen() {
   const { t } = useTranslation();
@@ -191,7 +203,7 @@ export default function AdminBookingsScreen() {
     if (id === selectedRestaurantId) return;
     setSelectedRestaurantId(id);
     setPersistedRestaurantId(id);
-    if (viewMode === "timetable") loadGrid(id, gridDate);
+    if (usesGrid(viewMode)) loadGrid(id, gridDate);
   };
 
   // When the user switches status filter, reset the sort to that tab's
@@ -208,14 +220,14 @@ export default function AdminBookingsScreen() {
     setSort(defaultSortFor(statusFilter));
   }, [statusFilter, setSort]);
 
-  const switchToTimetable = () => {
-    setViewMode("timetable");
+  const switchToGridMode = (mode: ViewMode) => {
+    setViewMode(mode);
     if (selectedRestaurantId) loadGrid(selectedRestaurantId, gridDate);
   };
 
   const reconcileAfterBookingMutation = () => {
     setRefreshKey((key) => key + 1);
-    if (selectedRestaurantId && effectiveViewMode === "timetable") {
+    if (selectedRestaurantId && usesGrid(effectiveViewMode)) {
       loadGrid(selectedRestaurantId, gridDate);
     }
   };
@@ -299,14 +311,13 @@ export default function AdminBookingsScreen() {
       {Platform.OS !== "web" && (
         <Stack.Screen
           options={{
-            title:
-              effectiveViewMode === "timetable"
-                ? fmtDate(gridDate)
-                : statusFilter === "past"
-                  ? t("admin.bookings.screenTitle.past")
-                  : statusFilter === "cancelled"
-                    ? t("admin.bookings.screenTitle.cancelled")
-                    : t("admin.bookings.screenTitle.live"),
+            title: usesGrid(effectiveViewMode)
+              ? fmtDate(gridDate)
+              : statusFilter === "past"
+                ? t("admin.bookings.screenTitle.past")
+                : statusFilter === "cancelled"
+                  ? t("admin.bookings.screenTitle.cancelled")
+                  : t("admin.bookings.screenTitle.live"),
           }}
         />
       )}
@@ -446,148 +457,52 @@ export default function AdminBookingsScreen() {
           )}
 
           <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
-            <Pressable
-              testID="view-toggle-timetable"
-              style={[styles.modeBtn, viewMode === "timetable" && { backgroundColor: PRIMARY }]}
-              onPress={switchToTimetable}
-              accessibilityRole="radio"
-              accessibilityLabel={t("admin.bookings.viewToggle.timetableLabel")}
-              accessibilityState={{ checked: viewMode === "timetable" }}
-            >
-              <Icon
-                name="grid-outline"
-                size={15}
-                color={viewMode === "timetable" ? "#fff" : mutedColor}
-              />
-              {isWide && (
-                <ThemedText
-                  style={[
-                    styles.modeBtnText,
-                    { color: viewMode === "timetable" ? "#fff" : mutedColor },
-                  ]}
-                >
-                  {t("admin.bookings.viewToggle.timetable")}
-                </ThemedText>
-              )}
-            </Pressable>
-            <Pressable
-              testID="view-toggle-list"
-              style={[styles.modeBtn, viewMode === "list" && { backgroundColor: PRIMARY }]}
-              onPress={() => setViewMode("list")}
-              accessibilityRole="radio"
-              accessibilityLabel={t("admin.bookings.viewToggle.listLabel")}
-              accessibilityState={{ checked: viewMode === "list" }}
-            >
-              <Icon
-                name="list-outline"
-                size={15}
-                color={viewMode === "list" ? "#fff" : mutedColor}
-              />
-              {isWide && (
-                <ThemedText
-                  style={[styles.modeBtnText, { color: viewMode === "list" ? "#fff" : mutedColor }]}
-                >
-                  {t("admin.bookings.viewToggle.list")}
-                </ThemedText>
-              )}
-            </Pressable>
+            {(
+              [
+                { key: "timetable", icon: "grid-outline" },
+                { key: "service", icon: "restaurant-outline" },
+                { key: "list", icon: "list-outline" },
+              ] as const
+            ).map(({ key, icon }) => (
+              <Pressable
+                key={key}
+                testID={`view-toggle-${key}`}
+                style={[styles.modeBtn, viewMode === key && { backgroundColor: PRIMARY }]}
+                onPress={() => (usesGrid(key) ? switchToGridMode(key) : setViewMode(key))}
+                accessibilityRole="radio"
+                accessibilityLabel={t(`admin.bookings.viewToggle.${key}Label`)}
+                accessibilityState={{ checked: viewMode === key }}
+              >
+                <Icon name={icon} size={15} color={viewMode === key ? "#fff" : mutedColor} />
+                {isWide && (
+                  <ThemedText
+                    style={[styles.modeBtnText, { color: viewMode === key ? "#fff" : mutedColor }]}
+                  >
+                    {t(`admin.bookings.viewToggle.${key}`)}
+                  </ThemedText>
+                )}
+              </Pressable>
+            ))}
           </View>
         </View>
       )}
 
       {loading && effectiveViewMode === "list" ? (
         <ActivityIndicator style={styles.spinner} size="large" color={PRIMARY} />
-      ) : effectiveViewMode === "timetable" ? (
+      ) : usesGrid(effectiveViewMode) ? (
         <View style={[styles.gridCard, { backgroundColor: cardBg, borderColor }]}>
-          <View style={[styles.gridDateBar, { borderBottomColor: borderColor }]}>
-            <Pressable
-              testID="grid-nav-prev"
-              style={styles.gridNavBtn}
-              onPress={() => handleGridDateChange(-1)}
-              accessibilityRole="button"
-              accessibilityLabel={t("admin.bookings.timetable.previousDay")}
-            >
-              <Icon name="chevron-back" size="lg" color={PRIMARY} />
-            </Pressable>
-            <Pressable
-              onPress={resetToToday}
-              style={styles.gridDateLabel}
-              accessibilityRole="button"
-              accessibilityLabel={t("admin.bookings.timetable.jumpToTodayLabel", {
-                date: fmtDate(gridDate),
-              })}
-            >
-              <ThemedText style={styles.gridDateText}>{fmtDate(gridDate)}</ThemedText>
-              {gridDate.toDateString() !== new Date().toDateString() && (
-                <ThemedText style={[styles.gridTodayHint, { color: PRIMARY }]}>
-                  {t("admin.bookings.timetable.tapForToday")}
-                </ThemedText>
-              )}
-            </Pressable>
-            <Pressable
-              testID="grid-nav-next"
-              style={styles.gridNavBtn}
-              onPress={() => handleGridDateChange(1)}
-              accessibilityRole="button"
-              accessibilityLabel={t("admin.bookings.timetable.nextDay")}
-            >
-              <Icon name="chevron-forward" size="lg" color={PRIMARY} />
-            </Pressable>
-          </View>
-
-          <View style={[styles.gridLegend, { borderBottomColor: borderColor }]}>
-            <View
-              style={[
-                styles.legendItem,
-                {
-                  backgroundColor: `${PRIMARY}22`,
-                  borderRadius: 6,
-                  paddingHorizontal: 8,
-                  paddingVertical: 4,
-                },
-              ]}
-            >
-              <View style={[styles.legendDot, { backgroundColor: PRIMARY }]} />
-              <ThemedText style={[styles.legendText, { color: mutedColor }]}>
-                {t("admin.bookings.timetable.legend.seatedNow")}
-              </ThemedText>
-            </View>
-            <View
-              style={[
-                styles.legendItem,
-                { borderRadius: 6, paddingHorizontal: 8, paddingVertical: 4 },
-              ]}
-            >
-              <View style={[styles.legendDot, { backgroundColor: `${PRIMARY}44` }]} />
-              <ThemedText style={[styles.legendText, { color: mutedColor }]}>
-                {t("admin.bookings.timetable.legend.booked")}
-              </ThemedText>
-            </View>
-            <View
-              style={[
-                styles.legendItem,
-                { borderRadius: 6, paddingHorizontal: 8, paddingVertical: 4 },
-              ]}
-            >
-              <View
-                style={[
-                  styles.legendDot,
-                  { width: 3, backgroundColor: colors.error, borderRadius: 0 },
-                ]}
-              />
-              <ThemedText style={[styles.legendText, { color: mutedColor }]}>
-                {t("admin.bookings.timetable.legend.now")}
-              </ThemedText>
-            </View>
-            <ThemedText style={[styles.legendText, { color: mutedColor, marginLeft: 4 }]}>
-              {t("admin.bookings.timetable.legend.tapHint")}
-            </ThemedText>
-          </View>
+          <GridDateBar
+            date={gridDate}
+            onChangeDay={handleGridDateChange}
+            onResetToToday={resetToToday}
+            borderColor={borderColor}
+            primaryColor={PRIMARY}
+          />
 
           {gridLoading ? (
             <ActivityIndicator style={{ padding: 40 }} size="large" color={PRIMARY} />
-          ) : (
-            <AvailabilityGrid
+          ) : effectiveViewMode === "service" ? (
+            <ServiceView
               sections={gridSections}
               bookings={gridBookings}
               isDark={isDark}
@@ -600,6 +515,70 @@ export default function AdminBookingsScreen() {
               gridDateIso={isoDate(gridDate)}
               dateLabel={fmtDate(gridDate)}
             />
+          ) : (
+            <>
+              <View style={[styles.gridLegend, { borderBottomColor: borderColor }]}>
+                <View
+                  style={[
+                    styles.legendItem,
+                    {
+                      backgroundColor: `${PRIMARY}22`,
+                      borderRadius: 6,
+                      paddingHorizontal: 8,
+                      paddingVertical: 4,
+                    },
+                  ]}
+                >
+                  <View style={[styles.legendDot, { backgroundColor: PRIMARY }]} />
+                  <ThemedText style={[styles.legendText, { color: mutedColor }]}>
+                    {t("admin.bookings.timetable.legend.seatedNow")}
+                  </ThemedText>
+                </View>
+                <View
+                  style={[
+                    styles.legendItem,
+                    { borderRadius: 6, paddingHorizontal: 8, paddingVertical: 4 },
+                  ]}
+                >
+                  <View style={[styles.legendDot, { backgroundColor: `${PRIMARY}44` }]} />
+                  <ThemedText style={[styles.legendText, { color: mutedColor }]}>
+                    {t("admin.bookings.timetable.legend.booked")}
+                  </ThemedText>
+                </View>
+                <View
+                  style={[
+                    styles.legendItem,
+                    { borderRadius: 6, paddingHorizontal: 8, paddingVertical: 4 },
+                  ]}
+                >
+                  <View
+                    style={[
+                      styles.legendDot,
+                      { width: 3, backgroundColor: colors.error, borderRadius: 0 },
+                    ]}
+                  />
+                  <ThemedText style={[styles.legendText, { color: mutedColor }]}>
+                    {t("admin.bookings.timetable.legend.now")}
+                  </ThemedText>
+                </View>
+                <ThemedText style={[styles.legendText, { color: mutedColor, marginLeft: 4 }]}>
+                  {t("admin.bookings.timetable.legend.tapHint")}
+                </ThemedText>
+              </View>
+              <AvailabilityGrid
+                sections={gridSections}
+                bookings={gridBookings}
+                isDark={isDark}
+                onBookingPress={(b) => openBooking(b.id)}
+                groups={selectedRestaurant?.groups ?? []}
+                openTime={openTime}
+                closeTime={closeTime}
+                timezone={timezone}
+                defaultDurationMinutes={selectedRestaurant?.defaultBookingDurationMinutes ?? 90}
+                gridDateIso={isoDate(gridDate)}
+                dateLabel={fmtDate(gridDate)}
+              />
+            </>
           )}
         </View>
       ) : sorted.length === 0 ? (

--- a/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
+++ b/openresto-frontend/components/admin/bookings/AvailabilityGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { ScrollView, View, Pressable } from "react-native";
 import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
@@ -10,6 +10,7 @@ import { useAppTheme } from "@/hooks/use-app-theme";
 import { hexToRgba } from "@/utils/colors";
 import { Icon } from "@/components/common/Icon";
 import { getNowInTimezone } from "@/utils/date";
+import { useMinuteTick } from "@/hooks/use-minute-tick";
 import {
   buildTimeline,
   buildUnitRows,
@@ -31,23 +32,8 @@ export const LANE_H = 38;
 export const ROW_MIN_H = 48;
 const LANE_GAP = 4;
 const PX_PER_MINUTE = HOUR_W / 60;
-const MINUTE_TICK_MS = 60_000;
-
 function rowHeight(lanes: number): number {
   return Math.max(ROW_MIN_H, lanes * LANE_H + LANE_GAP * 2);
-}
-
-/**
- * Re-renders once a minute so the "now" marker and every bar's remaining time track the clock. A
- * timetable a front-of-house tablet is parked on all service is wrong the moment it stops moving.
- */
-function useMinuteTick(): number {
-  const [tick, setTick] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 1), MINUTE_TICK_MS);
-    return () => clearInterval(id);
-  }, []);
-  return tick;
 }
 
 type SittingState = "past" | "current" | "upcoming";

--- a/openresto-frontend/components/admin/bookings/GridDateBar.tsx
+++ b/openresto-frontend/components/admin/bookings/GridDateBar.tsx
@@ -1,0 +1,64 @@
+import { Pressable, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { ThemedText } from "@/components/themed-text";
+import { Icon } from "@/components/common/Icon";
+import { fmtDate } from "@/utils/formatters";
+import { styles } from "./bookings.styles";
+
+/**
+ * Day navigation for the views drawn from the grid fetch. Shared rather than duplicated because the
+ * timetable and the service view move through the same `gridDate`, and a second copy would let the
+ * two drift apart on a screen where they are one toggle away from each other.
+ */
+export function GridDateBar({
+  date,
+  onChangeDay,
+  onResetToToday,
+  borderColor,
+  primaryColor,
+}: {
+  date: Date;
+  onChangeDay: (delta: number) => void;
+  onResetToToday: () => void;
+  borderColor: string;
+  primaryColor: string;
+}) {
+  const { t } = useTranslation();
+  const isToday = date.toDateString() === new Date().toDateString();
+
+  return (
+    <View style={[styles.gridDateBar, { borderBottomColor: borderColor }]}>
+      <Pressable
+        testID="grid-nav-prev"
+        style={styles.gridNavBtn}
+        onPress={() => onChangeDay(-1)}
+        accessibilityRole="button"
+        accessibilityLabel={t("admin.bookings.timetable.previousDay")}
+      >
+        <Icon name="chevron-back" size="lg" color={primaryColor} />
+      </Pressable>
+      <Pressable
+        onPress={onResetToToday}
+        style={styles.gridDateLabel}
+        accessibilityRole="button"
+        accessibilityLabel={t("admin.bookings.timetable.jumpToTodayLabel", { date: fmtDate(date) })}
+      >
+        <ThemedText style={styles.gridDateText}>{fmtDate(date)}</ThemedText>
+        {!isToday && (
+          <ThemedText style={[styles.gridTodayHint, { color: primaryColor }]}>
+            {t("admin.bookings.timetable.tapForToday")}
+          </ThemedText>
+        )}
+      </Pressable>
+      <Pressable
+        testID="grid-nav-next"
+        style={styles.gridNavBtn}
+        onPress={() => onChangeDay(1)}
+        accessibilityRole="button"
+        accessibilityLabel={t("admin.bookings.timetable.nextDay")}
+      >
+        <Icon name="chevron-forward" size="lg" color={primaryColor} />
+      </Pressable>
+    </View>
+  );
+}

--- a/openresto-frontend/components/admin/bookings/ServiceView.styles.ts
+++ b/openresto-frontend/components/admin/bookings/ServiceView.styles.ts
@@ -54,6 +54,10 @@ export const styles = StyleSheet.create({
   summaryCovers: { ...theme.typography.caption, fontWeight: "600" },
 
   floor: { padding: theme.spacing.lg, gap: theme.spacing.xl },
+  /** Capped inside the page's card, which has the rest of the screen's chrome above it. */
+  floorInset: { maxHeight: 640 },
+  floorExpanded: { flex: 1 },
+  expandedSheet: { flex: 1 },
   section: { gap: theme.spacing.sm },
   sectionLabel: { ...theme.typography.labelSmall, letterSpacing: 0.8 },
   unitGrid: { flexDirection: "row", flexWrap: "wrap", gap: theme.spacing.sm },

--- a/openresto-frontend/components/admin/bookings/ServiceView.styles.ts
+++ b/openresto-frontend/components/admin/bookings/ServiceView.styles.ts
@@ -1,0 +1,97 @@
+import { StyleSheet } from "react-native";
+import { theme } from "@/theme/theme";
+
+/** Keeps a unit card wide enough for a guest name and a time range on one line. */
+export const UNIT_MIN_W = 210;
+
+export const styles = StyleSheet.create({
+  scrubBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.md,
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.md,
+    borderBottomWidth: 1,
+    flexWrap: "wrap",
+  },
+  scrubNavBtn: { ...theme.buttonSizes.icon },
+  scrubClock: {
+    ...theme.typography.bodyBold,
+    fontSize: 18,
+    fontVariant: ["tabular-nums"],
+    minWidth: 72,
+    textAlign: "center",
+  },
+  scrubTrack: {
+    flex: 1,
+    minWidth: 140,
+    height: theme.a11y.minTouchTarget,
+    justifyContent: "center",
+  },
+  scrubRail: { height: 4, borderRadius: theme.borderRadius.full },
+  scrubFill: { position: "absolute", left: 0, height: 4, borderRadius: theme.borderRadius.full },
+  scrubThumb: {
+    position: "absolute",
+    width: 16,
+    height: 16,
+    borderRadius: theme.borderRadius.full,
+    borderWidth: 2,
+    marginLeft: -8,
+  },
+
+  summary: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.lg,
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    flexWrap: "wrap",
+  },
+  summaryItem: { flexDirection: "row", alignItems: "center", gap: 6 },
+  summaryDot: { width: 10, height: 10, borderRadius: theme.borderRadius.full },
+  summaryText: { ...theme.typography.caption },
+  summaryCovers: { ...theme.typography.caption, fontWeight: "600" },
+
+  floor: { padding: theme.spacing.lg, gap: theme.spacing.xl },
+  section: { gap: theme.spacing.sm },
+  sectionLabel: { ...theme.typography.labelSmall, letterSpacing: 0.8 },
+  unitGrid: { flexDirection: "row", flexWrap: "wrap", gap: theme.spacing.sm },
+
+  unitCard: {
+    flexGrow: 1,
+    flexBasis: UNIT_MIN_W,
+    maxWidth: 320,
+    borderWidth: 1,
+    borderLeftWidth: 4,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing.md,
+    gap: 6,
+    minHeight: 108,
+  },
+  unitHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing.sm,
+  },
+  unitName: { ...theme.typography.bodyBold, fontSize: 15 },
+  unitSeats: { ...theme.typography.captionSmall },
+  statusPill: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: theme.borderRadius.full,
+  },
+  statusPillText: { ...theme.typography.captionSmall, fontWeight: "700", letterSpacing: 0.4 },
+
+  guestRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+  guestName: { ...theme.typography.body, fontSize: 14, fontWeight: "600", flexShrink: 1 },
+  guestCovers: { ...theme.typography.captionSmall },
+  sittingTimes: { ...theme.typography.caption, fontVariant: ["tabular-nums"] },
+  remaining: { ...theme.typography.caption, fontWeight: "700" },
+  nextUp: { ...theme.typography.captionSmall },
+
+  empty: { alignItems: "center", paddingVertical: 60, gap: theme.spacing.md },
+  emptyText: { ...theme.typography.body, fontStyle: "italic", textAlign: "center" },
+});

--- a/openresto-frontend/components/admin/bookings/ServiceView.tsx
+++ b/openresto-frontend/components/admin/bookings/ServiceView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  Modal,
   Pressable,
   ScrollView,
   View,
@@ -14,6 +15,7 @@ import Button from "@/components/common/Button";
 import { getThemeColors } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { useMinuteTick } from "@/hooks/use-minute-tick";
+import { useDialogFocus } from "@/hooks/use-dialog-focus";
 import { hexToRgba } from "@/utils/colors";
 import { getNowInTimezone } from "@/utils/date";
 import type { BookingDetailDto, SectionWithTables } from "@/api/admin";
@@ -110,6 +112,13 @@ export function ServiceView({
   /** Null means "follow the clock" — the floor only pins to an offset once staff scrub it. */
   const [scrubbed, setScrubbed] = useState<number | null>(null);
 
+  // A large room runs to more tables than the page's card can show without scrolling, so the floor
+  // can take the whole screen. It is a dialog rather than a wider card because the admin chrome
+  // around it is not what staff are reading during service.
+  const [expanded, setExpanded] = useState(false);
+  const sheetRef = useRef<View>(null);
+  useDialogFocus(expanded, sheetRef);
+
   // A day with no "now" on it (any day but today) has nothing to follow, so the floor opens on its
   // first sitting rather than on the window's edge, which is an hour of empty room by construction.
   const firstSitting = timeline.placements.length
@@ -179,8 +188,8 @@ export function ServiceView({
 
   const hasUnits = rowGroups.some((row) => row.units.length > 0);
 
-  return (
-    <View>
+  const body = (
+    <>
       <View style={[styles.scrubBar, { borderBottomColor: borderColor }]}>
         <IconButton
           name="chevron-back"
@@ -245,6 +254,18 @@ export function ServiceView({
             {t("admin.bookings.service.now")}
           </Button>
         )}
+
+        <IconButton
+          name={expanded ? "contract-outline" : "expand-outline"}
+          accessibilityLabel={t(
+            expanded ? "admin.bookings.service.collapseLabel" : "admin.bookings.service.expandLabel"
+          )}
+          onPress={() => setExpanded((open) => !open)}
+          color={mutedColor}
+          selected={expanded}
+          style={styles.scrubNavBtn}
+          testID="service-expand"
+        />
       </View>
 
       <View style={[styles.summary, { borderBottomColor: borderColor }]}>
@@ -269,7 +290,10 @@ export function ServiceView({
           </ThemedText>
         </View>
       ) : (
-        <ScrollView style={{ maxHeight: 640 }} contentContainerStyle={styles.floor}>
+        <ScrollView
+          style={expanded ? styles.floorExpanded : styles.floorInset}
+          contentContainerStyle={styles.floor}
+        >
           {floor.map((section) => (
             <View key={section.key} style={styles.section}>
               <ThemedText style={[styles.sectionLabel, { color: mutedColor }]}>
@@ -302,7 +326,26 @@ export function ServiceView({
           )}
         </ScrollView>
       )}
-    </View>
+    </>
+  );
+
+  if (!expanded) return <View>{body}</View>;
+
+  return (
+    <Modal visible animationType="fade" onRequestClose={() => setExpanded(false)}>
+      <View
+        ref={sheetRef}
+        role="dialog"
+        aria-modal
+        accessibilityViewIsModal
+        accessibilityLabel={t("admin.bookings.service.expandedLabel")}
+        tabIndex={-1}
+        style={[styles.expandedSheet, { backgroundColor: colors.page }]}
+        testID="service-expanded"
+      >
+        {body}
+      </View>
+    </Modal>
   );
 }
 

--- a/openresto-frontend/components/admin/bookings/ServiceView.tsx
+++ b/openresto-frontend/components/admin/bookings/ServiceView.tsx
@@ -1,0 +1,416 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Pressable,
+  ScrollView,
+  View,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+} from "react-native";
+import { useTranslation } from "react-i18next";
+import { ThemedText } from "@/components/themed-text";
+import { Icon } from "@/components/common/Icon";
+import { IconButton } from "@/components/common/IconButton";
+import Button from "@/components/common/Button";
+import { getThemeColors } from "@/theme/theme";
+import { useAppTheme } from "@/hooks/use-app-theme";
+import { useMinuteTick } from "@/hooks/use-minute-tick";
+import { hexToRgba } from "@/utils/colors";
+import { getNowInTimezone } from "@/utils/date";
+import type { BookingDetailDto, SectionWithTables } from "@/api/admin";
+import type { TableGroupDto } from "@/api/restaurants";
+import {
+  buildTimeline,
+  buildUnitRows,
+  clockMinutesAt,
+  formatClockMinutes,
+  nowOffset,
+  unitKeyFor,
+  UNASSIGNED_KEY,
+  type TimelinePlacement,
+} from "@/utils/bookingTimeline";
+import {
+  buildServiceFloor,
+  splitDuration,
+  summarise,
+  type UnitOccupancy,
+  type UnitStatus,
+} from "@/utils/serviceView";
+import { styles } from "./ServiceView.styles";
+
+/** Scrub granularity. Coarser than a minute so a drag across a service lands on readable times. */
+const SCRUB_STEP_MINUTES = 15;
+
+function snap(offset: number, min: number, max: number): number {
+  const stepped = Math.round(offset / SCRUB_STEP_MINUTES) * SCRUB_STEP_MINUTES;
+  return Math.min(max, Math.max(min, stepped));
+}
+
+export function ServiceView({
+  sections,
+  groups = [],
+  bookings,
+  isDark,
+  onBookingPress,
+  openTime = "11:00",
+  closeTime = "23:00",
+  timezone = "UTC",
+  defaultDurationMinutes = 90,
+  gridDateIso,
+  dateLabel,
+}: {
+  sections: SectionWithTables[];
+  /** Combinable groups for the location; each is a bookable unit beside its member tables. */
+  groups?: TableGroupDto[];
+  bookings: BookingDetailDto[];
+  isDark: boolean;
+  onBookingPress: (b: BookingDetailDto) => void;
+  openTime?: string;
+  closeTime?: string;
+  timezone?: string;
+  /** Sitting length assumed for a booking stored without an end time. */
+  defaultDurationMinutes?: number;
+  /** The day being shown ("YYYY-MM-DD"). Scrubbing starts at now only on the location's today. */
+  gridDateIso?: string;
+  /** Human-readable form of the same day, named in the empty state. */
+  dateLabel?: string;
+}) {
+  const { t } = useTranslation();
+  const tick = useMinuteTick();
+  const colors = getThemeColors(isDark);
+  const { primaryColor: PRIMARY } = useAppTheme();
+
+  const borderColor = colors.border;
+  const mutedColor = colors.muted;
+  const cardBg = colors.card;
+
+  // `tick` is the dependency: the clock is read fresh each minute so a floor left on "now"
+  // advances through service without a refetch.
+  const nowMinutes = useMemo(() => {
+    const local = getNowInTimezone(timezone);
+    if (gridDateIso && gridDateIso !== local.dateStr) return null;
+    return local.hours * 60 + local.minutes;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timezone, gridDateIso, tick]);
+
+  const timeline = useMemo(
+    () =>
+      buildTimeline({
+        openTime,
+        closeTime,
+        timezone,
+        bookings,
+        defaultDurationMinutes,
+        nowMinutes,
+      }),
+    [openTime, closeTime, timezone, bookings, defaultDurationMinutes, nowMinutes]
+  );
+
+  const now = nowOffset(timeline, openTime, nowMinutes);
+
+  /** Null means "follow the clock" — the floor only pins to an offset once staff scrub it. */
+  const [scrubbed, setScrubbed] = useState<number | null>(null);
+
+  // A day with no "now" on it (any day but today) has nothing to follow, so the floor opens on its
+  // first sitting rather than on the window's edge, which is an hour of empty room by construction.
+  const firstSitting = timeline.placements.length
+    ? Math.min(...timeline.placements.map((p) => p.startOffset))
+    : null;
+  const at = scrubbed ?? now ?? firstSitting ?? timeline.startOffset;
+  const isLive = scrubbed == null && now != null;
+
+  // Scrubbing is per day and per location: an offset picked against one service window means
+  // nothing on the next, and leaving it pinned would show a stale hour as if it were now.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setScrubbed(null);
+  }, [gridDateIso, openTime, closeTime, timezone]);
+
+  const hasUnassigned = bookings.some((b) => unitKeyFor(b) === UNASSIGNED_KEY);
+  const rowGroups = useMemo(
+    () => buildUnitRows(sections, groups, { includeUnassigned: hasUnassigned }),
+    [sections, groups, hasUnassigned]
+  );
+
+  const floor = useMemo(
+    () => buildServiceFloor({ rows: rowGroups, placements: timeline.placements, at }),
+    [rowGroups, timeline, at]
+  );
+  const summary = useMemo(() => summarise(floor), [floor]);
+
+  const statusColors: Record<UnitStatus, string> = {
+    seated: PRIMARY,
+    turning: colors.warning,
+    free: mutedColor,
+  };
+
+  const duration = (minutes: number): string => {
+    const parts = splitDuration(minutes);
+    if (parts.hours === 0) return t("admin.bookings.service.durationM", { minutes: parts.minutes });
+    if (parts.minutes === 0) return t("admin.bookings.service.durationH", { hours: parts.hours });
+    return t("admin.bookings.service.durationHm", parts);
+  };
+
+  const clock = (offset: number): string => formatClockMinutes(clockMinutesAt(openTime, offset));
+
+  // --- Scrubber -------------------------------------------------------------------------------
+
+  const [trackW, setTrackW] = useState(0);
+  const span = Math.max(1, timeline.endOffset - timeline.startOffset);
+  const trackRef = useRef({ width: 0, span, start: timeline.startOffset, end: timeline.endOffset });
+  trackRef.current = { width: trackW, span, start: timeline.startOffset, end: timeline.endOffset };
+
+  // Raw responder props rather than a PanResponder: the scrubber only needs where the finger is,
+  // not a gesture's velocity or touch history, and this way press and drag are the same handler.
+  const scrubTo = (e: GestureResponderEvent) => {
+    const { width, span: s, start, end } = trackRef.current;
+    if (width <= 0) return;
+    const ratio = Math.min(1, Math.max(0, e.nativeEvent.locationX / width));
+    setScrubbed(snap(start + ratio * s, start, end));
+  };
+
+  const step = (delta: number) =>
+    setScrubbed(snap(at + delta * SCRUB_STEP_MINUTES, timeline.startOffset, timeline.endOffset));
+
+  const thumbRatio = (at - timeline.startOffset) / span;
+
+  const onTrackLayout = (e: LayoutChangeEvent) => setTrackW(e.nativeEvent.layout.width);
+
+  // --- Render ---------------------------------------------------------------------------------
+
+  const hasUnits = rowGroups.some((row) => row.units.length > 0);
+
+  return (
+    <View>
+      <View style={[styles.scrubBar, { borderBottomColor: borderColor }]}>
+        <IconButton
+          name="chevron-back"
+          accessibilityLabel={t("admin.bookings.service.earlier", { minutes: SCRUB_STEP_MINUTES })}
+          onPress={() => step(-1)}
+          color={mutedColor}
+          style={styles.scrubNavBtn}
+          testID="service-scrub-back"
+        />
+        <ThemedText
+          style={[styles.scrubClock, { color: colors.text }]}
+          testID="service-scrub-clock"
+        >
+          {clock(at)}
+        </ThemedText>
+
+        <View
+          style={styles.scrubTrack}
+          onLayout={onTrackLayout}
+          accessibilityRole="adjustable"
+          accessibilityLabel={t("admin.bookings.service.scrubLabel")}
+          accessibilityValue={{ text: clock(at) }}
+          testID="service-scrub-track"
+          onStartShouldSetResponder={() => true}
+          onMoveShouldSetResponder={() => true}
+          onResponderGrant={scrubTo}
+          onResponderMove={scrubTo}
+        >
+          <View style={[styles.scrubRail, { backgroundColor: hexToRgba(mutedColor, 0.25) }]} />
+          <View
+            style={[styles.scrubFill, { width: `${thumbRatio * 100}%`, backgroundColor: PRIMARY }]}
+          />
+          <View
+            style={[
+              styles.scrubThumb,
+              {
+                left: `${thumbRatio * 100}%`,
+                backgroundColor: PRIMARY,
+                borderColor: cardBg,
+              },
+            ]}
+          />
+        </View>
+
+        <IconButton
+          name="chevron-forward"
+          accessibilityLabel={t("admin.bookings.service.later", { minutes: SCRUB_STEP_MINUTES })}
+          onPress={() => step(1)}
+          color={mutedColor}
+          style={styles.scrubNavBtn}
+          testID="service-scrub-forward"
+        />
+
+        {now != null && (
+          <Button
+            size="sm"
+            variant={isLive ? "primary" : "secondary"}
+            onPress={() => setScrubbed(null)}
+            accessibilityLabel={t("admin.bookings.service.backToNowLabel")}
+            testID="service-scrub-now"
+          >
+            {t("admin.bookings.service.now")}
+          </Button>
+        )}
+      </View>
+
+      <View style={[styles.summary, { borderBottomColor: borderColor }]}>
+        {(["seated", "turning", "free"] as const).map((status) => (
+          <View key={status} style={styles.summaryItem}>
+            <View style={[styles.summaryDot, { backgroundColor: statusColors[status] }]} />
+            <ThemedText style={[styles.summaryText, { color: mutedColor }]}>
+              {t(`admin.bookings.service.summary.${status}`, { count: summary[status] })}
+            </ThemedText>
+          </View>
+        ))}
+        <ThemedText style={[styles.summaryCovers, { color: colors.text }]} testID="service-covers">
+          {t("admin.bookings.service.summary.covers", { count: summary.covers })}
+        </ThemedText>
+      </View>
+
+      {!hasUnits ? (
+        <View style={styles.empty}>
+          <Icon name="grid-outline" size={40} color={mutedColor} />
+          <ThemedText style={[styles.emptyText, { color: mutedColor }]}>
+            {t("admin.bookings.timetable.noTablesFound")}
+          </ThemedText>
+        </View>
+      ) : (
+        <ScrollView style={{ maxHeight: 640 }} contentContainerStyle={styles.floor}>
+          {floor.map((section) => (
+            <View key={section.key} style={styles.section}>
+              <ThemedText style={[styles.sectionLabel, { color: mutedColor }]}>
+                {section.name.toUpperCase()}
+              </ThemedText>
+              <View style={styles.unitGrid}>
+                {section.units.map((occupancy) => (
+                  <UnitCard
+                    key={occupancy.unit.key}
+                    occupancy={occupancy}
+                    accent={statusColors[occupancy.status]}
+                    cardBg={cardBg}
+                    borderColor={borderColor}
+                    mutedColor={mutedColor}
+                    textColor={colors.text}
+                    onPress={onBookingPress}
+                    clock={clock}
+                    duration={duration}
+                  />
+                ))}
+              </View>
+            </View>
+          ))}
+          {bookings.length === 0 && (
+            <ThemedText style={[styles.emptyText, { color: mutedColor }]}>
+              {dateLabel
+                ? t("admin.bookings.timetable.noBookingsOnDay", { date: dateLabel })
+                : t("admin.bookings.timetable.noBookingsGeneric")}
+            </ThemedText>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+function UnitCard({
+  occupancy,
+  accent,
+  cardBg,
+  borderColor,
+  mutedColor,
+  textColor,
+  onPress,
+  clock,
+  duration,
+}: {
+  occupancy: UnitOccupancy;
+  accent: string;
+  cardBg: string;
+  borderColor: string;
+  mutedColor: string;
+  textColor: string;
+  onPress: (b: BookingDetailDto) => void;
+  clock: (offset: number) => string;
+  duration: (minutes: number) => string;
+}) {
+  const { t } = useTranslation();
+  const { unit, status, current, next, minutesRemaining, minutesUntilNext } = occupancy;
+  const openable: TimelinePlacement | null = current ?? next;
+
+  // Same fallback chain as the timetable, so one guest is never two different names across the
+  // two views of the same service.
+  const guest = (placement: TimelinePlacement) =>
+    placement.booking.customerName ||
+    placement.booking.customerEmail?.split("@")[0] ||
+    t("admin.bookings.timetable.guestFallback");
+
+  return (
+    <Pressable
+      accessibilityRole={openable ? "button" : undefined}
+      accessibilityLabel={
+        current
+          ? t("admin.bookings.service.seatedUnitLabel", {
+              unit: unit.name,
+              guest: guest(current),
+              seats: current.booking.seats,
+              remaining: duration(minutesRemaining),
+            })
+          : t("admin.bookings.service.freeUnitLabel", { unit: unit.name })
+      }
+      disabled={!openable}
+      onPress={() => openable && onPress(openable.booking)}
+      testID={`service-unit-${unit.key}`}
+      style={[
+        styles.unitCard,
+        { backgroundColor: cardBg, borderColor, borderLeftColor: accent },
+        status === "seated" && { backgroundColor: hexToRgba(accent, 0.07) },
+      ]}
+    >
+      <View style={styles.unitHeader}>
+        <ThemedText style={[styles.unitName, { color: textColor }]} numberOfLines={1}>
+          {unit.name}
+        </ThemedText>
+        {unit.seats != null && (
+          <ThemedText style={[styles.unitSeats, { color: mutedColor }]}>
+            {t("admin.bookings.timetable.peopleAbbrev", { count: unit.seats })}
+          </ThemedText>
+        )}
+      </View>
+
+      <View style={[styles.statusPill, { backgroundColor: hexToRgba(accent, 0.16) }]}>
+        <ThemedText style={[styles.statusPillText, { color: accent }]}>
+          {t(`admin.bookings.service.status.${status}`)}
+        </ThemedText>
+      </View>
+
+      {current ? (
+        <>
+          <View style={styles.guestRow}>
+            <ThemedText style={[styles.guestName, { color: textColor }]} numberOfLines={1}>
+              {guest(current)}
+            </ThemedText>
+            <ThemedText style={[styles.guestCovers, { color: mutedColor }]}>
+              {t("admin.bookings.timetable.peopleAbbrev", { count: current.booking.seats })}
+            </ThemedText>
+          </View>
+          <ThemedText style={[styles.sittingTimes, { color: mutedColor }]}>
+            {t("admin.bookings.service.sittingRange", {
+              start: clock(current.startOffset),
+              end: clock(current.endOffset),
+            })}
+          </ThemedText>
+          <ThemedText style={[styles.remaining, { color: accent }]}>
+            {t("admin.bookings.service.remaining", { duration: duration(minutesRemaining) })}
+          </ThemedText>
+        </>
+      ) : null}
+
+      {next && minutesUntilNext != null ? (
+        <ThemedText style={[styles.nextUp, { color: mutedColor }]} numberOfLines={1}>
+          {t("admin.bookings.service.nextUp", {
+            time: clock(next.startOffset),
+            duration: duration(minutesUntilNext),
+          })}
+        </ThemedText>
+      ) : !current ? (
+        <ThemedText style={[styles.nextUp, { color: mutedColor }]}>
+          {t("admin.bookings.service.nothingElse")}
+        </ThemedText>
+      ) : null}
+    </Pressable>
+  );
+}

--- a/openresto-frontend/hooks/use-bookings-grid.ts
+++ b/openresto-frontend/hooks/use-bookings-grid.ts
@@ -10,8 +10,8 @@ import { isoDate } from "@/utils/formatters";
 export interface UseBookingsGridOptions {
   /** Currently selected restaurant; the grid (re)loads when this changes. */
   restaurantId: number | null;
-  /** Active view mode — the grid only loads on restaurant change when this is "timetable". */
-  viewMode: "timetable" | "list";
+  /** Active view mode — the grid only loads on restaurant change for a grid-backed mode. */
+  viewMode: "timetable" | "service" | "list";
 }
 
 export interface UseBookingsGridResult {
@@ -76,9 +76,9 @@ export function useBookingsGrid({
     if (restaurantId) loadGrid(restaurantId, today);
   }, [restaurantId, loadGrid]);
 
-  // Load timetable on mount / when the selected restaurant changes (only in timetable view).
+  // Load the grid on mount / when the selected restaurant changes (grid-backed views only).
   useEffect(() => {
-    if (restaurantId && viewMode === "timetable") {
+    if (restaurantId && viewMode !== "list") {
       loadGrid(restaurantId, gridDate);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/openresto-frontend/hooks/use-minute-tick.ts
+++ b/openresto-frontend/hooks/use-minute-tick.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+const MINUTE_TICK_MS = 60_000;
+
+/**
+ * Re-renders once a minute so a clock-derived view tracks the clock. A screen a front-of-house
+ * tablet is parked on all service is wrong the moment it stops moving.
+ *
+ * The returned counter is not a time — it exists only to invalidate memos that read the clock
+ * themselves, so callers still resolve "now" through the restaurant's timezone rather than this.
+ */
+export function useMinuteTick(): number {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), MINUTE_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return tick;
+}

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -680,6 +680,9 @@
         "earlier": "{{minutes}} Minuten früher",
         "later": "{{minutes}} Minuten später",
         "scrubLabel": "Im Raum angezeigte Uhrzeit",
+        "expandLabel": "Raumplan im Vollbild anzeigen",
+        "collapseLabel": "Raumplan wieder einbetten",
+        "expandedLabel": "Raumplan, Vollbild",
         "status": {
           "seated": "Belegt",
           "turning": "Wechsel",

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -651,7 +651,9 @@
         "timetable": "Zeitplan",
         "list": "Liste",
         "timetableLabel": "Zeitplanansicht",
-        "listLabel": "Listenansicht"
+        "listLabel": "Listenansicht",
+        "service": "Service",
+        "serviceLabel": "Serviceansicht"
       },
       "timetable": {
         "previousDay": "Vorheriger Tag",
@@ -671,6 +673,37 @@
         "peopleAbbrev": "{{count}}P",
         "sittingLabel": "{{guest}}, {{seats}} Gedecke an {{unit}}, {{start}} bis {{end}}",
         "sittingLabelWithRemaining": "{{guest}}, {{seats}} Gedecke an {{unit}}, {{start}} bis {{end}}, {{remaining}}"
+      },
+      "service": {
+        "now": "Jetzt",
+        "backToNowLabel": "Der aktuellen Uhrzeit folgen",
+        "earlier": "{{minutes}} Minuten früher",
+        "later": "{{minutes}} Minuten später",
+        "scrubLabel": "Im Raum angezeigte Uhrzeit",
+        "status": {
+          "seated": "Belegt",
+          "turning": "Wechsel",
+          "free": "Frei"
+        },
+        "summary": {
+          "seated_one": "{{count}} belegt",
+          "seated_other": "{{count}} belegt",
+          "turning_one": "{{count}} im Wechsel",
+          "turning_other": "{{count}} im Wechsel",
+          "free_one": "{{count}} frei",
+          "free_other": "{{count}} frei",
+          "covers_one": "{{count}} Gedeck",
+          "covers_other": "{{count}} Gedecke"
+        },
+        "sittingRange": "{{start}} – {{end}}",
+        "remaining": "noch {{duration}}",
+        "nextUp": "Nächste {{time}} · in {{duration}}",
+        "nothingElse": "Heute nichts weiter",
+        "durationHm": "{{hours}} Std. {{minutes}} Min.",
+        "durationH": "{{hours}} Std.",
+        "durationM": "{{minutes}} Min.",
+        "seatedUnitLabel": "{{unit}}, {{guest}}, {{seats}} Gedecke, noch {{remaining}}",
+        "freeUnitLabel": "{{unit}}, frei"
       },
       "sort": {
         "time": "Uhrzeit",

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -680,6 +680,9 @@
         "earlier": "{{minutes}} minutes earlier",
         "later": "{{minutes}} minutes later",
         "scrubLabel": "Time shown on the floor",
+        "expandLabel": "Fill the screen with the floor",
+        "collapseLabel": "Return the floor to the page",
+        "expandedLabel": "Service floor, full screen",
         "status": {
           "seated": "Seated",
           "turning": "Turning",

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -651,7 +651,9 @@
         "timetable": "Timetable",
         "list": "List",
         "timetableLabel": "Timetable view",
-        "listLabel": "List view"
+        "listLabel": "List view",
+        "service": "Service",
+        "serviceLabel": "Service view"
       },
       "timetable": {
         "previousDay": "Previous day",
@@ -671,6 +673,37 @@
         "peopleAbbrev": "{{count}}p",
         "sittingLabel": "{{guest}}, {{seats}} covers on {{unit}}, {{start}} to {{end}}",
         "sittingLabelWithRemaining": "{{guest}}, {{seats}} covers on {{unit}}, {{start}} to {{end}}, {{remaining}}"
+      },
+      "service": {
+        "now": "Now",
+        "backToNowLabel": "Follow the current time",
+        "earlier": "{{minutes}} minutes earlier",
+        "later": "{{minutes}} minutes later",
+        "scrubLabel": "Time shown on the floor",
+        "status": {
+          "seated": "Seated",
+          "turning": "Turning",
+          "free": "Free"
+        },
+        "summary": {
+          "seated_one": "{{count}} seated",
+          "seated_other": "{{count}} seated",
+          "turning_one": "{{count}} turning",
+          "turning_other": "{{count}} turning",
+          "free_one": "{{count}} free",
+          "free_other": "{{count}} free",
+          "covers_one": "{{count}} cover",
+          "covers_other": "{{count}} covers"
+        },
+        "sittingRange": "{{start}} – {{end}}",
+        "remaining": "{{duration}} left",
+        "nextUp": "Next {{time}} · in {{duration}}",
+        "nothingElse": "Nothing else today",
+        "durationHm": "{{hours}}h {{minutes}}m",
+        "durationH": "{{hours}}h",
+        "durationM": "{{minutes}}m",
+        "seatedUnitLabel": "{{unit}}, {{guest}}, {{seats}} covers, {{remaining}} left",
+        "freeUnitLabel": "{{unit}}, free"
       },
       "sort": {
         "time": "Time",

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -680,6 +680,9 @@
         "earlier": "{{minutes}} minutos antes",
         "later": "{{minutes}} minutos después",
         "scrubLabel": "Hora mostrada en la sala",
+        "expandLabel": "Ver la sala a pantalla completa",
+        "collapseLabel": "Devolver la sala a la página",
+        "expandedLabel": "Sala, pantalla completa",
         "status": {
           "seated": "Ocupada",
           "turning": "En rotación",

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -651,7 +651,9 @@
         "timetable": "Horario",
         "list": "Lista",
         "timetableLabel": "Vista de horario",
-        "listLabel": "Vista de lista"
+        "listLabel": "Vista de lista",
+        "service": "Sala",
+        "serviceLabel": "Vista de sala"
       },
       "timetable": {
         "previousDay": "Día anterior",
@@ -671,6 +673,37 @@
         "peopleAbbrev": "{{count}}p",
         "sittingLabel": "{{guest}}, {{seats}} cubiertos en {{unit}}, de {{start}} a {{end}}",
         "sittingLabelWithRemaining": "{{guest}}, {{seats}} cubiertos en {{unit}}, de {{start}} a {{end}}, {{remaining}}"
+      },
+      "service": {
+        "now": "Ahora",
+        "backToNowLabel": "Seguir la hora actual",
+        "earlier": "{{minutes}} minutos antes",
+        "later": "{{minutes}} minutos después",
+        "scrubLabel": "Hora mostrada en la sala",
+        "status": {
+          "seated": "Ocupada",
+          "turning": "En rotación",
+          "free": "Libre"
+        },
+        "summary": {
+          "seated_one": "{{count}} ocupada",
+          "seated_other": "{{count}} ocupadas",
+          "turning_one": "{{count}} en rotación",
+          "turning_other": "{{count}} en rotación",
+          "free_one": "{{count}} libre",
+          "free_other": "{{count}} libres",
+          "covers_one": "{{count}} comensal",
+          "covers_other": "{{count}} comensales"
+        },
+        "sittingRange": "{{start}} – {{end}}",
+        "remaining": "quedan {{duration}}",
+        "nextUp": "Siguiente {{time}} · en {{duration}}",
+        "nothingElse": "Nada más hoy",
+        "durationHm": "{{hours}} h {{minutes}} min",
+        "durationH": "{{hours}} h",
+        "durationM": "{{minutes}} min",
+        "seatedUnitLabel": "{{unit}}, {{guest}}, {{seats}} comensales, quedan {{remaining}}",
+        "freeUnitLabel": "{{unit}}, libre"
       },
       "sort": {
         "time": "Hora",

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -651,7 +651,9 @@
         "timetable": "Planning",
         "list": "Liste",
         "timetableLabel": "Vue planning",
-        "listLabel": "Vue liste"
+        "listLabel": "Vue liste",
+        "service": "Salle",
+        "serviceLabel": "Vue salle"
       },
       "timetable": {
         "previousDay": "Jour précédent",
@@ -671,6 +673,37 @@
         "peopleAbbrev": "{{count}}p",
         "sittingLabel": "{{guest}}, {{seats}} couverts à {{unit}}, de {{start}} à {{end}}",
         "sittingLabelWithRemaining": "{{guest}}, {{seats}} couverts à {{unit}}, de {{start}} à {{end}}, {{remaining}}"
+      },
+      "service": {
+        "now": "Maintenant",
+        "backToNowLabel": "Suivre l'heure actuelle",
+        "earlier": "{{minutes}} minutes plus tôt",
+        "later": "{{minutes}} minutes plus tard",
+        "scrubLabel": "Heure affichée sur le plan de salle",
+        "status": {
+          "seated": "Occupée",
+          "turning": "En rotation",
+          "free": "Libre"
+        },
+        "summary": {
+          "seated_one": "{{count}} occupée",
+          "seated_other": "{{count}} occupées",
+          "turning_one": "{{count}} en rotation",
+          "turning_other": "{{count}} en rotation",
+          "free_one": "{{count}} libre",
+          "free_other": "{{count}} libres",
+          "covers_one": "{{count}} couvert",
+          "covers_other": "{{count}} couverts"
+        },
+        "sittingRange": "{{start}} – {{end}}",
+        "remaining": "{{duration}} restantes",
+        "nextUp": "Suivant {{time}} · dans {{duration}}",
+        "nothingElse": "Rien d'autre aujourd'hui",
+        "durationHm": "{{hours}} h {{minutes}} min",
+        "durationH": "{{hours}} h",
+        "durationM": "{{minutes}} min",
+        "seatedUnitLabel": "{{unit}}, {{guest}}, {{seats}} couverts, {{remaining}} restantes",
+        "freeUnitLabel": "{{unit}}, libre"
       },
       "sort": {
         "time": "Heure",

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -680,6 +680,9 @@
         "earlier": "{{minutes}} minutes plus tôt",
         "later": "{{minutes}} minutes plus tard",
         "scrubLabel": "Heure affichée sur le plan de salle",
+        "expandLabel": "Afficher le plan de salle en plein écran",
+        "collapseLabel": "Réduire le plan de salle",
+        "expandedLabel": "Plan de salle, plein écran",
         "status": {
           "seated": "Occupée",
           "turning": "En rotation",

--- a/openresto-frontend/tests/app/admin/bookings-index.test.tsx
+++ b/openresto-frontend/tests/app/admin/bookings-index.test.tsx
@@ -56,6 +56,17 @@ jest.mock("@/components/admin/bookings/AvailabilityGrid", () => ({
   },
 }));
 
+jest.mock("@/components/admin/bookings/ServiceView", () => ({
+  ServiceView: ({ onBookingPress }: any) => {
+    const { Pressable, Text } = require("react-native");
+    return (
+      <Pressable testID="service-press-booking" onPress={() => onBookingPress({ id: 43 })}>
+        <Text>ServiceFloor</Text>
+      </Pressable>
+    );
+  },
+}));
+
 jest.mock("@/components/admin/bookings/BookingDetailPopup", () => ({
   BookingDetailPopup: ({ onClose, onMutated }: any) => {
     const { Pressable, Text } = require("react-native");
@@ -286,6 +297,50 @@ describe("AdminBookingsScreen", () => {
     expect(screen.queryByTestId("view-toggle-timetable")).toBeNull();
     expect(screen.queryByTestId("view-toggle-list")).toBeNull();
     expect(screen.queryByText("Past")).toBeNull();
+  });
+
+  it("draws the service floor when the service view is chosen", async () => {
+    localStorage.setItem("bookings:viewMode", JSON.stringify("timetable"));
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByTestId("view-toggle-service")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("view-toggle-service"));
+
+    await waitFor(() => expect(screen.getByText("ServiceFloor")).toBeTruthy());
+    expect(screen.queryByText("GridBooking")).toBeNull();
+  });
+
+  // The service view reads the same grid fetch as the timetable, so entering it has to load one.
+  it("loads the day's grid when switching into the service view", async () => {
+    localStorage.setItem("bookings:viewMode", JSON.stringify("list"));
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByTestId("view-toggle-service")).toBeTruthy());
+    (adminGetTables as jest.Mock).mockClear();
+    fireEvent.press(screen.getByTestId("view-toggle-service"));
+
+    await waitFor(() => expect(adminGetTables).toHaveBeenCalledWith(1));
+  });
+
+  it("opens a booking pressed on the service floor", async () => {
+    localStorage.setItem("bookings:viewMode", JSON.stringify("service"));
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByTestId("view-toggle-service")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("view-toggle-service"));
+
+    await waitFor(() => expect(screen.getByTestId("service-press-booking")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("service-press-booking"));
+
+    expect(screen.getByTestId("popup-close")).toBeTruthy();
+  });
+
+  it("keeps the day navigation on both grid-backed views", async () => {
+    localStorage.setItem("bookings:viewMode", JSON.stringify("service"));
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByTestId("grid-nav-next")).toBeTruthy());
+    expect(screen.getByTestId("grid-nav-prev")).toBeTruthy();
   });
 
   it("shows clear button when searchQuery is present", async () => {

--- a/openresto-frontend/tests/components/admin/bookings/GridDateBar.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/GridDateBar.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { GridDateBar } from "@/components/admin/bookings/GridDateBar";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: () => ({ primaryColor: "#0a7ea4", appName: "Open Resto" }),
+}));
+
+describe("GridDateBar", () => {
+  const onChangeDay = jest.fn();
+  const onResetToToday = jest.fn();
+
+  const props = {
+    onChangeDay,
+    onResetToToday,
+    borderColor: "#ccc",
+    primaryColor: "#0a7ea4",
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("steps back a day when the previous chevron is pressed", () => {
+    render(<GridDateBar {...props} date={new Date()} />);
+
+    fireEvent.press(screen.getByTestId("grid-nav-prev"));
+
+    expect(onChangeDay).toHaveBeenCalledWith(-1);
+  });
+
+  it("steps forward a day when the next chevron is pressed", () => {
+    render(<GridDateBar {...props} date={new Date()} />);
+
+    fireEvent.press(screen.getByTestId("grid-nav-next"));
+
+    expect(onChangeDay).toHaveBeenCalledWith(1);
+  });
+
+  it("resets to today when the date label is pressed", () => {
+    const notToday = new Date();
+    notToday.setDate(notToday.getDate() + 3);
+    render(<GridDateBar {...props} date={notToday} />);
+
+    fireEvent.press(screen.getByText("tap for today"));
+
+    expect(onResetToToday).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the jump-to-today hint for a date that is not today", () => {
+    const notToday = new Date();
+    notToday.setDate(notToday.getDate() + 3);
+    render(<GridDateBar {...props} date={notToday} />);
+
+    expect(screen.getByText("tap for today")).toBeTruthy();
+  });
+
+  it("hides the jump-to-today hint when the date is already today", () => {
+    render(<GridDateBar {...props} date={new Date()} />);
+
+    expect(screen.queryByText("tap for today")).toBeNull();
+  });
+});

--- a/openresto-frontend/tests/components/admin/bookings/ServiceView.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/ServiceView.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Modal } from "react-native";
 import { render, screen, fireEvent, within } from "@testing-library/react-native";
 import { ServiceView } from "@/components/admin/bookings/ServiceView";
 
@@ -229,6 +230,47 @@ describe("ServiceView", () => {
       />
     );
     expect(within(screen.getByTestId("service-unit-table:101")).getByText("Guest")).toBeTruthy();
+  });
+
+  it("fills the screen with the floor when maximised, and gives the page back on collapse", () => {
+    render(<ServiceView {...props} />);
+
+    expect(screen.queryByTestId("service-expanded")).toBeNull();
+
+    fireEvent.press(screen.getByTestId("service-expand"));
+    expect(screen.getByTestId("service-expanded")).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId("service-expand"));
+    expect(screen.queryByTestId("service-expanded")).toBeNull();
+  });
+
+  it("gives the page back when the platform asks the sheet to close", () => {
+    render(<ServiceView {...props} />);
+    fireEvent.press(screen.getByTestId("service-expand"));
+
+    fireEvent(screen.UNSAFE_getByType(Modal), "requestClose");
+
+    expect(screen.queryByTestId("service-expanded")).toBeNull();
+  });
+
+  it("keeps the scrubbed time across maximising, so the floor does not jump", () => {
+    render(<ServiceView {...props} />);
+
+    fireEvent.press(screen.getByTestId("service-scrub-forward"));
+    const scrubbed = screen.getByTestId("service-scrub-clock").props.children;
+
+    fireEvent.press(screen.getByTestId("service-expand"));
+
+    expect(screen.getByTestId("service-scrub-clock").props.children).toBe(scrubbed);
+  });
+
+  it("still lays the room out while maximised", () => {
+    render(<ServiceView {...props} />);
+
+    fireEvent.press(screen.getByTestId("service-expand"));
+
+    expect(screen.getByText("Table 1")).toBeTruthy();
+    expect(within(screen.getByTestId("service-unit-table:101")).getByText(/Seated/)).toBeTruthy();
   });
 
   it("names no day in the empty state when it was not given one", () => {

--- a/openresto-frontend/tests/components/admin/bookings/ServiceView.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/ServiceView.test.tsx
@@ -1,0 +1,337 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react-native";
+import { ServiceView } from "@/components/admin/bookings/ServiceView";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: () => ({ primaryColor: "#0a7ea4", appName: "Open Resto" }),
+}));
+
+jest.mock("@/utils/colors", () => ({
+  hexToRgba: (_h: string, _a: number) => "rgba(0,0,0,0.1)",
+}));
+
+const DAY = "2026-08-23";
+
+function booking(
+  id: number,
+  hhmm: string,
+  minutes: number,
+  overrides: Partial<Record<string, unknown>> = {}
+) {
+  const date = `${DAY}T${hhmm}:00.000Z`;
+  return {
+    id,
+    tableId: 101,
+    tableGroupId: null,
+    date,
+    endTime: new Date(new Date(date).getTime() + minutes * 60000).toISOString(),
+    seats: 2,
+    customerEmail: "booked@test.com",
+    ...overrides,
+  };
+}
+
+const sections = [
+  {
+    id: 1,
+    name: "Main",
+    tables: [
+      { id: 101, name: "Table 1", seats: 4 },
+      { id: 102, name: "Table 2", seats: 2 },
+    ],
+  },
+];
+
+const props = {
+  sections: sections as never,
+  bookings: [booking(10, "18:00", 90)] as never,
+  isDark: false,
+  onBookingPress: jest.fn(),
+  openTime: "17:00",
+  closeTime: "23:00",
+  timezone: "UTC",
+  // Never the location's today, so the floor opens on the first sitting and the clock cannot
+  // walk these assertions off their times mid-run.
+  gridDateIso: DAY,
+};
+
+/**
+ * A 6pm sitting on Table 1 plus one on Table 2 at `hhmm`. The floor opens on the earliest sitting,
+ * so the anchor fixes the observed moment at 6pm and lets Table 2 be read before its party arrives.
+ */
+function anchoredAt(hhmm: string) {
+  return [booking(10, "18:00", 90), booking(11, hhmm, 90, { tableId: 102 })] as never;
+}
+
+describe("ServiceView", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("says so plainly when the location has no tables to lay out", () => {
+    render(<ServiceView {...props} sections={[] as never} />);
+    expect(screen.getByText(/No tables found/)).toBeTruthy();
+  });
+
+  it("lists every table in the section, booked or not", () => {
+    render(<ServiceView {...props} />);
+    expect(screen.getByText("MAIN")).toBeTruthy();
+    expect(screen.getByText("Table 1")).toBeTruthy();
+    expect(screen.getByText("Table 2")).toBeTruthy();
+  });
+
+  it("opens on the first sitting of a day that is not today, so the floor is not blank", () => {
+    render(<ServiceView {...props} />);
+    expect(screen.getByTestId("service-scrub-clock")).toHaveTextContent("6:00p");
+  });
+
+  it("names the guest, their covers and what is left of their sitting", () => {
+    render(<ServiceView {...props} />);
+
+    expect(screen.getByText("booked")).toBeTruthy();
+    expect(screen.getByText("6:00p – 7:30p")).toBeTruthy();
+    expect(screen.getByText("1h 30m left")).toBeTruthy();
+  });
+
+  it("prefers the guest's name over their email when there is one", () => {
+    render(
+      <ServiceView
+        {...props}
+        bookings={[booking(10, "18:00", 90, { customerName: "Patel" })] as never}
+      />
+    );
+    expect(screen.getByText("Patel")).toBeTruthy();
+  });
+
+  it("marks an occupied table seated and an unbooked one free", () => {
+    render(<ServiceView {...props} />);
+
+    expect(within(screen.getByTestId("service-unit-table:101")).getByText(/Seated/)).toBeTruthy();
+    expect(within(screen.getByTestId("service-unit-table:102")).getByText(/Free/)).toBeTruthy();
+  });
+
+  it("counts the covers actually seated at the shown moment", () => {
+    render(
+      <ServiceView
+        {...props}
+        bookings={
+          [
+            booking(10, "18:00", 90, { seats: 4 }),
+            booking(11, "21:00", 90, { seats: 6, tableId: 102 }),
+          ] as never
+        }
+      />
+    );
+    expect(within(screen.getByTestId("service-covers")).getByText("4 covers")).toBeTruthy();
+  });
+
+  it("opens the booking when its table is pressed", () => {
+    render(<ServiceView {...props} />);
+
+    fireEvent.press(screen.getByTestId("service-unit-table:101"));
+
+    expect(props.onBookingPress).toHaveBeenCalledWith(expect.objectContaining({ id: 10 }));
+  });
+
+  it("opens the sitting still to come when a free table is pressed", () => {
+    render(<ServiceView {...props} bookings={anchoredAt("20:00")} />);
+
+    fireEvent.press(screen.getByTestId("service-unit-table:102"));
+
+    expect(props.onBookingPress).toHaveBeenCalledWith(expect.objectContaining({ id: 11 }));
+  });
+
+  it("says nothing else is booked on a table with no sittings left", () => {
+    render(<ServiceView {...props} />);
+    expect(
+      within(screen.getByTestId("service-unit-table:102")).getByText(/Nothing else today/)
+    ).toBeTruthy();
+  });
+
+  it("announces the next sitting and how long the table stays free", () => {
+    render(<ServiceView {...props} bookings={anchoredAt("20:00")} />);
+    expect(
+      within(screen.getByTestId("service-unit-table:102")).getByText(/Next 8:00p/)
+    ).toBeTruthy();
+  });
+
+  // A table with a party due imminently cannot be offered to a walk-in, so it is not "free".
+  it("marks a table turning over when its next sitting is inside the turnaround", () => {
+    render(<ServiceView {...props} bookings={anchoredAt("18:30")} />);
+    expect(within(screen.getByTestId("service-unit-table:102")).getByText(/Turning/)).toBeTruthy();
+  });
+
+  it("marks the same table free when that sitting is beyond the turnaround", () => {
+    render(<ServiceView {...props} bookings={anchoredAt("18:45")} />);
+    expect(within(screen.getByTestId("service-unit-table:102")).getByText(/Free/)).toBeTruthy();
+  });
+
+  it("steps the shown time forward and back in quarter hours", () => {
+    render(<ServiceView {...props} />);
+
+    fireEvent.press(screen.getByTestId("service-scrub-forward"));
+    expect(screen.getByTestId("service-scrub-clock")).toHaveTextContent("6:15p");
+
+    fireEvent.press(screen.getByTestId("service-scrub-back"));
+    expect(screen.getByTestId("service-scrub-clock")).toHaveTextContent("6:00p");
+  });
+
+  it("re-reads the floor at the scrubbed time, not the time it opened on", () => {
+    render(<ServiceView {...props} bookings={[booking(10, "18:00", 30)] as never} />);
+
+    expect(within(screen.getByTestId("service-unit-table:101")).getByText(/Seated/)).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId("service-scrub-forward"));
+    fireEvent.press(screen.getByTestId("service-scrub-forward"));
+    fireEvent.press(screen.getByTestId("service-scrub-forward"));
+
+    expect(within(screen.getByTestId("service-unit-table:101")).getByText(/Free/)).toBeTruthy();
+  });
+
+  it("holds the scrubbed time at the edge of the day rather than running off it", () => {
+    render(<ServiceView {...props} />);
+
+    for (let i = 0; i < 40; i++) fireEvent.press(screen.getByTestId("service-scrub-back"));
+
+    expect(screen.getByTestId("service-scrub-clock")).toHaveTextContent("5:00p");
+  });
+
+  it("offers no jump back to now on a day that has no now on it", () => {
+    render(<ServiceView {...props} />);
+    expect(screen.queryByTestId("service-scrub-now")).toBeNull();
+  });
+
+  it("gives a combinable group its own place on the floor beside its member tables", () => {
+    render(
+      <ServiceView
+        {...props}
+        groups={[{ id: 5, name: "Long table", combinedSeats: 10, members: [] }] as never}
+        bookings={[booking(10, "18:00", 90, { tableId: null, tableGroupId: 5 })] as never}
+      />
+    );
+
+    expect(within(screen.getByTestId("service-unit-group:5")).getByText(/Seated/)).toBeTruthy();
+    expect(within(screen.getByTestId("service-unit-table:101")).getByText(/Free/)).toBeTruthy();
+  });
+
+  it("says so on a day with nothing booked at all", () => {
+    render(<ServiceView {...props} bookings={[] as never} dateLabel="Sun 23 Aug" />);
+    expect(screen.getByText("No bookings on Sun 23 Aug")).toBeTruthy();
+  });
+
+  it("falls back to a generic name for a guest with neither name nor email", () => {
+    render(
+      <ServiceView
+        {...props}
+        bookings={[booking(10, "18:00", 90, { customerName: null, customerEmail: null })] as never}
+      />
+    );
+    expect(within(screen.getByTestId("service-unit-table:101")).getByText("Guest")).toBeTruthy();
+  });
+
+  it("names no day in the empty state when it was not given one", () => {
+    render(<ServiceView {...props} bookings={[] as never} />);
+    expect(screen.getByText("No bookings on this day")).toBeTruthy();
+  });
+
+  it("falls back to its own service hours when the location supplies none", () => {
+    render(
+      <ServiceView
+        sections={props.sections}
+        bookings={[] as never}
+        isDark={false}
+        onBookingPress={jest.fn()}
+        gridDateIso={DAY}
+      />
+    );
+    expect(screen.getByText("Table 1")).toBeTruthy();
+  });
+});
+
+describe("ServiceView on the location's today", () => {
+  /** Today in the location's zone, which is the only day the floor has a "now" to follow. */
+  const today = new Date().toISOString().slice(0, 10);
+
+  function bookingToday(id: number, minutesFromNow: number, minutes: number, tableId = 101) {
+    const start = new Date(Date.now() + minutesFromNow * 60000);
+    return {
+      id,
+      tableId,
+      tableGroupId: null,
+      date: start.toISOString(),
+      endTime: new Date(start.getTime() + minutes * 60000).toISOString(),
+      seats: 2,
+      customerEmail: "booked@test.com",
+    };
+  }
+
+  const liveProps = {
+    ...props,
+    gridDateIso: today,
+    openTime: "00:00",
+    closeTime: "23:59",
+    bookings: [bookingToday(20, -15, 90)] as never,
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("follows the clock, so a party seated a quarter hour ago reads as seated", () => {
+    render(<ServiceView {...liveProps} />);
+    expect(within(screen.getByTestId("service-unit-table:101")).getByText(/Seated/)).toBeTruthy();
+  });
+
+  it("offers a way back to now once the floor has been scrubbed off it", () => {
+    render(<ServiceView {...liveProps} />);
+    const clock = screen.getByTestId("service-scrub-clock").props.children;
+
+    fireEvent.press(screen.getByTestId("service-scrub-forward"));
+    expect(screen.getByTestId("service-scrub-clock").props.children).not.toBe(clock);
+
+    fireEvent.press(screen.getByTestId("service-scrub-now"));
+    expect(screen.getByTestId("service-scrub-clock").props.children).toBe(clock);
+  });
+
+  it("maps a position on the track to a time, so the far ends are different moments", () => {
+    render(<ServiceView {...liveProps} />);
+    const track = screen.getByTestId("service-scrub-track");
+    const clock = () => screen.getByTestId("service-scrub-clock").props.children;
+
+    fireEvent(track, "layout", { nativeEvent: { layout: { width: 240 } } });
+
+    fireEvent(track, "responderGrant", { nativeEvent: { locationX: 0 } });
+    const atStart = clock();
+
+    fireEvent(track, "responderMove", { nativeEvent: { locationX: 240 } });
+    expect(clock()).not.toBe(atStart);
+
+    fireEvent(track, "responderMove", { nativeEvent: { locationX: 0 } });
+    expect(clock()).toBe(atStart);
+  });
+
+  it("clamps a drag past either end of the track to the day it draws", () => {
+    render(<ServiceView {...liveProps} />);
+    const track = screen.getByTestId("service-scrub-track");
+    const clock = () => screen.getByTestId("service-scrub-clock").props.children;
+
+    fireEvent(track, "layout", { nativeEvent: { layout: { width: 240 } } });
+
+    fireEvent(track, "responderGrant", { nativeEvent: { locationX: 0 } });
+    const atStart = clock();
+    fireEvent(track, "responderMove", { nativeEvent: { locationX: -400 } });
+
+    expect(clock()).toBe(atStart);
+  });
+
+  it("ignores a drag before the track has been measured", () => {
+    render(<ServiceView {...liveProps} />);
+    const before = screen.getByTestId("service-scrub-clock").props.children;
+
+    fireEvent(screen.getByTestId("service-scrub-track"), "responderGrant", {
+      nativeEvent: { locationX: 100 },
+    });
+
+    expect(screen.getByTestId("service-scrub-clock").props.children).toBe(before);
+  });
+});

--- a/openresto-frontend/tests/hooks/use-minute-tick.test.ts
+++ b/openresto-frontend/tests/hooks/use-minute-tick.test.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { useMinuteTick } from "@/hooks/use-minute-tick";
+
+describe("useMinuteTick", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts at 0", () => {
+    const { result } = renderHook(() => useMinuteTick());
+
+    expect(result.current).toBe(0);
+  });
+
+  it("advances once a minute has elapsed", () => {
+    const { result } = renderHook(() => useMinuteTick());
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(result.current).toBe(1);
+  });
+
+  it("clears its interval on unmount", () => {
+    const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+    const { unmount } = renderHook(() => useMinuteTick());
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openresto-frontend/tests/utils/serviceView.test.ts
+++ b/openresto-frontend/tests/utils/serviceView.test.ts
@@ -1,0 +1,181 @@
+import { buildTimeline, buildUnitRows, clockMinutesAt } from "@/utils/bookingTimeline";
+import {
+  buildServiceFloor,
+  splitDuration,
+  summarise,
+  TURNAROUND_MINUTES,
+  type ServiceSection,
+} from "@/utils/serviceView";
+import type { BookingDetailDto, SectionWithTables } from "@/api/admin";
+
+const DAY = "2026-08-23";
+
+function booking(
+  id: number,
+  hhmm: string,
+  minutes: number,
+  unit: { tableId?: number | null; tableGroupId?: number | null } = { tableId: 1 },
+  seats = 2
+): BookingDetailDto {
+  const date = `${DAY}T${hhmm}:00.000Z`;
+  return {
+    id,
+    restaurantId: 1,
+    restaurantName: "Test",
+    timezone: "UTC",
+    sectionId: 1,
+    sectionName: "Main",
+    tableId: unit.tableId ?? null,
+    tableGroupId: unit.tableGroupId ?? null,
+    tableName: "T1",
+    date,
+    endTime: new Date(new Date(date).getTime() + minutes * 60000).toISOString(),
+    customerEmail: `guest${id}@test.com`,
+    customerName: `Guest ${id}`,
+    seats,
+  };
+}
+
+const sections: SectionWithTables[] = [
+  {
+    id: 1,
+    name: "Main",
+    tables: [
+      { id: 1, name: "T1", seats: 4 },
+      { id: 2, name: "T2", seats: 2 },
+    ],
+  },
+];
+
+const OPEN = "17:00";
+
+/** The floor as it stands `hhmm` into the day, built the way the screen builds it. */
+function floorAt(hhmm: string, bookings: BookingDetailDto[], groups = []): ServiceSection[] {
+  const timeline = buildTimeline({
+    openTime: OPEN,
+    closeTime: "23:00",
+    timezone: "UTC",
+    bookings,
+    defaultDurationMinutes: 90,
+  });
+  const [h, m] = hhmm.split(":").map(Number);
+  // Offsets are measured from opening, so the observed clock time converts back the same way.
+  const at = h * 60 + m - clockMinutesAt(OPEN, 0);
+  return buildServiceFloor({
+    rows: buildUnitRows(sections, groups),
+    placements: timeline.placements,
+    at,
+  });
+}
+
+const unit = (floor: ServiceSection[], key: string) =>
+  floor.flatMap((s) => s.units).find((u) => u.unit.key === key)!;
+
+describe("buildServiceFloor", () => {
+  it("reads a table as seated at the minute its sitting starts", () => {
+    const floor = floorAt("18:00", [booking(1, "18:00", 90)]);
+    expect(unit(floor, "table:1").status).toBe("seated");
+  });
+
+  it("reads a table as free at the minute its sitting ends, not still seated", () => {
+    const floor = floorAt("19:30", [booking(1, "18:00", 90)]);
+    expect(unit(floor, "table:1").status).toBe("free");
+  });
+
+  it("counts down what is left of the sitting", () => {
+    const floor = floorAt("18:20", [booking(1, "18:00", 90)]);
+    expect(unit(floor, "table:1").minutesRemaining).toBe(70);
+  });
+
+  it("names the guest sitting there", () => {
+    const floor = floorAt("18:20", [booking(1, "18:00", 90)]);
+    expect(unit(floor, "table:1").current?.booking.customerName).toBe("Guest 1");
+  });
+
+  it("reads a free table with a sitting due within the turnaround as turning over", () => {
+    const floor = floorAt("18:00", [
+      booking(1, `18:${String(TURNAROUND_MINUTES).padStart(2, "0")}`, 90),
+    ]);
+    expect(unit(floor, "table:1").status).toBe("turning");
+  });
+
+  it("reads a free table whose next sitting is past the turnaround as free", () => {
+    const floor = floorAt("18:00", [
+      booking(1, `18:${String(TURNAROUND_MINUTES + 1).padStart(2, "0")}`, 90),
+    ]);
+    expect(unit(floor, "table:1").status).toBe("free");
+  });
+
+  it("reads a table with nothing booked as free", () => {
+    const floor = floorAt("18:00", [booking(1, "18:00", 90)]);
+    expect(unit(floor, "table:2").status).toBe("free");
+    expect(unit(floor, "table:2").next).toBeNull();
+  });
+
+  it("counts down to the next sitting while the table is still occupied", () => {
+    const floor = floorAt("18:00", [booking(1, "18:00", 60), booking(2, "19:30", 60)]);
+    const t1 = unit(floor, "table:1");
+    expect(t1.status).toBe("seated");
+    expect(t1.minutesUntilNext).toBe(90);
+  });
+
+  it("places a group booking on its group unit, which carries no table id to match on", () => {
+    const groups = [{ id: 5, name: "Long table", combinedSeats: 10, members: [] }];
+    const floor = floorAt("18:00", [booking(1, "18:00", 90, { tableGroupId: 5 })], groups as never);
+    expect(unit(floor, "group:5").status).toBe("seated");
+    expect(unit(floor, "table:1").status).toBe("free");
+  });
+
+  it("keeps sections in the order the rows came in", () => {
+    const floor = floorAt("18:00", []);
+    expect(floor.map((s) => s.key)).toEqual(["section:1"]);
+  });
+
+  it("picks the sitting covering the moment, not merely the first of the day", () => {
+    const floor = floorAt("20:00", [booking(1, "18:00", 60), booking(2, "20:00", 60)]);
+    expect(unit(floor, "table:1").current?.booking.id).toBe(2);
+  });
+});
+
+describe("summarise", () => {
+  it("counts covers from the guests actually seated, not the day's bookings", () => {
+    const floor = floorAt("18:00", [
+      booking(1, "18:00", 90, { tableId: 1 }, 4),
+      booking(2, "21:00", 90, { tableId: 2 }, 6),
+    ]);
+    expect(summarise(floor).covers).toBe(4);
+  });
+
+  it("partitions every unit across the three statuses", () => {
+    const floor = floorAt("18:00", [booking(1, "18:00", 90)]);
+    const summary = summarise(floor);
+    expect(summary.seated + summary.turning + summary.free).toBe(2);
+  });
+
+  it("counts an empty floor as all free", () => {
+    expect(summarise(floorAt("18:00", []))).toEqual({
+      seated: 0,
+      turning: 0,
+      free: 2,
+      covers: 0,
+    });
+  });
+});
+
+describe("splitDuration", () => {
+  it("leaves no remainder on a whole number of hours", () => {
+    expect(splitDuration(120)).toEqual({ hours: 2, minutes: 0 });
+  });
+
+  it("splits an hour and a half into both parts", () => {
+    expect(splitDuration(90)).toEqual({ hours: 1, minutes: 30 });
+  });
+
+  it("reports under an hour as minutes alone", () => {
+    expect(splitDuration(45)).toEqual({ hours: 0, minutes: 45 });
+  });
+
+  it("floors a span that has already elapsed at zero rather than going negative", () => {
+    expect(splitDuration(-10)).toEqual({ hours: 0, minutes: 0 });
+  });
+});

--- a/openresto-frontend/utils/bookingTimeline.ts
+++ b/openresto-frontend/utils/bookingTimeline.ts
@@ -270,6 +270,15 @@ export function nowOffset(
   return offset >= timeline.startOffset && offset <= timeline.endOffset ? offset : null;
 }
 
+/**
+ * The restaurant-local clock time a timeline offset falls on. Offsets are measured from the day's
+ * open time, so a view that draws its own labels needs this rather than re-deriving the open
+ * minute — and it stays right on a day with no bookings to read one off.
+ */
+export function clockMinutesAt(openTime: string, offset: number): number {
+  return parseClockMinutes(openTime) + offset;
+}
+
 /** Compact "1h 30m left" / "45m left" for what is left of a sitting. */
 export function formatRemaining(minutes: number): string {
   if (minutes <= 0) return "ending";

--- a/openresto-frontend/utils/serviceView.ts
+++ b/openresto-frontend/utils/serviceView.ts
@@ -1,0 +1,139 @@
+import type { TimelinePlacement, TimelineRowGroup, TimelineUnit } from "@/utils/bookingTimeline";
+
+/**
+ * A table with a sitting arriving within this window is not offerable to a walk-in, so the floor
+ * reads it as turning over rather than free.
+ *
+ * @see [serviceView.test.ts](../tests/utils/serviceView.test.ts) — pins that a table whose next
+ * sitting is exactly this far out reads as turning, and one a minute further out reads as free.
+ */
+export const TURNAROUND_MINUTES = 30;
+
+export type UnitStatus = "seated" | "turning" | "free";
+
+export interface UnitOccupancy {
+  unit: TimelineUnit;
+  status: UnitStatus;
+  /** The sitting covering the observed moment, if any. */
+  current: TimelinePlacement | null;
+  /** The next sitting to start after it, whether or not the unit is occupied now. */
+  next: TimelinePlacement | null;
+  /** Minutes until the current sitting ends. Zero when nothing is sitting there. */
+  minutesRemaining: number;
+  /** Minutes until the next sitting starts; null when nothing else is booked. */
+  minutesUntilNext: number | null;
+}
+
+export interface ServiceSection {
+  key: string;
+  name: string;
+  units: UnitOccupancy[];
+}
+
+export interface ServiceSummary {
+  seated: number;
+  turning: number;
+  free: number;
+  /** Covers sitting at the observed moment — the number front of house is actually serving. */
+  covers: number;
+}
+
+/**
+ * A unit's occupancy at one moment, in timeline-offset minutes. A sitting owns its table from its
+ * start up to but not including its end, so a table whose sitting ends at 20:00 is free at 20:00
+ * rather than double-counted against the sitting that starts there.
+ *
+ * @see [serviceView.test.ts](../tests/utils/serviceView.test.ts) — pins that a unit is seated at
+ * its sitting's start minute and free at its end minute.
+ */
+function occupancyFor(
+  unit: TimelineUnit,
+  placements: TimelinePlacement[],
+  at: number
+): UnitOccupancy {
+  const ordered = [...placements].sort((a, b) => a.startOffset - b.startOffset);
+  const current = ordered.find((p) => at >= p.startOffset && at < p.endOffset) ?? null;
+  const next = ordered.find((p) => p.startOffset > at) ?? null;
+
+  const minutesRemaining = current ? current.endOffset - at : 0;
+  const minutesUntilNext = next ? next.startOffset - at : null;
+
+  const status: UnitStatus = current
+    ? "seated"
+    : minutesUntilNext != null && minutesUntilNext <= TURNAROUND_MINUTES
+      ? "turning"
+      : "free";
+
+  return { unit, status, current, next, minutesRemaining, minutesUntilNext };
+}
+
+/**
+ * The floor as it stands at one moment: every bookable unit under its section, each carrying who is
+ * on it, how much of their sitting is left, and what arrives next.
+ *
+ * Rows come from the timetable's own `buildUnitRows`, so a combinable group is a unit beside its
+ * member tables rather than a replacement for them, and the two views can never disagree about what
+ * is bookable. Placements likewise come from `buildTimeline`, which has already resolved a missing
+ * end time and unwrapped a service that runs past midnight.
+ *
+ * @see [serviceView.test.ts](../tests/utils/serviceView.test.ts) — pins that a group booking lands
+ * on its group unit, that a unit with nothing booked reads free, and that sections keep their order.
+ */
+export function buildServiceFloor({
+  rows,
+  placements,
+  at,
+}: {
+  rows: TimelineRowGroup[];
+  placements: TimelinePlacement[];
+  /** Observed moment, as minutes from the timeline's left edge. */
+  at: number;
+}): ServiceSection[] {
+  const byUnit = new Map<string, TimelinePlacement[]>();
+  for (const placement of placements) {
+    const list = byUnit.get(placement.unitKey);
+    if (list) list.push(placement);
+    else byUnit.set(placement.unitKey, [placement]);
+  }
+
+  return rows.map((row) => ({
+    key: row.key,
+    name: row.name,
+    units: row.units.map((unit) => occupancyFor(unit, byUnit.get(unit.key) ?? [], at)),
+  }));
+}
+
+/**
+ * Floor totals at the observed moment. Covers counts guests actually seated, not the day's bookings,
+ * which is the number a pass on the room is checked against.
+ *
+ * @see [serviceView.test.ts](../tests/utils/serviceView.test.ts) — pins that covers count only
+ * seated units and that the three statuses partition the floor.
+ */
+export function summarise(sections: ServiceSection[]): ServiceSummary {
+  const summary: ServiceSummary = { seated: 0, turning: 0, free: 0, covers: 0 };
+
+  for (const section of sections) {
+    for (const occupancy of section.units) {
+      summary[occupancy.status] += 1;
+      if (occupancy.status === "seated" && occupancy.current) {
+        summary.covers += occupancy.current.booking.seats;
+      }
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * Splits a span of minutes into whole hours and the remaining minutes, so a caller can pick the
+ * hours-and-minutes, hours-only or minutes-only phrasing its locale needs rather than having an
+ * English "1h 30m" baked in here.
+ *
+ * @see [serviceView.test.ts](../tests/utils/serviceView.test.ts) — pins that a whole number of
+ * hours leaves no remainder and that a negative span floors at zero.
+ */
+export function splitDuration(minutes: number): { hours: number; minutes: number } {
+  const total = Math.max(0, Math.round(minutes));
+  return { hours: Math.floor(total / 60), minutes: total % 60 };
+}


### PR DESCRIPTION
## Summary

Adds a **Service** view mode to `/admin/bookings`, beside Timetable and List. It answers #334's use case directly: who is sitting where at a given time, and how long their booking lasts.

The timetable already drew a service, but as a wall of bars to be read across — the wrong shape for a tablet glanced at between covers. The service view draws the room instead: one card per bookable unit, grouped by section, each carrying its state at the observed moment.

Phase 1 only. No geometry, no floor-plan editor, no `PositionX`/`PositionY` — that stays out of scope.

## Related issue

Closes #334

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

**No backend change was needed.** The spec's two backend items already landed in `1d891a3`: `BookingDetailDto` carries `TableGroupId` and a server-resolved `EndTime` (via `BookingDuration.ResolveEnd`), and table groups already reach the screen on `RestaurantDto.groups`. The spec's "Fixes to Fold In" (hour bucketing, past-midnight close, group placement) landed there too.

## Changes

**The view**
- `components/admin/bookings/ServiceView.tsx` — one card per unit under its section: every table, plus each combinable group *beside* its member tables, since a member stays individually bookable.
- A card shows state, occupant, covers, the sitting's range, **time remaining**, and the next booking — so a free table also says how long it stays free. Pressing one opens the existing `BookingDetailPopup`.
- Floor totals: seated / turning / free, plus the covers actually sitting.

**Three states, not two.** A table with a party due within the turnaround window can't be offered to a walk-in, so it reads *turning over* rather than *free*.

**Maximise.** A big room runs to more tables than the page's card shows without scrolling — the one place scrolling hurts, since the point is taking the room in at a glance. The maximise control hands the floor the whole screen as a dialog, dropping the page header, search and location chips that staff aren't reading during service. Scrub state lives above the presentation, so maximising keeps the moment being looked at rather than snapping back to now.

**The scrubber** is the "at a given time" half. Defaults to now and advances on a minute tick, so a screen parked on it all service stays right; drag or step it to pin the floor to a chosen moment; **Now** returns it to the clock. On any day but today there is no now to follow, so it opens on the first sitting rather than an hour of empty room.

**Not seated-vs-no-show.** There's no `SeatedAt` on `Booking`, so "seated" means the sitting covers the observed moment. Flagged in the issue as a bigger change; left alone.

**Refactors folded in (no behaviour change)**
- Date bar extracted to `GridDateBar` and shared by both grid-backed views instead of copied.
- The view toggle loops over its modes instead of repeating a near-identical button per mode.
- The minute tick both views need is now one hook (`hooks/use-minute-tick.ts`), not a private copy in `AvailabilityGrid`.
- Placement reuses the timetable's own `buildTimeline`/`buildUnitRows`, and the same guest-name fallback chain, so the two views can't disagree about what is bookable, when a sitting ends, or what a guest is called.

**i18n** — new `admin.bookings.service.*` subtree in all four locales; `tests/i18n/parity.test.ts` passes.

## Testing

- [x] `OpenRestoApi.Tests` pass locally — *not run; no backend files touched*
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

```
Test Suites: 205 passed, 205 total
Tests:       2958 passed, 2958 total
```

- `tsc --noEmit` clean; `npm run check` adds no new warnings beyond two in the new test-mock block that match the existing `AvailabilityGrid` mock's style; `check:doc-links` resolves.
- New: `tests/utils/serviceView.test.ts` (18), `tests/components/admin/bookings/ServiceView.test.tsx` (31), plus `GridDateBar` and `use-minute-tick` tests, and four screen-level tests for the new mode.
- **100% statement/branch/function/line coverage** on all four new files.
- Boundaries are pinned on both sides per the repo's comment ladder: seated at a sitting's start minute vs free at its end minute; turning at exactly the turnaround vs free one minute past it.
- No new route, so `routes.snapshot.txt` is untouched (styles live under `components/`, never `app/`).

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed — no API contract change

## Note

Two dead things were removed rather than tested around: an unreachable "Ending now" branch (a sitting is only *current* while `at < end`, so remaining is always positive), and a nullable `minutesRemaining` that the type allowed but the data never produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X79GMYSoKHRe5u6HLVSV3Q
