### PR TITLE
Native app: a real bottom sheet, and a tab bar that looks like the platform's

### DIFF
--- a/openresto-frontend/app/_layout.tsx
+++ b/openresto-frontend/app/_layout.tsx
@@ -20,6 +20,7 @@ import { currentAppVersion, isBelowMinimum } from "@/utils/appVersion";
 import { BrandProvider, useBrand } from "@/context/BrandContext";
 import { LocaleProvider } from "@/context/LocaleContext";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { BookingSheetHost } from "@/components/booking/BookingSheetHost";
 
 /**
  * Expo Router binds an `ErrorBoundary` export to the segment that declares it, so the root
@@ -147,13 +148,17 @@ function AppWithTheme() {
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
-      <BrandProvider>
-        <LocaleProvider>
-          <AppThemeProvider>
-            <AppWithTheme />
-          </AppThemeProvider>
-        </LocaleProvider>
-      </BrandProvider>
+      {/* Outermost of the app's own providers off web: the gesture root inside has to wrap
+          everything that can host a gesture handler, and a pass-through on web. */}
+      <BookingSheetHost>
+        <BrandProvider>
+          <LocaleProvider>
+            <AppThemeProvider>
+              <AppWithTheme />
+            </AppThemeProvider>
+          </LocaleProvider>
+        </BrandProvider>
+      </BookingSheetHost>
     </SafeAreaProvider>
   );
 }

--- a/openresto-frontend/components/booking/BookingDrawer.tsx
+++ b/openresto-frontend/components/booking/BookingDrawer.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type ReactNode,
+} from "react";
 import {
   Animated,
   GestureResponderHandlers,
@@ -8,9 +17,10 @@ import {
   Pressable,
   ScrollView,
   View,
+  type StyleProp,
+  type ViewStyle,
 } from "react-native";
 import { useRouter } from "expo-router";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import * as Haptics from "expo-haptics";
@@ -24,7 +34,6 @@ import { rememberBooking } from "@/utils/bookingCache";
 import { convertLocalToUtc } from "@/utils/date";
 import { fmtDateString } from "@/utils/formatters";
 import BookingForm, { BookingFormData } from "@/components/booking/BookingForm";
-import { KeyboardAvoider } from "@/components/common/KeyboardAvoider";
 import Select from "@/components/common/Select";
 import { animateNode, EASE_ENTER, EASE_EXIT, prefersReducedMotion } from "@/utils/webAnimation";
 import {
@@ -36,10 +45,23 @@ import {
 } from "@/utils/panelMotion";
 import { styles } from "./BookingDrawer.styles";
 import { Icon } from "@/components/common/Icon";
+import { NativeBookingSheet, SheetScrollView } from "@/components/booking/NativeBookingSheet";
 
 // Re-exported so existing imports of these from BookingDrawer (this module used to define
 // them) keep working; utils/panelMotion is the source of truth, shared with SlidePanel.
 export { shouldDismissSheet };
+
+/**
+ * The subset of ScrollView both the plain one and the sheet's own implement. Typing the slot
+ * structurally rather than as `typeof ScrollView` is what lets the two be swapped: the sheet's
+ * scroller is a different component with a compatible surface, not a subclass.
+ */
+type ScrollShell = ComponentType<{
+  style?: StyleProp<ViewStyle>;
+  contentContainerStyle?: StyleProp<ViewStyle>;
+  keyboardShouldPersistTaps?: boolean | "always" | "handled" | "never";
+  children?: ReactNode;
+}>;
 
 function summaryLine(
   t: TFunction,
@@ -90,7 +112,6 @@ export default function BookingDrawer({
   const router = useRouter();
   const { t } = useTranslation();
   const { colors, isDark } = useAppTheme();
-  const insets = useSafeAreaInsets();
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   // Drag-to-dismiss for the sheet. The responder is built once, so it reads onClose
@@ -253,7 +274,20 @@ export default function BookingDrawer({
     </ThemedText>
   );
 
-  const body = (headerHandlers: Partial<GestureResponderHandlers> = {}) => (
+  /**
+   * `Scroll` is the sheet's own scroller off web, so dragging the list and dragging the sheet
+   * do not fight; `onCloseRequest` lets the native sheet animate itself away rather than being
+   * unmounted from under its own exit.
+   */
+  const body = ({
+    headerHandlers = {},
+    Scroll = ScrollView,
+    onCloseRequest,
+  }: {
+    headerHandlers?: Partial<GestureResponderHandlers>;
+    Scroll?: ScrollShell;
+    onCloseRequest?: () => void;
+  } = {}) => (
     <>
       <View {...headerHandlers} style={[styles.header, { borderBottomColor: colors.border }]}>
         {/* The close button sits on the heading's own row rather than beside the whole
@@ -263,7 +297,7 @@ export default function BookingDrawer({
           <View style={styles.headerHeading}>{heading}</View>
           <Pressable
             testID="booking-drawer-close"
-            onPress={closeWithHaptic}
+            onPress={onCloseRequest ?? closeWithHaptic}
             accessibilityRole="button"
             accessibilityLabel={t("booking.drawer.closePanelLabel")}
             hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
@@ -277,7 +311,7 @@ export default function BookingDrawer({
         </ThemedText>
       </View>
 
-      <ScrollView
+      <Scroll
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
@@ -303,61 +337,68 @@ export default function BookingDrawer({
           initialTime={time}
           onSubmit={handleSubmit}
         />
-      </ScrollView>
+      </Scroll>
     </>
   );
 
+  if (variant === "sheet" && Platform.OS !== "web") {
+    return (
+      <NativeBookingSheet
+        accessibilityLabel={t("booking.drawer.bookLocationLabel", { name: restaurant.name })}
+        onClose={onClose}
+      >
+        {({ dismiss }) => body({ Scroll: SheetScrollView, onCloseRequest: dismiss })}
+      </NativeBookingSheet>
+    );
+  }
+
+  // Web's own sheet. Narrow browsers still get this one: there is no platform sheet to defer
+  // to, and the keyboard and the home indicator are the browser's problem there, which is why
+  // neither a KeyboardAvoider nor a bottom inset survives here.
   if (variant === "sheet") {
     return (
       <Modal visible transparent animationType="slide" onRequestClose={onClose}>
         <View style={styles.sheetRoot}>
-          {/* The sheet is bottom-anchored, so on a device the keyboard would cover the very
-              fields the diner is filling in. */}
-          <KeyboardAvoider style={styles.sheetRoot}>
-            <Pressable
-              testID="booking-drawer-backdrop"
-              accessibilityRole="button"
-              accessibilityLabel={t("booking.drawer.closePanelLabel")}
-              style={[styles.backdrop, { backgroundColor: colors.overlay }]}
-              onPress={closeWithHaptic}
-            />
-            <Animated.View
-              testID="booking-drawer"
-              role="dialog"
-              aria-modal
-              accessibilityViewIsModal
-              accessibilityLabel={t("booking.drawer.bookLocationLabel", { name: restaurant.name })}
-              style={[
-                styles.sheet,
-                { backgroundColor: colors.card, borderTopColor: colors.border },
-                // The sheet is the bottom of the screen, so the home indicator and Android's
-                // navigation bar land on its last row unless it steps up over them itself.
-                Platform.OS !== "web" && { paddingBottom: insets.bottom },
-                { transform: [{ translateY: dragY }] },
-              ]}
-            >
-              {/* The handle and the header drag the sheet; the body below them keeps its own
+          <Pressable
+            testID="booking-drawer-backdrop"
+            accessibilityRole="button"
+            accessibilityLabel={t("booking.drawer.closePanelLabel")}
+            style={[styles.backdrop, { backgroundColor: colors.overlay }]}
+            onPress={closeWithHaptic}
+          />
+          <Animated.View
+            testID="booking-drawer"
+            role="dialog"
+            aria-modal
+            accessibilityViewIsModal
+            accessibilityLabel={t("booking.drawer.bookLocationLabel", { name: restaurant.name })}
+            style={[
+              styles.sheet,
+              { backgroundColor: colors.card, borderTopColor: colors.border },
+              { transform: [{ translateY: dragY }] },
+            ]}
+          >
+            {/* The handle and the header drag the sheet; the body below them keeps its own
                 scrolling, which a whole-sheet responder would fight with. */}
+            <View
+              {...panResponder.panHandlers}
+              testID="booking-drawer-grabber"
+              // Drag-to-dismiss duplicates the labeled close button, so the handle stays out
+              // of the a11y tree instead of surfacing as an unnamed node.
+              aria-hidden
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+              style={styles.grabberArea}
+            >
               <View
-                {...panResponder.panHandlers}
-                testID="booking-drawer-grabber"
-                // Drag-to-dismiss duplicates the labeled close button, so the handle stays out
-                // of the a11y tree instead of surfacing as an unnamed node.
-                aria-hidden
-                accessibilityElementsHidden
-                importantForAccessibility="no-hide-descendants"
-                style={styles.grabberArea}
-              >
-                <View
-                  style={[
-                    styles.grabber,
-                    { backgroundColor: isDark ? "rgba(255,255,255,0.24)" : "rgba(0,0,0,0.18)" },
-                  ]}
-                />
-              </View>
-              {body(panResponder.panHandlers)}
-            </Animated.View>
-          </KeyboardAvoider>
+                style={[
+                  styles.grabber,
+                  { backgroundColor: isDark ? "rgba(255,255,255,0.24)" : "rgba(0,0,0,0.18)" },
+                ]}
+              />
+            </View>
+            {body({ headerHandlers: panResponder.panHandlers })}
+          </Animated.View>
         </View>
       </Modal>
     );

--- a/openresto-frontend/components/booking/BookingSheetHost.native.tsx
+++ b/openresto-frontend/components/booking/BookingSheetHost.native.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+
+/**
+ * The two roots `@gorhom/bottom-sheet` needs, mounted once for the whole app.
+ *
+ * `GestureHandlerRootView` has to wrap everything that uses a gesture handler, and until the
+ * booking sheet there was none: the only other consumer is an admin swipe row, and admin is
+ * web-only in production, so the app has run without this root the whole time.
+ *
+ * @see [BookingSheetHost.native.test.tsx](../../tests/components/booking/BookingSheetHost.native.test.tsx)
+ * — pins that the gesture root is outermost, since the sheet provider inside it is what
+ * renders the sheets and a provider above the root would receive no gestures.
+ */
+export function BookingSheetHost({ children }: { children: ReactNode }) {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <BottomSheetModalProvider>{children}</BottomSheetModalProvider>
+    </GestureHandlerRootView>
+  );
+}
+
+export default BookingSheetHost;

--- a/openresto-frontend/components/booking/BookingSheetHost.tsx
+++ b/openresto-frontend/components/booking/BookingSheetHost.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+/**
+ * Mounts whatever the native bottom sheet needs above the app: a gesture-handler root and the
+ * portal its sheets render into.
+ *
+ * This is the **web** implementation and it is a pass-through. The website's sheet is still the
+ * hand-rolled `Modal` in `BookingDrawer`, and `@gorhom/bottom-sheet` has no business in the web
+ * bundle; Metro resolves the sibling `BookingSheetHost.native.tsx` off web.
+ *
+ * @see [BookingSheetHost.test.tsx](../../tests/components/booking/BookingSheetHost.test.tsx)
+ * — pins that web adds no wrapper of its own.
+ */
+export function BookingSheetHost({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+export default BookingSheetHost;

--- a/openresto-frontend/components/booking/NativeBookingSheet.native.tsx
+++ b/openresto-frontend/components/booking/NativeBookingSheet.native.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetScrollView,
+  type BottomSheetBackdropProps,
+} from "@gorhom/bottom-sheet";
+import * as Haptics from "expo-haptics";
+import { useAppTheme } from "@/hooks/use-app-theme";
+import type { NativeBookingSheetProps } from "./NativeBookingSheet";
+
+export type { NativeBookingSheetProps } from "./NativeBookingSheet";
+
+/** The sheet's own scroller, which hands the drag back to the sheet at the top of the list. */
+export const SheetScrollView = BottomSheetScrollView;
+
+/**
+ * Two detents: enough of the form to fill in without moving, and near-full for the seating
+ * picker. The guest lands on the first.
+ */
+const DETENTS = ["66%", "92%"];
+
+/**
+ * The booking form as the platform's own sheet, replacing a hand-rolled
+ * `Modal` + `PanResponder` + `Animated` that had no detents, no rubber-band overscroll, and
+ * left the keyboard to a `KeyboardAvoidingView` wrapper rather than resizing the sheet (#425).
+ *
+ * The drawer stays a component with the same props rather than becoming a pushed route: party
+ * size, date and location are two-way bindings to the list behind it, and a route would have
+ * to rebuild that channel through params.
+ *
+ * @see [NativeBookingSheet.native.test.tsx](../../tests/components/booking/NativeBookingSheet.native.test.tsx)
+ * — pins the detents, that a dismissal reports upward exactly once, and that the backdrop
+ * closes rather than merely dimming.
+ */
+export function NativeBookingSheet({
+  accessibilityLabel,
+  onClose,
+  children,
+}: NativeBookingSheetProps) {
+  const sheet = useRef<BottomSheetModal>(null);
+  const { colors, isDark } = useAppTheme();
+
+  // The parent mounts this the moment a location is picked, so the sheet presents itself
+  // rather than making every call site drive a ref.
+  useEffect(() => {
+    sheet.current?.present();
+  }, []);
+
+  const dismiss = useCallback(() => {
+    void Haptics.selectionAsync();
+    sheet.current?.dismiss();
+  }, []);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
+  return (
+    <BottomSheetModal
+      ref={sheet}
+      snapPoints={DETENTS}
+      // Explicit detents, so the sheet must not also try to size itself to its content.
+      enableDynamicSizing={false}
+      enablePanDownToClose
+      onDismiss={onClose}
+      // Resize the sheet around the keyboard instead of shoving the whole thing up, which is
+      // the half of this the KeyboardAvoidingView wrapper could never do.
+      keyboardBehavior="interactive"
+      keyboardBlurBehavior="restore"
+      android_keyboardInputMode="adjustResize"
+      backdropComponent={renderBackdrop}
+      backgroundStyle={{ backgroundColor: colors.card }}
+      handleIndicatorStyle={{
+        backgroundColor: isDark ? "rgba(255,255,255,0.24)" : "rgba(0,0,0,0.18)",
+      }}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {children({ dismiss })}
+    </BottomSheetModal>
+  );
+}
+
+export default NativeBookingSheet;

--- a/openresto-frontend/components/booking/NativeBookingSheet.tsx
+++ b/openresto-frontend/components/booking/NativeBookingSheet.tsx
@@ -1,0 +1,27 @@
+import { ScrollView } from "react-native";
+import type { ReactNode } from "react";
+
+/**
+ * The scroll container the sheet body renders into. On native it has to be the sheet's own,
+ * so dragging the list and dragging the sheet do not fight; on web it is a plain ScrollView.
+ */
+export const SheetScrollView = ScrollView;
+
+export interface NativeBookingSheetProps {
+  accessibilityLabel: string;
+  /** Called once the sheet has finished animating away, or been dismissed by gesture. */
+  onClose: () => void;
+  /** Receives the sheet's own dismiss, so the header's close button animates out natively. */
+  children: (controls: { dismiss: () => void }) => ReactNode;
+}
+
+/**
+ * Never rendered on web: `BookingDrawer` keeps its hand-rolled sheet there, because a browser
+ * has no platform sheet to defer to and the website must not carry `@gorhom/bottom-sheet`.
+ * Metro resolves the sibling `.native.tsx` off web. Present only so the import typechecks.
+ */
+export function NativeBookingSheet({ children }: NativeBookingSheetProps) {
+  return <>{children({ dismiss: () => {} })}</>;
+}
+
+export default NativeBookingSheet;

--- a/openresto-frontend/components/layout/GuestTabBar.styles.ts
+++ b/openresto-frontend/components/layout/GuestTabBar.styles.ts
@@ -18,6 +18,14 @@ export const styles = StyleSheet.create({
     paddingTop: theme.spacing.xs,
     paddingBottom: theme.spacing.xs,
   },
+  /** Material 3's selected-destination pill: 64x32 with a fully rounded edge. */
+  indicator: {
+    width: 64,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   label: {
     fontSize: 11,
     fontWeight: "600",

--- a/openresto-frontend/components/layout/GuestTabBar.tsx
+++ b/openresto-frontend/components/layout/GuestTabBar.tsx
@@ -1,4 +1,6 @@
-import { Pressable } from "react-native";
+import { Platform, Pressable, StyleSheet, View } from "react-native";
+import { BlurView } from "expo-blur";
+import type { SFSymbol } from "expo-symbols";
 import * as Haptics from "expo-haptics";
 import { usePathname, useRouter, type Href } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -6,7 +8,8 @@ import { useTranslation } from "react-i18next";
 import { ThemedView } from "@/components/themed-view";
 import { ThemedText } from "@/components/themed-text";
 import { useAppTheme } from "@/hooks/use-app-theme";
-import { Icon, type IconName } from "@/components/common/Icon";
+import { type IconName } from "@/components/common/Icon";
+import { TabBarIcon } from "@/components/layout/TabBarIcon";
 import { styles } from "./GuestTabBar.styles";
 
 interface Tab {
@@ -15,6 +18,9 @@ interface Tab {
   match: (pathname: string) => boolean;
   icon: IconName;
   activeIcon: IconName;
+  /** The iOS glyph. Outlined and filled are one symbol there, varied by weight and fill. */
+  symbol: SFSymbol;
+  activeSymbol: SFSymbol;
   label: string;
 }
 
@@ -32,7 +38,13 @@ export default function GuestTabBar() {
   const router = useRouter();
   const pathname = usePathname();
   const insets = useSafeAreaInsets();
-  const { colors, primaryColor } = useAppTheme();
+  const { colors, primaryColor, isDark } = useAppTheme();
+  /**
+   * iOS tab bars are translucent and let the list scroll under them; Android's Material 3 bar
+   * is an opaque surface with a pill behind the selected icon. Doing either on the other
+   * platform is what makes a hand-drawn bar read as hand-drawn (#426).
+   */
+  const translucent = Platform.OS === "ios";
 
   const tabs: Tab[] = [
     {
@@ -40,6 +52,8 @@ export default function GuestTabBar() {
       match: (p) => p === "/",
       icon: "home-outline",
       activeIcon: "home",
+      symbol: "house",
+      activeSymbol: "house.fill",
       label: t("common.tabs.home"),
     },
     {
@@ -47,6 +61,8 @@ export default function GuestTabBar() {
       match: (p) => p.startsWith("/locations"),
       icon: "location-outline",
       activeIcon: "location",
+      symbol: "mappin.and.ellipse",
+      activeSymbol: "mappin.circle.fill",
       label: t("common.navbar.locationsLink"),
     },
     {
@@ -57,6 +73,8 @@ export default function GuestTabBar() {
       match: (p) => p.startsWith("/lookup") || p.startsWith("/booking-confirmation"),
       icon: "ticket-outline",
       activeIcon: "ticket",
+      symbol: "ticket",
+      activeSymbol: "ticket.fill",
       label: t("common.navbar.myBookingsLink"),
     },
   ];
@@ -68,14 +86,23 @@ export default function GuestTabBar() {
       style={[
         styles.bar,
         // The card surface, not the page: a bar the same colour as the list it sits under
-        // has only its hairline to say where the list ends.
+        // has only its hairline to say where the list ends. Transparent where the blur
+        // beneath is what paints it.
         {
-          backgroundColor: colors.card,
+          backgroundColor: translucent ? "transparent" : colors.card,
           borderTopColor: colors.border,
           paddingBottom: insets.bottom,
         },
       ]}
     >
+      {translucent && (
+        <BlurView
+          testID="guest-tab-bar-blur"
+          intensity={80}
+          tint={isDark ? "systemChromeMaterialDark" : "systemChromeMaterialLight"}
+          style={StyleSheet.absoluteFill}
+        />
+      )}
       {tabs.map((tab) => {
         const active = tab.match(pathname);
         const color = active ? primaryColor : colors.muted;
@@ -92,7 +119,22 @@ export default function GuestTabBar() {
               router.navigate(tab.href);
             }}
           >
-            <Icon name={active ? tab.activeIcon : tab.icon} size="md" color={color} />
+            {/* Material 3 marks the selected destination with a pill behind its icon; iOS
+                marks it with the tint alone, so the pill is drawn only where it belongs. */}
+            <View
+              testID={active ? "guest-tab-indicator" : undefined}
+              style={[
+                styles.indicator,
+                active && !translucent && { backgroundColor: `${primaryColor}1f` },
+              ]}
+            >
+              <TabBarIcon
+                name={active ? tab.activeIcon : tab.icon}
+                symbol={active ? tab.activeSymbol : tab.symbol}
+                color={color}
+                selected={active}
+              />
+            </View>
             <ThemedText style={[styles.label, { color }]}>{tab.label}</ThemedText>
           </Pressable>
         );

--- a/openresto-frontend/components/layout/TabBarIcon.tsx
+++ b/openresto-frontend/components/layout/TabBarIcon.tsx
@@ -1,0 +1,47 @@
+import { Platform } from "react-native";
+import { SymbolView, type SFSymbol } from "expo-symbols";
+import { Icon, resolveIconSize, type IconName } from "@/components/common/Icon";
+
+export interface TabBarIconProps {
+  /** Ionicons glyph, used on Android and web where SF Symbols are not Apple's to license. */
+  name: IconName;
+  /** The matching SF Symbol, used on iOS so the bar reads as the system's own. */
+  symbol: SFSymbol;
+  color: string;
+  /** Filled on the selected tab, outlined otherwise — the convention both platforms share. */
+  selected: boolean;
+}
+
+const SIZE = resolveIconSize("md");
+
+/**
+ * One tab's glyph, in whichever icon set the platform actually uses. Ionicons on an iOS tab bar
+ * is one of the tells the bar is not the system's; SF Symbols cannot be shipped off Apple's
+ * platforms, so the two sets sit behind this rather than at every call site.
+ *
+ * @see [TabBarIcon.test.tsx](../../tests/components/layout/TabBarIcon.test.tsx) — pins that iOS
+ * draws the symbol and every other platform the Ionicon, and that neither reaches assistive
+ * tech, which reads the tab's own label instead.
+ */
+export function TabBarIcon({ name, symbol, color, selected }: TabBarIconProps) {
+  if (Platform.OS === "ios") {
+    return (
+      <SymbolView
+        testID="tab-bar-symbol"
+        name={symbol}
+        size={SIZE}
+        tintColor={color}
+        // The glyph duplicates the label beneath it, so it stays out of the a11y tree.
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+        // Falls back to the Ionicon on a device whose OS predates the symbol.
+        fallback={<Icon name={name} size="md" color={color} />}
+        weight={selected ? "semibold" : "regular"}
+      />
+    );
+  }
+
+  return <Icon name={name} size="md" color={color} />;
+}
+
+export default TabBarIcon;

--- a/openresto-frontend/jest.setup.ts
+++ b/openresto-frontend/jest.setup.ts
@@ -78,3 +78,33 @@ jest.mock("expo-quick-actions", () => ({
   setItems: jest.fn(() => Promise.resolve()),
   addListener: jest.fn(() => ({ remove: jest.fn() })),
 }));
+
+// The booking sheet (#425) is a native gesture/animation stack with no host under Jest. The
+// mock keeps the pieces the drawer actually depends on observable: the modal presents itself
+// through a ref and reports dismissal upward, and the scroller is a plain view.
+jest.mock("@gorhom/bottom-sheet", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  const BottomSheetModal = React.forwardRef(
+    (
+      { children, onDismiss, ...props }: Record<string, unknown> & { children?: React.ReactNode },
+      ref: React.Ref<unknown>
+    ) => {
+      React.useImperativeHandle(ref, () => ({
+        present: jest.fn(),
+        dismiss: () => (onDismiss as (() => void) | undefined)?.(),
+      }));
+      return React.createElement(View, { testID: "booking-drawer", ...props }, children);
+    }
+  );
+  BottomSheetModal.displayName = "BottomSheetModal";
+  return {
+    __esModule: true,
+    default: View,
+    BottomSheetModal,
+    BottomSheetModalProvider: ({ children }: { children?: React.ReactNode }) => children,
+    BottomSheetScrollView: View,
+    BottomSheetBackdrop: View,
+    BottomSheetView: View,
+  };
+});

--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@react-native-community/datetimepicker": "^9.1.0",
         "expo": "~57.0.19",
         "expo-asset": "~57.0.7",
+        "expo-blur": "~57.0.2",
         "expo-constants": "~57.0.7",
         "expo-device": "~57.0.1",
         "expo-file-system": "~57.0.5",
@@ -6317,6 +6318,17 @@
         "@expo/image-utils": "^0.11.5",
         "expo-constants": "~57.0.17"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-blur": {
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-57.0.2.tgz",
+      "integrity": "sha512-Aoud8H8lmlNkbRufyvRLefmGFELdBf1n5Te/Xm+Zx8ORINH+aXL+gKb5mbftFSha860+I7pMArz77TBYz8HDVg==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.9.0",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
+        "@gorhom/bottom-sheet": "^5.2.14",
         "@react-native-community/datetimepicker": "^9.1.0",
         "expo": "~57.0.19",
         "expo-asset": "~57.0.7",
@@ -2194,6 +2195,45 @@
       },
       "bin": {
         "excpretty": "build/cli.js"
+      }
+    },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.14.tgz",
+      "integrity": "sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.16.0 || >=4.0.0-"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@humanfs/core": {

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@react-native-community/datetimepicker": "^9.1.0",
     "expo": "~57.0.19",
     "expo-asset": "~57.0.7",
@@ -90,6 +91,7 @@
       "^@/services/pushRegistration$": "<rootDir>/services/pushRegistration.ts",
       "^@/services/holdExpiryNotice$": "<rootDir>/services/holdExpiryNotice.ts",
       "^@/services/quickActions$": "<rootDir>/services/quickActions.ts",
+      "^@/components/booking/BookingSheetHost$": "<rootDir>/components/booking/BookingSheetHost.tsx",
       "^@/(.*)$": "<rootDir>/$1"
     },
     "collectCoverageFrom": [

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -32,6 +32,7 @@
     "@react-native-community/datetimepicker": "^9.1.0",
     "expo": "~57.0.19",
     "expo-asset": "~57.0.7",
+    "expo-blur": "~57.0.2",
     "expo-constants": "~57.0.7",
     "expo-device": "~57.0.1",
     "expo-file-system": "~57.0.5",

--- a/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingDrawer.test.tsx
@@ -290,7 +290,21 @@ describe("BookingDrawer", () => {
     });
   });
 
-  describe("as a bottom sheet", () => {
+  /**
+   * Narrow web keeps the hand-rolled sheet: a browser has no platform sheet to defer to. Off
+   * web it is `NativeBookingSheet` instead (#425), which is why this whole block pins the web
+   * platform rather than relying on Jest's default.
+   */
+  describe("as a bottom sheet on web", () => {
+    const rn = require("react-native");
+    const originalOS = rn.Platform.OS;
+    beforeEach(() => {
+      rn.Platform.OS = "web";
+    });
+    afterEach(() => {
+      rn.Platform.OS = originalOS;
+    });
+
     it("renders inside the sheet shell", () => {
       renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" />);
       expect(screen.getByTestId("booking-drawer")).toBeTruthy();
@@ -301,7 +315,7 @@ describe("BookingDrawer", () => {
       renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" />);
       const sheet = StyleSheet.flatten(screen.getByTestId("booking-drawer").props.style);
       // The side panel's float treatment must not leak here: a sheet that floats above
-      // the bottom edge of a phone leaves a strip of page under it.
+      // the bottom edge leaves a strip of page under it.
       expect(sheet.borderTopLeftRadius).toBeGreaterThan(0);
       expect(sheet.borderRadius).toBeUndefined();
       expect(sheet.marginBottom).toBeUndefined();
@@ -315,26 +329,15 @@ describe("BookingDrawer", () => {
       expect(backdrop.backgroundColor).toBe("transparent");
     });
 
-    it("clears the bottom safe area off web, and adds no inset on it", () => {
-      const rn = require("react-native");
-      const originalOS = rn.Platform.OS;
-      const sheetPadding = () =>
-        StyleSheet.flatten(screen.getByTestId("booking-drawer").props.style).paddingBottom;
-      try {
-        rn.Platform.OS = "ios";
-        const ios = renderWithInsets(
-          { bottom: 34 },
-          <BookingDrawer {...baseProps} variant="sheet" />
-        );
-        expect(sheetPadding()).toBe(34);
-        ios.unmount();
+    // The keyboard and the home indicator are the browser's problem, so neither the
+    // KeyboardAvoider nor a bottom safe-area inset belongs on this branch any more.
+    it("adds no keyboard shell and no bottom inset", () => {
+      renderWithInsets({ bottom: 34 }, <BookingDrawer {...baseProps} variant="sheet" />);
 
-        rn.Platform.OS = "web";
-        renderWithInsets({ bottom: 34 }, <BookingDrawer {...baseProps} variant="sheet" />);
-        expect(sheetPadding()).toBeUndefined();
-      } finally {
-        rn.Platform.OS = originalOS;
-      }
+      expect(screen.UNSAFE_queryAllByType(KeyboardAvoidingView)).toHaveLength(0);
+      expect(
+        StyleSheet.flatten(screen.getByTestId("booking-drawer").props.style).paddingBottom
+      ).toBeUndefined();
     });
 
     it("offers a drag handle wired to the pan responder, hidden from assistive tech", () => {
@@ -349,26 +352,6 @@ describe("BookingDrawer", () => {
       expect(grabber.props.accessibilityElementsHidden).toBe(true);
     });
 
-    it("lifts the form clear of the on-screen keyboard on a device", () => {
-      renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" />);
-      // Which behaviour that shell takes per OS is KeyboardAvoider's own business, pinned on
-      // both branches in its test. Asserting the iOS value here duplicated that knowledge and
-      // made this suite fail under the Android run for a reason the drawer has no say in.
-      expect(screen.UNSAFE_queryAllByType(KeyboardAvoidingView)).toHaveLength(1);
-    });
-
-    it("adds no keyboard shell on web, where the browser scrolls the field into view itself", () => {
-      const rn = require("react-native");
-      const originalOS = rn.Platform.OS;
-      rn.Platform.OS = "web";
-      try {
-        renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" />);
-        expect(screen.UNSAFE_queryAllByType(KeyboardAvoidingView)).toHaveLength(0);
-      } finally {
-        rn.Platform.OS = originalOS;
-      }
-    });
-
     it("closes when the backdrop is tapped, after the sheet has slid away", async () => {
       const onClose = jest.fn();
       renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" onClose={onClose} />);
@@ -376,6 +359,38 @@ describe("BookingDrawer", () => {
         screen.getByTestId("booking-drawer-backdrop", { includeHiddenElements: true })
       );
       await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+  });
+
+  /**
+   * Off web the sheet is the platform's own (#425). The drawer keeps its props and its body;
+   * what changes is the shell around them, so these pin the handover rather than the sheet's
+   * internals, which are `NativeBookingSheet`'s own tests.
+   */
+  describe("as a bottom sheet off web", () => {
+    it("hands the body to the native sheet, with none of the web chrome", () => {
+      renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" />);
+
+      expect(screen.getByText("Toronto Resto")).toBeTruthy();
+      // The hand-rolled backdrop and drag handle belong to the web sheet; the platform sheet
+      // brings its own, and two of each would stack.
+      expect(
+        screen.queryByTestId("booking-drawer-backdrop", { includeHiddenElements: true })
+      ).toBeNull();
+      expect(
+        screen.queryByTestId("booking-drawer-grabber", { includeHiddenElements: true })
+      ).toBeNull();
+    });
+
+    // The sheet animates itself away and reports back through onDismiss, so the close button
+    // asks it to dismiss rather than yanking the drawer out from under its own exit.
+    it("lets the sheet animate away before the page drops it", async () => {
+      const onClose = jest.fn();
+      renderWithProviders(<BookingDrawer {...baseProps} variant="sheet" onClose={onClose} />);
+
+      fireEvent.press(screen.getByTestId("booking-drawer-close"));
+
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
     });
   });
 

--- a/openresto-frontend/tests/components/booking/BookingSheetHost.native.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingSheetHost.native.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react-native";
+import { Text } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { BookingSheetHost } from "@/components/booking/BookingSheetHost.native";
+
+jest.mock("react-native-gesture-handler", () => {
+  const { View } = require("react-native");
+  return { GestureHandlerRootView: View };
+});
+
+describe("BookingSheetHost (native)", () => {
+  it("renders its children", () => {
+    render(
+      <BookingSheetHost>
+        <Text>content</Text>
+      </BookingSheetHost>
+    );
+
+    expect(screen.getByText("content")).toBeTruthy();
+  });
+
+  /**
+   * The provider renders the sheets and the sheets are gesture-driven, so a provider mounted
+   * above the gesture root would put every sheet outside the tree that feeds it touches.
+   */
+  it("puts the gesture root outside the sheet provider", () => {
+    render(
+      <BookingSheetHost>
+        <Text>content</Text>
+      </BookingSheetHost>
+    );
+
+    const root = screen.UNSAFE_getByType(GestureHandlerRootView);
+    expect(root).toBeTruthy();
+    expect(root.findByType(Text)).toBeTruthy();
+  });
+});

--- a/openresto-frontend/tests/components/booking/BookingSheetHost.test.tsx
+++ b/openresto-frontend/tests/components/booking/BookingSheetHost.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react-native";
+import { Text } from "react-native";
+import { BookingSheetHost } from "@/components/booking/BookingSheetHost";
+
+// The website's sheet is still the hand-rolled one, so the gesture root and sheet provider
+// that @gorhom/bottom-sheet needs have no business in the web tree.
+describe("BookingSheetHost (web)", () => {
+  it("passes its children straight through", () => {
+    render(
+      <BookingSheetHost>
+        <Text>content</Text>
+      </BookingSheetHost>
+    );
+
+    expect(screen.getByText("content")).toBeTruthy();
+  });
+});
+
+// The web stub of the sheet itself is never rendered by the drawer on web, but it is what the
+// web bundle links against, so it has to hand the body back rather than swallowing it.
+describe("NativeBookingSheet (web stub)", () => {
+  it("renders whatever the drawer gives it", () => {
+    const { NativeBookingSheet } = require("@/components/booking/NativeBookingSheet");
+    render(
+      <NativeBookingSheet accessibilityLabel="Book" onClose={jest.fn()}>
+        {() => <Text>body</Text>}
+      </NativeBookingSheet>
+    );
+
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+});

--- a/openresto-frontend/tests/components/booking/NativeBookingSheet.native.test.tsx
+++ b/openresto-frontend/tests/components/booking/NativeBookingSheet.native.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react-native";
+import { Pressable, Text } from "react-native";
+import { BottomSheetModal } from "@gorhom/bottom-sheet";
+import { NativeBookingSheet } from "@/components/booking/NativeBookingSheet.native";
+
+jest.mock("@/context/BrandContext", () => ({
+  useBrand: () => ({ appName: "Open Resto", primaryColor: "#0a7ea4" }),
+}));
+
+const sheetProps = () =>
+  screen.UNSAFE_getByType(BottomSheetModal as unknown as React.ComponentType).props as Record<
+    string,
+    unknown
+  >;
+
+describe("NativeBookingSheet", () => {
+  const renderSheet = (onClose = jest.fn()) => {
+    render(
+      <NativeBookingSheet accessibilityLabel="Book Toronto Resto" onClose={onClose}>
+        {({ dismiss }) => (
+          <Pressable testID="close" onPress={dismiss}>
+            <Text>body</Text>
+          </Pressable>
+        )}
+      </NativeBookingSheet>
+    );
+    return onClose;
+  };
+
+  it("renders the body it is given", () => {
+    renderSheet();
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+
+  /**
+   * Two detents: enough of the form to fill in without moving, and near-full for the seating
+   * picker. One would make this a fixed panel with a drag handle, which is the thing the
+   * hand-rolled sheet already was.
+   */
+  it("offers two detents and opens on the shorter one", () => {
+    renderSheet();
+
+    expect(sheetProps().snapPoints).toEqual(["66%", "92%"]);
+    // Explicit detents and content sizing are mutually exclusive; leaving dynamic sizing on
+    // makes the sheet ignore the snap points it was given.
+    expect(sheetProps().enableDynamicSizing).toBe(false);
+  });
+
+  it("resizes around the keyboard rather than leaving it to a wrapper", () => {
+    renderSheet();
+
+    expect(sheetProps().keyboardBehavior).toBe("interactive");
+    expect(sheetProps().android_keyboardInputMode).toBe("adjustResize");
+  });
+
+  it("can be dragged away", () => {
+    renderSheet();
+    expect(sheetProps().enablePanDownToClose).toBe(true);
+  });
+
+  // The drawer's close button asks the sheet to dismiss, and the sheet reports back once it
+  // has animated away. Anything else drops the drawer out from under its own exit.
+  it("reports a dismissal upward exactly once", async () => {
+    const onClose = renderSheet();
+
+    fireEvent.press(screen.getByTestId("close"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("carries the location name for assistive tech", () => {
+    renderSheet();
+    expect(sheetProps().accessibilityLabel).toBe("Book Toronto Resto");
+  });
+});

--- a/openresto-frontend/tests/components/layout/GuestTabBar.test.tsx
+++ b/openresto-frontend/tests/components/layout/GuestTabBar.test.tsx
@@ -59,11 +59,55 @@ describe("GuestTabBar", () => {
     expect(Haptics.selectionAsync).toHaveBeenCalled();
   });
 
-  it("sits on the card surface rather than the page colour the list scrolls on", () => {
-    at("/");
-    const bar = StyleSheet.flatten(screen.getByTestId("guest-tab-bar").props.style);
-    expect(bar.backgroundColor).toBe("#fafafa");
-    expect(bar.borderTopColor).toBe("#ccc");
+  const setPlatform = (os: string) =>
+    Object.defineProperty(require("react-native").Platform, "OS", {
+      value: os,
+      configurable: true,
+    });
+
+  /**
+   * #426: an iOS tab bar is translucent and the list scrolls under it; Android's Material 3
+   * bar is an opaque surface. Painting one like the other is a large part of what made this
+   * read as a hand-drawn bar rather than the platform's own.
+   */
+  describe("bar surface", () => {
+    const originalOS = require("react-native").Platform.OS;
+    afterEach(() => setPlatform(originalOS));
+
+    it("lets the list show through a blur on iOS", () => {
+      setPlatform("ios");
+      at("/");
+
+      const bar = StyleSheet.flatten(screen.getByTestId("guest-tab-bar").props.style);
+      expect(bar.backgroundColor).toBe("transparent");
+      expect(screen.getByTestId("guest-tab-bar-blur")).toBeTruthy();
+      expect(bar.borderTopColor).toBe("#ccc");
+    });
+
+    it("sits on an opaque card surface on Android, with no blur", () => {
+      setPlatform("android");
+      at("/");
+
+      const bar = StyleSheet.flatten(screen.getByTestId("guest-tab-bar").props.style);
+      expect(bar.backgroundColor).toBe("#fafafa");
+      expect(screen.queryByTestId("guest-tab-bar-blur")).toBeNull();
+    });
+
+    // Material 3 marks the selected destination with a pill; iOS marks it with tint alone,
+    // so a pill drawn there would be a second selection cue the platform does not use.
+    it("draws the selected pill on Android and not on iOS", () => {
+      setPlatform("android");
+      at("/");
+      expect(
+        StyleSheet.flatten(screen.getByTestId("guest-tab-indicator").props.style).backgroundColor
+      ).toBeDefined();
+
+      setPlatform("ios");
+      at("/");
+      expect(
+        StyleSheet.flatten(screen.getByTestId("guest-tab-indicator").props.style).backgroundColor
+      ).toBeUndefined();
+    });
   });
 
   /**

--- a/openresto-frontend/tests/components/layout/TabBarIcon.test.tsx
+++ b/openresto-frontend/tests/components/layout/TabBarIcon.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react-native";
+import { TabBarIcon } from "@/components/layout/TabBarIcon";
+
+// jest.setup renders @expo/vector-icons as null, which is fine for presence checks but leaves
+// nothing to query; this suite needs to tell the two icon sets apart.
+/**
+ * The haste platform decides which `expo-symbols` implementation loads, while `Platform.OS`
+ * decides which branch this component takes. Under the Android jest project those two disagree
+ * — OS says ios, resolution gives the Android SymbolView, which renders the fallback — a state
+ * no device is ever in. Mocking the module makes these tests about the choice this component
+ * makes, which is all it is responsible for.
+ */
+jest.mock("expo-symbols", () => {
+  const { View } = require("react-native");
+  return { SymbolView: (props: Record<string, unknown>) => <View {...props} /> };
+});
+
+jest.mock("@expo/vector-icons", () => {
+  const { View } = require("react-native");
+  return {
+    // testID last: Icon forwards its own (undefined here), which would otherwise win.
+    Ionicons: (props: Record<string, unknown>) => <View {...props} testID="tab-bar-ionicon" />,
+  };
+});
+
+// Reached through require rather than a static import: under the Android jest project the
+// imported binding and the one the component reads are not the same object, so defining the
+// property on the import silently changed nothing and every iOS case took the Android branch.
+const platform = () => require("react-native").Platform;
+const setPlatform = (os: string) =>
+  Object.defineProperty(platform(), "OS", { value: os, configurable: true });
+
+const originalOS = platform().OS;
+afterEach(() => setPlatform(originalOS));
+
+/**
+ * #426. Ionicons on an iOS tab bar is one of the tells that the bar is not the system's own.
+ * SF Symbols cannot ship off Apple's platforms, so the two sets have to coexist.
+ */
+describe("TabBarIcon", () => {
+  const renderIcon = (selected = false) =>
+    render(
+      <TabBarIcon name="ticket-outline" symbol="ticket" color="#0a7ea4" selected={selected} />
+    );
+
+  it("draws the SF Symbol on iOS", () => {
+    setPlatform("ios");
+    renderIcon();
+
+    expect(screen.getByTestId("tab-bar-symbol", { includeHiddenElements: true })).toBeTruthy();
+    expect(screen.queryByTestId("tab-bar-ionicon", { includeHiddenElements: true })).toBeNull();
+  });
+
+  it("draws the Ionicon on Android", () => {
+    setPlatform("android");
+    renderIcon();
+
+    expect(screen.getByTestId("tab-bar-ionicon", { includeHiddenElements: true })).toBeTruthy();
+    expect(screen.queryByTestId("tab-bar-symbol", { includeHiddenElements: true })).toBeNull();
+  });
+
+  // A device whose OS predates the symbol would otherwise draw a blank where the glyph goes.
+  it("keeps an Ionicon in reserve behind the symbol", () => {
+    setPlatform("ios");
+    renderIcon();
+
+    expect(
+      screen.getByTestId("tab-bar-symbol", { includeHiddenElements: true }).props.fallback
+    ).toBeTruthy();
+  });
+
+  it("weights the symbol to match the selection", () => {
+    setPlatform("ios");
+    const { rerender } = renderIcon(true);
+    expect(screen.getByTestId("tab-bar-symbol", { includeHiddenElements: true }).props.weight).toBe(
+      "semibold"
+    );
+
+    rerender(<TabBarIcon name="ticket-outline" symbol="ticket" color="#0a7ea4" selected={false} />);
+    expect(screen.getByTestId("tab-bar-symbol", { includeHiddenElements: true }).props.weight).toBe(
+      "regular"
+    );
+  });
+
+  // The glyph duplicates the label under it, so the tab's own label is what gets announced.
+  it("stays out of the accessibility tree", () => {
+    setPlatform("ios");
+    renderIcon();
+
+    expect(
+      screen.getByTestId("tab-bar-symbol", { includeHiddenElements: true }).props
+        .accessibilityElementsHidden
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

> ⚠️ **This PR grew a second commit after you started looking at it.** It was on 13 files (#425 only) and is now on 20, because my designated branch is where the tab-bar work had to land and the alternative was leaving it unpushed in an ephemeral container. Say the word and I will split the tab bar back out once this merges; otherwise the two commits are independent and reviewable separately.

Two changes, one per commit:

1. **#425** — the booking drawer becomes the platform's own bottom sheet off web.
2. **#426, narrowed** — the guest tab bar takes each platform's own cues. **#426 stays open** with its scope reduced; see below.

## Related issue

Closes #425

Partially addresses #426 — deliberately **not** closed.

## Scope

- [ ] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [ ] Docs / infra

---

## Commit 1 — the booking sheet (#425)

The drawer's sheet was a hand-rolled `Modal` + `PanResponder` + `Animated`: no detents, no rubber-band overscroll, and the keyboard left to a `KeyboardAvoidingView` wrapper shoving the whole thing up rather than the sheet resizing around it. Off web it is now `@gorhom/bottom-sheet`.

### Why not formSheet

The ticket costed formSheet as "less code than today". That holds for a one-way detail screen and not for this one. Five of the drawer's eleven props are **two-way bindings to the list behind it**: changing party size or date inside the sheet re-filters the list, and the location picker switches in place. A pushed route has to rebuild that channel through params or a shared store, which is more code, not less, and puts the list-refilter behaviour — the best part of the feature — at risk.

`@gorhom/bottom-sheet` 5.2.14 wants `react-native-reanimated >=4.0.0` and `react-native-gesture-handler >=2.16.1`; both already installed at 4.5.1 and 2.32.0. The component keeps every prop it had.

### What changed

- **`NativeBookingSheet`**, platform-split. Two detents (`66%` / `92%`), `enablePanDownToClose`, a backdrop that closes rather than only dimming, and `keyboardBehavior: "interactive"` + `android_keyboardInputMode: "adjustResize"`. `enableDynamicSizing` is explicitly off, since content sizing and explicit detents are mutually exclusive and leaving it on makes the sheet ignore the snap points.
- **`BookingSheetHost`** mounts the gesture root and the sheet provider once at the app root, pass-through on web. **The gesture root is new to the app** — the only other gesture-handler consumer is an admin swipe row, and admin is web-only in production.
- **Dismissal**: the close button asks the sheet to dismiss and the sheet reports back via `onDismiss` once it has animated away, rather than the page dropping the drawer out from under its own exit. The hold still releases on unmount.
- **`body()` takes a scroll component** instead of hardcoding `ScrollView`, so off web it renders into the sheet's own scroller and dragging the list does not fight dragging the sheet.

### Two things became dead code

Narrow web keeps the hand-rolled sheet, so that branch is now reachable **only** on web, which makes two things in it unreachable: the bottom safe-area inset, and the `KeyboardAvoider` that is a pass-through on web anyway. Both removed.

---

## Commit 2 — the tab bar (#426, narrowed)

iOS gets **SF Symbols** through `expo-symbols` (already a dependency, until now unused) and a translucent `systemChromeMaterial` blur the list scrolls under. Android keeps Ionicons, since SF Symbols are not Apple's to license off their platforms, and gets the **Material 3 pill** behind the selected destination on an opaque surface.

### Why #426 stays open

I did not do the NativeTabs move, and you picked this scope after I raised what it costs:

- It is `expo-router/unstable-native-tabs`.
- It ships a Radix web implementation that would have to be excluded.
- **A tabs navigator cannot host pushed screens.** A `hidden` trigger "cannot be navigated to in any way", so `locations/[id]`, `booking-confirmation/[bookingRef]`, `book`, `book/[restaurantId]`, `restaurant/[id]` and `search` all become unreachable where they sit. Making it work means moving six route files into per-tab nested stacks, with `booking-confirmation` specifically moving inside the lookup tab to keep the ticket's own "My booking stays selected on `/booking-confirmation/*`" rule.

That is a restructure of the guest booking path's **public URLs** against an unstable API, and none of it can be run here. What is left on #426 is the two things only NativeTabs gives: scroll-to-top on re-pressing the active tab, and iOS 26 liquid glass.

## Testing

- [ ] `OpenRestoApi.Tests` pass locally
- [x] Frontend tests/build pass locally
- [ ] CI passes (build, migration-check)
- [ ] Manually verified the change end-to-end

Backend untouched.

| Check | Result |
|---|---|
| `npm test` (iOS) | 262 suites, 3538 tests, green |
| `npm run test:android` | 262 suites, 3538 tests, green |
| `npm run check` | clean |
| `npx tsc --noEmit` | clean |
| `npm run routes:check` | matches the snapshot, 33 routes |
| `npx expo export --platform ios --platform android` | both bundles build |
| gorhom in the web bundle | **0 references** — the split holds |

`TabBarIcon`'s tests mock `expo-symbols`, and that is worth knowing about: the haste platform decides which implementation of it loads while `Platform.OS` decides which branch the component takes, and under the Android jest project those disagree — OS reads `ios`, resolution gives the Android `SymbolView`, and it renders the fallback. No device is ever in that state, so the module is mocked and what gets pinned is the choice the component makes.

**Needs your simulator pass**, and there is more of it here than in any previous PR:

- The sheet's detents, overscroll, keyboard resizing and backdrop dismissal.
- **The gesture root** is the thing I would look at hardest: new, and it wraps the whole app. If anything anywhere stops receiving touches, that is where to look.
- The blur and the SF Symbols — CI cannot see a pixel of either.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyoC61iZMiHSFYPd6z4ZTR