### PR TITLE
Native app: predictive back on Android, and a My Bookings quick action

### DIFF
--- a/openresto-frontend/app.config.ts
+++ b/openresto-frontend/app.config.ts
@@ -117,7 +117,11 @@ export function buildExpoConfig(
               monochromeImage: "./assets/images/android-icon-monochrome.png",
             }),
       },
-      predictiveBackGestureEnabled: false,
+      // Android 15+ previews the screen underneath as the gesture is dragged. Every overlay
+      // in the app dismisses through `Modal.onRequestClose`, which React Native bridges to the
+      // new OnBackInvokedCallback API; nothing hand-rolls `BackHandler`, which is what would
+      // swallow the gesture instead (#430).
+      predictiveBackGestureEnabled: true,
       ...(native
         ? {
             package: native.androidPackage,

--- a/openresto-frontend/app/(user)/_layout.tsx
+++ b/openresto-frontend/app/(user)/_layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Platform, View } from "react-native";
 import {
   Slot,
@@ -18,6 +18,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { focusTarget } from "@/utils/focusRegistry";
 import KeyboardShortcutsHelp from "@/components/common/KeyboardShortcutsHelp";
 import { useBrand } from "@/context/BrandContext";
+import { registerQuickActions } from "@/services/quickActions";
 import { useAppTheme } from "@/hooks/use-app-theme";
 
 /**
@@ -64,7 +65,7 @@ function tabRoot(): NativeStackNavigationOptions {
 }
 
 export default function UserLayout() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const router = useRouter();
   const brand = useBrand();
   const segments = useSegments();
@@ -76,6 +77,21 @@ export default function UserLayout() {
   const isUserRouteActive = segments[0] === "(user)";
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
   const { colors } = useAppTheme();
+
+  /**
+   * Long-pressing the app icon offers the one destination a returning guest wants (#431).
+   * Inert on web, where there is no icon to press. Keyed on the language rather than on `t`
+   * so the label is rewritten when the guest switches locale and not on every render.
+   */
+  useEffect(
+    () =>
+      registerQuickActions({
+        title: t("common.navbar.myBookingsLink"),
+        onSelect: () => router.push("/lookup"),
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [i18n.language]
+  );
 
   useKeyboardShortcuts(
     isUserRouteActive

--- a/openresto-frontend/constants/quickActions.ts
+++ b/openresto-frontend/constants/quickActions.ts
@@ -1,0 +1,7 @@
+/**
+ * Identifies the app's one home-screen quick action (#431). It lives here rather than beside
+ * either half of `services/quickActions` because a `.native` module's import of its own
+ * platform-neutral sibling resolves back to itself: only types survive that round trip, so a
+ * value both halves need has to sit outside the split.
+ */
+export const MY_BOOKING_ACTION_ID = "my-booking";

--- a/openresto-frontend/jest.setup.ts
+++ b/openresto-frontend/jest.setup.ts
@@ -69,3 +69,12 @@ jest.mock("@react-native-community/datetimepicker", () => {
     default: (props: Record<string, unknown>) => React.createElement(View, props),
   };
 });
+
+// Home-screen quick actions (#431) are a native module with no JS host under Jest, and its own
+// web stub is not what the default (iOS) platform resolves. Inert here; the service's own tests
+// replace this with a mock that can fire a launch.
+jest.mock("expo-quick-actions", () => ({
+  initial: undefined,
+  setItems: jest.fn(() => Promise.resolve()),
+  addListener: jest.fn(() => ({ remove: jest.fn() })),
+}));

--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -22,6 +22,7 @@
         "expo-localization": "~57.0.1",
         "expo-network": "~57.0.1",
         "expo-notifications": "~57.0.16",
+        "expo-quick-actions": "^6.0.2",
         "expo-router": "~57.0.18",
         "expo-sharing": "~57.0.15",
         "expo-splash-screen": "~57.0.5",
@@ -4031,7 +4032,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4391,6 +4391,57 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
       }
     },
     "node_modules/anser": {
@@ -6457,6 +6508,66 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-quick-actions": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/expo-quick-actions/-/expo-quick-actions-6.0.2.tgz",
+      "integrity": "sha512-IVoTMCx55MjSnPqUEb5jhePpOAUdOTonifY3QXM/DBFxc6qMzBy5iJWEkfDZcFAzFzahK1ZW9tFaNv4pi2AAvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.7",
+        "schema-utils": "^4.3.2",
+        "sf-symbols-typescript": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-quick-actions/node_modules/@expo/image-utils": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.17.tgz",
+      "integrity": "sha512-1eVrX6FFkPNl9DJNiw3Gjsf6PtG7HttbapEVvcROVrA9PCMikujOJWWHDYKGptmKoVIIVajFZE8UHGHUb3mPug==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/require-utils": "^55.0.8",
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.0.0",
+        "getenv": "^2.0.0",
+        "jimp-compact": "0.16.1",
+        "parse-png": "^2.1.0",
+        "semver": "^7.6.0"
+      }
+    },
+    "node_modules/expo-quick-actions/node_modules/@expo/require-utils": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.8.tgz",
+      "integrity": "sha512-DDS5R67iz2SJwncbpcUMHtnsq31dSfllhaEncKxGlK0/ewgc2CaXUCkDA2AumfT7ubnSXiPkU9Gn8v2xCrvj+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-quick-actions/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-router": {
       "version": "57.0.18",
       "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-57.0.18.tgz",
@@ -6696,6 +6807,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
@@ -11625,6 +11752,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -11796,6 +11932,47 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -41,6 +41,7 @@
     "expo-localization": "~57.0.1",
     "expo-network": "~57.0.1",
     "expo-notifications": "~57.0.16",
+    "expo-quick-actions": "^6.0.2",
     "expo-router": "~57.0.18",
     "expo-sharing": "~57.0.15",
     "expo-splash-screen": "~57.0.5",
@@ -88,6 +89,7 @@
       "^@/services/storage$": "<rootDir>/services/storage.ts",
       "^@/services/pushRegistration$": "<rootDir>/services/pushRegistration.ts",
       "^@/services/holdExpiryNotice$": "<rootDir>/services/holdExpiryNotice.ts",
+      "^@/services/quickActions$": "<rootDir>/services/quickActions.ts",
       "^@/(.*)$": "<rootDir>/$1"
     },
     "collectCoverageFrom": [

--- a/openresto-frontend/services/quickActions.native.ts
+++ b/openresto-frontend/services/quickActions.native.ts
@@ -1,0 +1,60 @@
+import { Platform } from "react-native";
+import * as QuickActions from "expo-quick-actions";
+import { MY_BOOKING_ACTION_ID } from "@/constants/quickActions";
+import type { QuickActionOptions } from "./quickActions";
+
+export type { QuickActionOptions } from "./quickActions";
+
+/**
+ * SF Symbols are iOS-only by Apple's licence, so Android gets no icon and falls back to the
+ * app icon. `ticket` matches the glyph `GuestTabBar` gives the same destination. Resolved per
+ * call rather than captured at module load, which would freeze whichever platform imported it
+ * first.
+ */
+function icon(): string | undefined {
+  return Platform.OS === "ios" ? "symbol:ticket" : undefined;
+}
+
+/**
+ * The action the app was cold-started from, if any.
+ *
+ * Read off the namespace defensively rather than imported by name: `initial` is exported by
+ * expo-quick-actions' native build and **not** by its web one, so a static named import is a
+ * reference that does not exist in every build of the package it comes from.
+ */
+function initialAction(): { id?: string } | undefined {
+  return (QuickActions as { initial?: { id?: string } }).initial;
+}
+
+/**
+ * Whether the action that launched this process has been acted on. `QuickActions.initial` is a
+ * snapshot taken at launch and never cleared, so without this a remount would navigate the
+ * guest back to the lookup screen long after they had moved on.
+ */
+let handledInitialAction = false;
+
+/** Test seam: the module-level latch above outlives a Jest module registry reset. */
+export function resetInitialActionForTests(): void {
+  handledInitialAction = false;
+}
+
+/**
+ * @see [quickActions.native.test.ts](../tests/services/quickActions.native.test.ts) — pins the
+ * cold-start launch firing once, the icon being iOS-only, and a refusing device not throwing.
+ */
+export function registerQuickActions({ title, onSelect }: QuickActionOptions): () => void {
+  // Nothing here may throw into the layout that mounts it: a device that refuses shortcuts
+  // still has to render the app.
+  void QuickActions.setItems([{ id: MY_BOOKING_ACTION_ID, title, icon: icon() }]).catch(() => {});
+
+  const subscription = QuickActions.addListener((action) => {
+    if (action.id === MY_BOOKING_ACTION_ID) onSelect();
+  });
+
+  if (!handledInitialAction && initialAction()?.id === MY_BOOKING_ACTION_ID) {
+    handledInitialAction = true;
+    onSelect();
+  }
+
+  return () => subscription.remove();
+}

--- a/openresto-frontend/services/quickActions.ts
+++ b/openresto-frontend/services/quickActions.ts
@@ -1,0 +1,25 @@
+export interface QuickActionOptions {
+  /**
+   * Label shown under the app icon, already localized. Registering at runtime rather than
+   * declaring the action in the config plugin is what lets it follow the guest's chosen
+   * language: a static action's title is frozen in whatever locale the publisher built in.
+   */
+  title: string;
+  /** Called when the app is launched, or resumed, from the action. */
+  onSelect: () => void;
+}
+
+/**
+ * Publishes the app's home-screen quick actions and listens for launches from them, returning
+ * a teardown.
+ *
+ * This is the **web** implementation and it is inert: a browser has no app icon to long-press.
+ * Native resolves the sibling `quickActions.native.ts` through Metro's platform extensions,
+ * which keeps expo-quick-actions out of the web bundle.
+ *
+ * @see [quickActions.test.ts](../tests/services/quickActions.test.ts) — pins that web
+ * registers nothing and hands back a teardown that is safe to call.
+ */
+export function registerQuickActions(_options: QuickActionOptions): () => void {
+  return () => {};
+}

--- a/openresto-frontend/tests/app.config.test.ts
+++ b/openresto-frontend/tests/app.config.test.ts
@@ -78,6 +78,15 @@ describe("buildExpoConfig without a native config", () => {
     expect(config.owner).toBeUndefined();
   });
 
+  // #430. The gesture previews the screen underneath instead of jumping, which is one of the
+  // first things that reads as "not a native app" when it is off. Every overlay dismisses
+  // through Modal.onRequestClose, pinned structurally in backDismissal.test.ts.
+  it("lets Android preview the screen behind the back gesture", () => {
+    const config = buildExpoConfig({}, null, "./native");
+
+    expect(config.android?.predictiveBackGestureEnabled).toBe(true);
+  });
+
   it("still honours EXPO_PUBLIC_APP_NAME for the name", () => {
     process.env.EXPO_PUBLIC_APP_NAME = "Named By Env";
     try {

--- a/openresto-frontend/tests/app/(user)/layout.test.tsx
+++ b/openresto-frontend/tests/app/(user)/layout.test.tsx
@@ -6,6 +6,7 @@ import { Platform } from "react-native";
 // factory is allowed to close over them.
 const mockScreenOptions: Record<string, unknown>[] = [];
 const mockScreens: { name: string; options: Record<string, unknown> }[] = [];
+const mockPush = jest.fn();
 
 // The layout's offline strip takes the top safe-area inset, and the hook throws outside a
 // provider — the app mounts one in app/_layout.tsx, these tests render the layout alone.
@@ -25,6 +26,10 @@ jest.mock("@/context/BrandContext", () => {
   const brand = { primaryColor: "#0a7ea4", appName: "Open Resto" };
   return { useBrand: () => brand };
 });
+
+jest.mock("@/services/quickActions", () => ({
+  registerQuickActions: jest.fn(() => () => {}),
+}));
 
 jest.mock("@/api/admin", () => ({
   getAdminOverview: jest.fn(),
@@ -53,7 +58,7 @@ jest.mock("expo-router", () => {
   return {
     Slot: () => null,
     Stack,
-    useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+    useRouter: () => ({ push: mockPush, replace: jest.fn() }),
     usePathname: () => "/",
     useSegments: () => ["(user)"],
   };
@@ -80,6 +85,11 @@ function renderOn(os: "ios" | "android") {
     optionsFor: (name: string) => mockScreens.find((screen) => screen.name === name)?.options,
   };
 }
+
+beforeEach(() => {
+  mockPush.mockClear();
+  jest.mocked(require("@/services/quickActions").registerQuickActions).mockClear();
+});
 
 afterEach(() => {
   Object.defineProperty(Platform, "OS", { value: originalOS, configurable: true });
@@ -160,6 +170,33 @@ describe("UserLayout back button", () => {
     const { screenOptions } = renderOn("android");
 
     expect(screenOptions).not.toHaveProperty("headerBackButtonDisplayMode");
+  });
+});
+
+/**
+ * Issue #431. Long-pressing the app icon is the returning guest's shortcut back to their
+ * booking. Registered at runtime, not declared in the config plugin, so the label follows the
+ * language the guest picked instead of the one the publisher built in.
+ */
+describe("UserLayout quick actions", () => {
+  const { registerQuickActions } = require("@/services/quickActions");
+
+  // The same i18n key GuestTabBar gives the tab, so the shortcut and the tab cannot end up
+  // naming the same destination differently.
+  it("offers the booking lookup under the label the tab bar uses", () => {
+    renderOn("ios");
+
+    expect(registerQuickActions).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "My Bookings" })
+    );
+  });
+
+  it("sends a launch from the action to the lookup screen", () => {
+    renderOn("ios");
+
+    registerQuickActions.mock.calls.at(-1)[0].onSelect();
+
+    expect(mockPush).toHaveBeenCalledWith("/lookup");
   });
 });
 

--- a/openresto-frontend/tests/backDismissal.test.ts
+++ b/openresto-frontend/tests/backDismissal.test.ts
@@ -1,0 +1,66 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(__dirname, "..");
+const SEARCHED = ["app", "components"];
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    return path.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+/**
+ * The attribute list of every `<Modal` element in a file: everything from the tag name to the
+ * `>` that ends the opening tag, skipping any `>` nested inside a `{...}` prop value.
+ */
+function modalOpeningTags(source: string): string[] {
+  const tags: string[] = [];
+  const pattern = /<Modal[\s/>]/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    let depth = 0;
+    for (let i = match.index; i < source.length; i++) {
+      const char = source[i];
+      if (char === "{") depth++;
+      else if (char === "}") depth--;
+      else if (char === ">" && depth === 0) {
+        tags.push(source.slice(match.index, i));
+        break;
+      }
+    }
+  }
+  return tags;
+}
+
+/**
+ * Android's predictive back gesture (#430) reaches an overlay through `Modal.onRequestClose`.
+ * A `Modal` without one does not merely ignore the gesture: the press falls through to the
+ * activity and the app closes with the overlay still on screen, which is the worst outcome of
+ * the three. The rule is structural rather than a list, so a Modal added tomorrow is covered
+ * the day it ships — same reasoning as the backend's audit-coverage test.
+ *
+ * Nothing in the app hand-rolls `BackHandler`; if something starts to, this test will not see
+ * it, and the flag in `app.config.ts` would need re-checking on a device.
+ */
+describe("every overlay can be dismissed by the Android back gesture", () => {
+  const files = SEARCHED.flatMap((dir) => sourceFiles(join(root, dir)));
+
+  it("finds the Modals it is meant to be checking", () => {
+    const withModals = files.filter((f) => modalOpeningTags(readFileSync(f, "utf8")).length > 0);
+    // A parser change that quietly matched nothing would make every assertion below vacuous.
+    expect(withModals.length).toBeGreaterThan(5);
+  });
+
+  it("gives each one an onRequestClose", () => {
+    const missing = files.flatMap((file) =>
+      modalOpeningTags(readFileSync(file, "utf8"))
+        .filter((tag) => !tag.includes("onRequestClose"))
+        .map(() => file.slice(root.length + 1))
+    );
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/openresto-frontend/tests/services/quickActions.native.test.ts
+++ b/openresto-frontend/tests/services/quickActions.native.test.ts
@@ -1,0 +1,126 @@
+import { Platform } from "react-native";
+import * as QuickActions from "expo-quick-actions";
+import { registerQuickActions, resetInitialActionForTests } from "@/services/quickActions.native";
+import { MY_BOOKING_ACTION_ID } from "@/constants/quickActions";
+
+jest.mock("expo-quick-actions", () => ({
+  initial: undefined,
+  setItems: jest.fn(() => Promise.resolve()),
+  addListener: jest.fn(() => ({ remove: jest.fn() })),
+}));
+
+const mocked = QuickActions as unknown as {
+  initial: { id: string } | undefined;
+  setItems: jest.Mock;
+  addListener: jest.Mock;
+};
+
+const setPlatform = (os: string) =>
+  Object.defineProperty(Platform, "OS", { value: os, configurable: true });
+
+/** The action payload handed to `setItems` on the most recent call. */
+const publishedAction = () => mocked.setItems.mock.calls[0][0][0];
+
+/** Fires a launch through the listener the service registered. */
+const launchFrom = (id: string) => mocked.addListener.mock.calls[0][0]({ id });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mocked.setItems.mockResolvedValue(undefined);
+  mocked.addListener.mockReturnValue({ remove: jest.fn() });
+  mocked.initial = undefined;
+  resetInitialActionForTests();
+  setPlatform("ios");
+});
+
+describe("registerQuickActions (native)", () => {
+  it("publishes the one action under the title it was given", () => {
+    registerQuickActions({ title: "Ma réservation", onSelect: jest.fn() });
+
+    expect(publishedAction()).toMatchObject({
+      id: MY_BOOKING_ACTION_ID,
+      title: "Ma réservation",
+    });
+  });
+
+  it("takes an SF Symbol on iOS", () => {
+    registerQuickActions({ title: "My booking", onSelect: jest.fn() });
+
+    expect(publishedAction().icon).toBe("symbol:ticket");
+  });
+
+  // Apple's licence keeps SF Symbols off other platforms; Android falls back to the app icon.
+  it("asks for no icon on Android", () => {
+    setPlatform("android");
+    registerQuickActions({ title: "My booking", onSelect: jest.fn() });
+
+    expect(publishedAction().icon).toBeUndefined();
+  });
+
+  it("routes a launch from the action", () => {
+    const onSelect = jest.fn();
+    registerQuickActions({ title: "My booking", onSelect });
+
+    launchFrom(MY_BOOKING_ACTION_ID);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a launch from some other action", () => {
+    const onSelect = jest.fn();
+    registerQuickActions({ title: "My booking", onSelect });
+
+    launchFrom("something-else");
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("acts on the action that cold-started the app", () => {
+    mocked.initial = { id: MY_BOOKING_ACTION_ID };
+    const onSelect = jest.fn();
+
+    registerQuickActions({ title: "My booking", onSelect });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * `initial` is a snapshot taken at launch and never cleared, so a second registration — a
+   * remount, or the guest switching language — must not navigate them back to lookup from
+   * wherever they have since got to.
+   */
+  it("acts on the cold-start action only once per process", () => {
+    mocked.initial = { id: MY_BOOKING_ACTION_ID };
+    const onSelect = jest.fn();
+
+    registerQuickActions({ title: "My booking", onSelect });
+    registerQuickActions({ title: "Ma réservation", onSelect });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat a cold start from another action as its own", () => {
+    mocked.initial = { id: "something-else" };
+    const onSelect = jest.fn();
+
+    registerQuickActions({ title: "My booking", onSelect });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("stops listening when torn down", () => {
+    const remove = jest.fn();
+    mocked.addListener.mockReturnValue({ remove });
+
+    registerQuickActions({ title: "My booking", onSelect: jest.fn() })();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  // A device that refuses shortcuts still has to render the app.
+  it("swallows a device that rejects the shortcuts", () => {
+    mocked.setItems.mockRejectedValue(new Error("no shortcut manager"));
+
+    expect(() => registerQuickActions({ title: "My booking", onSelect: jest.fn() })).not.toThrow();
+  });
+});

--- a/openresto-frontend/tests/services/quickActions.test.ts
+++ b/openresto-frontend/tests/services/quickActions.test.ts
@@ -1,0 +1,18 @@
+import { registerQuickActions } from "@/services/quickActions";
+import { MY_BOOKING_ACTION_ID } from "@/constants/quickActions";
+
+// A browser has no app icon to long-press, so the web half is inert by design. Pinned so the
+// asymmetry is answered by a test rather than re-derived.
+describe("quickActions (web)", () => {
+  it("registers nothing and hands back a teardown that is safe to call", () => {
+    const onSelect = jest.fn();
+    const teardown = registerQuickActions({ title: "My booking", onSelect });
+
+    expect(() => teardown()).not.toThrow();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("names the action so both halves match on it", () => {
+    expect(MY_BOOKING_ACTION_ID).toBe("my-booking");
+  });
+});


### PR DESCRIPTION
## Summary

The two small ones from the remaining four. #425 (bottom sheet) and #426 (native tab bar) both restructure `_layout.tsx` and #426 says to do it after #425, so they follow in their own PR rather than riding along here.

## Related issue

Closes #430
Closes #431

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

## Changes

### #430 — predictive back

`predictiveBackGestureEnabled` was `false`, so on Android 15+ the gesture jumps instead of previewing the screen underneath.

The ticket assumed the flag was off because of the overlays that intercept back, and budgeted the work for verifying them rather than for the flag. The audit says otherwise: **every** `Modal` in the app already passes `onRequestClose`, which React Native bridges to the new `OnBackInvokedCallback` API, and **nothing anywhere hand-rolls `BackHandler`** — the legacy path that would actually swallow the gesture. So the flag is the change, and the verification is the test below.

`backDismissal.test.ts` parses every `<Modal>` opening tag under `app/` and `components/` and fails on one without an `onRequestClose`. Structural rather than a list, same reasoning as the backend's audit-coverage test, so a Modal added later is covered the day it ships instead of the day someone notices back closing the whole app. It carries a guard against matching nothing, so it cannot pass vacuously, and I checked it fails on a real violation before trusting it:

```
✕ gives each one an onRequestClose
+   "components/common/ModalCard.tsx"
```

Tab roots keep `gestureEnabled: false`; predictive back applies to pushed screens and modals, which is what the audit covers.

### #431 — quick action

One action, straight to `/lookup`.

**Registered at runtime rather than declared in the config plugin, which is a deliberate departure from the ticket.** A static action's title is baked in at build time in whatever language the publisher built in; `setItems` lets it follow the locale the guest picked, and the layout re-registers on language change. That matters for a self-hoster running in fr/es/de. The plugin turns out to be only for static actions and dynamic app icons anyway — with neither in play it returns the config untouched, and autolinking covers the native module and its AppDelegate subscriber, so there is no plugin entry to add.

The label is `common.navbar.myBookingsLink`, the same key `GuestTabBar` gives the tab, so the shortcut and the tab cannot name one destination two ways. SF Symbol on iOS, no icon on Android where Apple's licence keeps SF Symbols out and the app icon is the fallback.

Three things pinned, each of which would be a real bug:

- `QuickActions.initial` is a launch snapshot that is never cleared, so a cold-start action fires **once per process** and not again on a remount or a language switch — otherwise a guest who has since navigated elsewhere gets yanked back to lookup.
- A device that refuses shortcuts still has to render the app, so a rejecting `setItems` is swallowed.
- `initial` is read off the namespace rather than imported by name, because expo-quick-actions exports it from its **native build and not its web one**. oxlint caught that; a named import would have been a reference to something that does not exist in every build of the package.

The action id lives in `constants/` because a `.native` module importing its own platform-neutral sibling resolves back to itself — only types survive that round trip. Same constraint `pushRegistration.native.ts` works around with `import type`.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

Backend untouched.

| Check | Result |
|---|---|
| `npm test` (iOS) | 258 suites, 3521 tests, green |
| `npm run test:android` | 258 suites, 3521 tests, green |
| `npm run check` | clean |
| `npx tsc --noEmit` | clean |

**Needs your simulator pass before merge.** Both of these are behaviours no CI here can see: the gesture previewing correctly against each overlay (`BookingDrawer`, `AnchoredPanel`, `ModalCard`, `LargePartyNoticeModal`, the `LookupScreen` cancel sheet), and the long-press menu actually appearing and routing.

The one carried risk is `expo-quick-actions` itself: its README compatibility table stops at Expo SDK 54 and this repo is on 57. Its `expo-module.config.json` uses the current `apple`/`appDelegateSubscribers` shape and depends only on `ExpoModulesCore`, so it looks fine, but only a native build proves it. If it fails to compile, that breaks self-hosters' builds and not just ours, so it is worth confirming before this ships.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

## One thing to keep an eye on

`RestaurantActionModal.test.tsx` failed once on a full Android run and passed on a re-run and in isolation. It is a slow pre-existing suite (13 tests at ~700ms against jest's 5s default) and it tipped over under parallel load, not for any Android-specific reason. I have not touched it, but the Android job doubles CI's exposure to it, so if it starts flaking that is the cause and raising its timeout is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyoC61iZMiHSFYPd6z4ZTR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyoC61iZMiHSFYPd6z4ZTR)_