### PR TITLE
Stop the date-picker grid spec assuming tomorrow is on screen

### DIFF
--- a/openresto-frontend/e2e/date-picker-keyboard.spec.ts
+++ b/openresto-frontend/e2e/date-picker-keyboard.spec.ts
@@ -76,9 +76,17 @@ test.describe("Date picker keyboard grid", () => {
 
     await expect(page.getByTestId("date-picker-grid")).toHaveAttribute("role", "grid");
     await expect(page.getByTestId(`date-picker-day-${day}`)).toHaveAttribute("role", "gridcell");
-    await expect(
-      page.getByTestId(`date-picker-day-${await dayFrom(page, day, 1)}`)
-    ).toHaveAttribute("aria-selected", "false");
+
+    // The unselected day is taken off the grid rather than computed as `day + 1`. The grid
+    // renders exactly one month, so on the last day of one there is no tomorrow in it, and
+    // asserting on a computed date failed as a missing element rather than a selected one —
+    // red on main every 31st. The neighbour below still has to be a real gridcell, so this
+    // pins the same property without assuming which day is on screen.
+    await expect(page.locator(`${DAY_CELLS}[aria-selected="true"]`)).toHaveCount(1);
+    await expect(page.locator(`${DAY_CELLS}[aria-selected="false"]`).first()).toHaveAttribute(
+      "role",
+      "gridcell"
+    );
   });
 
   test("moves the highlight, and the keyboard with it, on the arrow keys", async ({ page }) => {


### PR DESCRIPTION
## Summary

`Playwright E2E (Extensive)` is red on `main`. One test, `date-picker-keyboard.spec.ts:73`, times out looking for `date-picker-day-2026-09-01`:

```
Error: expect(locator).toHaveAttribute(expected) failed
Locator: getByTestId('date-picker-day-2026-09-01')
Error: element(s) not found
1 failed, 92 passed
```

The picker renders exactly one month, so on the last day of one there is no tomorrow in the grid. Today is the 31st.

This is not new and did not come from #412 — the spec has not changed since v1.9.0. It is the same defect as the two `DatePickerWeb` unit tests that PR fixed, in the suite that PR could not see: Extensive is `skipped` on pull requests and runs first on `main` after the merge, so a PR is structurally unable to catch it.

## Related issue

<!-- none -->

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

The unselected neighbour now comes off the grid rather than being computed from the date, which is what the test meant in the first place: exactly one day reads selected, and the rest of the month reports it. That holds whichever day the calendar opens on.

Pinning a fake clock is what fixed the unit-test twins and is the wrong tool here. This suite drives a real browser against a real backend, so moving only the browser's clock would desync it from the server that computes availability.

The other three date-dependent tests in the file are left alone. Each presses an arrow key first, which navigates the picker into the next month, so the cell exists by the time it is asserted — that is why only this one went red. This test asked for a cell it never navigated to.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally — `tsc --noEmit` clean, `npm run check` exit 0, Prettier clean
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

Being straight about the gap: **I could not run the E2E suite locally** — Docker is not usable in this environment, so CI is the only real check on this one. The change is confined to assertions inside a single test, and the reasoning is above; but it is verified by inspection and typecheck, not by a green local run.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed

### Worth considering separately

Three date-dependent failures in two suites in one day is a pattern, not a coincidence. Both suites assume "tomorrow" is reachable from "today" without saying so. A cheap guard would be a scheduled CI run against a pinned end-of-month date, so this class fails on a Tuesday rather than on the 31st.

There is also a structural gap worth naming: `e2e-extensive` is gated to `push` on `main`, so a whole test suite's failures can only ever be discovered after a merge. That is the trade for fast PR feedback and may well be the right one, but it means `main` going red post-merge is expected behaviour rather than a surprise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4RTNcy7Sw7xAmDmJ8S6Dm)_