### PR TITLE
fix(frontend): patch decode-uri-component ReDoS vulnerability (GHSA-vcc3-ghjq-m6fr)

### DIFF
--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -5385,12 +5385,12 @@
       "license": "MIT"
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/dedent": {
@@ -9086,9 +9086,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9108,9 +9105,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9132,9 +9126,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9154,9 +9145,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -122,7 +122,8 @@
     "shell-quote": ">=1.8.4",
     "brace-expansion": ">=5.0.9",
     "js-yaml": ">=5.2.2",
-    "nanoid": "^3.3.17"
+    "nanoid": "^3.3.17",
+    "decode-uri-component": ">=0.5.0"
   },
   "engines": {
     "node": ">=24.15.0"


### PR DESCRIPTION
## Summary

Scheduled dependency audit found 3 moderate `npm audit` findings in `openresto-frontend`, all rooted in a single transitive package: `expo-router`'s bundled `query-string@7.1.3` depends on `decode-uri-component@^0.2.2`, which is vulnerable to a denial-of-service via exponential decoding of malformed percent-encoded input ([GHSA-vcc3-ghjq-m6fr](https://github.com/advisories/GHSA-vcc3-ghjq-m6fr)). This is exercised during URL/deep-link parsing in expo-router's internal routing.

`npm audit`'s suggested fix (downgrade `expo-router` to `5.1.11`) does not apply here — that advisory data predates Expo's switch to SDK-numbered `expo-router` versions, so npm's automatic fix is stale and would be a downgrade. Instead this overrides just the vulnerable leaf package to `0.5.0`, the first patched release, using the same `overrides` mechanism already used in this file for `uuid`, `shell-quote`, `brace-expansion`, and `js-yaml`.

No vulnerabilities or CVEs were found in the root `package.json`, `openresto-cli`, or the backend (`dotnet list package --vulnerable` reports clean for all three .csproj projects). Everything else outdated is dev-tooling only (analyzers, test SDKs, lint/build tools) with no security advisories — see the note below.

## Related issue

Closes #

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

- `openresto-frontend/package.json`: add `"decode-uri-component": ">=0.5.0"` to `overrides`
- `openresto-frontend/package-lock.json`: regenerated; `decode-uri-component` now resolves to `0.5.0` everywhere in the tree

## Testing

- [x] Frontend tests/build pass locally (`npm test` — 3382/3383 passing; the one failure, `RestaurantInfoForm`'s 10 MB file-size test, times out only under full-suite parallel load and passes cleanly in isolation — pre-existing flake, unrelated to this change and reproduced against the pre-change lockfile too)
- [x] `npm run check` (prettier + oxlint) passes with only pre-existing warnings
- [x] `npm audit` — 0 vulnerabilities (was 3 moderate)
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [ ] Docs updated if API contracts or setup changed

---

### Other outdated dependencies found (informational, not included in this PR)

None of these have known vulnerabilities; they're excluded here because they're either dev-tooling-only or carry real breaking-change/compat risk that deserves its own PR and testing pass:

- **Backend (`OpenRestoApi`, `OpenRestoApi.Tests`, `tools/OpenApiExport`)**: `Roslynator.Analyzers`/`Roslynator.Formatting.Analyzers` 4.12.9 → 5.0.0 (major), `Microsoft.CodeAnalysis.CSharp.Workspaces`/`Workspaces.MSBuild` 5.3.0 → 5.9.0, `Microsoft.NET.Test.Sdk` 18.8.1 → 18.9.0, `xunit.runner.visualstudio` 3.1.5 → 4.0.0 (major). The `CodeAnalysis.CSharp.Workspaces`/`Workspaces.MSBuild` pair is explicitly version-pinned per CLAUDE.md to avoid a `TypeLoadException` in `dotnet ef migrations add` — bumping it needs the re-check documented there, not a routine dependency PR.
- **Frontend**: several Expo SDK 57 packages have small patch releases already permitted by their existing `~`-ranges (expo, expo-asset, expo-constants, etc.) — a plain lockfile refresh would pick these up. Major bumps (`react-native-gesture-handler` 2→3, `typescript` 6→7, `jest` 29→30, `@testing-library/react-native` 13→14) are pinned deliberately for the React Native/Expo compatibility matrix and shouldn't move outside a coordinated Expo SDK bump.
- **Root**: `concurrently` 9.2.4 → 10.0.5 (major, dev-only).
- **`openresto-cli`**: `commander` 12.1.0 → 15.0.0 (major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ST3KhPAVGjK1m8AywENV4m

---
_Generated by [Claude Code](https://claude.ai/code/session_01ST3KhPAVGjK1m8AywENV4m)_