### PR TITLE
CLI follow-ups: 1-year key expiry default, sections CRUD, version-synced Docker release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,10 +133,47 @@ jobs:
           cache-from: type=gha,scope=nginx
           cache-to: type=gha,mode=max,scope=nginx
 
+  build-cli:
+    name: Build CLI (multi-arch)
+    runs-on: ubuntu-latest
+    needs: [verify-version]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/karanshukla/openresto-cli
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: ./openresto-cli
+          file: ./openresto-cli/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=cli
+          cache-to: type=gha,mode=max,scope=cli
+
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-backend, build-frontend, build-nginx]
+    needs: [build-backend, build-frontend, build-nginx, build-cli]
     steps:
       - uses: actions/checkout@v7
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,10 @@ extensive set by default (i.e., untagged).
 
 ```bash
 # 1. Add a ## [x.y.z] - YYYY-MM-DD section to CHANGELOG.md
-# 2. Bump "version" in package.json (root) and openresto-frontend/package.json
-#    to the tag without the v prefix, then regenerate both lockfiles:
-npm install --package-lock-only && npm install --package-lock-only --prefix openresto-frontend
+# 2. Bump "version" in package.json (root), openresto-frontend/package.json, and
+#    openresto-cli/package.json to the tag without the v prefix, then regenerate
+#    all three lockfiles:
+npm install --package-lock-only && npm install --package-lock-only --prefix openresto-frontend && npm install --package-lock-only --prefix openresto-cli
 # 3. Confirm everything agrees before tagging (CI runs this too):
 ./scripts/check-release-version.sh v1.0.0
 git tag v1.0.0
@@ -98,11 +99,11 @@ Never hand-edit the lockfiles; `--package-lock-only` is what keeps their top-lev
 
 **Pick the number by semver, not by habit.** A release containing any new feature is a minor bump, even a small one. Patch is for fixes only.
 
-`scripts/check-release-version.sh` is the guard against a half-finished bump: it asserts the two `package.json`s, the two `package-lock.json`s, and a CHANGELOG section all agree with the tag. The `verify-version` job in `release.yml` gates all three image builds on it, so a mismatch fails the release before anything reaches GHCR. v1.6.0 shipped with all four version fields still reading `1.5.0`, which is what this exists to prevent.
+`scripts/check-release-version.sh` is the guard against a half-finished bump: it asserts the three `package.json`s, the three `package-lock.json`s, and a CHANGELOG section all agree with the tag. The `verify-version` job in `release.yml` gates all four image builds on it, so a mismatch fails the release before anything reaches GHCR. v1.6.0 shipped with all four version fields still reading `1.5.0`, which is what this exists to prevent.
 
 The frontend's Expo config takes its `version` from `openresto-frontend/package.json` (`app.config.ts` imports it), so there is nothing to bump there. `app.json` deliberately carries no `version` key: `app.config.ts` overrides everything it sets, so a value there is silently dead.
 
-This triggers `.github/workflows/release.yml`, which builds `linux/amd64` + `linux/arm64` images for backend, frontend, and nginx; pushes them to GHCR (`ghcr.io/karanshukla/openresto-{backend,frontend,nginx}:<tag>`); and creates a GitHub Release with the per-version CHANGELOG section as notes and a pinned `docker-compose.yml` as a downloadable asset.
+This triggers `.github/workflows/release.yml`, which builds `linux/amd64` + `linux/arm64` images for backend, frontend, nginx, and the CLI; pushes them to GHCR (`ghcr.io/karanshukla/openresto-{backend,frontend,nginx,cli}:<tag>`); and creates a GitHub Release with the per-version CHANGELOG section as notes and a pinned `docker-compose.yml` as a downloadable asset.
 
 `docker-compose.release.yml` in the repo is the self-hoster install template. It references `${OPENRESTO_VERSION:-latest}` — the release workflow substitutes the actual tag before attaching it to the release. Self-hosters can also run any version directly:
 
@@ -260,7 +261,7 @@ Five invariants:
 
 ### The CLI and its OpenAPI contract
 
-`openresto-cli/` is a standalone TypeScript package (Node 24, `commander` as the only runtime dep), versioned independently at 0.1.0 — deliberately **not** wired into `scripts/check-release-version.sh` or the release workflow, and not published to npm yet. User docs live in `openresto-cli/README.md`. Two conventions are load-bearing:
+`openresto-cli/` is a standalone TypeScript package (Node 24, `commander` as the only runtime dep). It is not its own product — it's an extension of OpenResto — so its `package.json` version stays synced with the root/frontend version on every release (`scripts/check-release-version.sh` enforces this the same way it does for the other two packages) and it ships only as a Docker image (`ghcr.io/karanshukla/openresto-cli:<tag>`, built by `release.yml` alongside backend/frontend/nginx); it is not published to npm. User docs live in `openresto-cli/README.md`. Two conventions are load-bearing:
 
 - **The API key is never accepted as argv** (`ps` exposure — the same rule `scripts/demo_data.py` follows for the admin password). `auth login` prompts with hidden input or reads stdin; `OPENRESTO_URL`/`OPENRESTO_API_KEY` env vars override the `~/.config/openresto/config.json` profile (written mode 0600).
 - **The committed contract must match the controllers byte-for-byte.** `tools/OpenApiExport` boots the real API in-process (`WebApplicationFactory`, in-memory SQLite — build-time MSBuild generation was tried and rejected; the tool's doc comment says why) and writes `openresto-cli/openapi/v1.json`; `openapi-typescript` compiles it to `openresto-cli/src/generated/api.d.ts`. The `openapi-drift` CI job regenerates both and fails on any diff, so an API-shape change must ship with:

--- a/OpenRestoApi.Tests/Integration/ApiKeysControllerTests.cs
+++ b/OpenRestoApi.Tests/Integration/ApiKeysControllerTests.cs
@@ -140,6 +140,20 @@ public class ApiKeysControllerTests(TestWebAppFactory factory) : IClassFixture<T
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
+    [Fact]
+    public async Task Revoke_AsManager_Returns403()
+    {
+        HttpClient owner = OwnerClient();
+        HttpResponseMessage createResponse = await owner.PostAsJsonAsync(
+            "/api/admin/api-keys", ValidCreateBody("Owner's key"));
+        int id = (await createResponse.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetInt32();
+
+        HttpClient manager = await ManagerClientAsync("apikeys-manager-revoke@test.com");
+        HttpResponseMessage response = await manager.PostAsync($"/api/admin/api-keys/{id}/revoke", null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
     // ── self (issue #319 Phase 2) ───────────────────────────────────────────
 
     [Fact]

--- a/OpenRestoApi.Tests/Services/ApiKeyServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/ApiKeyServiceTests.cs
@@ -175,6 +175,48 @@ public class ApiKeyServiceTests
         Assert.Equal(BaseTime.AddDays(30), created.ExpiresAt);
     }
 
+    [Fact]
+    public async Task CreateAsync_DefaultsToOneYearExpiry_WhenExpiryIsOmitted()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_DefaultsToOneYearExpiry_WhenExpiryIsOmitted));
+        AdminCredential owner = SeedUser(db, "owner@example.com");
+        var clock = new FakeClock(BaseTime);
+        ApiKeyService svc = CreateService(db, owner.Id, clock);
+
+        ApiKeyCreatedDto created = await svc.CreateAsync(ValidRequest());
+
+        Assert.Equal(BaseTime.AddYears(1), created.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task CreateAsync_NeverExpires_ProducesNoExpiry()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_NeverExpires_ProducesNoExpiry));
+        AdminCredential owner = SeedUser(db, "owner@example.com");
+        ApiKeyService svc = CreateService(db, owner.Id);
+        CreateApiKeyRequest req = ValidRequest();
+        req.NeverExpires = true;
+
+        ApiKeyCreatedDto created = await svc.CreateAsync(req);
+
+        Assert.Null(created.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsAnExpiresAtCombinedWithNeverExpires()
+    {
+        using AppDbContext db = TestDbFactory.Create(nameof(CreateAsync_RejectsAnExpiresAtCombinedWithNeverExpires));
+        AdminCredential owner = SeedUser(db, "owner@example.com");
+        var clock = new FakeClock(BaseTime);
+        ApiKeyService svc = CreateService(db, owner.Id, clock);
+        CreateApiKeyRequest req = ValidRequest();
+        req.ExpiresAt = BaseTime.AddDays(30);
+        req.NeverExpires = true;
+
+        ValidationException ex = await Assert.ThrowsAsync<ValidationException>(() => svc.CreateAsync(req));
+        Assert.Equal(ErrorCodes.ApiKeyExpiresAtWithNeverExpires, ex.Code);
+    }
+
     // ── GetAllAsync ──────────────────────────────────────────────────────────
 
     [Fact]

--- a/OpenRestoApi/Controllers/ApiKeysController.cs
+++ b/OpenRestoApi/Controllers/ApiKeysController.cs
@@ -35,8 +35,8 @@ public class ApiKeysController(ApiKeyService apiKeys) : ControllerBase
     [NoApiKeyAccess]
     public async Task<IActionResult> Create([FromBody] CreateApiKeyRequest req)
     {
-        // ValidationException (missing name/scopes, invalid scope pair, past expiry) → 400,
-        // mapped by GlobalExceptionHandler.
+        // ValidationException (missing name/scopes, invalid scope pair, past expiry, or an
+        // expiry combined with neverExpires) → 400, mapped by GlobalExceptionHandler.
         ApiKeyCreatedDto created = await _apiKeys.CreateAsync(req);
         return CreatedAtAction(nameof(GetAll), new { }, created);
     }

--- a/OpenRestoApi/Core/Application/DTOs/ApiKeyDto.cs
+++ b/OpenRestoApi/Core/Application/DTOs/ApiKeyDto.cs
@@ -49,7 +49,16 @@ public class CreateApiKeyRequest
 {
     public string Name { get; set; } = null!;
     public List<ApiKeyScopeDto> Scopes { get; set; } = [];
+
+    /// <summary>An explicit expiry. Omit this to get the safe default (see
+    /// <see cref="NeverExpires"/>); when set, it must be in the future and
+    /// <see cref="NeverExpires"/> must not also be true.</summary>
     public DateTime? ExpiresAt { get; set; }
+
+    /// <summary>Opts a key out of the default one-year expiry entirely. Only meaningful when
+    /// <see cref="ExpiresAt"/> is omitted — setting both is rejected rather than silently
+    /// preferring one, since a client sending both almost certainly means only one of them.</summary>
+    public bool NeverExpires { get; set; }
 }
 
 /// <summary>

--- a/OpenRestoApi/Core/Application/Services/ApiKeyService.cs
+++ b/OpenRestoApi/Core/Application/Services/ApiKeyService.cs
@@ -41,7 +41,7 @@ public class ApiKeyService(
         int userId = RequireCallerId();
         string name = NormalizeName(req.Name);
         List<ApiKeyScopeDto> scopes = NormalizeScopes(req.Scopes);
-        DateTime? expiresAt = NormalizeExpiresAt(req.ExpiresAt);
+        DateTime? expiresAt = ResolveExpiresAt(req.ExpiresAt, req.NeverExpires);
 
         var entity = new AdminApiKey
         {
@@ -210,9 +210,26 @@ public class ApiKeyService(
         return normalized;
     }
 
-    private DateTime? NormalizeExpiresAt(DateTime? expiresAt)
+    /// <summary>
+    /// An explicit <c>expiresAt</c> must be in the future and rules out <c>neverExpires</c>;
+    /// omitting it defaults to <see cref="ApiKeyFields.DefaultExpiryYears"/> from now unless
+    /// <c>neverExpires</c> opts out entirely.
+    /// <seealso>ApiKeyServiceTests.CreateAsync_DefaultsToOneYearExpiry_WhenExpiryIsOmitted</seealso>
+    /// <seealso>ApiKeyServiceTests.CreateAsync_NeverExpires_ProducesNoExpiry</seealso>
+    /// <seealso>ApiKeyServiceTests.CreateAsync_RejectsAnExpiresAtCombinedWithNeverExpires</seealso>
+    /// </summary>
+    private DateTime? ResolveExpiresAt(DateTime? expiresAt, bool neverExpires)
     {
-        if (expiresAt is null) return null;
+        if (expiresAt is null)
+        {
+            return neverExpires ? null : _clock.UtcNow.AddYears(ApiKeyFields.DefaultExpiryYears);
+        }
+
+        if (neverExpires)
+        {
+            throw new ValidationException("An expiry date cannot be combined with never expiring.")
+            { Code = ErrorCodes.ApiKeyExpiresAtWithNeverExpires };
+        }
 
         DateTime utc = expiresAt.Value.Kind == DateTimeKind.Utc ? expiresAt.Value : expiresAt.Value.ToUniversalTime();
         if (utc <= _clock.UtcNow)

--- a/OpenRestoApi/Core/Application/Utilities/ApiKeyFields.cs
+++ b/OpenRestoApi/Core/Application/Utilities/ApiKeyFields.cs
@@ -13,4 +13,8 @@ public static class ApiKeyFields
     public const int MaxPrefixLength = 16;
 
     public const int MaxScopesJsonLength = 2000;
+
+    /// <summary>The safe-by-default expiry window applied when a create request omits
+    /// <c>ExpiresAt</c> and does not opt into <c>NeverExpires</c>.</summary>
+    public const int DefaultExpiryYears = 1;
 }

--- a/OpenRestoApi/Core/Application/Utilities/ErrorCodes.cs
+++ b/OpenRestoApi/Core/Application/Utilities/ErrorCodes.cs
@@ -100,6 +100,7 @@ public static class ErrorCodes
     public const string ApiKeyScopesRequired = "api_key.scopes_required";
     public const string ApiKeyScopeInvalid = "api_key.scope_invalid";
     public const string ApiKeyExpiresAtInPast = "api_key.expires_at_in_past";
+    public const string ApiKeyExpiresAtWithNeverExpires = "api_key.expires_at_with_never_expires";
     public const string ApiKeyNotFound = "api_key.not_found";
     public const string ApiKeyScopeMissing = "api_key.scope_missing";
     public const string ApiKeyNotAllowed = "api_key.not_allowed";

--- a/openresto-cli/.dockerignore
+++ b/openresto-cli/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+openapi
+*.md
+.gitignore

--- a/openresto-cli/Dockerfile
+++ b/openresto-cli/Dockerfile
@@ -1,0 +1,26 @@
+# openresto-cli ships only as a Docker image (no npm publish) — see CLAUDE.md's
+# "The CLI and its OpenAPI contract". Multi-stage so the published image carries
+# only the compiled dist/ and production dependencies (just `commander`), not
+# TypeScript/openapi-typescript or the generated OpenAPI contract's build tooling.
+
+FROM node:24-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:24-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=build /app/dist ./dist
+RUN chown -R node:node /app
+
+USER node
+ENTRYPOINT ["node", "dist/index.js"]

--- a/openresto-cli/README.md
+++ b/openresto-cli/README.md
@@ -3,7 +3,35 @@
 A command-line client for the OpenResto admin API, authenticated with an
 [admin API key](../OpenRestoApi/Controllers/ApiKeysController.cs) rather than a browser session.
 
+It isn't its own product — it's an extension of OpenResto — so its version tracks the main
+project's on every release and it's distributed as a Docker image only (not published to npm).
+
 ## Install
+
+### Docker (recommended)
+
+```bash
+docker run --rm \
+  -e OPENRESTO_URL=https://booking.example.com \
+  -e OPENRESTO_API_KEY=orst_1_your-secret \
+  ghcr.io/karanshukla/openresto-cli:<tag> bookings list
+```
+
+Use `latest` for the newest release, or pin a specific version (e.g. `1.9.0`) to match your
+server. Env vars are the simplest way to configure a one-off container since there's no
+persistent home directory; to use saved profiles (`~/.config/openresto/config.json`) instead,
+mount a config directory across runs:
+
+```bash
+docker run --rm -it -v openresto-cli-config:/home/node/.config/openresto \
+  ghcr.io/karanshukla/openresto-cli:<tag> auth login
+docker run --rm -v openresto-cli-config:/home/node/.config/openresto \
+  ghcr.io/karanshukla/openresto-cli:<tag> bookings list
+```
+
+(`auth login` needs `-it` so its hidden-input prompt has a real terminal; later commands don't.)
+
+### From source
 
 ```bash
 cd openresto-cli
@@ -125,15 +153,27 @@ example per group:
   asking for confirmation.
 
 - **tables** — `list` (a location's sections and tables together, since a table can't be
-  created/edited/deleted without naming its section), `create`, `update`, `delete`. There is no
-  separate `sections` command group; use `tables list --location <id>` to find a section's id,
-  then pass it as `--section` to the other table commands. Full section CRUD (rename, reorder)
-  is left to the admin UI.
+  created/edited/deleted without naming its section), `create`, `update`, `delete`. Use
+  `tables list --location <id>` or `sections list --location <id>` to find a section's id, then
+  pass it as `--section` to the other table commands.
 
   ```bash
   openresto tables list --location 1
   openresto tables create --location 1 --section 2 --name "T5" --seats 4
   ```
+
+- **sections** — `list`, `create`, `update` (rename), `delete`. Reordering sections is left to
+  the admin UI (no CLI command for it yet).
+
+  ```bash
+  openresto sections create --location 1 --name "Patio"
+  openresto sections delete 2 --location 1
+  ```
+
+  `delete` removes the section's tables along with it; any upcoming bookings referencing the
+  section or one of its tables keep their booking and only lose that reference (the server nulls
+  the FK rather than cascading — see CLAUDE.md's "Deletion & cascade behaviour"). The CLI previews
+  how many bookings that affects before asking for confirmation.
 
 - **brand** — `get`, `set` (via flags, or `--from-json <file>` / `--from-json -` for stdin — an
   empty string clears a field, an omitted one leaves it unchanged, matching `PATCH /api/brand`).

--- a/openresto-cli/openapi/v1.json
+++ b/openresto-cli/openapi/v1.json
@@ -3711,7 +3711,12 @@
               "null",
               "string"
             ],
+            "description": "An explicit expiry. Omit this to get the safe default (see\n    bool CreateApiKeyRequest.NeverExpires); when set, it must be in the future and\n    bool CreateApiKeyRequest.NeverExpires must not also be true.",
             "format": "date-time"
+          },
+          "neverExpires": {
+            "type": "boolean",
+            "description": "Opts a key out of the default one-year expiry entirely. Only meaningful when\n    DateTime? CreateApiKeyRequest.ExpiresAt is omitted \u2014 setting both is rejected rather than silently\n    preferring one, since a client sending both almost certainly means only one of them."
           }
         }
       },

--- a/openresto-cli/package-lock.json
+++ b/openresto-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openresto-cli",
-  "version": "0.1.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openresto-cli",
-      "version": "0.1.0",
+      "version": "1.9.0",
       "dependencies": {
         "commander": "^12.1.0"
       },

--- a/openresto-cli/package.json
+++ b/openresto-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openresto-cli",
-  "version": "0.1.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Command-line client for the OpenResto admin API, driven by admin API keys.",
   "type": "module",
@@ -17,7 +17,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "generate:types": "node scripts/generate-types.mjs",
-    "test": "npm run build && node --test dist/*.test.js",
+    "test": "npm run build && node --test 'dist/**/*.test.js'",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/openresto-cli/src/commands/sections.test.ts
+++ b/openresto-cli/src/commands/sections.test.ts
@@ -1,0 +1,223 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { Command } from "commander";
+import { registerSectionsCommands } from "./sections.js";
+
+interface Call {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .exitOverride()
+    .option("--profile <name>")
+    .option("--json")
+    .option("--yes");
+  registerSectionsCommands(program);
+  return program;
+}
+
+function fakeFetch(
+  responder: (call: Call) => { status: number; body?: unknown },
+): { fetch: typeof fetch; calls: Call[] } {
+  const calls: Call[] = [];
+  const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    const call: Call = { method: init?.method ?? "GET", url, body };
+    calls.push(call);
+    const { status, body: responseBody } = responder(call);
+    const text = responseBody === undefined ? "" : JSON.stringify(responseBody);
+    return new Response(text || null, {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+function captureLogs(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args: unknown[]) => lines.push(args.map(String).join(" "));
+  console.error = (...args: unknown[]) =>
+    lines.push(args.map(String).join(" "));
+  return {
+    lines,
+    restore: () => {
+      console.log = originalLog;
+      console.error = originalError;
+    },
+  };
+}
+
+let originalFetch: typeof fetch;
+let originalUrl: string | undefined;
+let originalKey: string | undefined;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalUrl = process.env.OPENRESTO_URL;
+  originalKey = process.env.OPENRESTO_API_KEY;
+  process.env.OPENRESTO_URL = "https://cli.example";
+  process.env.OPENRESTO_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalUrl === undefined) delete process.env.OPENRESTO_URL;
+  else process.env.OPENRESTO_URL = originalUrl;
+  if (originalKey === undefined) delete process.env.OPENRESTO_API_KEY;
+  else process.env.OPENRESTO_API_KEY = originalKey;
+});
+
+describe("sections list", () => {
+  test("GETs the admin sections lookup for the given location", async () => {
+    const { fetch, calls } = fakeFetch(() => ({
+      status: 200,
+      body: [{ id: 1, name: "Patio" }],
+    }));
+    globalThis.fetch = fetch;
+    const { lines, restore } = captureLogs();
+
+    try {
+      await buildProgram().parseAsync(
+        ["sections", "list", "--location", "7", "--json"],
+        { from: "user" },
+      );
+    } finally {
+      restore();
+    }
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "GET");
+    assert.equal(
+      calls[0].url,
+      "https://cli.example/api/admin/restaurants/7/sections",
+    );
+    assert.match(lines.join("\n"), /"name": "Patio"/);
+  });
+});
+
+describe("sections create", () => {
+  test("POSTs the new section's name to the restaurant-scoped endpoint", async () => {
+    const { fetch, calls } = fakeFetch(() => ({
+      status: 200,
+      body: { id: 9, name: "Patio", sortOrder: 2, tables: [] },
+    }));
+    globalThis.fetch = fetch;
+    const { restore } = captureLogs();
+
+    try {
+      await buildProgram().parseAsync(
+        ["sections", "create", "--location", "7", "--name", "Patio"],
+        { from: "user" },
+      );
+    } finally {
+      restore();
+    }
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.equal(
+      calls[0].url,
+      "https://cli.example/api/restaurants/7/sections",
+    );
+    assert.deepEqual(calls[0].body, { name: "Patio" });
+  });
+});
+
+describe("sections update", () => {
+  test("PUTs the rename to the section's own URL", async () => {
+    const { fetch, calls } = fakeFetch(() => ({
+      status: 200,
+      body: { id: 9, name: "Renamed", sortOrder: 2, tables: [] },
+    }));
+    globalThis.fetch = fetch;
+    const { restore } = captureLogs();
+
+    try {
+      await buildProgram().parseAsync(
+        ["sections", "update", "9", "--location", "7", "--name", "Renamed"],
+        { from: "user" },
+      );
+    } finally {
+      restore();
+    }
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.equal(
+      calls[0].url,
+      "https://cli.example/api/restaurants/7/sections/9",
+    );
+    assert.deepEqual(calls[0].body, { name: "Renamed" });
+  });
+});
+
+describe("sections delete", () => {
+  test("--yes skips the prompt, previews the booking impact, then deletes", async () => {
+    const { fetch, calls } = fakeFetch((call) => {
+      if (call.url.endsWith("/impact")) {
+        return { status: 200, body: { bookings: 3 } };
+      }
+      return { status: 204 };
+    });
+    globalThis.fetch = fetch;
+    const { lines, restore } = captureLogs();
+
+    try {
+      await buildProgram().parseAsync(
+        ["sections", "delete", "9", "--location", "7", "--yes"],
+        { from: "user" },
+      );
+    } finally {
+      restore();
+    }
+
+    assert.equal(calls.length, 2);
+    assert.ok(calls[0].url.endsWith("/api/restaurants/7/sections/9/impact"));
+    assert.equal(calls[1].method, "DELETE");
+    assert.equal(
+      calls[1].url,
+      "https://cli.example/api/restaurants/7/sections/9",
+    );
+    assert.match(lines.join("\n"), /Section 9 removed\./);
+  });
+
+  test("without --yes and no TTY, refuses before ever calling delete", async () => {
+    const { fetch, calls } = fakeFetch((call) => {
+      if (call.url.endsWith("/impact")) {
+        return { status: 200, body: { bookings: 0 } };
+      }
+      return { status: 204 };
+    });
+    globalThis.fetch = fetch;
+    const originalIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = false;
+    const { lines, restore } = captureLogs();
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      await buildProgram().parseAsync(
+        ["sections", "delete", "9", "--location", "7"],
+        {
+          from: "user",
+        },
+      );
+    } finally {
+      restore();
+      process.stdin.isTTY = originalIsTTY;
+    }
+
+    assert.ok(!calls.some((c) => c.method === "DELETE"));
+    assert.equal(process.exitCode, 1);
+    assert.match(lines.join("\n"), /--yes/);
+    process.exitCode = originalExitCode;
+  });
+});

--- a/openresto-cli/src/commands/sections.ts
+++ b/openresto-cli/src/commands/sections.ts
@@ -1,0 +1,122 @@
+import { Command } from "commander";
+import { clientFor, getGlobalOptions, handle } from "../context.js";
+import { printResult } from "../output.js";
+import { confirmOrExit } from "../confirm.js";
+
+interface Section {
+  id: number;
+  name: string;
+}
+
+const LIST_COLUMNS = ["id", "name"];
+
+/**
+ * Sections hang off a restaurant (`RestaurantsController`'s `{id}/sections[/{sectionId}]`
+ * routes), so every command here takes `--location`. `list` uses the lighter admin lookup
+ * endpoint (id/name only) rather than `tables list`'s sections-with-tables shape — pair it with
+ * `tables list --location <id>` when you need table detail per section too.
+ */
+export function registerSectionsCommands(program: Command): void {
+  const sections = program
+    .command("sections")
+    .description("Manage a location's sections");
+
+  sections
+    .command("list")
+    .description("List a location's sections")
+    .requiredOption("--location <id>", "Restaurant/location id", Number)
+    .action(
+      handle(async (options: { location: number }, command: Command) => {
+        const { client } = clientFor(command);
+        const globals = getGlobalOptions(command);
+        const result = await client.get<Section[]>(
+          `/api/admin/restaurants/${options.location}/sections`,
+        );
+        printResult(result, Boolean(globals.json), LIST_COLUMNS);
+      }),
+    );
+
+  sections
+    .command("create")
+    .description("Add a section to a location")
+    .requiredOption("--location <id>", "Restaurant/location id", Number)
+    .requiredOption("--name <name>", "Section name")
+    .action(
+      handle(
+        async (
+          options: { location: number; name: string },
+          command: Command,
+        ) => {
+          const { client } = clientFor(command);
+          const globals = getGlobalOptions(command);
+          const result = await client.post(
+            `/api/restaurants/${options.location}/sections`,
+            { body: { name: options.name } },
+          );
+          printResult(result, Boolean(globals.json));
+        },
+      ),
+    );
+
+  sections
+    .command("update <sectionId>")
+    .description("Rename a section")
+    .requiredOption("--location <id>", "Restaurant/location id", Number)
+    .requiredOption("--name <name>", "New section name")
+    .action(
+      handle(
+        async (
+          sectionId: string,
+          options: { location: number; name: string },
+          command: Command,
+        ) => {
+          const { client } = clientFor(command);
+          const globals = getGlobalOptions(command);
+          const result = await client.put(
+            `/api/restaurants/${options.location}/sections/${encodeURIComponent(sectionId)}`,
+            { body: { name: options.name } },
+          );
+          printResult(result, Boolean(globals.json));
+        },
+      ),
+    );
+
+  sections
+    .command("delete <sectionId>")
+    .description(
+      "Remove a section — its tables go too; bookings referencing the section (or one of its " +
+        "tables) keep their booking, losing only the section/table link",
+    )
+    .requiredOption("--location <id>", "Restaurant/location id", Number)
+    .option("--yes", "Skip the confirmation prompt")
+    .action(
+      handle(
+        async (
+          sectionId: string,
+          options: { location: number; yes?: boolean },
+          command: Command,
+        ) => {
+          const { client } = clientFor(command);
+          const globals = getGlobalOptions(command);
+
+          let message = `This will remove section ${sectionId} and its tables.`;
+          try {
+            const impact = await client.get<{ bookings: number }>(
+              `/api/restaurants/${options.location}/sections/${sectionId}/impact`,
+            );
+            if (impact.bookings > 0) {
+              message += ` ${impact.bookings} upcoming booking(s) will lose their section reference.`;
+            }
+          } catch {
+            // Best-effort preview only.
+          }
+
+          await confirmOrExit(message, Boolean(options.yes ?? globals.yes));
+          await client.delete(
+            `/api/restaurants/${options.location}/sections/${encodeURIComponent(sectionId)}`,
+          );
+          console.log(`Section ${sectionId} removed.`);
+        },
+      ),
+    );
+}

--- a/openresto-cli/src/generated/api.d.ts
+++ b/openresto-cli/src/generated/api.d.ts
@@ -3555,8 +3555,19 @@ export interface components {
         CreateApiKeyRequest: {
             name?: string;
             scopes?: components["schemas"]["ApiKeyScopeDto"][];
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description An explicit expiry. Omit this to get the safe default (see
+             *         bool CreateApiKeyRequest.NeverExpires); when set, it must be in the future and
+             *         bool CreateApiKeyRequest.NeverExpires must not also be true.
+             */
             expiresAt?: null | string;
+            /**
+             * @description Opts a key out of the default one-year expiry entirely. Only meaningful when
+             *         DateTime? CreateApiKeyRequest.ExpiresAt is omitted — setting both is rejected rather than silently
+             *         preferring one, since a client sending both almost certainly means only one of them.
+             */
+            neverExpires?: boolean;
         };
         CreateHighlightRequest: {
             title?: string;

--- a/openresto-cli/src/index.ts
+++ b/openresto-cli/src/index.ts
@@ -1,20 +1,33 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { Command } from "commander";
 import { registerAuthCommands } from "./commands/auth.js";
 import { registerBookingsCommands } from "./commands/bookings.js";
 import { registerAvailabilityCommands } from "./commands/availability.js";
 import { registerLocationsCommands } from "./commands/locations.js";
 import { registerTablesCommands } from "./commands/tables.js";
+import { registerSectionsCommands } from "./commands/sections.js";
 import { registerBrandCommands } from "./commands/brand.js";
 import { registerUsersCommands } from "./commands/users.js";
 import { registerAuditCommands } from "./commands/audit.js";
+
+// The CLI isn't its own product — it's versioned in lockstep with OpenResto (package.json's
+// "version" is bumped alongside the root/frontend one on every release, per
+// scripts/check-release-version.sh), so `--version` reads it from package.json rather than
+// carrying a second hardcoded number that would drift.
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const { version } = JSON.parse(
+  readFileSync(path.join(packageDir, "..", "package.json"), "utf-8"),
+) as { version: string };
 
 const program = new Command();
 
 program
   .name("openresto")
   .description("Command-line client for the OpenResto admin API")
-  .version("0.1.0")
+  .version(version)
   .option("--profile <name>", 'Named profile to use (default: "default")')
   .option("--json", "Output raw JSON instead of a table")
   .option("--yes", "Skip confirmation prompts on destructive commands");
@@ -24,6 +37,7 @@ registerBookingsCommands(program);
 registerAvailabilityCommands(program);
 registerLocationsCommands(program);
 registerTablesCommands(program);
+registerSectionsCommands(program);
 registerBrandCommands(program);
 registerUsersCommands(program);
 registerAuditCommands(program);

--- a/openresto-frontend/api/apiKeys.ts
+++ b/openresto-frontend/api/apiKeys.ts
@@ -51,6 +51,7 @@ export interface CreateApiKeyInput {
   name: string;
   scopes: ApiKeyScope[];
   expiresAt?: string;
+  neverExpires?: boolean;
 }
 
 /** The one response that ever carries the full secret — shown once, then gone. */

--- a/openresto-frontend/components/admin/settings/ApiKeysCard.tsx
+++ b/openresto-frontend/components/admin/settings/ApiKeysCard.tsx
@@ -69,7 +69,7 @@ interface NewKeyState {
 const emptyNewKey = (): NewKeyState => ({
   name: "",
   scopes: emptyScopeState(),
-  expiryPreset: "none",
+  expiryPreset: "1y",
 });
 
 /**
@@ -135,11 +135,11 @@ export function ApiKeysCard({
     }
 
     setBusy(true);
-    const result = await adminCreateApiKey({
-      name,
-      scopes,
-      expiresAt: expiryIsoFor(newKey.expiryPreset),
-    });
+    const result = await adminCreateApiKey(
+      newKey.expiryPreset === "none"
+        ? { name, scopes, neverExpires: true }
+        : { name, scopes, expiresAt: expiryIsoFor(newKey.expiryPreset) }
+    );
     setBusy(false);
 
     if (!result.ok) {

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -1625,7 +1625,7 @@
           "guests": "Gäste"
         },
         "expiryLabel": "Ablauf",
-        "expiryHint": "Lasse „Kein Ablauf“ ausgewählt für einen Schlüssel, der nie abläuft.",
+        "expiryHint": "Standardmäßig 1 Jahr. Wähle „Kein Ablauf“ für einen Schlüssel, der nie abläuft.",
         "expiryPreset": {
           "none": "Kein Ablauf",
           "thirtyDays": "30 Tage",

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -1625,7 +1625,7 @@
           "guests": "Guests"
         },
         "expiryLabel": "Expiry",
-        "expiryHint": "Leave on \"No expiry\" for a key that never expires.",
+        "expiryHint": "Defaults to 1 year. Choose \"No expiry\" for a key that never expires.",
         "expiryPreset": {
           "none": "No expiry",
           "thirtyDays": "30 days",

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -1625,7 +1625,7 @@
           "guests": "Comensales"
         },
         "expiryLabel": "Caducidad",
-        "expiryHint": "Deja «Sin caducidad» para una clave que nunca expire.",
+        "expiryHint": "El valor predeterminado es 1 año. Elige «Sin caducidad» para una clave que nunca expire.",
         "expiryPreset": {
           "none": "Sin caducidad",
           "thirtyDays": "30 días",

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -1625,7 +1625,7 @@
           "guests": "Clients"
         },
         "expiryLabel": "Expiration",
-        "expiryHint": "Laissez sur « Sans expiration » pour une clé qui n'expire jamais.",
+        "expiryHint": "Par défaut, 1 an. Choisissez « Sans expiration » pour une clé qui n'expire jamais.",
         "expiryPreset": {
           "none": "Sans expiration",
           "thirtyDays": "30 jours",

--- a/openresto-frontend/tests/api/apiKeys.test.ts
+++ b/openresto-frontend/tests/api/apiKeys.test.ts
@@ -89,6 +89,17 @@ describe("adminCreateApiKey", () => {
     });
   });
 
+  it("passes neverExpires when the caller opts out of expiry entirely", async () => {
+    okWith({ ...CREATED, expiresAt: null });
+
+    await adminCreateApiKey({ ...input, neverExpires: true });
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
+      ...input,
+      neverExpires: true,
+    });
+  });
+
   it("surfaces the server's rejection message", async () => {
     failWith({ message: "A key with that name already exists." });
 

--- a/openresto-frontend/tests/components/admin/settings/ApiKeysCard.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/ApiKeysCard.test.tsx
@@ -182,11 +182,17 @@ describe("ApiKeysCard", () => {
     fireEvent.press(screen.getByLabelText("Add this key"));
 
     await waitFor(() => expect(screen.getByText('"New service" created.')).toBeTruthy());
-    expect(apiKeysApi.adminCreateApiKey).toHaveBeenCalledWith({
-      name: "New service",
-      scopes: [{ resource: "bookings", access: "read" }],
-      expiresAt: undefined,
-    });
+    // Default preset is 1 year, so an explicit expiresAt goes out even though the caller
+    // never touched the expiry field.
+    const call = (apiKeysApi.adminCreateApiKey as jest.Mock).mock.calls[0][0];
+    expect(call).toEqual(
+      expect.objectContaining({
+        name: "New service",
+        scopes: [{ resource: "bookings", access: "read" }],
+      })
+    );
+    expect(typeof call.expiresAt).toBe("string");
+    expect(call.neverExpires).toBeUndefined();
     // The secret modal opens showing the full value exactly once.
     expect(screen.getByTestId("api-key-secret-value")).toHaveTextContent(
       "orst_55_thefullsecretvalue"
@@ -238,6 +244,40 @@ describe("ApiKeysCard", () => {
     const call = (apiKeysApi.adminCreateApiKey as jest.Mock).mock.calls[0][0];
     expect(typeof call.expiresAt).toBe("string");
     expect(new Date(call.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    expect(call.neverExpires).toBeUndefined();
+  });
+
+  it("defaults the expiry preset to 1 year", async () => {
+    await renderLoaded();
+    await openAddForm();
+
+    expect(screen.getByLabelText("1 year").props.accessibilityState.checked).toBe(true);
+    expect(screen.getByLabelText("No expiry").props.accessibilityState.checked).toBe(false);
+  });
+
+  it("sends neverExpires and no expiresAt when No expiry is chosen explicitly", async () => {
+    (apiKeysApi.adminCreateApiKey as jest.Mock).mockResolvedValue({
+      ok: true,
+      key: { ...BOOKINGS_KEY, id: 9, secret: "orst_09_x", expiresAt: null },
+    });
+    await renderLoaded();
+    await openAddForm();
+    fireEvent.changeText(
+      screen.getByPlaceholderText("e.g. Reservations widget"),
+      "Forever service"
+    );
+    fireEvent.press(screen.getByLabelText("Read access to Bookings"));
+    fireEvent.press(screen.getByLabelText("No expiry"));
+
+    fireEvent.press(screen.getByLabelText("Add this key"));
+
+    await waitFor(() =>
+      expect(apiKeysApi.adminCreateApiKey).toHaveBeenCalledWith({
+        name: "Forever service",
+        scopes: [{ resource: "bookings", access: "read" }],
+        neverExpires: true,
+      })
+    );
   });
 
   it("surfaces a server rejection verbatim", async () => {

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -27,6 +27,8 @@ VERSIONED_FILES=(
   package-lock.json
   openresto-frontend/package.json
   openresto-frontend/package-lock.json
+  openresto-cli/package.json
+  openresto-cli/package-lock.json
 )
 
 failures=0
@@ -52,7 +54,7 @@ if [ "$failures" -gt 0 ]; then
   cat >&2 <<EOF
 
 $failures check(s) failed. To fix:
-  - bump "version" in package.json and openresto-frontend/package.json to $VERSION
+  - bump "version" in package.json, openresto-frontend/package.json, and openresto-cli/package.json to $VERSION
   - run 'npm install --package-lock-only' in each of those directories
   - add a '## [$VERSION] - YYYY-MM-DD' section to CHANGELOG.md
 EOF


### PR DESCRIPTION
## Summary

Implements the decided items from #404: API keys default to a 1-year expiry (no-expiry becomes an explicit opt-in), the CLI gains a `sections` command group, and the CLI is version-synced with the product and released as a Docker image alongside the other three.

## Related issue

Refs #404 (the remaining items there — server version check, account-wide key admin, MCP — stay open)

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

**Key expiry defaults to 1 year**
- `CreateApiKeyRequest` gains `neverExpires` (default false). Omitted `expiresAt` now defaults to creation + 1 year (`ApiKeyFields.DefaultExpiryYears`); "no expiry" requires `neverExpires: true`; sending both an `expiresAt` and `neverExpires` is rejected. Boundary tests on all four paths.
- UI: the expiry preset defaults to 1 year; "No expiry" stays selectable and sends the explicit flag. Expiry hint copy updated in all four locales.
- OpenAPI contract + generated types regenerated for the new field (drift job stays green).
- Ownership rule re-verified while here: create/list/revoke are Owner-only and self-scoped, Managers are bounced in API and UI — the one missing test (Manager gets 403 on revoke) added.

**CLI `sections` command group**
- `sections list|create|update|delete` against the existing section endpoints, with the delete impact preview surfacing that bookings keep their history (SectionId is nulled, not cascaded). Reorder deliberately left to the admin UI.
- Found while adding tests: the CLI's test glob (`dist/*.test.js`) never matched `dist/commands/*.test.js`, so no command-group tests were actually running. Fixed to a recursive glob; suite went 50 → 55.

**Version sync + Docker release**
- CLI version synced to the product (0.1.0 → 1.9.0); `openresto --version` now reads package.json at runtime so it can't drift again. `scripts/check-release-version.sh` asserts the CLI's package.json + lockfile alongside the existing four fields (verified with a real `v1.9.0` run: 7/7 checks pass).
- New `openresto-cli/Dockerfile` (multi-stage node:24-alpine, prod deps only, non-root) and a `build-cli` job in `release.yml` mirroring the other image jobs — multi-arch push to `ghcr.io/karanshukla/openresto-cli`, gated on `verify-version`, and `create-release` now needs it.
- CLAUDE.md release/CLI sections and the CLI README updated to the new reality (version-synced, Docker install documented, npm publish still deliberately out).

## Testing

- [x] `OpenRestoApi.Tests` pass locally (1892/1892)
- [x] Frontend tests/build pass locally (full Jest suite 3016 tests, tsc, prettier + oxlint) — CLI: 55/55, typecheck + build clean
- [x] CI passes (build, migration-check) — in flight on push; no migration in this PR
- [x] Manually verified the change end-to-end (Dockerfile stages replayed by hand — sandbox has no Docker daemon — `--version` prints 1.9.0 and `sections --help` renders with prod deps only; `check-release-version.sh v1.9.0` run for real)

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up/down where practical)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed (contract regenerated; CLAUDE.md + CLI README updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HXwY9SLUmRkjwDc4jsotm

---
_Generated by [Claude Code](https://claude.ai/code/session_016HXwY9SLUmRkjwDc4jsotm)_