### PR TITLE
Steady the admin chrome: toolbar, brand mark, and the scroll-to-top FAB

### DIFF
--- a/openresto-frontend/app/(user)/index.tsx
+++ b/openresto-frontend/app/(user)/index.tsx
@@ -372,10 +372,10 @@ export default function HomeScreen() {
           </View>
         </View>
 
-        <Footer onLayout={fab.measureFooter} />
+        <Footer />
       </ScrollView>
 
-      <ScrollToTopFab visible={fab.visible} travel={fab.travel} onPress={scrollToTop} />
+      <ScrollToTopFab visible={fab.visible} onPress={scrollToTop} />
     </ThemedView>
   );
 }

--- a/openresto-frontend/app/(user)/index.tsx
+++ b/openresto-frontend/app/(user)/index.tsx
@@ -172,7 +172,7 @@ export default function HomeScreen() {
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
         onScroll={fab.trackScroll}
-        scrollEventThrottle={100}
+        scrollEventThrottle={16}
         {...(HOME_SCROLL_TIMELINE as object)}
       >
         <View style={{ flex: 1 }}>
@@ -375,7 +375,7 @@ export default function HomeScreen() {
         <Footer onLayout={fab.measureFooter} />
       </ScrollView>
 
-      <ScrollToTopFab visible={fab.visible} lift={fab.lift} onPress={scrollToTop} />
+      <ScrollToTopFab visible={fab.visible} travel={fab.travel} onPress={scrollToTop} />
     </ThemedView>
   );
 }

--- a/openresto-frontend/app/admin/bookings/index.tsx
+++ b/openresto-frontend/app/admin/bookings/index.tsx
@@ -25,12 +25,12 @@ import {
   Platform,
 } from "react-native";
 import { useRouter, Stack, useLocalSearchParams } from "expo-router";
-import { theme } from "@/theme/theme";
 import { useAppTheme } from "@/hooks/use-app-theme";
 
 import { AvailabilityGrid } from "@/components/admin/bookings/AvailabilityGrid";
 import { ServiceView } from "@/components/admin/bookings/ServiceView";
 import { GridDateBar } from "@/components/admin/bookings/GridDateBar";
+import { BookingStatusTabs } from "@/components/admin/bookings/BookingStatusTabs";
 import { BookingDetailPopup } from "@/components/admin/bookings/BookingDetailPopup";
 import { BookingsWideTable } from "@/components/admin/bookings/BookingsWideTable";
 import { BookingsCardList } from "@/components/admin/bookings/BookingsCardList";
@@ -384,107 +384,81 @@ export default function AdminBookingsScreen() {
       </View>
 
       {!searchQuery && (
-        <View
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            flexWrap: "wrap",
-            gap: 8,
-          }}
-        >
-          {restaurants.length > 1 &&
-            restaurants.map((r) => (
-              <Pressable
-                key={r.id}
-                style={[
-                  styles.chip,
-                  { borderColor },
-                  r.id === selectedRestaurantId && {
-                    backgroundColor: PRIMARY,
-                    borderColor: PRIMARY,
-                  },
-                ]}
-                onPress={() => handleSelectRestaurant(r.id)}
-              >
-                <ThemedText
-                  style={
-                    r.id === selectedRestaurantId
-                      ? styles.chipTextActive
-                      : [styles.chipText, { color: mutedColor }]
-                  }
-                >
-                  {r.name}
-                </ThemedText>
-              </Pressable>
-            ))}
-
-          <View style={{ flex: 1 }} />
-
-          {viewMode === "list" && (
-            <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
-              {(
-                [
-                  { key: "active", label: t("admin.bookings.tabs.active"), color: PRIMARY },
-                  { key: "past", label: t("admin.bookings.tabs.past"), color: "#7c3aed" },
-                  {
-                    key: "cancelled",
-                    label: t("admin.bookings.tabs.cancelled"),
-                    color: theme.status.cancelled.text,
-                  },
-                ] as const
-              ).map(({ key, label, color }) => (
+        <View style={styles.filterBar} testID="bookings-toolbar">
+          {restaurants.length > 1 && (
+            <View style={styles.locationChips}>
+              {restaurants.map((r) => (
                 <Pressable
-                  key={key}
-                  style={[styles.modeBtn, statusFilter === key && { backgroundColor: color }]}
-                  onPress={() => setStatusFilter(key)}
-                  accessibilityRole="radio"
-                  accessibilityLabel={t("admin.bookings.tabs.showLabel", {
-                    tab: label.toLowerCase(),
-                  })}
-                  accessibilityState={{ checked: statusFilter === key }}
+                  key={r.id}
+                  style={[
+                    styles.chip,
+                    { borderColor },
+                    r.id === selectedRestaurantId && {
+                      backgroundColor: PRIMARY,
+                      borderColor: PRIMARY,
+                    },
+                  ]}
+                  onPress={() => handleSelectRestaurant(r.id)}
                 >
                   <ThemedText
-                    style={[
-                      styles.modeBtnText,
-                      { color: statusFilter === key ? "#fff" : mutedColor },
-                    ]}
+                    style={
+                      r.id === selectedRestaurantId
+                        ? styles.chipTextActive
+                        : [styles.chipText, { color: mutedColor }]
+                    }
                   >
-                    {label}
+                    {r.name}
                   </ThemedText>
                 </Pressable>
               ))}
             </View>
           )}
 
-          <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
-            {(
-              [
-                { key: "timetable", icon: "grid-outline" },
-                { key: "service", icon: "restaurant-outline" },
-                { key: "list", icon: "list-outline" },
-              ] as const
-            ).map(({ key, icon }) => (
-              <Pressable
-                key={key}
-                testID={`view-toggle-${key}`}
-                style={[styles.modeBtn, viewMode === key && { backgroundColor: PRIMARY }]}
-                onPress={() => (usesGrid(key) ? switchToGridMode(key) : setViewMode(key))}
-                accessibilityRole="radio"
-                accessibilityLabel={t(`admin.bookings.viewToggle.${key}Label`)}
-                accessibilityState={{ checked: viewMode === key }}
-              >
-                <Icon name={icon} size={15} color={viewMode === key ? "#fff" : mutedColor} />
-                {isWide && (
-                  <ThemedText
-                    style={[styles.modeBtnText, { color: viewMode === key ? "#fff" : mutedColor }]}
-                  >
-                    {t(`admin.bookings.viewToggle.${key}`)}
-                  </ThemedText>
-                )}
-              </Pressable>
-            ))}
+          <View style={styles.viewControls}>
+            <View style={[styles.modeToggle, { borderColor, backgroundColor: cardBg }]}>
+              {(
+                [
+                  { key: "timetable", icon: "grid-outline" },
+                  { key: "service", icon: "restaurant-outline" },
+                  { key: "list", icon: "list-outline" },
+                ] as const
+              ).map(({ key, icon }) => (
+                <Pressable
+                  key={key}
+                  testID={`view-toggle-${key}`}
+                  style={[styles.modeBtn, viewMode === key && { backgroundColor: PRIMARY }]}
+                  onPress={() => (usesGrid(key) ? switchToGridMode(key) : setViewMode(key))}
+                  accessibilityRole="radio"
+                  accessibilityLabel={t(`admin.bookings.viewToggle.${key}Label`)}
+                  accessibilityState={{ checked: viewMode === key }}
+                >
+                  <Icon name={icon} size={15} color={viewMode === key ? "#fff" : mutedColor} />
+                  {isWide && (
+                    <ThemedText
+                      style={[
+                        styles.modeBtnText,
+                        { color: viewMode === key ? "#fff" : mutedColor },
+                      ]}
+                    >
+                      {t(`admin.bookings.viewToggle.${key}`)}
+                    </ThemedText>
+                  )}
+                </Pressable>
+              ))}
+            </View>
           </View>
         </View>
+      )}
+
+      {effectiveViewMode === "list" && !searchQuery && (
+        <BookingStatusTabs
+          value={statusFilter}
+          onChange={setStatusFilter}
+          borderColor={borderColor}
+          cardBg={cardBg}
+          mutedColor={mutedColor}
+          primaryColor={PRIMARY}
+        />
       )}
 
       {loading && effectiveViewMode === "list" ? (

--- a/openresto-frontend/components/admin/bookings/BookingStatusTabs.tsx
+++ b/openresto-frontend/components/admin/bookings/BookingStatusTabs.tsx
@@ -1,0 +1,60 @@
+import { Pressable, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { ThemedText } from "@/components/themed-text";
+import { theme } from "@/theme/theme";
+import type { BookingStatusFilter } from "@/api/admin";
+import { styles } from "./bookings.styles";
+
+/**
+ * Which set of bookings the list shows. It belongs to the list rather than to the screen's
+ * toolbar: the grid fetch ignores it entirely, so a toolbar that carried it had to drop it in the
+ * timetable and service views, and a control appearing and vanishing beside the view toggle reads
+ * as the toolbar rearranging itself rather than as a filter that only applies to one view.
+ */
+export function BookingStatusTabs({
+  value,
+  onChange,
+  borderColor,
+  cardBg,
+  mutedColor,
+  primaryColor,
+}: {
+  value: BookingStatusFilter;
+  onChange: (value: BookingStatusFilter) => void;
+  borderColor: string;
+  cardBg: string;
+  mutedColor: string;
+  primaryColor: string;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <View style={[styles.modeToggle, styles.statusTabs, { borderColor, backgroundColor: cardBg }]}>
+      {(
+        [
+          { key: "active", label: t("admin.bookings.tabs.active"), color: primaryColor },
+          { key: "past", label: t("admin.bookings.tabs.past"), color: "#7c3aed" },
+          {
+            key: "cancelled",
+            label: t("admin.bookings.tabs.cancelled"),
+            color: theme.status.cancelled.text,
+          },
+        ] as const
+      ).map(({ key, label, color }) => (
+        <Pressable
+          key={key}
+          testID={`status-tab-${key}`}
+          style={[styles.modeBtn, value === key && { backgroundColor: color }]}
+          onPress={() => onChange(key)}
+          accessibilityRole="radio"
+          accessibilityLabel={t("admin.bookings.tabs.showLabel", { tab: label.toLowerCase() })}
+          accessibilityState={{ checked: value === key }}
+        >
+          <ThemedText style={[styles.modeBtnText, { color: value === key ? "#fff" : mutedColor }]}>
+            {label}
+          </ThemedText>
+        </Pressable>
+      ))}
+    </View>
+  );
+}

--- a/openresto-frontend/components/admin/bookings/bookings.styles.ts
+++ b/openresto-frontend/components/admin/bookings/bookings.styles.ts
@@ -33,6 +33,27 @@ export const styles = StyleSheet.create({
   },
   chipText: { ...theme.typography.label },
   chipTextActive: { color: "#fff", fontWeight: "600", fontSize: 13 },
+  /**
+   * The screen's filter chrome, stacked rather than one wrapping row. A single row put the
+   * location chips, a flexible spacer and the toggles together, so where the toggles landed
+   * depended on how many chips fit beside them — and on which mode was showing, since the status
+   * tabs only exist in list view. Giving each its own row fixes the toggles in place.
+   */
+  filterBar: { gap: theme.spacing.sm },
+  locationChips: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: theme.spacing.sm,
+  },
+  /** Sits above the list it filters, so it does not stretch to the screen's width. */
+  statusTabs: { alignSelf: "flex-start" },
+  viewControls: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: theme.spacing.sm,
+  },
   modeToggle: {
     flexDirection: "row",
     borderWidth: 1,

--- a/openresto-frontend/components/booking/LookupScreen.tsx
+++ b/openresto-frontend/components/booking/LookupScreen.tsx
@@ -210,7 +210,7 @@ export default function LookupScreen({
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
         onScroll={fab.trackScroll}
-        scrollEventThrottle={100}
+        scrollEventThrottle={16}
       >
         <PageContainer style={[styles.page, twoColumn ? styles.pageWide : styles.pageIdle]}>
           <View style={styles.header}>
@@ -337,7 +337,7 @@ export default function LookupScreen({
         </SlidePanel>
       )}
 
-      <ScrollToTopFab visible={fab.visible} lift={fab.lift} onPress={scrollToTop} />
+      <ScrollToTopFab visible={fab.visible} travel={fab.travel} onPress={scrollToTop} />
 
       {showCancelConfirm && (
         <ConfirmModal

--- a/openresto-frontend/components/booking/LookupScreen.tsx
+++ b/openresto-frontend/components/booking/LookupScreen.tsx
@@ -324,7 +324,7 @@ export default function LookupScreen({
           </View>
         </PageContainer>
 
-        <Footer onLayout={fab.measureFooter} />
+        <Footer />
       </ScrollView>
 
       {isCompact && showPanel && (
@@ -337,7 +337,7 @@ export default function LookupScreen({
         </SlidePanel>
       )}
 
-      <ScrollToTopFab visible={fab.visible} travel={fab.travel} onPress={scrollToTop} />
+      <ScrollToTopFab visible={fab.visible} onPress={scrollToTop} />
 
       {showCancelConfirm && (
         <ConfirmModal

--- a/openresto-frontend/components/common/BrandGlyph.tsx
+++ b/openresto-frontend/components/common/BrandGlyph.tsx
@@ -1,0 +1,43 @@
+import { Image } from "expo-image";
+import { Icon, resolveIconSize, type IconSize } from "@/components/common/Icon";
+import { buildFaviconDataUri } from "@/constants/faviconIcons";
+
+/**
+ * The brand's chosen mark, drawn wherever the app stands for itself rather than for a screen.
+ *
+ * It renders the same Lucide glyph the favicon and PWA icon use, from the one source of truth in
+ * `constants/faviconIcons`, rather than an Ionicons lookalike: four of the fifteen choices
+ * (chef's hat, soup, cake, sandwich) have no Ionicons equivalent at all, so a mapping would quietly
+ * show a different icon than the one the brand settings say is selected.
+ *
+ * A brand with no icon configured, or one naming an icon this build no longer ships, falls back to
+ * the generic mark — `buildFaviconDataUri` returns nothing for an id it cannot resolve, so a stale
+ * value degrades rather than rendering a blank tile.
+ *
+ * @see [BrandGlyph.test.tsx](../../tests/components/common/BrandGlyph.test.tsx) — pins that a
+ * configured icon draws the brand's own mark and that an absent or unknown one falls back.
+ */
+export function BrandGlyph({
+  iconId,
+  size = "md",
+  color,
+}: {
+  /** `BrandSettings.faviconIcon`; undefined when the brand has not chosen one. */
+  iconId?: string;
+  size?: IconSize | number;
+  color: string;
+}) {
+  const uri = iconId ? buildFaviconDataUri(iconId, color) : "";
+  if (!uri) return <Icon name="restaurant-outline" size={size} color={color} />;
+
+  const px = resolveIconSize(size);
+  return (
+    <Image
+      source={{ uri }}
+      style={{ width: px, height: px }}
+      contentFit="contain"
+      accessible={false}
+      testID="brand-glyph"
+    />
+  );
+}

--- a/openresto-frontend/components/common/ScrollToTopFab.tsx
+++ b/openresto-frontend/components/common/ScrollToTopFab.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { LayoutChangeEvent, Pressable, View } from "react-native";
+import { useMemo, useState } from "react";
+import { Animated, LayoutChangeEvent, Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -12,6 +12,23 @@ export const SHOW_AFTER_SCROLL_Y = 300;
 
 /** Inset used once the container is no wider than the content column and has no gutter to sit in. */
 export const FAB_MIN_GUTTER = 20;
+
+/**
+ * How far the FAB travels up from where it rests, given the lift it has been handed and the
+ * safe-area inset it is already sitting on. The footer carries that inset itself, so the two
+ * never stack — the FAB only moves once the lift exceeds ground it already covers.
+ *
+ * The travel is applied as a transform rather than by moving the FAB's `bottom`, because it
+ * changes on every scroll event once the footer is entering view: `bottom` puts the browser
+ * through layout for each of those, a frame behind the scroll that caused it, which is what made
+ * the FAB judder up and down the page on web. A transform is composited and moves with it.
+ *
+ * @see [ScrollToTopFab.test.tsx](../../tests/components/ScrollToTopFab.test.tsx) — pins that the
+ * FAB stays put while the lift is inside the inset it already clears, and rises by the excess.
+ */
+export function fabTravel(lift: number, bottomInset: number): number {
+  return Math.max(0, lift - bottomInset);
+}
 
 /**
  * Right inset for the FAB inside a container of `containerWidth`. Above the content
@@ -31,13 +48,14 @@ interface Props {
   visible: boolean;
   onPress: () => void;
   /**
-   * How far to rise off the bottom of the container, on top of the resting gutter, so the
-   * FAB clears a footer scrolling into view underneath it. See `useScrollToTopFab`.
+   * How far to rise off the resting gutter, so the FAB clears a footer scrolling into view
+   * underneath it. An `Animated.Value` rather than a number because it changes on every scroll
+   * event: see `useScrollToTopFab` for why that must not go through React.
    */
-  lift?: number;
+  travel?: Animated.Value;
 }
 
-export default function ScrollToTopFab({ visible, onPress, lift = 0 }: Props) {
+export default function ScrollToTopFab({ visible, onPress, travel }: Props) {
   const { primaryColor } = useAppTheme();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -46,33 +64,41 @@ export default function ScrollToTopFab({ visible, onPress, lift = 0 }: Props) {
   // follows the column it belongs to rather than the window.
   const [laneWidth, setLaneWidth] = useState(0);
 
-  // Deliberately not gated on width or orientation. Every screen that mounts this
-  // is long enough to bury its own header on a desktop window too.
-  if (!visible) return null;
+  // Negated because a positive travel means "further up the page", and translateY grows downward.
+  const rise = useMemo(
+    () => (travel ? Animated.multiply(travel, -1) : new Animated.Value(0)),
+    [travel]
+  );
 
+  // The lane stays mounted while the FAB is hidden so it keeps its measured width. Unmounting it
+  // dropped that back to zero on every hide, and the FAB reappeared against the fallback gutter
+  // for a frame before layout put it back against the content column — a sideways jump each time
+  // it came back. Deliberately not gated on width or orientation: every screen that mounts this
+  // is long enough to bury its own header on a desktop window too.
   return (
-    <View
+    <Animated.View
       testID="scroll-to-top-lane"
       pointerEvents="box-none"
       onLayout={(e: LayoutChangeEvent) => setLaneWidth(e.nativeEvent.layout.width)}
       style={[
         styles.lane,
         {
-          // The footer carries the safe-area inset itself, so once it is tall enough to
-          // govern the two never stack.
-          bottom: Math.max(insets.bottom, lift) + FAB_MIN_GUTTER,
+          bottom: insets.bottom + FAB_MIN_GUTTER,
           paddingRight: fabGutter(laneWidth),
+          transform: [{ translateY: rise }],
         },
       ]}
     >
-      <Pressable
-        style={[styles.fab, { backgroundColor: primaryColor }]}
-        onPress={onPress}
-        accessibilityLabel={t("common.actions.scrollToTop")}
-        accessibilityRole="button"
-      >
-        <Icon name="chevron-up" size={22} color="#fff" />
-      </Pressable>
-    </View>
+      {visible && (
+        <Pressable
+          style={[styles.fab, { backgroundColor: primaryColor }]}
+          onPress={onPress}
+          accessibilityLabel={t("common.actions.scrollToTop")}
+          accessibilityRole="button"
+        >
+          <Icon name="chevron-up" size={22} color="#fff" />
+        </Pressable>
+      )}
+    </Animated.View>
   );
 }

--- a/openresto-frontend/components/common/ScrollToTopFab.tsx
+++ b/openresto-frontend/components/common/ScrollToTopFab.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { Animated, LayoutChangeEvent, Pressable } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import { Animated, LayoutChangeEvent, Pressable, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -13,22 +13,8 @@ export const SHOW_AFTER_SCROLL_Y = 300;
 /** Inset used once the container is no wider than the content column and has no gutter to sit in. */
 export const FAB_MIN_GUTTER = 20;
 
-/**
- * How far the FAB travels up from where it rests, given the lift it has been handed and the
- * safe-area inset it is already sitting on. The footer carries that inset itself, so the two
- * never stack — the FAB only moves once the lift exceeds ground it already covers.
- *
- * The travel is applied as a transform rather than by moving the FAB's `bottom`, because it
- * changes on every scroll event once the footer is entering view: `bottom` puts the browser
- * through layout for each of those, a frame behind the scroll that caused it, which is what made
- * the FAB judder up and down the page on web. A transform is composited and moves with it.
- *
- * @see [ScrollToTopFab.test.tsx](../../tests/components/ScrollToTopFab.test.tsx) — pins that the
- * FAB stays put while the lift is inside the inset it already clears, and rises by the excess.
- */
-export function fabTravel(lift: number, bottomInset: number): number {
-  return Math.max(0, lift - bottomInset);
-}
+/** Long enough to read as a fade rather than a flicker, short enough not to trail the scroll. */
+export const FADE_MS = 160;
 
 /**
  * Right inset for the FAB inside a container of `containerWidth`. Above the content
@@ -47,15 +33,19 @@ export function fabGutter(containerWidth: number): number {
 interface Props {
   visible: boolean;
   onPress: () => void;
-  /**
-   * How far to rise off the resting gutter, so the FAB clears a footer scrolling into view
-   * underneath it. An `Animated.Value` rather than a number because it changes on every scroll
-   * event: see `useScrollToTopFab` for why that must not go through React.
-   */
-  travel?: Animated.Value;
 }
 
-export default function ScrollToTopFab({ visible, onPress, travel }: Props) {
+/**
+ * The return-to-top shortcut. It holds one position for the whole scroll and fades out where the
+ * footer would otherwise be underneath it; `useScrollToTopFab` decides when.
+ *
+ * Nothing here tracks the scroll position. An earlier version rode above the footer, which meant
+ * recomputing an offset on every scroll event and moving an element that reads as pinned (#399).
+ *
+ * @see [ScrollToTopFab.test.tsx](../../tests/components/ScrollToTopFab.test.tsx) — pins that it
+ * rests on the same gutter whether shown or hidden, and takes no presses once faded.
+ */
+export default function ScrollToTopFab({ visible, onPress }: Props) {
   const { primaryColor } = useAppTheme();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -64,11 +54,14 @@ export default function ScrollToTopFab({ visible, onPress, travel }: Props) {
   // follows the column it belongs to rather than the window.
   const [laneWidth, setLaneWidth] = useState(0);
 
-  // Negated because a positive travel means "further up the page", and translateY grows downward.
-  const rise = useMemo(
-    () => (travel ? Animated.multiply(travel, -1) : new Animated.Value(0)),
-    [travel]
-  );
+  const opacity = useRef(new Animated.Value(visible ? 1 : 0)).current;
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: visible ? 1 : 0,
+      duration: FADE_MS,
+      useNativeDriver: true,
+    }).start();
+  }, [visible, opacity]);
 
   // The lane stays mounted while the FAB is hidden so it keeps its measured width. Unmounting it
   // dropped that back to zero on every hide, and the FAB reappeared against the fallback gutter
@@ -76,7 +69,7 @@ export default function ScrollToTopFab({ visible, onPress, travel }: Props) {
   // it came back. Deliberately not gated on width or orientation: every screen that mounts this
   // is long enough to bury its own header on a desktop window too.
   return (
-    <Animated.View
+    <View
       testID="scroll-to-top-lane"
       pointerEvents="box-none"
       onLayout={(e: LayoutChangeEvent) => setLaneWidth(e.nativeEvent.layout.width)}
@@ -85,20 +78,23 @@ export default function ScrollToTopFab({ visible, onPress, travel }: Props) {
         {
           bottom: insets.bottom + FAB_MIN_GUTTER,
           paddingRight: fabGutter(laneWidth),
-          transform: [{ translateY: rise }],
         },
       ]}
     >
-      {visible && (
+      <Animated.View style={{ opacity }} pointerEvents={visible ? "auto" : "none"}>
         <Pressable
+          testID="scroll-to-top-fab"
           style={[styles.fab, { backgroundColor: primaryColor }]}
           onPress={onPress}
+          disabled={!visible}
+          accessibilityElementsHidden={!visible}
+          importantForAccessibility={visible ? "auto" : "no-hide-descendants"}
           accessibilityLabel={t("common.actions.scrollToTop")}
           accessibilityRole="button"
         >
           <Icon name="chevron-up" size={22} color="#fff" />
         </Pressable>
-      )}
-    </Animated.View>
+      </Animated.View>
+    </View>
   );
 }

--- a/openresto-frontend/components/layout/AdminSidebar.tsx
+++ b/openresto-frontend/components/layout/AdminSidebar.tsx
@@ -21,6 +21,7 @@ import Button from "@/components/common/Button";
 import LanguageSwitcher from "@/components/common/LanguageSwitcher";
 import { styles } from "./AdminSidebar.styles";
 import { Icon, type IconName } from "@/components/common/Icon";
+import { BrandGlyph } from "@/components/common/BrandGlyph";
 
 interface NavItem {
   id: string;
@@ -200,7 +201,7 @@ export default function AdminSidebar() {
     >
       <View style={styles.brand}>
         <View style={[styles.brandIcon, { backgroundColor: PRIMARY }]}>
-          <Icon name="restaurant-outline" size="md" color={theme.colors.white} />
+          <BrandGlyph iconId={brand.faviconIcon} size="md" color={theme.colors.white} />
         </View>
         <View style={styles.brandTextGroup}>
           <ThemedText style={styles.brandName} numberOfLines={1}>

--- a/openresto-frontend/components/layout/Footer.tsx
+++ b/openresto-frontend/components/layout/Footer.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  View,
-  Pressable,
-  Linking,
-  useWindowDimensions,
-  type LayoutChangeEvent,
-} from "react-native";
+import { View, Pressable, Linking, useWindowDimensions } from "react-native";
 import { Link } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
@@ -16,8 +10,7 @@ import { fetchSocialLinks, SocialLinkDto } from "@/api/restaurants";
 import { styles } from "./Footer.styles";
 import { Icon, type IconName } from "@/components/common/Icon";
 
-/** `onLayout` reports the band's height to a screen whose scroll-to-top FAB has to clear it. */
-export default function Footer({ onLayout }: { onLayout?: (e: LayoutChangeEvent) => void }) {
+export default function Footer() {
   const { brand, colors } = useAppTheme();
   const { t } = useTranslation();
   const { width } = useWindowDimensions();
@@ -37,7 +30,6 @@ export default function Footer({ onLayout }: { onLayout?: (e: LayoutChangeEvent)
 
   return (
     <ThemedView
-      onLayout={onLayout}
       style={[styles.footer, { borderTopColor: colors.border, paddingBottom: insets.bottom }]}
     >
       <View style={[styles.inner, isMobile && styles.innerMobile]}>

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -136,13 +136,6 @@ export default function LocationsScreen({
     itemRefs.current[id] = ref;
   }, []);
 
-  // With the footer out of the column there is nothing left in this scroll for the FAB to
-  // climb over, and a height measured before the drawer opened would lift it over nothing.
-  const { setFooterHeight } = fab;
-  useEffect(() => {
-    if (sideDrawer) setFooterHeight(0);
-  }, [sideDrawer, setFooterHeight]);
-
   const scrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(
     () => () => {
@@ -297,10 +290,10 @@ export default function LocationsScreen({
               )}
             </PageContainer>
 
-            {!sideDrawer && <Footer onLayout={fab.measureFooter} />}
+            {!sideDrawer && <Footer />}
           </ScrollView>
 
-          <ScrollToTopFab visible={fab.visible} travel={fab.travel} onPress={scrollToTop} />
+          <ScrollToTopFab visible={fab.visible} onPress={scrollToTop} />
         </View>
 
         {drawer && (

--- a/openresto-frontend/components/restaurant/LocationsScreen.tsx
+++ b/openresto-frontend/components/restaurant/LocationsScreen.tsx
@@ -234,7 +234,7 @@ export default function LocationsScreen({
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
             onScroll={handleScroll}
-            scrollEventThrottle={100}
+            scrollEventThrottle={16}
           >
             <PageContainer style={styles.page}>
               <View style={styles.header}>
@@ -300,7 +300,7 @@ export default function LocationsScreen({
             {!sideDrawer && <Footer onLayout={fab.measureFooter} />}
           </ScrollView>
 
-          <ScrollToTopFab visible={fab.visible} lift={fab.lift} onPress={scrollToTop} />
+          <ScrollToTopFab visible={fab.visible} travel={fab.travel} onPress={scrollToTop} />
         </View>
 
         {drawer && (

--- a/openresto-frontend/hooks/use-scroll-to-top-fab.ts
+++ b/openresto-frontend/hooks/use-scroll-to-top-fab.ts
@@ -1,6 +1,8 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Animated } from "react-native";
 import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from "react-native";
-import { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { fabTravel, SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
 
 /**
  * How far the FAB has to rise to stay off a footer `footerHeight` tall, with
@@ -9,7 +11,7 @@ import { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
  * rather than on the links in it. The footer's own height is the ceiling: a bouncing
  * scroll reports a negative distance, which would otherwise walk the FAB up the page.
  *
- * @see [use-scroll-to-top-fab.test.ts](../tests/hooks/use-scroll-to-top-fab.test.ts) —
+ * @see [use-scroll-to-top-fab.test.ts](../tests/hooks/use-scroll-to-top-fab.test.tsx) —
  * pins that it stays flat while the footer is off screen, lifts once it is not, and
  * holds at the footer's top edge through an overscroll.
  */
@@ -24,25 +26,49 @@ export function fabLift(footerHeight: number, fromBottom: number): number {
  * `measureFooter` goes on the footer inside the scroll. A screen that takes the footer
  * back out of the scroll passes 0 through `setFooterHeight`, since the FAB then has
  * nothing to climb over.
+ *
+ * **The rise is an `Animated.Value`, and the footer's height is a ref, so that neither is React
+ * state.** This hook is called by the screen, so state here re-renders the whole page — every
+ * card, every row — and the rise changes on every scroll event for the length of the footer.
+ * `scrollEventThrottle` looks like it would blunt that, but react-native-web reads the prop only
+ * to decide whether to warn and never throttles, so the screen was re-rendering several times a
+ * frame at the one moment the user is watching something move. Writing an `Animated.Value`
+ * updates the node's transform without rendering at all. `visible` stays state deliberately: it
+ * flips twice in a scroll, and it adds and removes a child.
+ *
+ * @see [use-scroll-to-top-fab.test.ts](../tests/hooks/use-scroll-to-top-fab.test.tsx) — pins that
+ * scrolling past the footer moves the rise without re-rendering the screen that owns it.
  */
 export function useScrollToTopFab() {
   const [visible, setVisible] = useState(false);
-  const [lift, setLift] = useState(0);
-  const [footerHeight, setFooterHeight] = useState(0);
+  const insets = useSafeAreaInsets();
+  const travel = useRef(new Animated.Value(0)).current;
+  const footerHeight = useRef(0);
+
+  const setFooterHeight = useCallback((height: number) => {
+    footerHeight.current = height;
+  }, []);
+
+  const measureFooter = useCallback(
+    (e: LayoutChangeEvent) => setFooterHeight(e.nativeEvent.layout.height),
+    [setFooterHeight]
+  );
 
   const trackScroll = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
       const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
-      setVisible(contentOffset.y > SHOW_AFTER_SCROLL_Y);
       const fromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
-      setLift(fabLift(footerHeight, fromBottom));
+      travel.setValue(fabTravel(fabLift(footerHeight.current, fromBottom), insets.bottom));
+      // Same value as last time is a no-op in React, so this only renders on the two crossings.
+      setVisible(contentOffset.y > SHOW_AFTER_SCROLL_Y);
     },
-    [footerHeight]
+    [travel, insets.bottom]
   );
 
-  const measureFooter = useCallback((e: LayoutChangeEvent) => {
-    setFooterHeight(e.nativeEvent.layout.height);
-  }, []);
-
-  return { visible, lift, trackScroll, measureFooter, setFooterHeight };
+  // Stable, so a screen wrapping `trackScroll` in its own handler does not hand the ScrollView a
+  // new onScroll every render.
+  return useMemo(
+    () => ({ visible, travel, trackScroll, measureFooter, setFooterHeight }),
+    [visible, travel, trackScroll, measureFooter, setFooterHeight]
+  );
 }

--- a/openresto-frontend/hooks/use-scroll-to-top-fab.ts
+++ b/openresto-frontend/hooks/use-scroll-to-top-fab.ts
@@ -1,74 +1,38 @@
-import { useCallback, useMemo, useRef, useState } from "react";
-import { Animated } from "react-native";
-import type { LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { fabTravel, SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
+import { useCallback, useMemo, useState } from "react";
+import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+import { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
 
 /**
- * How far the FAB has to rise to stay off a footer `footerHeight` tall, with
- * `fromBottom` px of the scroll still to go. Zero until the footer starts entering the
- * viewport, then tracks it one for one, so the FAB comes to rest on the footer's top edge
- * rather than on the links in it. The footer's own height is the ceiling: a bouncing
- * scroll reports a negative distance, which would otherwise walk the FAB up the page.
+ * Drives the scroll-to-top FAB: it is offered once the scroll is far enough down to be worth
+ * undoing, and from then to the end of the page.
  *
- * @see [use-scroll-to-top-fab.test.ts](../tests/hooks/use-scroll-to-top-fab.test.tsx) —
- * pins that it stays flat while the footer is off screen, lifts once it is not, and
- * holds at the footer's top edge through an overscroll.
- */
-export function fabLift(footerHeight: number, fromBottom: number): number {
-  return Math.min(footerHeight, Math.max(0, footerHeight - fromBottom));
-}
-
-/**
- * Drives the scroll-to-top FAB for a screen whose scroll ends in a `<Footer />`: when it
- * shows, and how far it has to rise to stay clear of that footer.
+ * It used to stand down over the footer, and before that to climb over it — rising as the footer
+ * came into view so as not to sit on its links. Both were wrong. The climb meant an element that
+ * reads as pinned sliding the footer's height up the page on every scroll near the bottom, driven
+ * by a value that changed on every scroll event: the judder in #399. Standing down instead took
+ * the shortcut away at the bottom of the page, which is exactly where it is most wanted. Neither
+ * was needed: the FAB sits in the gutter beside the content column, and the footer's own row ends
+ * on that same edge, so they never overlapped in the first place.
  *
- * `measureFooter` goes on the footer inside the scroll. A screen that takes the footer
- * back out of the scroll passes 0 through `setFooterHeight`, since the FAB then has
- * nothing to climb over.
+ * Visibility is the only thing a scroll changes here, and it changes twice in a scroll rather than
+ * continuously — so this hook, which the *screen* calls, re-renders the page twice rather than on
+ * every scroll event. That matters more than it looks: react-native-web reads
+ * `scrollEventThrottle` only to decide whether to warn and never throttles, so anything held here
+ * that tracks the scroll position re-renders every card on the page several times a frame.
  *
- * **The rise is an `Animated.Value`, and the footer's height is a ref, so that neither is React
- * state.** This hook is called by the screen, so state here re-renders the whole page — every
- * card, every row — and the rise changes on every scroll event for the length of the footer.
- * `scrollEventThrottle` looks like it would blunt that, but react-native-web reads the prop only
- * to decide whether to warn and never throttles, so the screen was re-rendering several times a
- * frame at the one moment the user is watching something move. Writing an `Animated.Value`
- * updates the node's transform without rendering at all. `visible` stays state deliberately: it
- * flips twice in a scroll, and it adds and removes a child.
- *
- * @see [use-scroll-to-top-fab.test.ts](../tests/hooks/use-scroll-to-top-fab.test.tsx) — pins that
- * scrolling past the footer moves the rise without re-rendering the screen that owns it.
+ * @see [use-scroll-to-top-fab.test.tsx](../tests/hooks/use-scroll-to-top-fab.test.tsx) — pins that
+ * it holds to the end of the scroll, and that a gesture's worth of positions renders the screen
+ * once rather than once each.
  */
 export function useScrollToTopFab() {
   const [visible, setVisible] = useState(false);
-  const insets = useSafeAreaInsets();
-  const travel = useRef(new Animated.Value(0)).current;
-  const footerHeight = useRef(0);
 
-  const setFooterHeight = useCallback((height: number) => {
-    footerHeight.current = height;
+  const trackScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    // Same value as last time is a no-op in React, so this renders only on the crossing.
+    setVisible(e.nativeEvent.contentOffset.y > SHOW_AFTER_SCROLL_Y);
   }, []);
-
-  const measureFooter = useCallback(
-    (e: LayoutChangeEvent) => setFooterHeight(e.nativeEvent.layout.height),
-    [setFooterHeight]
-  );
-
-  const trackScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
-      const fromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
-      travel.setValue(fabTravel(fabLift(footerHeight.current, fromBottom), insets.bottom));
-      // Same value as last time is a no-op in React, so this only renders on the two crossings.
-      setVisible(contentOffset.y > SHOW_AFTER_SCROLL_Y);
-    },
-    [travel, insets.bottom]
-  );
 
   // Stable, so a screen wrapping `trackScroll` in its own handler does not hand the ScrollView a
   // new onScroll every render.
-  return useMemo(
-    () => ({ visible, travel, trackScroll, measureFooter, setFooterHeight }),
-    [visible, travel, trackScroll, measureFooter, setFooterHeight]
-  );
+  return useMemo(() => ({ visible, trackScroll }), [visible, trackScroll]);
 }

--- a/openresto-frontend/tests/app/admin/bookings-index.test.tsx
+++ b/openresto-frontend/tests/app/admin/bookings-index.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import { Platform } from "react-native";
-import { render, screen, waitFor, fireEvent, act } from "@testing-library/react-native";
+import { render, screen, waitFor, fireEvent, act, within } from "@testing-library/react-native";
 import AdminBookingsScreen from "@/app/admin/bookings/index";
 import {
   getAdminBookings,
@@ -910,5 +910,64 @@ describe("AdminBookingsScreen filter persistence", () => {
     await waitFor(() => {
       expect(JSON.parse(localStorage.getItem("bookings:restaurantId") as string)).toBe(2);
     });
+  });
+});
+
+describe("AdminBookingsScreen toolbar", () => {
+  const originalPlatform = Platform.OS;
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+    (getAdminBookings as jest.Mock).mockResolvedValue([]);
+    (adminGetTables as jest.Mock).mockResolvedValue([]);
+    (adminLookupBookings as jest.Mock).mockResolvedValue([]);
+    Object.keys(mockSearchParams).forEach((k) => delete mockSearchParams[k]);
+    // The persisted view mode only reaches the screen on web, and these are all about what the
+    // toolbar holds in a given mode.
+    Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(Platform, "OS", { value: originalPlatform, configurable: true });
+  });
+
+  // The toolbar used to carry the status tabs, which only apply to the list, so switching view
+  // rearranged it. It now holds the same controls in every mode.
+  it("keeps the status tabs out of the toolbar", async () => {
+    localStorage.setItem("bookings:viewMode", JSON.stringify("list"));
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByTestId("status-tab-active")).toBeTruthy());
+    const toolbar = screen.getByTestId("bookings-toolbar");
+
+    expect(within(toolbar).queryByTestId("status-tab-active")).toBeNull();
+    expect(within(toolbar).getByTestId("view-toggle-list")).toBeTruthy();
+  });
+
+  it("offers the same view toggle in every mode", async () => {
+    for (const mode of ["timetable", "service", "list"]) {
+      localStorage.setItem("bookings:viewMode", JSON.stringify(mode));
+      const view = render(<AdminBookingsScreen />);
+
+      await waitFor(() => expect(screen.getByTestId("bookings-toolbar")).toBeTruthy());
+      const toolbar = screen.getByTestId("bookings-toolbar");
+      for (const key of ["timetable", "service", "list"]) {
+        expect(within(toolbar).getByTestId(`view-toggle-${key}`)).toBeTruthy();
+      }
+      view.unmount();
+    }
+  });
+
+  it("filters the list by status from below the toolbar", async () => {
+    localStorage.setItem("bookings:viewMode", JSON.stringify("list"));
+    render(<AdminBookingsScreen />);
+
+    await waitFor(() => expect(screen.getByTestId("status-tab-cancelled")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("status-tab-cancelled"));
+
+    await waitFor(() =>
+      expect(getAdminBookings).toHaveBeenCalledWith(expect.anything(), undefined, "cancelled")
+    );
   });
 });

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -2,11 +2,10 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { screen, fireEvent, act } from "@testing-library/react-native";
-import { Animated, StyleSheet } from "react-native";
+import { screen, fireEvent } from "@testing-library/react-native";
+import { StyleSheet } from "react-native";
 import ScrollToTopFab, {
   fabGutter,
-  fabTravel,
   FAB_MIN_GUTTER,
   SHOW_AFTER_SCROLL_Y,
 } from "@/components/common/ScrollToTopFab";
@@ -29,9 +28,18 @@ describe("ScrollToTopFab", () => {
     expect(screen.getByRole("button")).toBeTruthy();
   });
 
-  it("does not render when not visible", () => {
+  // The lane stays mounted while hidden so it keeps its measured width; unmounting it dropped
+  // that to zero and the FAB reappeared against the fallback gutter for a frame before layout put
+  // it back beside the content column — a sideways jump every time it came back.
+  it("keeps its place in the layout while hidden, so it does not jump back in", () => {
     renderWithProviders(<ScrollToTopFab visible={false} onPress={jest.fn()} />);
+    expect(screen.getByTestId("scroll-to-top-lane")).toBeTruthy();
+    // Present in the layout, but gone from the a11y tree and from the press target.
     expect(screen.queryByRole("button")).toBeNull();
+    expect(
+      screen.getByTestId("scroll-to-top-fab", { includeHiddenElements: true }).props
+        .accessibilityElementsHidden
+    ).toBe(true);
   });
 
   // The FAB used to be gated to portrait phones under 700px wide, which hid it
@@ -95,36 +103,27 @@ describe("ScrollToTopFab", () => {
     expect(StyleSheet.flatten(lane.props.style).paddingRight).toBe(FAB_MIN_GUTTER);
   });
 
-  // The lift is what keeps the FAB off the footer's own links at the end of a scroll; see
-  // useScrollToTopFab for where the number comes from.
-  describe("fabTravel", () => {
-    it("stays put while the lift is inside ground the FAB already covers", () => {
-      expect(fabTravel(0, 34)).toBe(0);
-      expect(fabTravel(34, 34)).toBe(0);
-    });
+  // The FAB used to climb over the footer, recomputing an offset on every scroll event and
+  // sliding an element that reads as pinned up the page (#399). It holds one place now.
+  it("rests on the same gutter whether it is showing or not", () => {
+    const { unmount } = renderWithProviders(<ScrollToTopFab visible onPress={jest.fn()} />);
+    const shown = StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
+    unmount();
 
-    it("rises by whatever the lift exceeds that by, so the two never stack", () => {
-      expect(fabTravel(35, 34)).toBe(1);
-      expect(fabTravel(88, 34)).toBe(88 - 34);
-      expect(fabTravel(88, 0)).toBe(88);
-    });
+    renderWithProviders(<ScrollToTopFab visible={false} onPress={jest.fn()} />);
+    const hidden = StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
+
+    expect(hidden.bottom).toBe(shown.bottom);
+    expect(hidden.transform).toBeUndefined();
   });
 
-  // The rise is a transform, not a change of `bottom`: it moves on every scroll event, and
-  // putting the browser through layout for each of those is what made it judder.
-  it("rests on the gutter and rises by a transform rather than by moving its bottom", () => {
-    const travel = new Animated.Value(0);
-    renderWithProviders(<ScrollToTopFab visible travel={travel} onPress={jest.fn()} />);
+  it("takes no presses once it has faded out", () => {
+    const onPress = jest.fn();
+    renderWithProviders(<ScrollToTopFab visible={false} onPress={onPress} />);
 
-    const style = StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
-    expect(style.bottom).toBe(FAB_MIN_GUTTER);
-    expect(style.transform).toBeDefined();
+    fireEvent.press(screen.getByTestId("scroll-to-top-fab", { includeHiddenElements: true }));
 
-    act(() => travel.setValue(88));
-    // The bottom is fixed; the movement is the transform's, so `bottom` must not have followed.
-    expect(StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style).bottom).toBe(
-      FAB_MIN_GUTTER
-    );
+    expect(onPress).not.toHaveBeenCalled();
   });
 
   it("calls onPress when pressed", () => {

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -2,10 +2,11 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { screen, fireEvent } from "@testing-library/react-native";
-import { StyleSheet } from "react-native";
+import { screen, fireEvent, act } from "@testing-library/react-native";
+import { Animated, StyleSheet } from "react-native";
 import ScrollToTopFab, {
   fabGutter,
+  fabTravel,
   FAB_MIN_GUTTER,
   SHOW_AFTER_SCROLL_Y,
 } from "@/components/common/ScrollToTopFab";
@@ -96,16 +97,33 @@ describe("ScrollToTopFab", () => {
 
   // The lift is what keeps the FAB off the footer's own links at the end of a scroll; see
   // useScrollToTopFab for where the number comes from.
-  it("rises off the bottom by the lift it is given", () => {
-    const { unmount } = renderWithProviders(<ScrollToTopFab visible onPress={jest.fn()} />);
+  describe("fabTravel", () => {
+    it("stays put while the lift is inside ground the FAB already covers", () => {
+      expect(fabTravel(0, 34)).toBe(0);
+      expect(fabTravel(34, 34)).toBe(0);
+    });
+
+    it("rises by whatever the lift exceeds that by, so the two never stack", () => {
+      expect(fabTravel(35, 34)).toBe(1);
+      expect(fabTravel(88, 34)).toBe(88 - 34);
+      expect(fabTravel(88, 0)).toBe(88);
+    });
+  });
+
+  // The rise is a transform, not a change of `bottom`: it moves on every scroll event, and
+  // putting the browser through layout for each of those is what made it judder.
+  it("rests on the gutter and rises by a transform rather than by moving its bottom", () => {
+    const travel = new Animated.Value(0);
+    renderWithProviders(<ScrollToTopFab visible travel={travel} onPress={jest.fn()} />);
+
+    const style = StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
+    expect(style.bottom).toBe(FAB_MIN_GUTTER);
+    expect(style.transform).toBeDefined();
+
+    act(() => travel.setValue(88));
+    // The bottom is fixed; the movement is the transform's, so `bottom` must not have followed.
     expect(StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style).bottom).toBe(
       FAB_MIN_GUTTER
-    );
-    unmount();
-
-    renderWithProviders(<ScrollToTopFab visible lift={88} onPress={jest.fn()} />);
-    expect(StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style).bottom).toBe(
-      88 + FAB_MIN_GUTTER
     );
   });
 

--- a/openresto-frontend/tests/components/admin/bookings/BookingStatusTabs.test.tsx
+++ b/openresto-frontend/tests/components/admin/bookings/BookingStatusTabs.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { BookingStatusTabs } from "@/components/admin/bookings/BookingStatusTabs";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+
+const props = {
+  value: "active" as const,
+  onChange: jest.fn(),
+  borderColor: "#ddd",
+  cardBg: "#fff",
+  mutedColor: "#666",
+  primaryColor: "#0a7ea4",
+};
+
+describe("BookingStatusTabs", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("offers each set of bookings the list can show", () => {
+    render(<BookingStatusTabs {...props} />);
+
+    expect(screen.getByText("Active")).toBeTruthy();
+    expect(screen.getByText("Past")).toBeTruthy();
+    expect(screen.getByText("Cancelled")).toBeTruthy();
+  });
+
+  it("reports the tab that was pressed", () => {
+    render(<BookingStatusTabs {...props} />);
+
+    fireEvent.press(screen.getByTestId("status-tab-cancelled"));
+
+    expect(props.onChange).toHaveBeenCalledWith("cancelled");
+  });
+
+  it("marks the active set as checked and the others as not", () => {
+    render(<BookingStatusTabs {...props} value="past" />);
+
+    expect(screen.getByTestId("status-tab-past").props.accessibilityState.checked).toBe(true);
+    expect(screen.getByTestId("status-tab-active").props.accessibilityState.checked).toBe(false);
+  });
+});

--- a/openresto-frontend/tests/components/common/BrandGlyph.test.tsx
+++ b/openresto-frontend/tests/components/common/BrandGlyph.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { BrandGlyph } from "@/components/common/BrandGlyph";
+import { FAVICON_ICONS } from "@/constants/faviconIcons";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+
+jest.mock("expo-image", () => {
+  const { View } = require("react-native");
+  return { Image: (props: Record<string, unknown>) => <View {...props} /> };
+});
+
+describe("BrandGlyph", () => {
+  it("draws the brand's own mark when one is configured", () => {
+    render(<BrandGlyph iconId="wine" color="#fff" />);
+
+    const glyph = screen.getByTestId("brand-glyph");
+    expect(glyph.props.source.uri).toContain("svg");
+  });
+
+  it("draws the mark in the colour it was given, so it reads on a brand-coloured tile", () => {
+    render(<BrandGlyph iconId="wine" color="#ffffff" />);
+
+    expect(decodeURIComponent(screen.getByTestId("brand-glyph").props.source.uri)).toContain(
+      'stroke="#ffffff"'
+    );
+  });
+
+  // Four of the fifteen choices have no Ionicons equivalent, so the real glyph is drawn rather
+  // than a lookalike — this pins that every choice actually resolves to one.
+  it("resolves every icon the brand settings offer", () => {
+    for (const icon of FAVICON_ICONS) {
+      const view = render(<BrandGlyph iconId={icon.id} color="#fff" />);
+      expect(screen.getByTestId("brand-glyph")).toBeTruthy();
+      view.unmount();
+    }
+  });
+
+  it("falls back to the generic mark when the brand has chosen no icon", () => {
+    render(<BrandGlyph color="#fff" />);
+    expect(screen.queryByTestId("brand-glyph")).toBeNull();
+  });
+
+  it("falls back rather than drawing a blank tile for an icon this build no longer ships", () => {
+    render(<BrandGlyph iconId="tractor" color="#fff" />);
+    expect(screen.queryByTestId("brand-glyph")).toBeNull();
+  });
+
+  it("sizes the mark to the icon scale it was asked for", () => {
+    render(<BrandGlyph iconId="wine" color="#fff" size={24} />);
+    expect(screen.getByTestId("brand-glyph").props.style).toMatchObject({
+      width: 24,
+      height: 24,
+    });
+  });
+});

--- a/openresto-frontend/tests/components/layout/AdminSidebar.test.tsx
+++ b/openresto-frontend/tests/components/layout/AdminSidebar.test.tsx
@@ -18,8 +18,13 @@ jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
+const mockBrand: { primaryColor: string; appName: string; faviconIcon?: string } = {
+  primaryColor: "#0a7ea4",
+  appName: "Open Resto",
+};
+
 jest.mock("@/context/BrandContext", () => ({
-  useBrand: () => ({ primaryColor: "#0a7ea4", appName: "Open Resto" }),
+  useBrand: () => mockBrand,
 }));
 
 jest.mock("@/context/ThemeContext", () => ({
@@ -116,6 +121,29 @@ describe("AdminSidebar", () => {
     );
     await waitFor(() => expect(screen.getByText("CONFIGURE")).toBeTruthy());
     expect(screen.queryByText("Users")).toBeNull();
+  });
+
+  it("wears the mark the brand settings selected, not a generic one", async () => {
+    mockBrand.faviconIcon = "wine";
+    try {
+      render(
+        <AuthProvider>
+          <AdminSidebar />
+        </AuthProvider>
+      );
+      expect(await screen.findByTestId("brand-glyph")).toBeTruthy();
+    } finally {
+      delete mockBrand.faviconIcon;
+    }
+  });
+
+  it("wears the generic mark when the brand has selected none", () => {
+    render(
+      <AuthProvider>
+        <AdminSidebar />
+      </AuthProvider>
+    );
+    expect(screen.queryByTestId("brand-glyph")).toBeNull();
   });
 
   it("navigates to brand settings when Brand is pressed", async () => {

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -452,6 +452,17 @@ describe("LocationsScreen", () => {
 
     // The FAB used to rest in the column's own bottom corner whatever was under it, so at
     // the end of the list it landed on the footer's links.
+    /**
+     * The FAB's rise, read off the transform driving it. It moves by transform rather than by its
+     * `bottom` because it changes on every scroll event; see ScrollToTopFab.
+     */
+    const fabRise = (): number => {
+      const style = StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
+      const translate = (style.transform as { translateY: unknown }[])[0];
+      const value = translate.translateY as number | { __getValue(): number };
+      return -(typeof value === "number" ? value : value.__getValue());
+    };
+
     it("lifts the FAB over the footer it measured once the list reaches the end", async () => {
       (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
       renderWithProviders(<LocationsScreen />);
@@ -463,8 +474,7 @@ describe("LocationsScreen", () => {
       const scrollView = screen.UNSAFE_getByType(ScrollView);
 
       fireEvent.scroll(scrollView, scrollEvent(400));
-      const lane = () => StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
-      const resting = lane().bottom;
+      expect(fabRise()).toBe(0);
 
       fireEvent.scroll(scrollView, {
         nativeEvent: {
@@ -473,7 +483,7 @@ describe("LocationsScreen", () => {
           layoutMeasurement: { height: 900 },
         },
       });
-      expect(lane().bottom).toBe(resting + 88);
+      expect(fabRise()).toBe(88);
     });
 
     it("drops the lift again when the drawer takes the footer out of the column", async () => {
@@ -493,17 +503,13 @@ describe("LocationsScreen", () => {
         },
       };
       fireEvent.scroll(scrollView, atEnd);
-      const lifted = StyleSheet.flatten(
-        screen.getByTestId("scroll-to-top-lane").props.style
-      ).bottom;
+      const lifted = fabRise();
 
       fireEvent.press(screen.getByTestId("book-1"));
       await waitFor(() => expect(screen.getByTestId("mock-drawer")).toBeTruthy());
       fireEvent.scroll(scrollView, atEnd);
 
-      expect(
-        StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style).bottom
-      ).toBeLessThan(lifted);
+      expect(fabRise()).toBeLessThan(lifted);
     });
 
     it("leaves the footer in the column for the phone sheet, which takes no width off it", async () => {

--- a/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
+++ b/openresto-frontend/tests/components/restaurant/LocationsScreen.test.tsx
@@ -452,29 +452,29 @@ describe("LocationsScreen", () => {
 
     // The FAB used to rest in the column's own bottom corner whatever was under it, so at
     // the end of the list it landed on the footer's links.
+    /** Whether the FAB is currently offered, rather than faded out under the footer. */
     /**
-     * The FAB's rise, read off the transform driving it. It moves by transform rather than by its
-     * `bottom` because it changes on every scroll event; see ScrollToTopFab.
+     * Whether the FAB is being offered. Read off the control rather than by querying for it: it
+     * stays mounted while hidden so it keeps its measured place, and fades rather than unmounting,
+     * so a role query answers "is it painted" rather than "is it offered".
      */
-    const fabRise = (): number => {
-      const style = StyleSheet.flatten(screen.getByTestId("scroll-to-top-lane").props.style);
-      const translate = (style.transform as { translateY: unknown }[])[0];
-      const value = translate.translateY as number | { __getValue(): number };
-      return -(typeof value === "number" ? value : value.__getValue());
-    };
+    const fabShowing = (): boolean =>
+      screen.getByTestId("scroll-to-top-fab", { includeHiddenElements: true }).props
+        .accessibilityElementsHidden !== true;
 
-    it("lifts the FAB over the footer it measured once the list reaches the end", async () => {
+    // The FAB used to climb over the footer and then to stand down over it. The climb slid an
+    // element that reads as pinned up the page on every scroll near the bottom; standing down took
+    // the shortcut away at the end of the page, which is where it is most wanted (#399). It sits
+    // in the gutter beside the content column, which the footer's own row does not reach.
+    it("keeps the FAB to the very end of the list", async () => {
       (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
       renderWithProviders(<LocationsScreen />);
       await waitFor(() => expect(screen.getByTestId("book-1")).toBeTruthy());
 
-      fireEvent(screen.getByTestId("mock-footer"), "layout", {
-        nativeEvent: { layout: { height: 88, width: 1280, x: 0, y: 0 } },
-      });
       const scrollView = screen.UNSAFE_getByType(ScrollView);
 
       fireEvent.scroll(scrollView, scrollEvent(400));
-      expect(fabRise()).toBe(0);
+      expect(fabShowing()).toBe(true);
 
       fireEvent.scroll(scrollView, {
         nativeEvent: {
@@ -483,17 +483,14 @@ describe("LocationsScreen", () => {
           layoutMeasurement: { height: 900 },
         },
       });
-      expect(fabRise()).toBe(88);
+      expect(fabShowing()).toBe(true);
     });
 
-    it("drops the lift again when the drawer takes the footer out of the column", async () => {
+    it("keeps the FAB with the drawer open, which takes the footer out of the column", async () => {
       (fetchRestaurants as jest.Mock).mockResolvedValue(mockRestaurants);
       renderWithProviders(<LocationsScreen />);
       await waitFor(() => expect(screen.getByTestId("book-1")).toBeTruthy());
 
-      fireEvent(screen.getByTestId("mock-footer"), "layout", {
-        nativeEvent: { layout: { height: 88, width: 1280, x: 0, y: 0 } },
-      });
       const scrollView = screen.UNSAFE_getByType(ScrollView);
       const atEnd = {
         nativeEvent: {
@@ -502,14 +499,12 @@ describe("LocationsScreen", () => {
           layoutMeasurement: { height: 900 },
         },
       };
-      fireEvent.scroll(scrollView, atEnd);
-      const lifted = fabRise();
 
       fireEvent.press(screen.getByTestId("book-1"));
       await waitFor(() => expect(screen.getByTestId("mock-drawer")).toBeTruthy());
       fireEvent.scroll(scrollView, atEnd);
 
-      expect(fabRise()).toBeLessThan(lifted);
+      expect(fabShowing()).toBe(true);
     });
 
     it("leaves the footer in the column for the phone sheet, which takes no width off it", async () => {

--- a/openresto-frontend/tests/hooks/use-scroll-to-top-fab.test.tsx
+++ b/openresto-frontend/tests/hooks/use-scroll-to-top-fab.test.tsx
@@ -1,4 +1,7 @@
-import { renderHook, act } from "@testing-library/react-native";
+import { renderHook as renderHookRaw, act } from "@testing-library/react-native";
+import type { Animated } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import React from "react";
 import { fabLift, useScrollToTopFab } from "@/hooks/use-scroll-to-top-fab";
 import { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
 
@@ -16,6 +19,21 @@ const scrollEvent = (y: number, fromBottom = 1000) =>
 
 const layoutEvent = (height: number) =>
   ({ nativeEvent: { layout: { height, width: 1280, x: 0, y: 0 } } }) as never;
+
+/** The hook reads the safe-area inset the FAB already rests on, so it needs the provider. */
+const ZERO_INSETS = {
+  frame: { x: 0, y: 0, width: 1280, height: 900 },
+  insets: { top: 0, left: 0, right: 0, bottom: 0 },
+};
+
+const renderHook = <T,>(cb: () => T) =>
+  renderHookRaw(cb, {
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(SafeAreaProvider, { initialMetrics: ZERO_INSETS }, children),
+  });
+
+/** The rise the FAB is currently being held at, read off the Animated.Value driving it. */
+const riseOf = (travel: Animated.Value): number => (travel as unknown as { _value: number })._value;
 
 describe("fabLift", () => {
   // The FAB used to sit in its container's bottom corner whatever was under it, so at the
@@ -54,15 +72,50 @@ describe("useScrollToTopFab", () => {
     expect(result.current.visible).toBe(true);
   });
 
+  // The hook runs in the screen, so a render here is a render of the whole page — every card,
+  // every row. The rise changes on every scroll event for the length of the footer, and
+  // react-native-web never throttles onScroll, so driving it through state re-rendered the page
+  // several times a frame at the one moment the user is watching something move.
+  it("does not re-render the screen once per scroll event", () => {
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useScrollToTopFab();
+    });
+
+    act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
+    act(() => result.current.trackScroll(scrollEvent(600, 1000)));
+    const settled = renders;
+
+    // A gesture's worth of positions, all with the FAB already shown and only the rise moving.
+    for (let fromBottom = FOOTER_HEIGHT; fromBottom >= 0; fromBottom -= 4) {
+      act(() => result.current.trackScroll(scrollEvent(600, fromBottom)));
+    }
+
+    expect(riseOf(result.current.travel)).toBe(FOOTER_HEIGHT);
+    // React may still render once more before bailing on an unchanged `visible`; what must not
+    // happen is a render for each of the twenty-odd positions.
+    expect(renders).toBeLessThanOrEqual(settled + 1);
+  });
+
+  it("hands the ScrollView the same handler across renders", () => {
+    const { result, rerender } = renderHook(() => useScrollToTopFab());
+    const first = result.current.trackScroll;
+
+    rerender({});
+
+    expect(result.current.trackScroll).toBe(first);
+  });
+
   it("lifts the FAB by the footer it measured, not by a guess", () => {
     const { result } = renderHook(() => useScrollToTopFab());
 
     act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
     act(() => result.current.trackScroll(scrollEvent(600, 1000)));
-    expect(result.current.lift).toBe(0);
+    expect(riseOf(result.current.travel)).toBe(0);
 
     act(() => result.current.trackScroll(scrollEvent(600, 0)));
-    expect(result.current.lift).toBe(FOOTER_HEIGHT);
+    expect(riseOf(result.current.travel)).toBe(FOOTER_HEIGHT);
   });
 
   // A screen that takes the footer back out of its scroll — Locations, once the booking
@@ -72,10 +125,10 @@ describe("useScrollToTopFab", () => {
 
     act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
     act(() => result.current.trackScroll(scrollEvent(600, 0)));
-    expect(result.current.lift).toBe(FOOTER_HEIGHT);
+    expect(riseOf(result.current.travel)).toBe(FOOTER_HEIGHT);
 
     act(() => result.current.setFooterHeight(0));
     act(() => result.current.trackScroll(scrollEvent(600, 0)));
-    expect(result.current.lift).toBe(0);
+    expect(riseOf(result.current.travel)).toBe(0);
   });
 });

--- a/openresto-frontend/tests/hooks/use-scroll-to-top-fab.test.tsx
+++ b/openresto-frontend/tests/hooks/use-scroll-to-top-fab.test.tsx
@@ -1,11 +1,6 @@
-import { renderHook as renderHookRaw, act } from "@testing-library/react-native";
-import type { Animated } from "react-native";
-import { SafeAreaProvider } from "react-native-safe-area-context";
-import React from "react";
-import { fabLift, useScrollToTopFab } from "@/hooks/use-scroll-to-top-fab";
+import { renderHook, act } from "@testing-library/react-native";
+import { useScrollToTopFab } from "@/hooks/use-scroll-to-top-fab";
 import { SHOW_AFTER_SCROLL_Y } from "@/components/common/ScrollToTopFab";
-
-const FOOTER_HEIGHT = 88;
 
 /** A scroll event `fromBottom` px short of the end of a page one viewport taller than its scroll. */
 const scrollEvent = (y: number, fromBottom = 1000) =>
@@ -17,51 +12,8 @@ const scrollEvent = (y: number, fromBottom = 1000) =>
     },
   }) as never;
 
-const layoutEvent = (height: number) =>
-  ({ nativeEvent: { layout: { height, width: 1280, x: 0, y: 0 } } }) as never;
-
-/** The hook reads the safe-area inset the FAB already rests on, so it needs the provider. */
-const ZERO_INSETS = {
-  frame: { x: 0, y: 0, width: 1280, height: 900 },
-  insets: { top: 0, left: 0, right: 0, bottom: 0 },
-};
-
-const renderHook = <T,>(cb: () => T) =>
-  renderHookRaw(cb, {
-    wrapper: ({ children }: { children: React.ReactNode }) =>
-      React.createElement(SafeAreaProvider, { initialMetrics: ZERO_INSETS }, children),
-  });
-
-/** The rise the FAB is currently being held at, read off the Animated.Value driving it. */
-const riseOf = (travel: Animated.Value): number => (travel as unknown as { _value: number })._value;
-
-describe("fabLift", () => {
-  // The FAB used to sit in its container's bottom corner whatever was under it, so at the
-  // end of a scroll it came to rest on the footer's own links (#352 follow-up).
-  it("stays flat while the footer is still below the fold", () => {
-    expect(fabLift(FOOTER_HEIGHT, FOOTER_HEIGHT + 1)).toBe(0);
-    expect(fabLift(FOOTER_HEIGHT, 1000)).toBe(0);
-  });
-
-  it("rises with the footer once it starts entering the viewport", () => {
-    expect(fabLift(FOOTER_HEIGHT, FOOTER_HEIGHT - 1)).toBe(1);
-    expect(fabLift(FOOTER_HEIGHT, 20)).toBe(FOOTER_HEIGHT - 20);
-  });
-
-  // At the very bottom the whole footer is on screen, so the FAB rests on its top edge.
-  it("clears the whole footer at the end of the scroll", () => {
-    expect(fabLift(FOOTER_HEIGHT, 0)).toBe(FOOTER_HEIGHT);
-  });
-
-  // Overscroll on iOS reports a negative distance; the FAB must not chase it up the page.
-  it("does not keep climbing past the footer when the scroll overshoots", () => {
-    expect(fabLift(FOOTER_HEIGHT, -60)).toBe(FOOTER_HEIGHT);
-    expect(fabLift(0, -60)).toBe(0);
-  });
-});
-
 describe("useScrollToTopFab", () => {
-  it("shows the FAB only once the scroll is worth undoing", () => {
+  it("stays away until the scroll is worth undoing", () => {
     const { result } = renderHook(() => useScrollToTopFab());
     expect(result.current.visible).toBe(false);
 
@@ -72,10 +24,29 @@ describe("useScrollToTopFab", () => {
     expect(result.current.visible).toBe(true);
   });
 
+  // It used to stand down over the footer, which took the shortcut away at the bottom of the page
+  // — exactly where it is most wanted (#399).
+  it("holds to the very end of the scroll, where it is most wanted", () => {
+    const { result } = renderHook(() => useScrollToTopFab());
+
+    act(() => result.current.trackScroll(scrollEvent(600, 0)));
+
+    expect(result.current.visible).toBe(true);
+  });
+
+  it("goes away again on the way back up", () => {
+    const { result } = renderHook(() => useScrollToTopFab());
+
+    act(() => result.current.trackScroll(scrollEvent(600)));
+    expect(result.current.visible).toBe(true);
+
+    act(() => result.current.trackScroll(scrollEvent(0)));
+    expect(result.current.visible).toBe(false);
+  });
+
   // The hook runs in the screen, so a render here is a render of the whole page — every card,
-  // every row. The rise changes on every scroll event for the length of the footer, and
-  // react-native-web never throttles onScroll, so driving it through state re-rendered the page
-  // several times a frame at the one moment the user is watching something move.
+  // every row. react-native-web never throttles onScroll, so anything held here that tracks the
+  // scroll position re-rendered the page several times a frame (#399).
   it("does not re-render the screen once per scroll event", () => {
     let renders = 0;
     const { result } = renderHook(() => {
@@ -83,18 +54,17 @@ describe("useScrollToTopFab", () => {
       return useScrollToTopFab();
     });
 
-    act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
-    act(() => result.current.trackScroll(scrollEvent(600, 1000)));
+    act(() => result.current.trackScroll(scrollEvent(600)));
     const settled = renders;
 
-    // A gesture's worth of positions, all with the FAB already shown and only the rise moving.
-    for (let fromBottom = FOOTER_HEIGHT; fromBottom >= 0; fromBottom -= 4) {
-      act(() => result.current.trackScroll(scrollEvent(600, fromBottom)));
+    // A gesture's worth of positions, none of which crosses the threshold.
+    for (let y = 600; y < 900; y += 12) {
+      act(() => result.current.trackScroll(scrollEvent(y)));
     }
 
-    expect(riseOf(result.current.travel)).toBe(FOOTER_HEIGHT);
-    // React may still render once more before bailing on an unchanged `visible`; what must not
-    // happen is a render for each of the twenty-odd positions.
+    expect(result.current.visible).toBe(true);
+    // React may still render once more before bailing on an unchanged value; what must not happen
+    // is a render for each of the twenty-five positions.
     expect(renders).toBeLessThanOrEqual(settled + 1);
   });
 
@@ -105,30 +75,5 @@ describe("useScrollToTopFab", () => {
     rerender({});
 
     expect(result.current.trackScroll).toBe(first);
-  });
-
-  it("lifts the FAB by the footer it measured, not by a guess", () => {
-    const { result } = renderHook(() => useScrollToTopFab());
-
-    act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
-    act(() => result.current.trackScroll(scrollEvent(600, 1000)));
-    expect(riseOf(result.current.travel)).toBe(0);
-
-    act(() => result.current.trackScroll(scrollEvent(600, 0)));
-    expect(riseOf(result.current.travel)).toBe(FOOTER_HEIGHT);
-  });
-
-  // A screen that takes the footer back out of its scroll — Locations, once the booking
-  // drawer opens — hands the FAB nothing to climb over.
-  it("drops the lift when the footer leaves the scroll", () => {
-    const { result } = renderHook(() => useScrollToTopFab());
-
-    act(() => result.current.measureFooter(layoutEvent(FOOTER_HEIGHT)));
-    act(() => result.current.trackScroll(scrollEvent(600, 0)));
-    expect(riseOf(result.current.travel)).toBe(FOOTER_HEIGHT);
-
-    act(() => result.current.setFooterHeight(0));
-    act(() => result.current.trackScroll(scrollEvent(600, 0)));
-    expect(riseOf(result.current.travel)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Two admin-chrome fixes.

**1. The bookings toolbar shifted as you clicked around it.** Two causes, both in the same wrapping row:

- **A flexible spacer between the chips and the toggles.** `<View style={{ flex: 1 }} />` sat inside a `flexWrap` row, so whether the toggles landed beside the location chips or wrapped to their own line depended on how many chips fit — and therefore on the location list, the window width, and the label lengths.
- **The status tabs lived in that same row but only apply to the list.** Entering or leaving List view added or removed a control right next to the view toggle, so the toolbar visibly rearranged itself on a click that was only meant to change the view.

**2. The sidebar wore a hardcoded icon.** The tile beside the app name was an Ionicons place setting, so a brand that had chosen a wine glass or a chef's hat in settings still saw cutlery on every admin screen.

**3. The scroll-to-top FAB juddered on web (#399).** Three things ran on every scroll event, and `scrollEventThrottle` blunted none of them — react-native-web reads that prop only to decide whether to warn, and never throttles.

## Related issue

Closes #399. Also a follow-up to #400.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

**Toolbar**
- Chips and the view toggle get a row each. The spacer is gone; the toggle starts at the same place regardless of what is above it.
- The status tabs move out of the toolbar and render above the list they filter. That is where they belong: `loadGrid` calls `getAdminBookings(rid, date)` with no status argument, so the filter has never applied to the timetable or service views and could not simply be shown in them. A filter that appears and vanishes beside the view buttons reads as the toolbar rearranging itself rather than as a control scoped to one view.
- Extracted `BookingStatusTabs`, matching how `GridDateBar` and the other row components on this screen are organised.

Net effect: the toolbar holds the same controls in every mode, and nothing in it moves. **No behaviour change** — the tabs filter exactly as before, stay hidden during a search, and keep their persisted value.

**Sidebar mark**
- New `BrandGlyph` draws the same Lucide glyph the favicon and PWA icon use, from the single source of truth in `constants/faviconIcons`.
- Deliberately *not* an Ionicons mapping: four of the fifteen options (chef's hat, soup, cake, sandwich) have no Ionicons equivalent at all, so a mapping would quietly show a different icon than the settings say is selected.
- A brand with no icon chosen keeps the generic mark, and so does one naming an icon this build no longer ships — `buildFaviconDataUri` resolves nothing for an unknown id, so a stale value degrades to the fallback rather than rendering a blank tile.
- It is a component rather than an inline branch because "the brand's mark at this size in this colour" is the same question anywhere the app stands for itself.

**FAB (#399)**

Measured against the running app rather than reasoned about: the FAB moved on **9 of 60 scroll events**, jumping 7–10px each time — still, lurch, still.

- **The offset was never worth having.** It existed so the FAB would not sit on the footer's links, but the FAB sits in the gutter beside the content column and the footer's own row ends on that same edge — they never overlapped. What it bought instead was an element that reads as pinned sliding 65px up the page on every scroll near the bottom. The FAB now holds one place for the whole scroll.
- **It stays to the end of the page.** Standing it down over the footer (tried on the way to this) took the shortcut away at the bottom, which is exactly where it is most wanted. It appears once the scroll is worth undoing and stays, fading in and out rather than popping.
- **Nothing in this path tracks the scroll position any more.** Visibility is the only thing a scroll changes and it changes twice per scroll, so the screen re-renders twice rather than on every event — `scrollEventThrottle` never helped, because react-native-web reads it only to decide whether to warn and never throttles.
- **The lane keeps its measured width across a hide.** It used to unmount, so the FAB reappeared against the fallback gutter for a frame before layout put it back beside the column — a sideways jump every time.
- The footer's height is nobody's business now, so `Footer` loses its `onLayout` and the hook its measurement.

Verified in the browser after the change: **97 scroll events, zero style writes on the FAB.**

An interim commit on this branch tried an `Animated.Value` for the offset and made it worse — nothing drives such a value, so its transform reached the DOM only when something else re-rendered the FAB, and removing the per-scroll renders removed the very thing that had been updating it. The final commit supersedes it.

## Testing## Testing

- [x] `OpenRestoApi.Tests` pass locally — *not run; no backend files touched*
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

```
Test Suites: 207 passed, 207 total
Tests:       2971 passed, 2971 total
```

- `tsc --noEmit` clean; `npm run check` adds no new warnings; `check:doc-links` resolves.
- New `BookingStatusTabs.test.tsx` (3 tests) and `BrandGlyph.test.tsx` (6 tests), both at 100% coverage on their component.
- New `AdminBookingsScreen toolbar` describe pins the structural rule directly: the status tabs are **not** inside `bookings-toolbar` while being on screen, all three view buttons **are** in it in every mode, and filtering still reaches `getAdminBookings` from the tabs' new home. That describe needs `Platform.OS = "web"`, since the persisted view mode only reaches the screen there.
- The FAB rules are pinned directly rather than by appearance: a gesture's worth of scroll positions must not produce a render each, and the FAB must still be offered at the very end of the scroll (the regression that standing it down introduced).
- Both sides of the glyph boundary are pinned: a configured icon draws the brand's own mark, an absent or unknown one falls back — plus a test that every one of the fifteen offered icons actually resolves, which is the failure a lookalike mapping would have hidden.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed — no API contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X79GMYSoKHRe5u6HLVSV3Q

