### PR TITLE
Cut the 2.0.0 release section and bump every version field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-09-03
+
+Hi all! Two point oh, and the headline is that OpenResto is now an app. The guest booking screens build as a native iOS and Android app that you publish under your own developer accounts, pointed at your own instance, with push reminders and Apple or Google Wallet passes to go with them. Upstream never ships a binary and the stores never see an "OpenResto" app. Alongside that, the admin API grew scoped API keys and a real command-line client on npm, and front of house got a service floor showing who is sitting where right now. Five security fixes landed here too, and the first two are worth reading even if you skip everything else: booking references are now unguessable, and an API key can no longer mint itself a login.
+
+### Breaking Changes
+
+- **The CLI's user-management verbs are gone**: `openresto users create`, `users role` and `users reset-password`. An API key could use them to create an admin account with a role and password of its choosing and then sign in as it, reaching the whole surface keys are deliberately excluded from. The server now refuses those three verbs to any key session, so the commands could only ever have failed. `users list`, `users activate` and `users deactivate` are unchanged. **If you script account creation, move it to the admin UI**; there is no key-based replacement, by design.
+- **The two guest by-reference endpoints are now limited to 10 requests per minute per IP**, down from the 120 they shared with general browsing. `GET /api/bookings/ref/{ref}` and `POST /api/bookings/ref/{ref}/cancel` are the only unauthenticated endpoints where a correct guess hands over someone else's booking, so they now sit at the same ceiling as login. A guest reads a reference off an email and looks it up once, so this is invisible in normal use. **It is not invisible behind a shared address**: an office, a hotel or carrier-grade NAT puts many guests in one bucket. Raise it in front of the app if that describes your deployment.
+- **New booking references carry a four-digit tail**, so the word format reads `crispy-basil-thyme-0482` rather than `crispy-basil-thyme`. The old format drew 177,000 combinations from a non-cryptographic PRNG, which is walkable in about a day from one known email address. References now come from a CSPRNG and the space is 1.77 billion. **Every reference ever issued still resolves and still cancels**, and the numeric format is unchanged, but an integration that pattern-matches the old three-word shape needs updating.
+
 ### Added
 
 - **Guests can ask to be reminded about a booking, as a push notification** (#419). A confirmed booking in the native app (and on the website, when the server has VAPID keys) carries a **Remind me** toggle; the phone asks for notification permission only then, and the server pushes the day before and two hours before the sitting (`GuestPush__ReminderLeadHours`), in the language the app was in. A device is registered against one booking, holds nothing but its push address, and is forgotten once the sitting starts, the booking is cancelled or an admin purges it. Native delivery goes through Expo's push service, so the APNs and FCM credentials stay with the self-hoster's EAS project and never reach the server; browser delivery reuses the admin notifications' Web Push path. A reminder window that had already opened when the guest opted in is skipped, so booking tomorrow's table does not produce a "24 hours to go" push seconds after the confirmation.
@@ -428,4 +438,5 @@ Hello! Thanks for reading the changelog, and for the 50 stars on Github! This pr
 [1.7.0]: https://github.com/karanshukla/openresto/releases/tag/v1.7.0
 [1.8.0]: https://github.com/karanshukla/openresto/releases/tag/v1.8.0
 [1.9.0]: https://github.com/karanshukla/openresto/releases/tag/v1.9.0
-[Unreleased]: https://github.com/karanshukla/openresto/compare/v1.9.0...HEAD
+[2.0.0]: https://github.com/karanshukla/openresto/releases/tag/v2.0.0
+[Unreleased]: https://github.com/karanshukla/openresto/compare/v2.0.0...HEAD

--- a/OpenRestoApi/OpenRestoApi.csproj
+++ b/OpenRestoApi/OpenRestoApi.csproj
@@ -8,7 +8,7 @@
          AssemblyInformationalVersionAttribute) so the CLI can warn a self-hoster running an old
          server against a new CLI. Bump alongside package.json on every release —
          scripts/check-release-version.sh enforces the two agree. -->
-    <Version>1.9.0</Version>
+    <Version>2.0.0</Version>
     <!-- Exclude the local SQLite DB + its WAL/SHM sidecars from dotnet watch.
          SQLite writes to -wal/-shm on every transaction; if watch sees those as
          source changes it restarts the process mid-write and corrupts the main

--- a/openresto-cli/package-lock.json
+++ b/openresto-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openresto-cli",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openresto-cli",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0"

--- a/openresto-cli/package.json
+++ b/openresto-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openresto-cli",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Command-line client for the OpenResto admin API, driven by admin API keys.",
   "keywords": [
     "openresto",

--- a/openresto-frontend/package-lock.json
+++ b/openresto-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openresto-frontend",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openresto-frontend",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@gorhom/bottom-sheet": "^5.2.14",

--- a/openresto-frontend/package.json
+++ b/openresto-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openresto-frontend",
   "main": "expo-router/entry",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "scripts": {
     "start": "expo start",
     "dev": "expo start",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openresto",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openresto",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "concurrently": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openresto",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "A self-hosted restaurant booking management system. Customers browse restaurants, hold tables in real-time, and book instantly. Admins manage reservations, tables, sections, and branding from a dedicated dashboard.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares the repo for tagging `v2.0.0`. `scripts/check-release-version.sh` gates all four image builds plus the npm publish on nine version fields and a matching CHANGELOG section, so a half-finished bump fails the release *after* tagging rather than before. This does the bump and cuts the release section.

It also adds a **Breaking Changes** section, which no release in this repo has needed before. Three things change for someone already running 1.9, and all three were buried under Security or Added where an upgrader would not look for them.

## Related issue

n/a — release preparation.

## Scope

- [ ] API (OpenRestoApi)
- [ ] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

- `CHANGELOG.md`: moved the whole `[Unreleased]` body under `## [2.0.0] - 2026-09-03`, keeping an empty `[Unreleased]` above it to match the convention at every prior tag. Added the release intro paragraph each section carries, the `[2.0.0]` link ref, and repointed the `[Unreleased]` compare link at `v2.0.0...HEAD`.
- `CHANGELOG.md`: new **Breaking Changes** section covering the CLI's three removed user-management verbs (`users create`, `users role`, `users reset-password`), the guest by-reference endpoints dropping from 120 requests a minute to 10 per IP, and the four-digit tail on new booking references. The first has no replacement and the second bites behind a shared address (office, hotel, CGNAT), so both say what to do instead rather than only what changed.
- Version bumped to `2.0.0` in `package.json`, `openresto-frontend/package.json`, `openresto-cli/package.json` and `<Version>` in `OpenRestoApi/OpenRestoApi.csproj`.
- The three lockfiles regenerated with `npm install --package-lock-only`. Only the two top-level `version` keys in each moved; no dependency resolves differently.

No source, config or migration changes.

## Testing

- [x] `OpenRestoApi.Tests` pass locally — 2241/2241, 98.52% line / 92.2% branch
- [x] Frontend tests/build pass locally — 3648/3648 across 273 suites; `openresto-cli` 79/79
- [x] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end — `./scripts/check-release-version.sh v2.0.0` reports all nine fields plus the CHANGELOG section agreeing on 2.0.0; `npm run check:doc-links` resolves; Prettier clean via the pre-commit hook with nothing reformatted

The suites above were run against the tip of `main` as the readiness check that produced this PR. This diff touches no code, so they are unchanged by it.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

The three migrations already on `main` since 1.9 (`AddAdminApiKeys`, `AddNativeAppSettings`, `AddGuestPushSubscriptions`) are `CreateTable` plus two nullable `AddColumn`s, with no non-constant defaults, and have already applied cleanly to the VPS database on deploy.

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

## Still open before tagging

Two items from the readiness review are deliberately **not** in this PR:

1. The **Date Boundary** workflow has never run. Its cron is Monday 03:00 UTC and it was created after that window on Aug 31, so the first scheduled fire is Sep 7. It is a `workflow_dispatch` if you want it exercised before the tag.
2. The **iOS 4.2 submission probe** is listed in `CLAUDE.md` as not built and separable. Android ships without it. Worth making that an explicit 2.0 scope decision rather than an unstated gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FojjzMeTTVQRtPGHE3ucm8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FojjzMeTTVQRtPGHE3ucm8)_