### PR TITLE
Preview the booking confirmation on the admin email settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The admin email settings page now previews the booking confirmation** (`/admin/settings/email`). The panel beside the SMTP form renders the real confirmation for a stand-in booking, with the location's own name, photo, hours, address and reference format, and the brand colour, icon and footer from your brand settings. The From line follows the sender name and address as you type them, before you save, and the panel says plainly when confirmations are off or SMTP is not configured yet, which are the two ways a guest ends up receiving nothing. Instances with more than one location get a picker, since each one renders differently. Nothing is sent and nothing is stored.
+- `GET /api/admin/email-settings/preview` (scope `email:read`, optional `?restaurantId=`) returns that rendered HTML plus the subject, so a script can check what guests are receiving without booking a table.
+
+### Changed
+
+- The confirmation email's subject is now built by `EmailTemplateService` alongside its body. The send path and the new preview call the same builder, so the two cannot drift.
+
 ## [2.0.0] - 2026-09-03
 
 Hey everyone,

--- a/OpenRestoApi.Tests/Controllers/EmailStatusControllerTests.cs
+++ b/OpenRestoApi.Tests/Controllers/EmailStatusControllerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Moq;
 using OpenRestoApi.Controllers;
 using OpenRestoApi.Core.Application.Interfaces;
@@ -16,9 +17,28 @@ namespace OpenRestoApi.Tests.Controllers;
 public class EmailStatusControllerTests
 {
     private readonly Mock<EmailSettingsService> _service = new(null!, null!, null!, null!);
+    private readonly Mock<IRestaurantRepository> _restaurants = new();
+    private readonly Mock<IBrandSettingsRepository> _brand = new();
 
     private EmailStatusController ControllerFor(ICurrentUserService currentUser)
-        => new(_service.Object, currentUser);
+        => new(_service.Object, currentUser, PreviewService());
+
+    public EmailStatusControllerTests()
+    {
+        // Defaults, so a test that is not about the preview needs no arrangement for it. A test
+        // that is re-stubs the location list; setting these up per-controller would overwrite it.
+        _restaurants.Setup(r => r.GetAllActiveWithSectionsAsync()).ReturnsAsync([]);
+        _brand.Setup(b => b.GetAsync()).ReturnsAsync(new BrandSettings());
+    }
+
+    private EmailPreviewService PreviewService()
+    {
+        return new EmailPreviewService(
+            _restaurants.Object,
+            new BrandService(_brand.Object, new ConfigurationBuilder().Build()),
+            new EmailTemplateService(),
+            new SystemClock());
+    }
 
     private static EmailSettings Configured(bool sendBookingConfirmations) => new()
     {
@@ -131,5 +151,27 @@ public class EmailStatusControllerTests
         List<EmailFailureResponse> failures = FailuresOf(await ControllerFor(key).GetFailures());
 
         Assert.Equal("guest@test.com", Assert.Single(failures).RecipientEmail);
+    }
+
+    /// <summary>
+    /// Rendering the confirmation for a location the admin picked is the whole of the preview:
+    /// the same template the send path uses, against that location's own name and branding.
+    /// </summary>
+    [Fact]
+    public async Task Preview_RendersTheRequestedLocation()
+    {
+        _restaurants.Setup(r => r.GetAllActiveWithSectionsAsync()).ReturnsAsync(
+        [
+            new Restaurant { Id = 1, Name = "Riverside", Timezone = "UTC" },
+            new Restaurant { Id = 2, Name = "Old Town", Timezone = "UTC" },
+        ]);
+
+        var result = Assert.IsType<EmailPreviewResult>(
+            Assert.IsType<OkObjectResult>(
+                await ControllerFor(FakeCurrentUser.Anonymous()).Preview(restaurantId: 2)).Value);
+
+        Assert.Equal("Old Town", result.RestaurantName);
+        Assert.Contains("Old Town", result.Html, StringComparison.Ordinal);
+        Assert.Contains("Old Town", result.Subject, StringComparison.Ordinal);
     }
 }

--- a/OpenRestoApi.Tests/Services/EmailPreviewServiceTests.cs
+++ b/OpenRestoApi.Tests/Services/EmailPreviewServiceTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.Configuration;
+using Moq;
+using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Application.Utilities;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Tests.Services;
+
+/// <summary>
+/// The admin's confirmation-email preview. What it renders has to be the real template applied to
+/// the real brand row — a preview that agreed with nothing is worse than none.
+/// </summary>
+public class EmailPreviewServiceTests
+{
+    private sealed class FixedClock(DateTime now) : ISystemClock
+    {
+        public DateTime UtcNow { get; } = now;
+    }
+
+    private static readonly DateTime Now = new(2026, 9, 7, 10, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IRestaurantRepository> _restaurants = new();
+    private readonly Mock<IBrandSettingsRepository> _brandRepo = new();
+
+    private static Restaurant Location(int id, string name) => new()
+    {
+        Id = id,
+        Name = name,
+        Address = $"{id} Example Street",
+        Timezone = "UTC",
+        OpenTime = "11:00",
+        CloseTime = "23:00",
+    };
+
+    private EmailPreviewService Service(params Restaurant[] locations)
+    {
+        _restaurants.Setup(r => r.GetAllActiveWithSectionsAsync()).ReturnsAsync([.. locations]);
+        _brandRepo.Setup(b => b.GetAsync()).ReturnsAsync(new BrandSettings
+        {
+            AppName = "Tasting Room",
+            PrimaryColor = "#aa3311",
+            WebsiteUrl = "https://bookings.example.com",
+        });
+
+        var configuration = new ConfigurationBuilder().Build();
+        return new EmailPreviewService(
+            _restaurants.Object,
+            new BrandService(_brandRepo.Object, configuration),
+            new EmailTemplateService(),
+            new FixedClock(Now));
+    }
+
+    [Fact]
+    public async Task Preview_RendersTheNamedLocation()
+    {
+        EmailPreviewResult result = await Service(Location(1, "Riverside"), Location(2, "Old Town"))
+            .BuildConfirmationPreviewAsync(2);
+
+        Assert.Equal(2, result.RestaurantId);
+        Assert.Equal("Old Town", result.RestaurantName);
+        Assert.Contains("Old Town", result.Html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Preview_FallsBackToTheFirstLocationWhenNoneIsNamed()
+    {
+        EmailPreviewResult result = await Service(Location(1, "Riverside"), Location(2, "Old Town"))
+            .BuildConfirmationPreviewAsync(null);
+
+        Assert.Equal(1, result.RestaurantId);
+        Assert.Equal("Riverside", result.RestaurantName);
+    }
+
+    /// <summary>An id that names nothing is a stale selection, not an error worth a broken panel.</summary>
+    [Fact]
+    public async Task Preview_FallsBackToTheFirstLocationWhenTheIdIsUnknown()
+    {
+        EmailPreviewResult result = await Service(Location(1, "Riverside")).BuildConfirmationPreviewAsync(99);
+
+        Assert.Equal(1, result.RestaurantId);
+    }
+
+    /// <summary>
+    /// A fresh install has no locations yet, and the brand settings are exactly what an admin is
+    /// looking at the preview to check.
+    /// </summary>
+    [Fact]
+    public async Task Preview_UsesAPlaceholderLocationWhenTheInstanceHasNone()
+    {
+        EmailPreviewResult result = await Service().BuildConfirmationPreviewAsync(null);
+
+        Assert.Null(result.RestaurantId);
+        Assert.Equal(EmailPreviewSample.PlaceholderRestaurant.Name, result.RestaurantName);
+        Assert.Contains("Tasting Room", result.Html, StringComparison.Ordinal);
+    }
+
+    /// <summary>The subject is the send path's own, not a second copy of the wording.</summary>
+    [Fact]
+    public async Task Preview_CarriesTheSubjectTheSendPathUses()
+    {
+        Restaurant location = Location(1, "Riverside");
+
+        EmailPreviewResult result = await Service(location).BuildConfirmationPreviewAsync(null);
+
+        Assert.Equal(new EmailTemplateService().BuildConfirmationSubject(location), result.Subject);
+    }
+
+    [Fact]
+    public async Task Preview_RendersTheBrandColourAndManageLink()
+    {
+        EmailPreviewResult result = await Service(Location(1, "Riverside")).BuildConfirmationPreviewAsync(null);
+
+        Assert.Contains("#aa3311", result.Html, StringComparison.Ordinal);
+        Assert.Contains(
+            $"https://bookings.example.com/booking-confirmation/{EmailPreviewSample.RefFor(BookingRefFormat.AlphaNumeric)}",
+            result.Html,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>The sample booking is rendered, never written — the preview is a read.</summary>
+    [Fact]
+    public async Task Preview_PersistsNothing()
+    {
+        await Service(Location(1, "Riverside")).BuildConfirmationPreviewAsync(null);
+
+        _restaurants.Verify(r => r.SaveChangesAsync(), Times.Never);
+        _brandRepo.Verify(b => b.SaveChangesAsync(), Times.Never);
+        _brandRepo.Verify(b => b.AddAsync(It.IsAny<BrandSettings>()), Times.Never);
+    }
+}

--- a/OpenRestoApi.Tests/Utilities/EmailPreviewSampleTests.cs
+++ b/OpenRestoApi.Tests/Utilities/EmailPreviewSampleTests.cs
@@ -1,0 +1,96 @@
+using OpenRestoApi.Core.Application.Utilities;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Tests.Utilities;
+
+/// <summary>
+/// The stand-in booking behind the admin's confirmation-email preview. It is illustrative, but
+/// not arbitrary: it sits on a day the location actually opens, inside that day's service, so a
+/// preview never shows a sitting the location could not take.
+/// </summary>
+public class EmailPreviewSampleTests
+{
+    // A Monday, so "the next open day" is a forward walk with somewhere to go.
+    private static readonly DateTime Monday = new(2026, 9, 7, 10, 0, 0, DateTimeKind.Utc);
+
+    private static Restaurant Location(string open = "11:00", string close = "23:00", string openDays = "1,2,3,4,5,6,7")
+        => new() { Id = 1, Name = "Test", Timezone = "UTC", OpenTime = open, CloseTime = close, OpenDays = openDays };
+
+    [Fact]
+    public void BookingFor_SkipsForwardToTheNextDayTheLocationOpens()
+    {
+        // Saturday only.
+        Booking booking = EmailPreviewSample.BookingFor(Location(openDays: "6"), Monday);
+
+        Assert.Equal(DayOfWeek.Saturday, booking.Date.DayOfWeek);
+        Assert.Equal(new DateTime(2026, 9, 12, 19, 0, 0, DateTimeKind.Utc), booking.Date);
+    }
+
+    [Fact]
+    public void BookingFor_SitsAtSevenWhenTheDaysServiceReachesIt()
+    {
+        Booking booking = EmailPreviewSample.BookingFor(Location("11:00", "23:00"), Monday);
+
+        Assert.Equal(new TimeSpan(19, 0, 0), booking.Date.TimeOfDay);
+    }
+
+    /// <summary>The other side of the same boundary: a lunch-only location previews its own service.</summary>
+    [Fact]
+    public void BookingFor_SitsAtOpeningTimeWhenServiceEndsBeforeSeven()
+    {
+        Booking booking = EmailPreviewSample.BookingFor(Location("08:00", "15:00"), Monday);
+
+        Assert.Equal(new TimeSpan(8, 0, 0), booking.Date.TimeOfDay);
+    }
+
+    /// <summary>
+    /// A close earlier than the open runs past midnight, so 19:00 is inside that service rather
+    /// than after it — measuring the window as a plain subtraction is what would get this wrong.
+    /// </summary>
+    [Fact]
+    public void BookingFor_SitsAtSevenInsideAServiceRunningPastMidnight()
+    {
+        Booking booking = EmailPreviewSample.BookingFor(Location("18:00", "02:00"), Monday);
+
+        Assert.Equal(new TimeSpan(19, 0, 0), booking.Date.TimeOfDay);
+    }
+
+    [Fact]
+    public void BookingFor_TakesTheFirstTableOfTheFirstSection()
+    {
+        Restaurant restaurant = Location();
+        var terrace = new Section { Id = 2, Name = "Terrace", SortOrder = 1 };
+        var window = new Section { Id = 3, Name = "Window", SortOrder = 0 };
+        window.Tables.Add(new Table { Id = 9, Name = "W1", Seats = 2 });
+        terrace.Tables.Add(new Table { Id = 4, Name = "T1", Seats = 4 });
+        restaurant.Sections.Add(terrace);
+        restaurant.Sections.Add(window);
+
+        Booking booking = EmailPreviewSample.BookingFor(restaurant, Monday);
+
+        Assert.Equal("Window", booking.Section?.Name);
+        Assert.Equal("W1", booking.Table?.Name);
+    }
+
+    [Fact]
+    public void BookingFor_UsesTheLocationsOwnReferenceFormatAndSittingLength()
+    {
+        Restaurant restaurant = Location();
+        restaurant.BookingRefFormat = BookingRefFormat.Numeric;
+        restaurant.DefaultBookingDurationMinutes = 90;
+
+        Booking booking = EmailPreviewSample.BookingFor(restaurant, Monday);
+
+        Assert.Equal(EmailPreviewSample.RefFor(BookingRefFormat.Numeric), booking.BookingRef);
+        Assert.Equal(booking.Date.AddMinutes(90), booking.EndTime);
+    }
+
+    /// <summary>Unparseable hours must not take the preview down with them.</summary>
+    [Fact]
+    public void BookingFor_FallsBackToSevenWhenTheDaysHoursDoNotParse()
+    {
+        Booking booking = EmailPreviewSample.BookingFor(Location("not-a-time", "also-not"), Monday);
+
+        Assert.Equal(new TimeSpan(19, 0, 0), booking.Date.TimeOfDay);
+    }
+}

--- a/OpenRestoApi/Controllers/EmailStatusController.cs
+++ b/OpenRestoApi/Controllers/EmailStatusController.cs
@@ -26,10 +26,12 @@ namespace OpenRestoApi.Controllers;
 [RequiresScope(ApiKeyScopes.Email, ApiKeyScopes.Read)]
 public class EmailStatusController(
     EmailSettingsService emailSettings,
-    ICurrentUserService currentUser) : ControllerBase
+    ICurrentUserService currentUser,
+    EmailPreviewService emailPreview) : ControllerBase
 {
     private readonly EmailSettingsService _emailSettings = emailSettings;
     private readonly ICurrentUserService _currentUser = currentUser;
+    private readonly EmailPreviewService _emailPreview = emailPreview;
 
     /// <summary>
     /// Whether outgoing mail can be sent at all, and whether booking confirmations are switched
@@ -74,6 +76,17 @@ public class EmailStatusController(
         });
         return Ok(response);
     }
+
+    /// <summary>
+    /// The booking confirmation as a guest would receive it, rendered from a stand-in booking at
+    /// <paramref name="restaurantId"/> (the first location when none is named). Nothing is sent
+    /// and nothing is stored; the sample carries no real customer, so it needs no
+    /// <see cref="BookingGuestVisibility"/> gate.
+    /// </summary>
+    /// <seealso>EmailStatusControllerTests.Preview_RendersTheRequestedLocation</seealso>
+    [HttpGet("preview")]
+    public async Task<IActionResult> Preview([FromQuery] int? restaurantId)
+        => Ok(await _emailPreview.BuildConfirmationPreviewAsync(restaurantId));
 }
 
 public class EmailStatusResponse

--- a/OpenRestoApi/Core/Application/Interfaces/IEmailTemplateService.cs
+++ b/OpenRestoApi/Core/Application/Interfaces/IEmailTemplateService.cs
@@ -14,4 +14,10 @@ public interface IEmailTemplateService
     /// <c>DateFormatter</c>; URLs are RFC-3986 escaped.
     /// </summary>
     string BuildConfirmationEmail(Booking booking, Restaurant restaurant, BrandSettings brand, string websiteUrl);
+
+    /// <summary>
+    /// Subject line of the confirmation email. Lives beside the body so the send path and the
+    /// admin's preview render the same header, rather than each spelling the wording out.
+    /// </summary>
+    string BuildConfirmationSubject(Restaurant restaurant);
 }

--- a/OpenRestoApi/Core/Application/Services/BookingConfirmationService.cs
+++ b/OpenRestoApi/Core/Application/Services/BookingConfirmationService.cs
@@ -36,8 +36,7 @@ public sealed class BookingConfirmationService(
 
             var brand = await _brandService.GetAsync();
             string websiteUrl = _brandService.GetWebsiteUrl(brand);
-            // Subject uses an en-dash (U+2013), not a hyphen — preserved verbatim from the original.
-            string subject = $"Booking confirmed – {restaurant.Name}";
+            string subject = _templateService.BuildConfirmationSubject(restaurant);
             string body = _templateService.BuildConfirmationEmail(booking, restaurant, brand, websiteUrl);
             await _emailService.SendEmailAsync(booking.CustomerEmail, subject, body);
         }

--- a/OpenRestoApi/Core/Application/Services/EmailPreviewService.cs
+++ b/OpenRestoApi/Core/Application/Services/EmailPreviewService.cs
@@ -1,0 +1,59 @@
+using OpenRestoApi.Core.Application.Interfaces;
+using OpenRestoApi.Core.Application.Utilities;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Core.Application.Services;
+
+/// <summary>
+/// What a guest receives, rendered for the admin without sending anything. The point of it is
+/// that it goes through the same <see cref="IEmailTemplateService"/> the send path does rather
+/// than a second copy of the markup — a preview that mimicked the template would drift from it
+/// silently, and the drift would only show up in a diner's inbox.
+/// </summary>
+public sealed class EmailPreviewService(
+    IRestaurantRepository restaurants,
+    BrandService brandService,
+    IEmailTemplateService templateService,
+    ISystemClock clock)
+{
+    private readonly IRestaurantRepository _restaurants = restaurants;
+    private readonly BrandService _brandService = brandService;
+    private readonly IEmailTemplateService _templateService = templateService;
+    private readonly ISystemClock _clock = clock;
+
+    /// <summary>
+    /// Renders the confirmation for a stand-in booking at <paramref name="restaurantId"/>, or at
+    /// the first location when none is named. Falls back to a placeholder location so an instance
+    /// with nothing set up yet still previews its branding.
+    /// </summary>
+    public async Task<EmailPreviewResult> BuildConfirmationPreviewAsync(int? restaurantId)
+    {
+        List<Restaurant> active = await _restaurants.GetAllActiveWithSectionsAsync();
+        Restaurant restaurant = active.FirstOrDefault(r => r.Id == restaurantId)
+            ?? active.FirstOrDefault()
+            ?? EmailPreviewSample.PlaceholderRestaurant;
+
+        BrandSettings brand = await _brandService.GetAsync();
+        string websiteUrl = _brandService.GetWebsiteUrl(brand);
+
+        Booking booking = EmailPreviewSample.BookingFor(restaurant, _clock.UtcNow);
+
+        return new EmailPreviewResult
+        {
+            RestaurantId = restaurant.Id == 0 ? null : restaurant.Id,
+            RestaurantName = restaurant.Name,
+            RecipientEmail = EmailPreviewSample.CustomerEmail,
+            Subject = _templateService.BuildConfirmationSubject(restaurant),
+            Html = _templateService.BuildConfirmationEmail(booking, restaurant, brand, websiteUrl),
+        };
+    }
+}
+
+public class EmailPreviewResult
+{
+    public int? RestaurantId { get; set; }
+    public string RestaurantName { get; set; } = string.Empty;
+    public string RecipientEmail { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+    public string Html { get; set; } = string.Empty;
+}

--- a/OpenRestoApi/Core/Application/Services/EmailTemplateService.cs
+++ b/OpenRestoApi/Core/Application/Services/EmailTemplateService.cs
@@ -10,6 +10,11 @@ namespace OpenRestoApi.Core.Application.Services;
 /// <inheritdoc cref="IEmailTemplateService" />
 public sealed class EmailTemplateService : IEmailTemplateService
 {
+    // The en-dash (U+2013) is verbatim from the original inline subject and is deliberately not
+    // a hyphen.
+    public string BuildConfirmationSubject(Restaurant restaurant) =>
+        $"Booking confirmed \u2013 {restaurant.Name}";
+
     public string BuildConfirmationEmail(Booking booking, Restaurant restaurant, BrandSettings brand, string websiteUrl)
     {
         DateTime localDate = TimeZoneHelper.ConvertUtcToLocal(booking.Date, restaurant.Timezone);

--- a/OpenRestoApi/Core/Application/Utilities/EmailPreviewSample.cs
+++ b/OpenRestoApi/Core/Application/Utilities/EmailPreviewSample.cs
@@ -1,0 +1,116 @@
+using OpenRestoApi.Core.Application.Services;
+using OpenRestoApi.Core.Domain;
+
+namespace OpenRestoApi.Core.Application.Utilities;
+
+/// <summary>
+/// The stand-in booking the admin's confirmation-email preview renders. It carries no persisted
+/// row and is never saved: it exists so the real template can be run against a location's own
+/// branding, hours, reference format and floor plan without a diner having booked anything.
+/// </summary>
+public static class EmailPreviewSample
+{
+    public const string CustomerName = "Alex Morgan";
+    public const string CustomerEmail = "alex.morgan@example.com";
+    public const string SpecialRequests = "Window table if one is free. We're celebrating an anniversary.";
+    public const int Seats = 2;
+
+    /// <summary>
+    /// The hour the sample sitting prefers, when the location's service that day reaches it.
+    /// A dinner sitting is what most confirmations are, and it exercises the template's longer
+    /// time range; a lunch-only location gets its own opening time instead.
+    /// </summary>
+    public const int PreferredHour = 19;
+
+    /// <summary>
+    /// Fixed rather than generated, so refreshing the preview does not reshuffle the reference
+    /// under the admin. Both shapes are real ones — see <see cref="BookingRefGenerator"/> and
+    /// <see cref="NumericBookingRefGenerator"/>.
+    /// </summary>
+    public static string RefFor(BookingRefFormat format) => format switch
+    {
+        BookingRefFormat.Numeric => "48273910",
+        _ => "golden-basil-thyme-0482"
+    };
+
+    /// <summary>
+    /// Stands in for a location on an instance that has none yet, so the preview still shows the
+    /// brand colour, header and footer rather than failing. Id 0 marks it as unsaved.
+    /// </summary>
+    public static Restaurant PlaceholderRestaurant => new()
+    {
+        Name = "Your Restaurant",
+        Address = "1 Example Street, Your Town",
+        Timezone = "UTC",
+    };
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso>EmailPreviewSampleTests.BookingFor_SkipsForwardToTheNextDayTheLocationOpens</seealso>
+    /// <seealso>EmailPreviewSampleTests.BookingFor_SitsAtSevenWhenTheDaysServiceReachesIt</seealso>
+    /// <seealso>EmailPreviewSampleTests.BookingFor_SitsAtOpeningTimeWhenServiceEndsBeforeSeven</seealso>
+    /// <seealso>EmailPreviewSampleTests.BookingFor_TakesTheFirstTableOfTheFirstSection</seealso>
+    public static Booking BookingFor(Restaurant restaurant, DateTime nowUtc)
+    {
+        DateTime localStart = NextSittingLocal(restaurant, nowUtc);
+        DateTime startUtc = TimeZoneHelper.ConvertLocalToUtc(
+            DateTime.SpecifyKind(localStart, DateTimeKind.Unspecified), restaurant.Timezone);
+
+        Section? section = restaurant.Sections.OrderBy(s => s.SortOrder).FirstOrDefault();
+        Table? table = section?.Tables.OrderBy(t => t.Id).FirstOrDefault();
+
+        return new Booking
+        {
+            RestaurantId = restaurant.Id,
+            Restaurant = restaurant,
+            BookingRef = RefFor(restaurant.BookingRefFormat),
+            CustomerName = CustomerName,
+            CustomerEmail = CustomerEmail,
+            SpecialRequests = SpecialRequests,
+            Seats = Seats,
+            Section = section,
+            SectionId = section?.Id,
+            Table = table,
+            TableId = table?.Id,
+            Date = startUtc,
+            EndTime = startUtc.AddMinutes(restaurant.DefaultBookingDurationMinutes),
+        };
+    }
+
+    private static DateTime NextSittingLocal(Restaurant restaurant, DateTime nowUtc)
+    {
+        DateTime day = TimeZoneHelper.ConvertUtcToLocal(nowUtc, restaurant.Timezone).Date.AddDays(1);
+
+        // An OpenDays naming no recognisable day means every day (ServiceWindowHelper.IsOpenOn),
+        // and anything it does name is inside 1..7, so a week's walk always lands on an open day.
+        // The bound is there so a future change to that reading cannot spin the request forever.
+        for (int ahead = 0; ahead < 7 && !ServiceWindowHelper.IsOpenOn(restaurant, IsoDay.Of(day)); ahead++)
+        {
+            day = day.AddDays(1);
+        }
+
+        return day.AddMinutes(StartMinutesOfDay(restaurant, IsoDay.Of(day)));
+    }
+
+    private static int StartMinutesOfDay(Restaurant restaurant, int isoDay)
+    {
+        (string open, string close) = OpeningHoursHelper.GetHoursForDay(restaurant, isoDay);
+        if (!OpeningHoursHelper.TryParseTime(open, out int openHour, out int openMinute)
+            || !OpeningHoursHelper.TryParseTime(close, out int closeHour, out int closeMinute))
+        {
+            return PreferredHour * 60;
+        }
+
+        int openMinutes = (openHour * 60) + openMinute;
+        int closeMinutes = (closeHour * 60) + closeMinute;
+        // A close earlier than the open runs past midnight, so the service is measured forward
+        // from the open rather than as a difference between two times of day.
+        int serviceLength = closeMinutes > openMinutes
+            ? closeMinutes - openMinutes
+            : (1440 - openMinutes) + closeMinutes;
+
+        int preferredOffset = (((PreferredHour * 60) - openMinutes) + 1440) % 1440;
+        return preferredOffset < serviceLength ? openMinutes + preferredOffset : openMinutes;
+    }
+}

--- a/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
+++ b/OpenRestoApi/Extensions/ServiceCollectionExtensions.cs
@@ -356,6 +356,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<RestaurantManagementService>();
         services.AddScoped<BrandService>();
         services.AddScoped<EmailSettingsService>();
+        services.AddScoped<EmailPreviewService>();
         services.AddScoped<HighlightService>();
         services.AddScoped<SocialLinkService>();
         services.AddScoped<IAvailabilityService, AvailabilityService>();

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -115,6 +115,11 @@ curl -H "X-API-Key: $OPENRESTO_API_KEY" \
 # Recent delivery failures
 curl -H "X-API-Key: $OPENRESTO_API_KEY" \
   https://bookings.example.com/api/admin/email-settings/failures
+
+# The confirmation a guest would receive, rendered from a stand-in booking. Nothing is sent.
+# Add ?restaurantId=<id> to render a location other than the first.
+curl -H "X-API-Key: $OPENRESTO_API_KEY" \
+  https://bookings.example.com/api/admin/email-settings/preview
 ```
 
 Some of the admin surface is deliberately out of reach of any key, no matter its scopes: auth

--- a/openresto-cli/openapi/v1.json
+++ b/openresto-cli/openapi/v1.json
@@ -1783,6 +1783,33 @@
         }
       }
     },
+    "/api/admin/email-settings/preview": {
+      "get": {
+        "tags": [
+          "EmailStatus"
+        ],
+        "summary": "The booking confirmation as a guest would receive it, rendered from a stand-in booking at\nrestaurantId (the first location when none is named). Nothing is sent\nand nothing is stored; the sample carries no real customer, so it needs no\nBookingGuestVisibility gate.",
+        "parameters": [
+          {
+            "name": "restaurantId",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/highlights": {
       "get": {
         "tags": [

--- a/openresto-cli/src/generated/api.d.ts
+++ b/openresto-cli/src/generated/api.d.ts
@@ -2110,6 +2110,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/email-settings/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * The booking confirmation as a guest would receive it, rendered from a stand-in booking at
+         *     restaurantId (the first location when none is named). Nothing is sent
+         *     and nothing is stored; the sample carries no real customer, so it needs no
+         *     BookingGuestVisibility gate.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    restaurantId?: number | string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/highlights": {
         parameters: {
             query?: never;

--- a/openresto-frontend/api/admin.ts
+++ b/openresto-frontend/api/admin.ts
@@ -476,6 +476,31 @@ export async function getEmailFailures(): Promise<EmailFailureDto[]> {
   }
 }
 
+/** The confirmation email as a guest would receive it, rendered server-side for the admin. */
+export interface EmailPreviewDto {
+  restaurantId: number | null;
+  restaurantName: string;
+  recipientEmail: string;
+  subject: string;
+  html: string;
+}
+
+/**
+ * Renders the booking confirmation for a stand-in booking. The HTML comes from the same template
+ * the send path uses, so the panel never has to keep a copy of the markup in step with it.
+ */
+export async function getEmailPreview(restaurantId?: number): Promise<EmailPreviewDto | null> {
+  try {
+    const query = restaurantId === undefined ? "" : `?restaurantId=${restaurantId}`;
+    const res = await get(`/admin/email-settings/preview${query}`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error("getEmailPreview error:", err);
+    return null;
+  }
+}
+
 export interface EmailSettingsDto {
   host: string;
   port: number;

--- a/openresto-frontend/app/admin/settings/email.tsx
+++ b/openresto-frontend/app/admin/settings/email.tsx
@@ -1,23 +1,31 @@
+import { View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { EmailDeliveryPanel } from "@/components/admin/settings/EmailDeliveryPanel";
+import { EmailPreviewPanel } from "@/components/admin/settings/EmailPreviewPanel";
 import { EmailSettingsCard } from "@/components/admin/settings/EmailSettingsCard";
 import { PushNotificationsCard } from "@/components/admin/settings/PushNotificationsCard";
 import { SettingsPage, useSettingsPalette } from "@/components/admin/settings/SettingsPage";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { useEmailSettings } from "@/hooks/use-email-settings";
+import { styles } from "@/components/admin/settings/settings.styles";
 
 export default function EmailSettingsScreen() {
   const { t } = useTranslation();
   const palette = useSettingsPalette();
   const { isDark } = useAppTheme();
-  // Owned here so the form and the delivery panel beside it stay one source of truth.
+  // Owned here so the form and the panels beside it stay one source of truth.
   const email = useEmailSettings();
 
   return (
     <SettingsPage
       title={t("admin.settings.emailRoute.title")}
       subtitle={t("admin.settings.emailRoute.subtitle")}
-      aside={<EmailDeliveryPanel {...palette} isDark={isDark} email={email} />}
+      aside={
+        <View style={styles.asideStack}>
+          <EmailDeliveryPanel {...palette} isDark={isDark} email={email} />
+          <EmailPreviewPanel {...palette} isDark={isDark} email={email} />
+        </View>
+      }
     >
       <EmailSettingsCard {...palette} isDark={isDark} email={email} />
       <PushNotificationsCard />

--- a/openresto-frontend/components/admin/settings/EmailPreviewPanel.styles.ts
+++ b/openresto-frontend/components/admin/settings/EmailPreviewPanel.styles.ts
@@ -1,0 +1,76 @@
+import { StyleSheet } from "react-native";
+import { theme } from "@/theme/theme";
+
+/**
+ * The email itself renders inside a DOM <iframe>, so its box is plain CSS rather than an RN
+ * style — the same split `BookingResultPanel` makes for its map.
+ */
+export const frameStyle = {
+  width: "100%",
+  height: 460,
+  border: "0",
+  display: "block",
+  backgroundColor: "#f9fafb",
+} as const;
+
+export const styles = StyleSheet.create({
+  panel: {
+    borderRadius: theme.borderRadius.card,
+    borderWidth: 1,
+    overflow: "hidden",
+    ...theme.shadows.sm,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.md,
+    padding: theme.spacing.lg,
+  },
+  headerIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: theme.borderRadius.lg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerCopy: { flex: 1 },
+  headerTitle: { ...theme.typography.bodyBold },
+  headerSub: { ...theme.typography.caption, marginTop: 1 },
+  body: {
+    borderTopWidth: 1,
+    padding: theme.spacing.lg,
+    gap: theme.spacing.md,
+  },
+  // The mail-client chrome around the rendered body: the three header lines a guest sees above
+  // it in their inbox, which is where fromName/fromEmail land.
+  envelope: {
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.lg,
+    overflow: "hidden",
+  },
+  envelopeRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.xsm,
+  },
+  envelopeRowDivider: { borderTopWidth: 1 },
+  envelopeLabel: { fontSize: 11, fontWeight: "600", width: 56, lineHeight: 16 },
+  envelopeValue: { flex: 1, fontSize: 12, lineHeight: 16 },
+  envelopeSubject: { fontWeight: "700" },
+  frame: {
+    borderTopWidth: 1,
+  },
+  note: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: theme.spacing.xsm,
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing.md,
+  },
+  noteText: { flex: 1, fontSize: 12, lineHeight: 17 },
+  hint: { fontSize: 11, lineHeight: 15 },
+  loading: { padding: theme.spacing.xl, alignItems: "center" },
+});

--- a/openresto-frontend/components/admin/settings/EmailPreviewPanel.tsx
+++ b/openresto-frontend/components/admin/settings/EmailPreviewPanel.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useState } from "react";
+import { Platform, Pressable, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { ThemedText } from "@/components/themed-text";
+import { Icon } from "@/components/common/Icon";
+import { AnimatedAccordion } from "@/components/common/AnimatedAccordion";
+import Select from "@/components/common/Select";
+import { getEmailPreview, type EmailPreviewDto } from "@/api/admin";
+import { fetchRestaurants } from "@/api/restaurants";
+import { useBrand } from "@/context/BrandContext";
+import { useAppTheme } from "@/hooks/use-app-theme";
+import { usePersistedState } from "@/hooks/use-persisted-state";
+import { theme } from "@/theme/theme";
+import type { EmailSettingsState } from "@/hooks/use-email-settings";
+import { styles, frameStyle } from "./EmailPreviewPanel.styles";
+
+interface LocationOption {
+  id: number;
+  name: string;
+}
+
+/**
+ * The booking confirmation as a guest receives it, beside the settings that decide whether it is
+ * sent at all.
+ *
+ * The body is rendered by the server through the same template the send path uses and dropped
+ * into an iframe — deliberately not a React miniature of the email. A miniature would be a second
+ * copy of the markup, and the copy that drifted would be the one nobody sees until it is in an
+ * inbox. The envelope around it is where this screen's own unsaved state shows: the From line
+ * follows the sender fields as they are typed, and the notice under it says when a preview is all
+ * a guest would be getting.
+ *
+ * @see [EmailPreviewPanel.test.tsx](../../../tests/components/admin/settings/EmailPreviewPanel.test.tsx)
+ *   — pins that the From line follows the unsaved fields and that confirmations being off is said
+ *   out loud.
+ */
+export function EmailPreviewPanel({
+  borderColor,
+  mutedColor,
+  cardBg,
+  isDark,
+  email,
+}: {
+  borderColor: string;
+  mutedColor: string;
+  cardBg: string;
+  isDark: boolean;
+  email: EmailSettingsState;
+}) {
+  const { t } = useTranslation();
+  const { primaryColor } = useAppTheme();
+  const brand = useBrand();
+  const [expanded, setExpanded] = usePersistedState("settings:email:preview:expanded", true);
+  const [locations, setLocations] = useState<LocationOption[]>([]);
+  const [selectedId, setSelectedId] = useState<number | undefined>(undefined);
+  const [preview, setPreview] = useState<EmailPreviewDto | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetchRestaurants().then((list) => setLocations(list.map((r) => ({ id: r.id, name: r.name }))));
+  }, []);
+
+  useEffect(() => {
+    let stale = false;
+    getEmailPreview(selectedId).then((result) => {
+      if (stale) return;
+      setPreview(result);
+      setLoaded(true);
+    });
+    return () => {
+      stale = true;
+    };
+  }, [selectedId]);
+
+  const surface2 = isDark ? "#252729" : "#f9fafb";
+  const warnColor = theme.colors.warning;
+  const warnSoft = isDark ? `${warnColor}22` : "#fffbeb";
+
+  const senderName = email.fromName.trim() || brand.appName;
+  const senderAddress = email.fromEmail.trim();
+
+  // The two ways a guest ends up with nothing, in the order an admin fixes them.
+  const blockedNotice = !email.isConfigured
+    ? t("admin.settings.emailPreview.notConfigured")
+    : !email.sendConfirmations
+      ? t("admin.settings.emailPreview.confirmationsOff")
+      : null;
+
+  const row = (label: string, value: string, first: boolean, strong = false) => (
+    <View
+      style={[
+        styles.envelopeRow,
+        !first && styles.envelopeRowDivider,
+        { borderTopColor: borderColor },
+      ]}
+    >
+      <ThemedText style={[styles.envelopeLabel, { color: mutedColor }]}>{label}</ThemedText>
+      <ThemedText style={[styles.envelopeValue, strong && styles.envelopeSubject]}>
+        {value}
+      </ThemedText>
+    </View>
+  );
+
+  return (
+    <View style={[styles.panel, { backgroundColor: cardBg, borderColor }]}>
+      <View style={styles.header}>
+        <View style={[styles.headerIcon, { backgroundColor: `${primaryColor}18` }]}>
+          <Icon name="mail-outline" size="xl" color={primaryColor} />
+        </View>
+        <View style={styles.headerCopy}>
+          <ThemedText style={styles.headerTitle}>
+            {t("admin.settings.emailPreview.title")}
+          </ThemedText>
+          <ThemedText style={[styles.headerSub, { color: mutedColor }]}>
+            {t("admin.settings.emailPreview.subtitle")}
+          </ThemedText>
+        </View>
+        <Pressable
+          onPress={() => setExpanded((v) => !v)}
+          accessibilityRole="button"
+          accessibilityLabel={t("admin.settings.emailPreview.title")}
+          accessibilityState={{ expanded }}
+          hitSlop={8}
+        >
+          <Icon name={expanded ? "chevron-up" : "chevron-down"} size="lg" color={mutedColor} />
+        </Pressable>
+      </View>
+
+      <AnimatedAccordion expanded={expanded}>
+        <View style={[styles.body, { borderTopColor: borderColor }]}>
+          {locations.length > 1 && (
+            <Select
+              options={locations.map((l) => ({ label: l.name, value: l.id }))}
+              selectedValue={preview?.restaurantId ?? undefined}
+              onSelect={(value) => setSelectedId(Number(value))}
+              accessibilityLabel={t("admin.settings.emailPreview.locationLabel")}
+            />
+          )}
+
+          {blockedNotice && (
+            <View
+              style={[styles.note, { backgroundColor: warnSoft, borderColor: `${warnColor}50` }]}
+            >
+              <Icon name="alert-circle-outline" size="md" color={warnColor} />
+              <ThemedText style={[styles.noteText, { color: warnColor }]}>
+                {blockedNotice}
+              </ThemedText>
+            </View>
+          )}
+
+          {preview ? (
+            <View
+              testID="email-preview-envelope"
+              style={[styles.envelope, { borderColor, backgroundColor: surface2 }]}
+            >
+              {row(
+                t("admin.settings.emailPreview.from"),
+                senderAddress
+                  ? `${senderName} <${senderAddress}>`
+                  : t("admin.settings.emailPreview.senderNotSet", { name: senderName }),
+                true
+              )}
+              {row(t("admin.settings.emailPreview.to"), preview.recipientEmail, false)}
+              {row(t("admin.settings.emailPreview.subject"), preview.subject, false, true)}
+
+              {Platform.OS === "web" && (
+                <View style={[styles.frame, { borderTopColor: borderColor }]}>
+                  {React.createElement("iframe", {
+                    // A DOM element, so it takes the DOM attribute: React warns on `testID`
+                    // here, which react-native-web only maps for components it renders itself.
+                    "data-testid": "email-preview-frame",
+                    title: t("admin.settings.emailPreview.frameTitle"),
+                    srcDoc: preview.html,
+                    // No scripts, no same-origin: the body is HTML the server composed from
+                    // brand and location fields an admin can edit, so it renders sealed off
+                    // from the admin session it is being viewed inside.
+                    sandbox: "",
+                    style: frameStyle,
+                  })}
+                </View>
+              )}
+            </View>
+          ) : (
+            <View style={styles.loading}>
+              <ThemedText style={[styles.hint, { color: mutedColor }]}>
+                {loaded
+                  ? t("admin.settings.emailPreview.unavailable")
+                  : t("admin.settings.emailPreview.loading")}
+              </ThemedText>
+            </View>
+          )}
+
+          <ThemedText style={[styles.hint, { color: mutedColor }]}>
+            {t("admin.settings.emailPreview.hint")}
+          </ThemedText>
+        </View>
+      </AnimatedAccordion>
+    </View>
+  );
+}

--- a/openresto-frontend/components/admin/settings/settings.styles.ts
+++ b/openresto-frontend/components/admin/settings/settings.styles.ts
@@ -39,6 +39,8 @@ export const styles = StyleSheet.create({
   // within its own parent, so a column shrink-wrapped to the preview would have nowhere to go
   // and the preview would scroll away with the form.
   split: { flexDirection: "row", gap: theme.spacing.xl },
+  // Two stacked panels in the aside slot, which takes a single node.
+  asideStack: { gap: theme.spacing.lg },
   splitForm: { flex: 1, minWidth: 0 },
   splitAside: { width: 500, flexShrink: 0 },
   // The pair of location-wide bulk actions (pause bookings, extend bookings) under the page

--- a/openresto-frontend/locales/de.json
+++ b/openresto-frontend/locales/de.json
@@ -1302,6 +1302,21 @@
         "recentFailures_one": "{{count}} aktueller Fehler",
         "recentFailures_other": "{{count}} aktuelle Fehler"
       },
+      "emailPreview": {
+        "title": "Vorschau der Bestätigung",
+        "subtitle": "Was ein Gast nach der Buchung erhält",
+        "locationLabel": "Standort der Vorschau",
+        "from": "Von",
+        "to": "An",
+        "subject": "Betreff",
+        "senderNotSet": "{{name}} (noch keine Absenderadresse)",
+        "frameTitle": "Vorschau der Buchungsbestätigungs-E-Mail",
+        "notConfigured": "Es wird noch nichts versendet: SMTP-Daten eintragen und Verbindung testen.",
+        "confirmationsOff": "Buchungsbestätigungen sind ausgeschaltet, Gäste erhalten also nichts.",
+        "hint": "Eine Beispielbuchung mit Ihrem echten Branding. Es wird nichts versendet.",
+        "loading": "Vorschau wird erstellt …",
+        "unavailable": "Die Vorschau konnte nicht erstellt werden."
+      },
       "bookingConfirmation": {
         "sectionLabel": "Buchungsbestätigungen",
         "toggleLabel": "Buchungsbestätigungs-E-Mails senden",

--- a/openresto-frontend/locales/en.json
+++ b/openresto-frontend/locales/en.json
@@ -1302,6 +1302,21 @@
         "recentFailures_one": "{{count}} recent failure",
         "recentFailures_other": "{{count}} recent failures"
       },
+      "emailPreview": {
+        "title": "Confirmation preview",
+        "subtitle": "What a guest receives after booking",
+        "locationLabel": "Preview location",
+        "from": "From",
+        "to": "To",
+        "subject": "Subject",
+        "senderNotSet": "{{name}} (no sender address set yet)",
+        "frameTitle": "Booking confirmation email preview",
+        "notConfigured": "Nothing is sent yet: add your SMTP details and test the connection.",
+        "confirmationsOff": "Booking confirmations are off, so guests receive nothing.",
+        "hint": "A sample booking, rendered with your real branding. Nothing is sent.",
+        "loading": "Rendering the preview…",
+        "unavailable": "The preview could not be rendered."
+      },
       "bookingConfirmation": {
         "sectionLabel": "Booking confirmations",
         "toggleLabel": "Send booking confirmation emails",

--- a/openresto-frontend/locales/es.json
+++ b/openresto-frontend/locales/es.json
@@ -1302,6 +1302,21 @@
         "recentFailures_one": "{{count}} error reciente",
         "recentFailures_other": "{{count}} errores recientes"
       },
+      "emailPreview": {
+        "title": "Vista previa de la confirmación",
+        "subtitle": "Lo que recibe un cliente tras reservar",
+        "locationLabel": "Local de la vista previa",
+        "from": "De",
+        "to": "Para",
+        "subject": "Asunto",
+        "senderNotSet": "{{name}} (aún sin dirección de remitente)",
+        "frameTitle": "Vista previa del correo de confirmación de reserva",
+        "notConfigured": "Todavía no se envía nada: añade tus datos SMTP y prueba la conexión.",
+        "confirmationsOff": "Las confirmaciones de reserva están desactivadas, así que los clientes no reciben nada.",
+        "hint": "Una reserva de ejemplo, con tu identidad visual real. No se envía nada.",
+        "loading": "Generando la vista previa…",
+        "unavailable": "No se ha podido generar la vista previa."
+      },
       "bookingConfirmation": {
         "sectionLabel": "Confirmaciones de reserva",
         "toggleLabel": "Enviar correos de confirmación de reserva",

--- a/openresto-frontend/locales/fr.json
+++ b/openresto-frontend/locales/fr.json
@@ -1302,6 +1302,21 @@
         "recentFailures_one": "{{count}} échec récent",
         "recentFailures_other": "{{count}} échecs récents"
       },
+      "emailPreview": {
+        "title": "Aperçu de la confirmation",
+        "subtitle": "Ce qu'un client reçoit après sa réservation",
+        "locationLabel": "Établissement de l'aperçu",
+        "from": "De",
+        "to": "À",
+        "subject": "Objet",
+        "senderNotSet": "{{name}} (aucune adresse d'expéditeur définie)",
+        "frameTitle": "Aperçu de l'e-mail de confirmation de réservation",
+        "notConfigured": "Rien n'est encore envoyé : renseignez vos paramètres SMTP et testez la connexion.",
+        "confirmationsOff": "Les confirmations de réservation sont désactivées : les clients ne reçoivent rien.",
+        "hint": "Une réservation d'exemple, avec votre identité visuelle réelle. Rien n'est envoyé.",
+        "loading": "Génération de l'aperçu…",
+        "unavailable": "Impossible de générer l'aperçu."
+      },
       "bookingConfirmation": {
         "sectionLabel": "Confirmations de réservation",
         "toggleLabel": "Envoyer les e-mails de confirmation de réservation",

--- a/openresto-frontend/tests/app/admin/settings/routes.test.tsx
+++ b/openresto-frontend/tests/app/admin/settings/routes.test.tsx
@@ -58,6 +58,9 @@ jest.mock("@/components/admin/settings/EmailSettingsCard", () => ({
 jest.mock("@/components/admin/settings/EmailDeliveryPanel", () => ({
   EmailDeliveryPanel: stub("EmailDeliveryPanel"),
 }));
+jest.mock("@/components/admin/settings/EmailPreviewPanel", () => ({
+  EmailPreviewPanel: stub("EmailPreviewPanel"),
+}));
 // The email route owns the SMTP state both its halves share; the cards are stubbed, so the
 // route only needs the hook to exist, not to reach the API.
 jest.mock("@/hooks/use-email-settings", () => ({
@@ -138,6 +141,7 @@ describe("admin settings routes", () => {
       expect(screen.getByText("Email & Push")).toBeTruthy();
       expect(screen.getByText("EmailSettingsCard")).toBeTruthy();
       expect(screen.getByText("EmailDeliveryPanel")).toBeTruthy();
+      expect(screen.getByText("EmailPreviewPanel")).toBeTruthy();
       expect(screen.getByText("PushNotificationsCard")).toBeTruthy();
     });
   });

--- a/openresto-frontend/tests/components/admin/settings/EmailPreviewPanel.test.tsx
+++ b/openresto-frontend/tests/components/admin/settings/EmailPreviewPanel.test.tsx
@@ -1,0 +1,246 @@
+import React from "react";
+import { Platform, StyleSheet } from "react-native";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import { EmailPreviewPanel } from "@/components/admin/settings/EmailPreviewPanel";
+import { useEmailSettings } from "@/hooks/use-email-settings";
+import * as adminApi from "@/api/admin";
+import * as restaurantsApi from "@/api/restaurants";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("@/api/admin", () => ({
+  getEmailSettings: jest.fn(),
+  saveEmailSettings: jest.fn(),
+  testEmailConnection: jest.fn(),
+  getEmailFailures: jest.fn(),
+  getEmailPreview: jest.fn(),
+}));
+
+jest.mock("@/api/restaurants", () => ({
+  fetchRestaurants: jest.fn(),
+}));
+
+jest.mock("@/context/BrandContext", () => {
+  const brand = { primaryColor: "#0a7ea4", appName: "Tasting Room" };
+  return { useBrand: () => brand };
+});
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+const baseProps = {
+  borderColor: "#ddd",
+  mutedColor: "#888",
+  cardBg: "#fff",
+  isDark: false,
+};
+
+const defaultSettings = {
+  host: "smtp.test.com",
+  port: 587,
+  username: "user@test.com",
+  password: "••••••••",
+  enableSsl: true,
+  fromName: "Riverside Bookings",
+  fromEmail: "hello@riverside.example",
+  isConfigured: true,
+  sendBookingConfirmations: true,
+};
+
+const preview = {
+  restaurantId: 1,
+  restaurantName: "Riverside",
+  recipientEmail: "alex.morgan@example.com",
+  subject: "Booking confirmed – Riverside",
+  html: "<html><body>Booking Confirmed</body></html>",
+};
+
+function Panel({ isDark }: { isDark: boolean }) {
+  const email = useEmailSettings();
+  return <EmailPreviewPanel {...baseProps} isDark={isDark} email={email} />;
+}
+
+async function renderPanel(settings: Partial<typeof defaultSettings> = {}, isDark = false) {
+  (adminApi.getEmailSettings as jest.Mock).mockResolvedValue({ ...defaultSettings, ...settings });
+  render(<Panel isDark={isDark} />);
+  await waitFor(() => expect(screen.getByText("Confirmation preview")).toBeTruthy());
+}
+
+function envelopeBackground() {
+  return StyleSheet.flatten(screen.getByTestId("email-preview-envelope").props.style)
+    .backgroundColor;
+}
+
+describe("EmailPreviewPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (adminApi.getEmailFailures as jest.Mock).mockResolvedValue([]);
+    (adminApi.getEmailPreview as jest.Mock).mockResolvedValue(preview);
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      { id: 1, name: "Riverside" },
+    ]);
+  });
+
+  it("renders the server's subject and sample recipient", async () => {
+    await renderPanel();
+
+    await waitFor(() => expect(screen.getByText("Booking confirmed – Riverside")).toBeTruthy());
+    expect(screen.getByText("alex.morgan@example.com")).toBeTruthy();
+  });
+
+  /**
+   * The point of putting the envelope beside the form: the sender fields are this screen's own,
+   * and the preview has to answer for them before they are saved.
+   */
+  it("shows the sender fields as typed, without waiting for a save", async () => {
+    await renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText("Riverside Bookings <hello@riverside.example>")).toBeTruthy()
+    );
+  });
+
+  it("falls back to the app name when no sender address is set", async () => {
+    await renderPanel({ fromName: "", fromEmail: "" });
+
+    await waitFor(() =>
+      expect(screen.getByText("Tasting Room (no sender address set yet)")).toBeTruthy()
+    );
+  });
+
+  /** The pair that keeps the preview honest about whether any of this reaches a guest. */
+  it("says so when confirmations are switched off", async () => {
+    await renderPanel({ sendBookingConfirmations: false });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Booking confirmations are off, so guests receive nothing.")
+      ).toBeTruthy()
+    );
+  });
+
+  it("says so when SMTP is not configured at all", async () => {
+    await renderPanel({ isConfigured: false, sendBookingConfirmations: false });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Nothing is sent yet: add your SMTP details and test the connection.")
+      ).toBeTruthy()
+    );
+  });
+
+  it("offers no location picker for a single location", async () => {
+    await renderPanel();
+
+    await waitFor(() => expect(adminApi.getEmailPreview).toHaveBeenCalled());
+    expect(screen.queryByLabelText(/Preview location/)).toBeNull();
+  });
+
+  it("offers a location picker once there is more than one", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      { id: 1, name: "Riverside" },
+      { id: 2, name: "Old Town" },
+    ]);
+    await renderPanel();
+
+    await waitFor(() => expect(screen.getByLabelText(/Preview location/)).toBeTruthy());
+  });
+
+  it("reports a preview it could not render rather than showing an empty frame", async () => {
+    (adminApi.getEmailPreview as jest.Mock).mockResolvedValue(null);
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      { id: 1, name: "Riverside" },
+      { id: 2, name: "Old Town" },
+    ]);
+    await renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText("The preview could not be rendered.")).toBeTruthy()
+    );
+  });
+
+  it("collapses so a long form can have the column back", async () => {
+    await renderPanel();
+    await waitFor(() => expect(screen.getByText("alex.morgan@example.com")).toBeTruthy());
+
+    fireEvent.press(screen.getByLabelText("Confirmation preview"));
+
+    await waitFor(() => expect(screen.queryByText("alex.morgan@example.com")).toBeNull());
+  });
+
+  /** Each location has its own photo, hours and reference format, so each renders differently. */
+  it("re-renders against the location the admin picks", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      { id: 1, name: "Riverside" },
+      { id: 2, name: "Old Town" },
+    ]);
+    await renderPanel();
+    await waitFor(() => expect(screen.getByLabelText(/Preview location/)).toBeTruthy());
+
+    fireEvent.press(screen.getByLabelText(/Preview location/));
+    fireEvent.press(await screen.findByLabelText("Old Town"));
+
+    await waitFor(() => expect(adminApi.getEmailPreview).toHaveBeenCalledWith(2));
+  });
+
+  /** The envelope is admin chrome, so it follows the admin's theme, not the email's own. */
+  it("draws its envelope on the admin's own surface in either theme", async () => {
+    await renderPanel();
+    await waitFor(() => expect(screen.getByTestId("email-preview-envelope")).toBeTruthy());
+    const light = envelopeBackground();
+
+    screen.unmount();
+    await renderPanel({}, true);
+    await waitFor(() => expect(screen.getByTestId("email-preview-envelope")).toBeTruthy());
+
+    expect(envelopeBackground()).not.toBe(light);
+  });
+
+  /**
+   * Switching location twice puts two requests in flight, and the slower one is not the answer:
+   * without the guard, the first location's email lands on top of the one being asked for.
+   */
+  it("discards a response the admin has already moved on from", async () => {
+    (restaurantsApi.fetchRestaurants as jest.Mock).mockResolvedValue([
+      { id: 1, name: "Riverside" },
+      { id: 2, name: "Old Town" },
+    ]);
+    let resolveFirst: (value: typeof preview) => void = () => {};
+    (adminApi.getEmailPreview as jest.Mock).mockImplementationOnce(
+      () => new Promise((resolve) => (resolveFirst = resolve))
+    );
+    const oldTown = { ...preview, restaurantId: 2, subject: "Booking confirmed – Old Town" };
+    (adminApi.getEmailPreview as jest.Mock).mockResolvedValue(oldTown);
+
+    await renderPanel();
+    fireEvent.press(screen.getByLabelText(/Preview location/));
+    fireEvent.press(await screen.findByLabelText("Old Town"));
+    await waitFor(() => expect(screen.getByText("Booking confirmed – Old Town")).toBeTruthy());
+
+    resolveFirst(preview);
+
+    await waitFor(() => expect(screen.getByText("Booking confirmed – Old Town")).toBeTruthy());
+    expect(screen.queryByText("Booking confirmed – Riverside")).toBeNull();
+  });
+
+  /**
+   * The body is the server's own HTML in a sandboxed iframe — web only, which is where the admin
+   * runs. A React miniature of the email is the thing this exists not to be.
+   */
+  it("renders the email body in a sandboxed iframe on web", async () => {
+    Object.defineProperty(Platform, "OS", { get: () => "web", configurable: true });
+    try {
+      await renderPanel();
+
+      await waitFor(() => expect(screen.getByTestId("email-preview-envelope")).toBeTruthy());
+      const frame = screen.UNSAFE_getByProps({ "data-testid": "email-preview-frame" });
+      expect(frame.props.srcDoc).toBe(preview.html);
+      expect(frame.props.sandbox).toBe("");
+    } finally {
+      Object.defineProperty(Platform, "OS", { get: () => "ios", configurable: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The SMTP form was the only place an admin could act on confirmation emails, and nothing on it showed what one looks like. The first sight of the template was a guest's inbox.

`/admin/settings/email` now renders the real confirmation for a stand-in booking, in a panel beside the form. The HTML comes from the server through `EmailTemplateService`, the same template the send path uses, and drops into a sandboxed iframe. A React miniature of the email would be a second copy of the markup, and the copy that drifted would be the one nobody sees until it has already been sent.

The envelope around the body carries this screen's own unsaved state: the From line follows the sender name and address as they are typed, and a notice says when confirmations are off or SMTP is not configured, which are the two ways a guest ends up receiving nothing. Instances with more than one location get a picker, since each one renders differently. Nothing is sent and nothing is stored.

## Related issue

Closes #

## Scope

- [x] API (OpenRestoApi)
- [x] Frontend (openresto-frontend)
- [ ] Database migration
- [x] Docs / infra

## Changes

- `GET /api/admin/email-settings/preview` on `EmailStatusController`, under the existing `email:read` scope with the rest of the read-only email surface. Optional `?restaurantId=`, defaulting to the first location. Returns the rendered HTML, the subject, the sample recipient and which location was rendered.
- `EmailPreviewService` resolves the location, the brand row and the public address, then calls the real template. `EmailPreviewSample` builds the stand-in booking: the next day the location opens, at 7pm when that day's service reaches it and at opening time otherwise (a service running past midnight is measured forward from the open, not as a subtraction), with the location's own reference format, sitting length, first section and first table. A fresh install with no locations gets a placeholder so branding still previews.
- `IEmailTemplateService.BuildConfirmationSubject`. The subject was inlined in `BookingConfirmationService`; both paths now call the one builder so they cannot drift.
- `EmailPreviewPanel` in the settings aside, collapsible and persisted like `BrandPreview`. The iframe is `sandbox=""`: the body is HTML composed from brand and location fields an admin can edit, so it renders sealed off from the admin session viewing it. Web only, which is where the admin runs.
- Copy in all four locales, and the new endpoint in `docs/http-api.md`.

## Testing

- [x] `OpenRestoApi.Tests` pass locally (2256 passed)
- [x] Frontend tests/build pass locally (3661 passed on both the iOS and Android jest platforms, `tsc`, `npm run check`, `check:doc-links`)
- [ ] CI passes (build, migration-check)
- [x] Manually verified the change end-to-end

Backend coverage is a unit test per rule: which day and hour the sample lands on, both sides of the "does this day's service reach 7pm" boundary, the past-midnight case, the reference format and sitting length, the section/table pick, the location fallbacks, that the subject matches the send path's, and that the preview persists nothing. Frontend is 100% statements, branches, functions and lines on the new panel, including the out-of-order response guard and the two "guests receive nothing" notices.

Manual check was against a local backend and Expo web with Chromium: the panel renders the real email, the From line follows the sender fields before they are saved, the location picker re-renders, and the envelope follows the admin's light/dark theme while the email itself stays light. `openapi/v1.json` and the CLI types were regenerated.

## Migrations

- [ ] This PR includes a database migration
- [ ] Migration was tested locally (up and, if applicable, down)

## Checklist

- [x] No secrets, connection strings, or credentials committed
- [x] Docs updated if API contracts or setup changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCcU8i3AQ8EPQ8kCZB38r

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCCcU8i3AQ8EPQ8kCZB38r)_