### PR TITLE
Hide the scroll-to-top FAB from the web a11y tree, not just from sight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The hidden scroll-to-top button no longer sits in the web accessibility tree.** The FAB stays mounted while hidden so it keeps its measured width, and hid itself with `accessibilityElementsHidden` and `importantForAccessibility`. Both are native-only: react-native-web drops them, so on the web build a screen reader was offered a "Scroll to top" button for the whole page, including at the top where pressing it does nothing. It now hides with `aria-hidden`, which React Native maps onto that same native pair and react-native-web forwards to the DOM.
+
 ## [1.9.0] - 2026-08-27
 
 Hi all! The headline this time is languages. OpenResto now speaks English, French, Spanish and German across the guest site and the whole admin, with a switcher on the page you are already on and a default a self-hoster can set from the environment. Alongside that, the admin timetable has been rebuilt around real sittings, and narrowing a location's hours now tells you which bookings you just stranded instead of leaving you to hear it from the guest.

--- a/openresto-frontend/components/common/ScrollToTopFab.tsx
+++ b/openresto-frontend/components/common/ScrollToTopFab.tsx
@@ -87,8 +87,11 @@ export default function ScrollToTopFab({ visible, onPress }: Props) {
           style={[styles.fab, { backgroundColor: primaryColor }]}
           onPress={onPress}
           disabled={!visible}
-          accessibilityElementsHidden={!visible}
-          importantForAccessibility={visible ? "auto" : "no-hide-descendants"}
+          // `aria-hidden`, not accessibilityElementsHidden/importantForAccessibility: React
+          // Native maps this one onto both of those, and react-native-web forwards it to the DOM
+          // — the native-only pair is dropped there, leaving a labelled button in the web a11y
+          // tree for the whole scroll.
+          aria-hidden={!visible}
           accessibilityLabel={t("common.actions.scrollToTop")}
           accessibilityRole="button"
         >

--- a/openresto-frontend/e2e/customer-nav.spec.ts
+++ b/openresto-frontend/e2e/customer-nav.spec.ts
@@ -107,8 +107,12 @@ test.describe("Customer navigation", () => {
         timeout: 15_000,
       });
 
-      // FAB is hidden at the top.
-      const fab = page.getByLabel("Scroll to top");
+      // FAB is hidden at the top. The lane it sits in stays mounted the whole time so it
+      // keeps its measured width (ScrollToTopFab.tsx), so "hidden" is a fade to nothing plus
+      // `aria-hidden` — not an unmount. A role locator is what reads that: it skips an
+      // aria-hidden subtree, where getByLabel matches the attribute on a faded-out element
+      // and toBeVisible counts opacity 0 as visible.
+      const fab = page.getByRole("button", { name: "Scroll to top" });
       await expect(fab).toHaveCount(0);
 
       // The home screen uses a react-native-web ScrollView, not window scroll —
@@ -118,8 +122,8 @@ test.describe("Customer navigation", () => {
       await page.mouse.wheel(0, 800);
       await expect(fab).toBeVisible({ timeout: 5_000 });
 
-      // Tap FAB → the RN ScrollView scrolls back up → scrollY drops ≤ 300 → FAB
-      // unmounts. The FAB disappearing IS the proof the press fired the scroll
+      // Tap FAB → the RN ScrollView scrolls back up → scrollY drops ≤ 300 → FAB leaves the
+      // a11y tree again. The FAB disappearing IS the proof the press fired the scroll
       // callback; we can't easily read RN's internal scroll offset from DOM.
       await fab.click();
       await expect(fab).toHaveCount(0);

--- a/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
+++ b/openresto-frontend/tests/components/ScrollToTopFab.test.tsx
@@ -36,9 +36,10 @@ describe("ScrollToTopFab", () => {
     expect(screen.getByTestId("scroll-to-top-lane")).toBeTruthy();
     // Present in the layout, but gone from the a11y tree and from the press target.
     expect(screen.queryByRole("button")).toBeNull();
+    // `aria-hidden` rather than the native-only accessibilityElementsHidden pair, because
+    // react-native-web forwards this one and drops those — see ScrollToTopFab.tsx.
     expect(
-      screen.getByTestId("scroll-to-top-fab", { includeHiddenElements: true }).props
-        .accessibilityElementsHidden
+      screen.getByTestId("scroll-to-top-fab", { includeHiddenElements: true }).props["aria-hidden"]
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Fixes the two `ScrollToTopFab` failures in `e2e-extensive` on main (run [33124277650](https://github.com/karanshukla/openresto/actions/runs/33124277650), both viewports, all 3 attempts).

Root cause is real, not a flaky spec. #401 made the FAB stay mounted while hidden so it keeps its measured width, and hid it with `accessibilityElementsHidden` + `importantForAccessibility`. Both are native-only. react-native-web 0.21 forwards neither (they are absent from `forwardedProps` and `createDOMProps`), so on the web build the hidden FAB stayed a labelled, reachable button for the whole page, including at the top where pressing it does nothing. The spec asserted the button was gone and it was only invisible.

Hidden state now uses `aria-hidden`. React Native maps that one prop onto the same native pair (`View.js` sets `accessibilityElementsHidden` and `importantForAccessibility: "no-hide-descendants"` from it), and react-native-web forwards it to the DOM, so one prop covers both platforms.

## Related issue

No issue filed. Regression from #401.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra (CHANGELOG)

## Changes

- `ScrollToTopFab.tsx`: `aria-hidden={!visible}` replaces the two native-only a11y props on the FAB's `Pressable`.
- `customer-nav.spec.ts`: assert absence by role rather than `getByLabel().toHaveCount(0)`. The DOM presence is deliberate now, so the assertion should read the a11y tree. `toBeVisible()` would not have worked either, Playwright counts `opacity: 0` as visible.
- `ScrollToTopFab.test.tsx`: the hidden-state assertion follows the prop.
- CHANGELOG entry under Unreleased.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally (not run, no backend change)
- [x] Frontend tests/build pass locally: 2971 unit tests across 207 suites, `npm run check`, `tsc --noEmit`, `check:doc-links`
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

**This PR's own CI does not exercise the specs it fixes.** `e2e-extensive` is gated to `push` on `main` (`ci.yml`), and `ci.yml` has no `workflow_dispatch`, so `customer-nav.spec.ts` runs for the first time on merge. The local run below is what stands in for it.

Docker Hub's blob CDN is blocked in the environment this was written in, so the stack ran without compose: backend on `:8080` under `ASPNETCORE_ENVIRONMENT=Testing`, Expo web on `:8081`, and a small node proxy standing in for nginx on `:5062`. Against that, all 5 `customer-nav` specs pass, both FAB cases included. Reverting only the component change and re-running puts the desktop case back to the exact CI failure, so `aria-hidden` is what repairs it and the locator swap alone does not.

Two supporting checks: rendering an RNW `Pressable` with `aria-hidden` through `react-dom/server` emits `<button aria-hidden="true" ... tabindex="-1">`, and a scratch Playwright run against that markup confirms the role locator returns 0 for an `aria-hidden` subtree while `getByLabel` still returns 1.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed (n/a, CHANGELOG only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BGmXcaqeGHNziTnGW8ar6